### PR TITLE
Add two more BG subtraction types to GROOT Project

### DIFF
--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -1163,20 +1163,24 @@ bool GCanvas::SetBGGate(GMarker *m1, GMarker *m2, GMarker *m3, GMarker *m4) {
            mark->linex->SetLineColor(kBlue);
            mark->linex->Draw();
         } 
+        RemoveMarker(); // remove marker #4 so the project will work...
+        RemoveMarker(); // remove marker #3 so the project will work...
      }
      return true;
    case 4:
      if(!m1 || !m2 )
         return false;
      else {
-       AddBGMarker(m3);
-       AddBGMarker(m4);
+       AddBGMarker(m1);
+       AddBGMarker(m2);
        for(int x=0;x<2;x++) {
          GMarker *mark = fBG_Markers.at(x);
          mark->linex = new TLine(mark->localx,GetUymin(),mark->localx,GetUymax());
          mark->linex->SetLineColor(kBlue);
          mark->linex->Draw();
        } 
+       RemoveMarker(); // remove marker #4 so the project will work...
+       RemoveMarker(); // remove marker #3 so the project will work...
      }  
      return true;
   };

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -1153,7 +1153,7 @@ bool GCanvas::SetBGGate(GMarker *m1, GMarker *m2, GMarker *m3, GMarker *m4) {
 
         AddBGMarker(m4);
         mark = new GMarker(*m3);
-        mark->x = m3->x + (abs(m1->x - m2->x)/2 + 1);
+        mark->x = m4->x + (abs(m1->x - m2->x)/2 + 1);
         mark->localx = gPad->AbsPixeltoX(mark->x);
         AddBGMarker(mark);
 


### PR DESCRIPTION

Type 3:  High & low gates subtract gates added.  Requires four markers.  The two subtract gates are created from markers3 and markers4 while the Add gate is from marker1 and marker2.  Add gate size is split between the the two gates (i.e. (Marker3 + AddSize/2) and (Marker4 + AddSize/2))  In the case where the Add gate size is odd, the lower gate has the extra bin.  Gates are inclusive.  

Type 4:  BG subtract gate is set static to marker1 and marker2.  Placing marker1 and marker2 and selecting 'b' places a consent subtract gate between the markers.  One can than go on to place the Add gate.  Gates are inclusive.
