### PR TITLE
Works for Apple.

### DIFF
--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -99,13 +99,14 @@ int TGRSIint::TabCompletionHook(char* buf, int* pLoc, ostream& out) {
 void TGRSIint::PrintLogo(bool print) {
 
    if(print)   {
-     #if PLATFORM == Linux
+     #ifdef LINUX
       const std::string &ref = ProgramName();
+      const unsigned int reflength = ref.length() - 78;
      #else
-      const std::string &ref = "Nuclear Data";
+      const std::string &ref = "Sorting Program for Online and Offline Nuclear Data";
+      const unsigned int reflength = 53;
      #endif
 
-     const unsigned int reflength = ref.length() - 78;
      const unsigned int width = reflength + (reflength % 2);
      printf("\t*%s*\n", std::string(width,'*').c_str());   
      printf("\t*%*s%*s*\n",width/2+5,"GRSI SPOON", width/2-5, "");

--- a/libraries/TGRSIint/makefile
+++ b/libraries/TGRSIint/makefile
@@ -6,6 +6,9 @@ CFLAGS += -fPIC
 
 ifeq ($(PLATFORM),Darwin)
 export __APPLE__ = 1
+else
+CFLAGS += -DLINUX
+WORDS = words.o
 endif
 
 #COMP_STRING="Now Compling "
@@ -18,10 +21,6 @@ CAT=cat
 all: libTGRSIint.so
 	@printf "\r ${FIN_COLOR}%s${FIN_OBJ_COLOR}%-30s ${NO_COLOR}\n" $(FIN_STRING) $^ ;
 
-
-#ifdef __LINUX__
-WORDS = words.o
-#endif
 
 libTGRSIint.so: $(OBJECTS)
 	@printf " ${COM_COLOR}%s${OBJ_COLOR}%s${NO_COLOR}" $(COMP_STRING) "$@"

--- a/makefile
+++ b/makefile
@@ -11,11 +11,11 @@ export CFLAGS = -std=c++0x -O2 -I$(PWD)/include
 
 ifeq ($(PLATFORM),Darwin)
 export __APPLE__:= 1
-export CFLAGS += -DOS_DARWIN -std=c++11 -DHAVE_ZLIB #-lz
-export CFLAGS += -m64 -I$(ROOTSYS)/include
+export CFLAGS += -DOS_DARWIN -DHAVE_ZLIB #-lz
+export CFLAGS += `root-config --cflags`
 export LFLAGS = -dynamiclib -undefined dynamic_lookup -single_module # 
 export SHAREDSWITCH = -install_name # ENDING SPACE
-export CPP = xcrun clang++ 
+export CPP = clang++ 
 else
 export __LINUX__:= 1	
 export CFLAGS += `root-config --cflags`


### PR DESCRIPTION
root-config --cflags creates some warnings from clang due to the unused -pthread flag, but compiling and running GRSIsort on MacOs X works now.
