### PR TITLE
Fixed Clang -O2 optimization problem

### DIFF
--- a/libraries/TGRSILoop/TGRSILoop.cxx
+++ b/libraries/TGRSILoop/TGRSILoop.cxx
@@ -260,12 +260,31 @@ void TGRSILoop::SetFileOdb(char *data, int size) {
    if(!node->HasChildren())
       return;
    node = node->GetChildren();
-   std::string expt;
-   while(1) {
-      std::string key = fOdb->GetNodeName(node);
-      if(key.compare("Name")==0) {
-         expt = node->GetText();
-         break;
+
+  while(1) {
+      if(strcmp("Name",fOdb->GetNodeName(node))){//If these are not equal, break and move on
+        if(!node->HasNextNode()){
+            break;
+        }
+        node = node->GetNextNode();
+        break;
+      }
+      else 
+        break;
+   }
+
+    const char* expt = node->GetText();
+
+   if(!strcmp("tigress",expt))
+      SetTIGOdb();
+   else if(!strcmp("griffin",expt))
+      SetGRIFFOdb();
+  // std::string expt;
+/*   while(1) {
+        std::string key(fOdb->GetNodeName(node), strlen(fOdb->GetNodeName(node))) ;
+        if(key.compare(name)==0) {
+        expt = node->GetText();
+        break;
       }
       if(!node->HasNextNode())
          break;
@@ -274,7 +293,7 @@ void TGRSILoop::SetFileOdb(char *data, int size) {
    if(expt.compare("tigress")==0)
       SetTIGOdb();
    else if(expt.compare("griffin")==0)
-      SetGRIFFOdb();
+      SetGRIFFOdb();*/
 }
 
 void TGRSILoop::SetGRIFFOdb() {


### PR DESCRIPTION
- This turned out to be caused by a slew std::string = const char* that clang optimized and did not do the proper casting. I think this is a strict aliasing-like problem (I could be wrong, my comp-sci lingo isn't perfect). I have corrected the code to use only const char*. 
- I assume this problem might carry through into epics and other odb read things,. I'll keep my eye out, but other mac users should as well.