### PR TITLE
multiple griffin frags per event + errors

### DIFF
--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -37,8 +37,8 @@ class TDataParser { //: public TObject {
 
   public:
     //static std::vector<TFragment*> TigressDataToFragment(uint32_t *data, int size,unsigned int midasserialnumber = 0, time_t midastime = 0);
-    static int TigressDataToFragment(uint32_t *data, int size,unsigned int midasserialnumber = 0, time_t midastime = 0);
-    static int GriffinDataToFragment(uint32_t *data, int size, int bank, unsigned int midasserialnumber = 0, time_t midastime = 0);
+    static int TigressDataToFragment(uint32_t *data, int size, int *iter, unsigned int midasserialnumber = 0, time_t midastime = 0);
+    static int GriffinDataToFragment(uint32_t *data, int size, int *iter, int bank, unsigned int midasserialnumber = 0, time_t midastime = 0);
    
     static int EPIXToScalar(float *data,int size,unsigned int midasserialnumber = 0,time_t midastime = 0);
 	 static int EightPIDataToFragment(uint32_t stream,uint32_t* data,

--- a/include/TFragment.h
+++ b/include/TFragment.h
@@ -60,7 +60,7 @@ public:
    UShort_t DataType;             //-> 
    UShort_t DetectorType;         //-> Detector Type (PACES,HPGe, etc)
    UInt_t ChannelId;              //-> Threshold crossing counter for a channel
-   UInt_t AcceptedChannelId;      //-> Accepted threshold crossing counter for a channel
+   //UInt_t AcceptedChannelId;      //-> Accepted threshold crossing counter for a channel
 
    std::vector<UShort_t>  KValue; //-> KValue for each pileup hit
 
@@ -85,8 +85,6 @@ public:
    using TObject::Print; 
    virtual void Print(Option_t *opt = ""); //!
    
-
-
    bool operator<(const TFragment &rhs) const { return (GetTimeStamp() < rhs.GetTimeStamp()); }
    bool operator>(const TFragment &rhs) const { return (GetTimeStamp() > rhs.GetTimeStamp()); }
 

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -51,7 +51,7 @@ TDataParser::~TDataParser() {}
 
 
 //std::vector<TFragment*> TDataParser::TigressDataToFragment(uint32_t *data, int size,unsigned int midasserialnumber, time_t midastime) {
-int TDataParser::TigressDataToFragment(uint32_t *data, int size,unsigned int midasserialnumber, time_t midastime) {
+int TDataParser::TigressDataToFragment(uint32_t *data,int size,int *iter,unsigned int midasserialnumber, time_t midastime) {
 //Converts A MIDAS File from the Tigress DAQ into a TFragment.
    std::vector<TFragment*> FragsFound;
    int NumFragsFound = 0;
@@ -379,7 +379,8 @@ bool TDataParser::SetTIGTimeStamp(uint32_t *data,TFragment *currentfrag ) {
 /////////////***************************************************************/////////////
 /////////////***************************************************************/////////////
 
-int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsigned int midasserialnumber, time_t midastime)	{
+
+int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int *iter, int bank, unsigned int midasserialnumber, time_t midastime)	{
 //Converts a Griffin flavoured MIDAS file into a TFragment
    int NumFragsFound = 1;
    TFragment *EventFrag = new TFragment();
@@ -390,8 +391,9 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
 	int x = 0;  
    //int x = 6;
 	if(!SetGRIFHeader(data[x++],EventFrag,bank)) {
-		printf(DYELLOW "data[0] = 0x%08x" RESET_COLOR "\n",data[0]);
+		printf(DYELLOW "data[%i] = 0x%08x" RESET_COLOR "\n",x-1,data[x-1]);
 		delete EventFrag;
+      *iter += x;
 		return -x;
 	}
 
@@ -402,17 +404,21 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
    //The master Filter Pattern is in an unstable state right now and is not
    //always written to the midas file
 	if(SetGRIFMasterFilterPattern(data[x],EventFrag)) {
+      //printf("in set grif filter pattern thingie.\n");
       x++;
 	} 
 
   if(SetGRIFMasterFilterId(data[x],EventFrag)) {
+      //printf("in set grif filter id thingie.\n");
       x++;
 	}
 
    //The channel trigger ID is in an unstable state right now and is not
    //always written to the midas file
 	if(!SetGRIFChannelTriggerId(data[x++],EventFrag)) {
+      //printf("in set grif channel trigger thingie.\n");
 		delete EventFrag;
+      *iter += x;
 		return -x;
 	}
 
@@ -424,6 +430,7 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
 
 	if(!SetGRIFTimeStampLow(data[x++],EventFrag)) {
 		delete EventFrag;
+      *iter += x;
 		return -x;
 	}
 
@@ -459,24 +466,26 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
                      }
                   }
                }
-               if(EventFrag->DataType == 1) {
-                  EventFrag->AcceptedChannelId = (value>>14) & 0x3fff;
+              
+               // Adding new data members to the fragment is not backwards 
+               // compatable.  Also, an unsigned int to care a 1 is a pretty exssive.
+               // If we really need this, I suggest moving to a TBits Objectt, which we 
+               // can move all such flags too and expained with out breaking things backwards.
+               //if(EventFrag->DataType == 1) {
+               //   EventFrag->AcceptedChannelId = (value>>14) & 0x3fff;
                   //printf("Set AcceptedChannelId to 0x%04x (from 0x%08x => 0x%04x)\n", EventFrag->AcceptedChannelId, value, value>>14);
-               } else {
-                  EventFrag->AcceptedChannelId = 0;
-               }
+               //} else {
+               //   EventFrag->AcceptedChannelId = 0;
+               //}
+
                if(record_stats)
 						FillStats(EventFrag); //we fill dead-time and run time stats from the fragment
-					TFragmentQueue::GetQueue("GOOD")->Add(EventFrag);				
-               if(x != size-1)
-               {
-//                  printf( DBLUE "x | size: " DRED "%i | %i" RESET_COLOR "\n",x,size); //once this happens we need to recursively call GriffinDataToFragment with the remaining datums.  
-                    ++x;
-                    NumFragsFound = NumFragsFound + TDataParser::GriffinDataToFragment(&data[x++],size-x,bank,midasserialnumber,midastime);
-               }
+					TFragmentQueue::GetQueue("GOOD")->Add(EventFrag);			
+               *iter +=(x+1);
                return NumFragsFound; //This will be more important when we start putting multiple fragments into a single mid event
 				} else  {
                TFragmentQueue::GetQueue("BAD")->Add(EventFrag);
+               *iter += x;
 					return -x;
             }
             break;
@@ -504,12 +513,13 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
  		   default:				
 	      	if((packet & 0x80000000) == 0x00000000) {
             if(x+1 < size) {
-					    EventFrag->KValue.push_back( (*(data+x) & 0x7c000000) >> 21 );
-					    EventFrag->Charge.push_back((*(data+x) & 0x03ffffff));	
-					    ++x;
- 					    EventFrag->KValue.back() |= (*(data+x) & 0x7c000000) >> 26;
+              EventFrag->KValue.push_back( (*(data+x) & 0x7c000000) >> 21 );
+              EventFrag->Charge.push_back((*(data+x) & 0x03ffffff));	
+              ++x;
+              EventFrag->KValue.back() |= (*(data+x) & 0x7c000000) >> 26;
               EventFrag->Cfd.push_back( (*(data+x) & 0x03ffffff));
             } else {
+               *iter += x;
                return -x;
 	          }
           }
@@ -517,6 +527,7 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int bank, unsig
 		};
 	}
    TFragmentQueue::GetQueue("BAD")->Add(EventFrag);
+   *iter += x;
 	return -x;
 }
 


### PR DESCRIPTION
Parsing multiple midas events with multiple griifin fragments had a strange failure mode.  Because we are double using the number of fragments found as the number of fragment found (if positive) and the error failure (if negative), recursive calling did funny things when the parsing failed mid stream.

It would subtract the number of the failed datum from the number of fragments extracted so far and there was a bit of a race going on to see if the total event would pass or fail.  This has been fixed.  The recursion call has been moved to the grsiloop, errors again get reported correctly (if run without the --suppress_errors flag) to the command line, recovers of the data stream are also noted here.  The logging of errors to a data file has not yet been updated.

Additional funny things are happening to the fragment counters (fFragsReadFromMIdas and fFragsSentToTree).  When I sort the multiple fragments per midas event, I am getting more events in the tree than from the file.  I think this error has been there for a while and was making it appear we where doing better than we really were in the above scenario.  I haven't hunted the bug down yet, and will open a ticket about this as well.