### PR TITLE
made setters, getters, and fixed spelling mistakes

### DIFF
--- a/include/TGRSITransition.h
+++ b/include/TGRSITransition.h
@@ -15,11 +15,21 @@ class TGRSITransition : public TObject {
       bool IsSortable() const { return true; }
       int Compare(const TObject *obj) const;
 
+      void SetEnergy(double &tmpenergy){energy = tmpenergy;}
+      void SetEnergyUncertainty(double &tmperror){ energy_uncertainty = tmperror;}
+      void SetIntensity(double &tmpintens){intensity = tmpintens;}
+      void SetIntensityUncertainty(double &tmpinterror){ intensity_uncertainty = tmpinterror;}
+
+      double GetEnergy() const {return energy;}
+      double GetEnergyUncertainty() const {return energy_uncertainty;}
+      double GetIntensity() const {return intensity;}
+      double GetIntensityUncertainty() const {return intensity_uncertainty;}
+
    protected:
       double energy;
-      double energy_uncertainity;
+      double energy_uncertainty;
       double intensity;
-      double intensity_uncertainity;
+      double intensity_uncertainty;
 
    ClassDef(TGRSITransition,1)
 };

--- a/libraries/TGRSIAnalysis/TNucleus/TGRSITransition.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TGRSITransition.cxx
@@ -7,9 +7,9 @@ ClassImp(TGRSITransition)
 TGRSITransition::TGRSITransition() {
   Class()->IgnoreTObjectStreamer(true);
   energy                 = 0.0; 
-  energy_uncertainity    = 0.0; 
+  energy_uncertainty    = 0.0; 
   intensity              = 0.0; 
-  intensity_uncertainity = 0.0;  
+  intensity_uncertainty = 0.0;  
 
 }
 

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -311,9 +311,9 @@ bool TNucleus::SetSourceData() {
       TGRSITransition *tran = new TGRSITransition; 
       std::stringstream ss(line);
       ss >> tran->energy;
-      ss >> tran->energy_uncertainity;
+      ss >> tran->energy_uncertainty;
       ss >> tran->intensity;
-      ss >> tran->intensity_uncertainity;
+      ss >> tran->intensity_uncertainty;
       TransitionList.Add(tran);
       printf("eng: %.02f\tinten: %.02f\n",((TGRSITransition*)TransitionList.Last())->energy,((TGRSITransition*)TransitionList.Last())->intensity);
    }                                                                                                         


### PR DESCRIPTION
This is a very small pull request but I thought it would be worthwhile to have on it's own for it's potential to break things for other people. If you use TGRSITransitions at all please read this! 
1. I have protected the members of TGRSITransitions, but made the TNucleus a friend class of the transitions. So this shouldn't change anything if you directly used the TNucleus. 
2. I then made setters and getters to the TGRSITransition members so please switch to those if you need to.
3. Finally the word uncertainty in TGRSITransition was spelt uncertainity and this drove me nuts trying to figure out why my compiler was grumpy, so I changed that to the proper spelling to avoid future headaches. However, this shouldn't be a problem for anyone because if it is, you would have had to change something at point 2. anyway. Sorry if this causes issues for anyones scripts, but I think this is the correct and safe way to do this. 
