### PR TITLE
Slight change to CalibrateENG

### DIFF
--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -322,7 +322,7 @@ double TChannel::CalibrateENG(int charge) {
    if(integration != 0)
       temp_int = (int)integration;  //the 4 is the dis. 
    
-   CalibrateENG(((double)charge+gRandom->Uniform()) / (double)temp_int);
+   return CalibrateENG(((double)charge+gRandom->Uniform()) / (double)temp_int);
 };
 
 double TChannel::CalibrateENG(double charge) {


### PR DESCRIPTION
As per [discussion](https://github.com/pcbend/GRSISort/pull/131).

Confirmed giving good results with s1249 data.
