### PR TITLE
Change to stdout redirection method

### DIFF
--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -962,7 +962,7 @@ int TChannel::WriteToRoot(TFile *fileptr) {
   WriteCalBuffer();
   std::string savedata = fFileData;
   
-
+  FILE* originalstdout = stdout;
   int fd = open("/dev/null", O_WRONLY); // turn off stdout.
   stdout = fdopen(fd, "w");
 
@@ -986,8 +986,7 @@ int TChannel::WriteToRoot(TFile *fileptr) {
     TChannel::DeleteAllChannels();
   }
 
-  fd = open("/dev/tty", O_WRONLY);  // turn on stdout.
-  stdout = fdopen(fd, "w");
+  stdout = originalstdout; //Restore stdout
 
   ParseInputData(savedata.c_str(),"q");
   SaveToSelf(savedata.c_str());

--- a/libraries/TGRSILoop/TGRSILoop.cxx
+++ b/libraries/TGRSILoop/TGRSILoop.cxx
@@ -601,13 +601,13 @@ bool TGRSILoop::ProcessGRIFFIN(uint32_t *ptr, int &dsize, int bank, TMidasEvent 
             }
             else
 					errfilename.append("error_log.log");
-            FILE *errfileptr = freopen(errfilename.c_str(),"a",stdout);
+				  FILE* originalstdout = stdout;
+				  FILE *errfileptr = freopen(errfilename.c_str(),"a",stdout);
 			   printf("\n//**********************************************//\n");
 				if(mevent) mevent->Print("a");
 			   printf("\n//**********************************************//\n");
 			   fclose(errfileptr);
-		      int fd = open("/dev/tty", O_WRONLY);
-	     		stdout = fdopen(fd, "w");
+	     		stdout = originalstdout;
 			}
 		}
 	}

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -323,7 +323,7 @@ void TGRSIint::GetOptions(int *argc, char **argv) {
           TGRSIOptions::SetProgressDialog(false);
        } else if((temp.compare("bad_frags")==0)     || (temp.compare("write_bad_frags")==0) ||
                  (temp.compare("bad_fragments")==0) || (temp.compare("write_bad_fragments")==0)) {
-          printf(DBLUE "    failed fragements being written too BadFragmentTree." RESET_COLOR "\n");
+          printf(DBLUE "    failed fragements being written to BadFragmentTree." RESET_COLOR "\n");
           TGRSIOptions::SetWriteBadFrags(true);
        } else if(temp.compare("help")==0) {
           fPrintHelp = true;


### PR DESCRIPTION
Previously, stdout redirections methods didn't work with utilities like nohup, since they assumed that stdout pointed to /dev/tty.  I am now storing where stdout points, and restoring it later.