### PR TITLE
Switched CalibrateENG calls to doubles so the energy calibration is used...

### DIFF
--- a/include/TCSMData.h
+++ b/include/TCSMData.h
@@ -88,7 +88,7 @@ public:
     SetHorizontal_DetectorNbr(mnemonic->arrayposition);
 	 SetHorizontal_DetectorPos(mnemonic->arraysubposition.c_str()[0]);
 	 SetHorizontal_StripNbr(mnemonic->segment);
-	 SetHorizontal_Energy(channel->CalibrateENG(frag->Charge.at(0)));
+	 SetHorizontal_Energy(channel->CalibrateENG(double(frag->Charge.at(0))));
 	 SetHorizontal_TimeCFD(frag->Cfd.at(0));
 	 SetHorizontal_TimeLED(frag->Led.at(0));
 	 SetHorizontal_Time(frag->TimeToTrig);
@@ -99,7 +99,7 @@ public:
 		SetVertical_DetectorNbr(mnemonic->arrayposition);
 		SetVertical_DetectorPos(mnemonic->arraysubposition.c_str()[0]);
 		SetVertical_StripNbr(mnemonic->segment);
-		SetVertical_Energy(channel->CalibrateENG(frag->Charge.at(0)));
+		SetVertical_Energy(channel->CalibrateENG(double(frag->Charge.at(0))));
 		SetVertical_TimeCFD(frag->Cfd.at(0));
 		SetVertical_TimeLED(frag->Led.at(0));
 		SetVertical_Time(frag->TimeToTrig);

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -75,7 +75,7 @@ double TFragment::GetEnergy() {
    TChannel *chan = TChannel::GetChannel(ChannelAddress);
    if(!chan || Charge.size()<1)
       return 0.00;
-   return chan->CalibrateENG((int)(Charge.at(0)));
+   return chan->CalibrateENG((double)(Charge.at(0)));
 }
 
 


### PR DESCRIPTION
... rather than going off of the integration.
