### PR TITLE
Offsetfix update for new banks, new firmware problems

### DIFF
--- a/util/bufferclean.C
+++ b/util/bufferclean.C
@@ -23,6 +23,9 @@ Bool_t CheckEvent(TMidasEvent *evt){
    void *ptr;
    int banksize = evt->LocateBank(NULL,"GRF2",&ptr);
 
+   if(!banksize)
+      banksize = evt->LocateBank(NULL,"GRF1",&ptr);
+
    uint32_t type  = 0xffffffff;
    uint32_t value = 0xffffffff;
 

--- a/util/offsetfix.C
+++ b/util/offsetfix.C
@@ -35,6 +35,9 @@ class TEventTime {
          void *ptr;
          int banksize = event->LocateBank(NULL,"GRF2",&ptr);
 
+         if(!banksize)
+            banksize = event->LocateBank(NULL,"GRF1",&ptr);
+
          uint32_t type  = 0xffffffff;
          uint32_t value = 0xffffffff;
     
@@ -211,7 +214,13 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
                break;
             }
             event->SetBankList();
-            if((banksize = event->LocateBank(NULL,"GRF2",&ptr))>0) {
+            
+
+               banksize = event->LocateBank(NULL,"GRF2",&ptr);
+            if(!banksize)
+               banksize = event->LocateBank(NULL,"GRF1",&ptr);
+
+            if(banksize>0) {
                int frags = TDataParser::GriffinDataToFragment((uint32_t*)(ptr),banksize,2,mserial,mtime);
                if(frags > -1){
                   events_read++;
@@ -511,6 +520,8 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
   
    void *ptr;
    int banksize = event->LocateBank(NULL,"GRF2",&ptr);
+   if(!banksize)
+      banksize = event->LocateBank(NULL,"GRF1",&ptr);
 
    uint32_t type  = 0xffffffff;
    uint32_t value = 0xffffffff;
@@ -575,6 +586,9 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    copyevent.SetBankList();
 
    banksize = copyevent.LocateBank(NULL,"GRF2",&ptr);
+   if(!banksize)
+      banksize = copyevent.LocateBank(NULL,"GRF1",&ptr);
+
    for(int x=0;x<banksize;x++) {
       value = *((int*)ptr+x);
       type  = value & 0xf0000000; 

--- a/util/offsetfix.C
+++ b/util/offsetfix.C
@@ -632,7 +632,8 @@ bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    time |= timelow &0x0fffffff;
 
 //   if((chanadd&0x0000ff00) != TEventTime::GetBestDigitizer()){
-   if((dettype<2) || ((chanadd&0xf) < 2) ){   
+ //  if((dettype<2) || ((chanadd&0xf) < 2) ){   
+   if(dettype > 1 && ((chanadd&0xF) > 1) && ((chanadd&0xF00)>1)) {
       time -= TEventTime::correctionmap.find(chanadd&0x0000ff00)->second;    
    }
    else{


### PR DESCRIPTION
Updates to both banks of offsetfix 
- Offset fix now checks if you are using subrun 0. This is important because if you are using firmware with 'bank' problems, timestamps can jump dramatically right at the start of subrun 0. Offsetfix now starts looking at event 1E5 in subrun 0, and at the start of the run for the rest. Please make sure that the 1E5 event doesn't just happen to fall at a bad spot and your time_diff spectra still make sense! 
- Split Mezzanines. Setting the SplitMezz flag within offset fix allows you to split the 4G mezzanines as we notices that the two mezzanines within a single 4G could have different time stamps. 
- Default file name. If you don't put an output file name on the command line, offsetfix defaults to putting the prefix 'fix' on the input file name.