### PR TITLE
Small change to GetEnergy

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -132,7 +132,7 @@ class TChannel : public TNamed	{
     //void CalibrateFragment(TFragment*);
 
     double CalibrateENG(double);
-    double CalibrateENG(int);
+    double CalibrateENG(int,bool);
     double CalibrateCFD(double);
     double CalibrateCFD(int);
     double CalibrateLED(double);

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -299,10 +299,13 @@ void TChannel::DestroyCalibrations()   {
    DestroyTIMECal();
 };
 
-double TChannel::CalibrateENG(int charge) {
+double TChannel::CalibrateENG(int charge, bool random_flag = true) {
     if(charge==0) 
       return 0.0000;
-   return CalibrateENG((double)charge) + gRandom->Uniform();
+   if(random_flag) 
+      return CalibrateENG((double)charge) + gRandom->Uniform();
+   else
+      return CalibrateENG((double)charge);
 };
 
 double TChannel::CalibrateENG(double charge) {

--- a/users/UserFillObj.h
+++ b/users/UserFillObj.h
@@ -13,7 +13,7 @@
         if(histcfd) histcfd->Fill(fragment->Cfd.at(0));
 
 	TH2D *mat = (TH2D*)(GetOutputList()->FindObject("hp_charge"));
-	if(mat) mat->Fill(channel->GetNumber(),fragment->Charge.at(0)/125.0+gRandom->Uniform());
+	if(mat) mat->Fill(channel->GetNumber(),fragment->Charge.at(0)/125.0);
 
 	hist = (TH1D*)(GetOutputList()->FindObject("test"));
 	if(hist) hist->Fill(channel->GetNumber());


### PR DESCRIPTION
Get energy still works the way it always did. However, it can now take a second argument which turns off the random number that is added following the spectrum contraction if it is set to "false".
