### PR TITLE
bulid windows / addback windows / detector distance interface added

### DIFF
--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -125,7 +125,8 @@ class TGRSIRunInfo : public TObject {
       static const char* GetXMLODBFileName() { return fGRSIRunInfo->fXMLODBFileName.c_str(); }
       static const char* GetXMLODBFileData() { return fGRSIRunInfo->fXMLODBFile.c_str(); }
 
-
+      static Bool_t  ReadInfoFile(const char *filename = "");
+      static Bool_t  ParseInputData(const char *inputdata = "",Option_t *opt = "q");
 
       static inline int  GetNumberOfSystems() { return fGRSIRunInfo->fNumberOfTrueSystems; }
 
@@ -144,6 +145,19 @@ class TGRSIRunInfo : public TObject {
       static inline bool Dante()     { return fGRSIRunInfo->fDante; }
       static inline bool ZeroDegree(){ return fGRSIRunInfo->fZeroDegree; }
       static inline bool Descant()   { return fGRSIRunInfo->fDescant; }
+
+      inline void SetRunInfoFileName(const char *fname) {  fRunInfoFileName.assign(fname); }
+      inline void SetRunInfoFile(const char *ffile)     {  fRunInfoFile.assign(ffile); }
+     
+
+      inline void SetBuildWindow(const long int t_bw)    { fBuildWindow = t_bw; } 
+      inline void SetAddBackWindow(const double   t_abw) { fAddBackWindow = t_abw; } 
+
+      static inline long int BuildWindow()    { return Get()->fBuildWindow; }
+      static inline double   AddBackWindow()  { return Get()->fAddBackWindow; }
+
+      inline void SetHPGeArrayPosition(const int arr_pos) { fHPGeArrayPosition = arr_pos; }
+      static inline int  HPGeArrayPosition()  { return Get()->fHPGeArrayPosition; }
 
    private:
       static TGRSIRunInfo *fGRSIRunInfo;
@@ -199,11 +213,25 @@ class TGRSIRunInfo : public TObject {
       std::string fMajorIndex;  
       std::string fMinorIndex;  
 
+      /////////////////////////////////////////////////
+      //////////////// Building Options ///////////////
+      /////////////////////////////////////////////////
+
+      std::string fRunInfoFileName;
+      std::string fRunInfoFile;
+	   static void trim(std::string *, const std::string & trimChars = " \f\n\r\t\v");
+
+      long int fBuildWindow;          // if building with a window(GRIFFIN) this is the size of the window. (default = 2us (200))
+      double   fAddBackWindow;        // Time used to build Addback-Ge-Events for TIGRESS/GRIFFIN.   (default =150 ns (15.0))
+      
+      double  fHPGeArrayPosition;        // Position of the HPGe Array (default = 110.0 mm );
+  
+
    public:
       void Print(Option_t *opt = "");
       void Clear(Option_t *opt = "");
 
-   ClassDef(TGRSIRunInfo,2);
+   ClassDef(TGRSIRunInfo,3);
 };
 
 #endif

--- a/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
+++ b/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
@@ -409,7 +409,7 @@ void TAnalysisTreeBuilder::SortFragmentTreeByTimeStamp() {
       //and send it to the event Q for processing.
       //if(buildevent) {
 //      if(abs(currentFrag->GetTimeStamp() - firstTimeStamp) > 200) {  // 2 micro-sec.
-      if((currentFrag->GetTimeStamp() - firstTimeStamp) > 200) {  // 2 micro-sec.
+      if((currentFrag->GetTimeStamp() - firstTimeStamp) > TGRSIRunInfo::BuildWindow() ) { //200) {  // 2 micro-sec.
          //printf("Adding %ld fragments to queue\n",event->size());
          //if(event->size() > 1) {
             //for(int i = 0; i < event->size(); ++i) {

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -4,6 +4,8 @@
 #include <TRandom.h>
 #include <TMath.h>
 
+#include <TGRSIRunInfo.h>
+
 ////////////////////////////////////////////////////////////
 //                    
 // TGriffin
@@ -239,7 +241,7 @@ void TGriffin::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
       corehit.SetDetectorNumber(gdata->GetCloverNumber(i));
       corehit.SetCrystalNumber(gdata->GetCoreNumber(i));
    
-      corehit.SetPosition();
+      corehit.SetPosition(TGRSIRunInfo::HPGeArrayPosition());
       
       corehit.SetPPG(gdata->GetPPG(i));
 
@@ -382,7 +384,7 @@ void TGriffin::BuildAddBack(Option_t *opt) {
 
          int d_time = std::abs(addback_hits.at(j).GetTime() - this->GetGriffinHit(i)->GetTime());
 
-         if( (res.Mag() < 105) && (d_time < 20) )    {    ///Still need to tune these values!! pcb.
+         if( (res.Mag() < 105) && (d_time < TGRSIRunInfo::AddBackWindow() ) )    {    ///Still need to tune these values!! pcb.
             used = true;
             addback_hits.at(j).Add(this->GetGriffinHit(i));
             break;
@@ -413,7 +415,7 @@ void TGriffin::BuildAddBackClover(Option_t *opt) {
             continue;
          int d_time = std::abs(addback_clover_hits.at(j).GetTime() - this->GetGriffinHit(i)->GetTime());
 
-         if(  (d_time < 20)  )    {    ///Still need to tune these values!! pcb.
+         if(  (d_time < TGRSIRunInfo::AddBackWindow() )  )    {    ///Still need to tune these values!! pcb.
             used = true;
             addback_clover_hits.at(j).Add(this->GetGriffinHit(i));
             break;

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -7,6 +7,8 @@
 #include <TMath.h>
 #include <TClass.h>
 
+#include <TGRSIRunInfo.h>
+
 ClassImp(TTigress)
 
 //double TTigress::beta = 0.00;
@@ -440,7 +442,7 @@ void TTigress::BuildCloverAddBack(Option_t *opt)	{
 
 		
 				if( clover_addback_hits.at(j).GetDetectorNumber() == this->GetTigressHit(i)->GetDetectorNumber() )	{
-				     if( (d_time < 11) )    { // gate hard coded to 110ns.
+				     if( (d_time < TGRSIRunInfo::AddBackWindow() ) )    { // gate hard coded to 110ns.
 		 		        used = true;
 		     		     clover_addback_hits.at(j).Add(this->GetTigressHit(i));
 		         	  break;
@@ -482,14 +484,14 @@ void TTigress::BuildAddBack(Option_t *opt)	{
 				int seg2 = this->GetTigressHit(i)->GetInitialHit();
 		
 				if( (seg1<5 && seg2<5) || (seg1>4 && seg2>4) )	{   // not front to back
-				     if( (res.Mag() < 54) && (d_time < 110) )    {  // time gate == 110  ns  pos gate == 54mm
+				     if( (res.Mag() < 54) && (d_time < TGRSIRunInfo::AddBackWindow() ) )    {  // time gate == 110  ns  pos gate == 54mm
 		 		        used = true;
 		     		    addback_hits.at(j).Add(this->GetTigressHit(i));
 		         		break;
 			     	}
 				}
 				else if( (seg1<5 && seg2>4) || (seg1>4 && seg2<5) )	{ // front to back
-				     if( (res.Mag() < 105) && (d_time < 110) )    {     // time gate == 110 ns pos gate == 105mm.
+				     if( (res.Mag() < 105) && (d_time < TGRSIRunInfo::AddBackWindow() ) )    {     // time gate == 110 ns pos gate == 105mm.
 		 		        used = true;
 		     		    addback_hits.at(j).Add(this->GetTigressHit(i));
 		         		break;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -1,6 +1,11 @@
 
 #include "TGRSIRunInfo.h"
 
+#include <fstream>
+#include <sstream>
+
+#include <TGRSIOptions.h>
+
 ClassImp(TGRSIRunInfo)
 
 TGRSIRunInfo *TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();  
@@ -38,6 +43,11 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    TObject::Streamer(b);  
    {Int_t  R__int ; b >> R__int;  fRunNumber = R__int;}
    {Int_t  R__int ; b >> R__int;  fSubRunNumber = R__int;}
+   if(R__v>2) {
+     {Int_t  R__int ; b >> R__int;  fHPGeArrayPosition = R__int;}
+     {Int_t  R__int ; b >> R__int;  fBuildWindow = R__int;}
+     {Double_t  R__double ; b >> R__double;  fAddBackWindow = R__double;}
+   }
    {Bool_t R__bool; b >> R__bool; fTigress = R__bool;   }
    {Bool_t R__bool; b >> R__bool; fSharc = R__bool;     }
    {Bool_t R__bool; b >> R__bool; fTriFoil = R__bool;   }
@@ -54,7 +64,15 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    {Bool_t R__bool; b >> R__bool; fZeroDegree = R__bool;}
    {Bool_t R__bool; b >> R__bool; fDescant = R__bool;   }
    {TString R__str; R__str.Streamer(b); fMajorIndex.assign(R__str.Data()); } 
+   //printf("fMajorIndex = %s\n",fMajorIndex.c_str());
    {TString R__str; R__str.Streamer(b); fMinorIndex.assign(R__str.Data()); }
+   //printf("fMinorIndex = %s\n",fMinorIndex.c_str());
+   if(R__v >2) {
+     {TString R__str; R__str.Streamer(b); fRunInfoFileName.assign(R__str.Data()); }
+     //printf("fRunInfoFileNameMajor = %s\n",fRunInfoFileName.c_str());
+     {TString R__str; R__str.Streamer(b); fRunInfoFile.assign(R__str.Data()); }
+     //printf("fMajorIndex = %s\n",fMajorIndex.c_str());
+   }
    fGRSIRunInfo = this;
    b.CheckByteCount(R__s,R__c,TGRSIRunInfo::IsA());
  } else {
@@ -62,6 +80,9 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    TObject::Streamer(b);  
    {Int_t R__int = fRunNumber;    b << R__int;}
    {Int_t R__int = fSubRunNumber; b << R__int;}
+   {Int_t R__int = fHPGeArrayPosition; b << R__int;}
+   {Int_t R__int = fBuildWindow;       b << R__int;}
+   {Double_t R__double = fAddBackWindow;  b << R__double;}
    {Bool_t R__bool = fTigress;    b << R__bool;}
    {Bool_t R__bool = fSharc;      b << R__bool;}
    {Bool_t R__bool = fTriFoil;    b << R__bool;}
@@ -77,8 +98,12 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    {Bool_t R__bool = fDante;      b << R__bool;}
    {Bool_t R__bool = fZeroDegree; b << R__bool;}
    {Bool_t R__bool = fDescant;    b << R__bool;}
-   {TString R__str; R__str = fMajorIndex.c_str(); R__str.Streamer(b);}
-   {TString R__str; R__str = fMinorIndex.c_str(); R__str.Streamer(b);}
+   //printf("fMajorIndex = %s\n",fMajorIndex.c_str());
+   //printf("fMinorIndex = %s\n",fMinorIndex.c_str());
+   {TString R__str(fMajorIndex.c_str());      R__str.Streamer(b); printf("TSring::data = %s\n",R__str.Data());  }//; R__str = fMajorIndex.c_str();      R__str.Streamer(b);}
+   {TString R__str(fMinorIndex.c_str());      R__str.Streamer(b);  printf("TSring::data = %s\n",R__str.Data()); }//; R__str = fMinorIndex.c_str();      R__str.Streamer(b);}
+   {TString R__str(fRunInfoFileName.c_str()); R__str.Streamer(b);   }//; R__str = fRunInfoFileName.c_str(); R__str.Streamer(b);}
+   {TString R__str(fRunInfoFile.c_str());     R__str.Streamer(b);   }//; R__str = fRunInfoFile.c_str();     R__str.Streamer(b);}
    b.SetByteCount(R__c,true);
  }
 }
@@ -100,8 +125,14 @@ void TGRSIRunInfo::SetInfoFromFile(TGRSIRunInfo *tmp) {
 TGRSIRunInfo::TGRSIRunInfo() : fRunNumber(0),fSubRunNumber(-1) { 
    //if(fNumberOfTrueSystems>0)
    //   TGRSIRunInfo::Get() = this;
-   //else 
-   Clear(); 
+   //else
+   
+   fHPGeArrayPosition = 110.0;
+   fBuildWindow       = 200;  
+   fAddBackWindow     = 15.0;
+
+   Clear();
+
 }
 
 TGRSIRunInfo::~TGRSIRunInfo() { }
@@ -119,7 +150,13 @@ void TGRSIRunInfo::Print(Option_t *opt) {
    printf("\t\tSCEPTAR:      %s\n", Sceptar() ? "true" : "false");
    printf("\t\tPACES:        %s\n", Paces() ? "true" : "false");
    printf("\t\tDESCANT:      %s\n", Descant() ? "true" : "false");
-   printf("\t=====================\n");
+   printf("\n");
+   printf(DBLUE"\tBuild Window   = " DRED "%lu"   RESET_COLOR "\n",TGRSIRunInfo::BuildWindow());
+   printf(DBLUE"\tAddBack Window = " DRED "%.01f" RESET_COLOR "\n",TGRSIRunInfo::AddBackWindow());
+   printf(DBLUE"\tArray Position = " DRED "%i"    RESET_COLOR "\n",TGRSIRunInfo::HPGeArrayPosition());
+   printf("\n");
+   printf("\t==============================\n");
+
 }
 
 void TGRSIRunInfo::Clear(Option_t *opt) {
@@ -214,15 +251,125 @@ void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum) {
          SetDescant();
       }
    }
+   if(Tigress()) {
+     Get()->fMajorIndex.assign("TriggerId");
+     Get()->fMinorIndex.assign("FragmentId");
+   } else if(Griffin()) {
+     Get()->fMajorIndex.assign("TimeStampHigh");
+     Get()->fMinorIndex.assign("TimeStampLow");
+   }
+
+   if(Get()->fRunInfoFile.length())
+      ParseInputData(Get()->fRunInfoFile.c_str());
+
    //TGRSIRunInfo::Get()->Print();
 }
 
 
-void TGRSIRunInfo::SetAnalysisTreeBranches(TTree*) {
+void TGRSIRunInfo::SetAnalysisTreeBranches(TTree*) {  }
 
 
+Bool_t TGRSIRunInfo::ReadInfoFile(const char *filename) {
+   std::string infilename;
+   infilename.append(filename);
 
+   if(infilename.length()==0)
+      return false;
+
+   std::ifstream infile;
+   infile.open(infilename.c_str());
+   if (!infile) {
+      printf("could not open file.\n");
+      return false;
+   }
+   infile.seekg(0,std::ios::end);
+   int length = infile.tellg();
+   if(length<1) {
+      printf("file is empty.\n");
+      return false;
+   }
+   char buffer[length];
+   infile.seekg(0,std::ios::beg);
+   infile.read(buffer,length);
+
+   Get()->SetRunInfoFileName(filename);
+   Get()->SetRunInfoFile(buffer);
+   
+   return ParseInputData((const char*)buffer); 
 }
+
+Bool_t TGRSIRunInfo::ParseInputData(const char *inputdata,Option_t *opt) {
+
+   std::istringstream infile(inputdata);
+   std::string line;
+   int linenumber = 0;
+
+   //Parse the info file. 
+   while (std::getline(infile, line)) {
+      linenumber++;
+      trim(&line);
+      int comment = line.find("//");
+      if (comment != std::string::npos) {
+         line = line.substr(0, comment);
+      }
+      if (!line.length())
+         continue;
+
+      int ntype = line.find(":");
+      if (ntype == std::string::npos) //no seperator, not useful.
+        continue;
+
+      std::string type = line.substr(0, ntype);
+      line = line.substr(ntype + 1, line.length());
+      trim(&line);
+      int j = 0;
+      while (type[j]) {
+        char c = *(type.c_str() + j);
+        c = toupper(c);
+        type[j++] = c;
+      }
+      if( type.compare("BW")==0 || type.compare("BUILDWINDOW")==0 ) {     
+        std::istringstream ss(line);
+        long int temp_bw; ss >> temp_bw;
+        Get()->SetBuildWindow(temp_bw);
+      } else if( type.compare("ABW")==0 || type.compare("ADDBACKWINDOW")==0 || type.compare("ADDBACK") ) {
+        std::istringstream ss(line);
+        double temp_abw; ss >> temp_abw;
+        Get()->SetAddBackWindow(temp_abw);
+      } else if( type.compare("CAL")==0 || type.compare("CALFILE")==0 ) {
+        TGRSIOptions::AddInputCalFile(line);
+      } else if( type.compare("MID")==0 || type.compare("MIDAS")==0 || type.compare("MIDASFILE")==0 ) {
+        TGRSIOptions::AddInputMidasFile(line);
+      } else if( type.compare("ARRAYPOS")==0 || type.compare("HPGEPOS")==0) {
+        std::istringstream ss(line);
+        double temp_int; ss >> temp_int;
+        Get()->SetHPGeArrayPosition(temp_int);
+      }
+   }
+
+   if(strcmp(opt,"q")) {
+     printf("parsed %i lines.\n",linenumber);
+     printf(DBLUE"\tBuild Window   = " DRED "%lu"   RESET_COLOR "\n",TGRSIRunInfo::BuildWindow());
+     printf(DBLUE"\tAddBack Window = " DRED "%.01f" RESET_COLOR "\n",TGRSIRunInfo::AddBackWindow());
+     printf(DBLUE"\tArray Position = " DRED "%i"    RESET_COLOR "\n",TGRSIRunInfo::HPGeArrayPosition());
+   }
+   return true;
+}
+
+
+void TGRSIRunInfo::trim(std::string * line, const std::string & trimChars) {
+//Removes the the string "trimCars" from  the string 'line'
+   if (line->length() == 0)
+      return;
+   std::size_t found = line->find_first_not_of(trimChars);
+   if (found != std::string::npos)
+      *line = line->substr(found, line->length());
+   found = line->find_last_not_of(trimChars);
+   if (found != std::string::npos)
+      *line = line->substr(0, found + 1);
+   return;
+}
+
 
 
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -399,6 +399,13 @@ bool TGRSIint::FileAutoDetect(std::string filename, long filesize) {
       //fInputCalFile->push_back(filename);
       TGRSIOptions::AddInputCalFile(filename);
       return true;
+   } else if(ext.compare("info")==0) { 
+      if(TGRSIRunInfo::ReadInfoFile(filename.c_str()))
+         return true;
+      else {
+         printf("Problem reading run-info file %s\n",filename.c_str());
+         return false;
+      }
    } else if(ext.compare("xml")==0) { 
       //fInputOdbFile->push_back(filename);
       TGRSIOptions::AddInputOdbFile(filename);

--- a/util/grsiruninfoexample.info
+++ b/util/grsiruninfoexample.info
@@ -1,0 +1,14 @@
+/////////////////////////////////////
+/////    Example *.info file   //////
+/////////////////////////////////////
+
+
+//The event building time, 10ns units. 
+BuildWindow: 200     // 2useconds
+
+//The Addback event window, 10ns units.
+AddBackWindow: 15.0  // 150.0 nseconds
+
+//The Array position in mm.
+HPGePos:       110.0 // 110.0 mm 
+


### PR DESCRIPTION

TGRSIRunInfo now contains a Build Window, AddBack Window and Array distance.
 
This variables do the obvious. They can be changed with a new file type optionally given at either the fragment-sort phase or the analysis-sort phase.  In order for the Auto-File reader function in TGRSIint to work, the file must have the extension .info

An example of this file has been added:  util/grsiruninfoexample.info
Just like the calfile, it is case insensitive and // starts a comment. 

So far, the parsable data is pretty limited, however the frame work from this point on is pretty easy to expand to include more options.  Thanks to some streamer magic, this up is backwards compatible.   In this case the it uses default windows/distance selected by me.

default build time = 2 us
default addback window = 150 ns
default distance = 110 mm.

These are close/the same as the values people have been using.

