### PR TITLE
Fix for issue #65

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,3 @@
-SHELL = /bin/bash
 SUBDIRS = src libraries
 ALLDIRS = $(SUBDIRS)
 
@@ -51,8 +50,10 @@ MAKE=make --no-print-directory
 
 all: print subdirs bin grsihist grsisort html end
 
+simple: print subdirs bin grsihist grsisort end
+
 print:
-	@echo "Compiling on $(PLATFORM) using $(SHELL)"
+	@echo "Compiling on $(PLATFORM)"
 
 subdirs: $(SUBDIRS)
 
@@ -74,12 +75,12 @@ ifeq ($(wildcard ./.grsi_history),)
 	@touch .grsi_history
 endif
 
-html: grsisort  
+html: libraries grsisort
 	@printf " ${COM_COLOR}Building      ${OBJ_COLOR} HTML Documentation ${NO_COLOR}\n"
 	@root -b -q util/html_generator.C >/dev/null
 	@$(RM) tempfile.out
 
-end: html
+end: grsisort
 	@printf " ${WARN_COLOR}Compilation Success. woohoo!${NO_COLOR}\n\n"
 
 clean:


### PR DESCRIPTION
Fixes #65. Type `make simple` for basic compilation without html generation.
