### PR TITLE
Switching the method of peak label display to a stabler method

### DIFF
--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -46,7 +46,6 @@ class GCanvas : public TCanvas {
       Int_t  GetNMarkers() { return fMarkers.size(); }
       Int_t  GetNBG_Markers() { return fBG_Markers.size(); }
       void SetMarkerMode(bool flag=true) {fMarkerMode = flag;}
-      void ShowPeaks();
 
       static void SetBackGroundSubtractionType();
 
@@ -99,9 +98,6 @@ class GCanvas : public TCanvas {
       bool PeakFitQ(GMarker *m1=0,GMarker *m2=0);
 
       static int fBGSubtraction_type;
-
-      bool DisplayPeaks();
-      bool RemovePeaks();
 
       Window_t fCanvasWindowID;
       TRootCanvas *fRootCanvas;

--- a/include/GRootGlobals.h
+++ b/include/GRootGlobals.h
@@ -2,6 +2,7 @@
 #define GROOTGLOBALS__H
 
 #include <TH2.h>
+#include <TH1.h>
 
 TH1D *ProjectionX(TH2 *mat,int lowbin=0,int highbin=-1); /*MENU*/
 TH1D *ProjectionY(TH2 *mat,int lowbin=0,int highbin=-1); /*MENU*/
@@ -10,6 +11,9 @@ TH1D *ProjectionY(TH2 *mat,double lowvalue,double highvalue=-1); /*MENU*/
 
 void SaveAll(const char* fname,Option_t *opt="recreate");
 
+void PeakSearch(TH1 *hst,double thresh);
+bool ShowPeaks();
+bool RemovePeaks();
 
 void Help();
 void Commands();

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -538,7 +538,7 @@ bool GCanvas::HandleKeyboardPress(Event_t *event,UInt_t *keysym) {
             edit = PeakFit();
             break;
          case kKey_s:
-            edit = DisplayPeaks();
+            edit = ShowPeaks();
             break;
          case kKey_S:
             edit = RemovePeaks();
@@ -1192,99 +1192,4 @@ TH1 *GCanvas::GetBackGroundHist(GMarker *addlow,GMarker *addhigh) {
       break;
   };
   return 0;
-}
-
-void GCanvas::ShowPeaks()
-{
-	// remove previous labels
-	TIter iter(this->GetListOfPrimitives());
-	TObject *obj;
-	while(obj=iter())
-	{
-		if (strcmp(obj->GetName(),"peaklabel")==0) obj->Delete();
-	}
-
-	TIter next(this->GetListOfPrimitives());
-	TH1* hst;
-	double thresh=0.01;
-	while(obj=next())
-	{
-		if (obj->InheritsFrom("TH1") && !obj->InheritsFrom("TH2") && !obj->InheritsFrom("TH3"))
-		{
-			hst = (TH1*) obj;
-			TSpectrum* spec = new TSpectrum();
-			spec->Search(hst,2,"Qnodraw",thresh);
-			TPolyMarker *pm = (TPolyMarker*)hst->GetListOfFunctions()->FindObject("TPolyMarker");
-			if (!pm)
-			{
-				printf("No TPolyMarker object in the list of functions for histogram %s\n",hst->GetName());
-				return;
-			}
-			TObjArray* testarray = (TObjArray*)hst->GetListOfFunctions()->FindObject("PeakLabels");
-			if (testarray)
-			{
-				hst->GetListOfFunctions()->Remove(testarray);
-				delete testarray;
-			}
-		
-			TObjArray* array = new TObjArray();
-			array->SetName("PeakLabels");
-			int n = pm->GetN();
-			if (n>20) n=20;
-			TText* text;
-			double *x = pm->GetX();
-			double *y = pm->GetY();
-			for (int i=0;i<n;i++)
-			{
-				text = new TText(x[i],y[i],Form("%.1f",x[i]));
-				text->SetName("peaklabel");
-				text->SetTextSize(0.025);
-				text->SetTextAngle(90);
-				text->SetTextAlign(12);
-				text->SetTextFont(42);
-				text->SetTextColor(hst->GetLineColor());
-				array->Add(text);
-			}
-			hst->GetListOfFunctions()->Remove(pm);
-			delete pm;
-			array->Draw();
-		}
-		else continue;
-	}
-	return;
-}
-
-bool GCanvas::DisplayPeaks()
-{
-	// if we already have this TExec attached, don't attach it again.
-	TIter iter(this->GetListOfExecs());
-	TObject *obj;
-	while(obj=iter())
-	{
-		if (strcmp(obj->GetName(),"ShowPeaks")==0) return false;
-	}
-
-	const char* name = this->GetName();
-	this->AddExec("ShowPeaks",Form("%s->ShowPeaks()",name));
-	return true;
-}
-
-bool GCanvas::RemovePeaks()
-{
-	// remove TExec attached to canvas
-	TIter iter(this->GetListOfExecs());
-	TObject *obj;
-	// this loop makes sure that all peak exec functions are clear
-	while(obj=iter())
-	{
-		if (strcmp(obj->GetName(),"ShowPeaks")==0) this->DeleteExec("ShowPeaks");
-	}
-
-	// clean up remaining labels
-	TIter next(this->GetListOfPrimitives());
-	while(obj=next())
-	{
-		if (strcmp(obj->GetName(),"peaklabel")==0) obj->Delete();
-	}
-	return true;
 }

--- a/libraries/GROOT/GROOTLinkDef.h
+++ b/libraries/GROOT/GROOTLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ function ProjectionX(TH2*,double,double);
 #pragma link C++ function ProjectionY(TH2*,double,double);
 
+#pragma link C++ function PeakSearch(TH1*,double);
 #pragma link C++ function Prompt();
 #pragma link C++ function SaveAll(const char*,Option_t*);
 


### PR DESCRIPTION
This will attach the TExec to the individual histograms instead of the TCanvas. This appears to be more stable and to label the histograms immediately upon redraw, rather than waiting for an Update command.