### PR TITLE
Added on-the-fly addback functionality into TGriffin.

### DIFF
--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <cstdio>
+#include <functional>
 
 #include <TBits.h>
 
@@ -15,84 +16,93 @@
 class TGriffinData;
 #endif
 //#include "TBGOData.h"
-#include "TVector3.h" 
+#include "TVector3.h"
 
 #include "TGriffinHit.h"
-#include "TGRSIDetector.h" 
+#include "TGRSIDetector.h"
 
 
 class TGriffin : public TGRSIDetector {
 
-  public:
-     TGriffin();
-     TGriffin(const TGriffin&);
-     virtual ~TGriffin();
-
-  public: 
-     void BuildHits(TGRSIDetectorData *data =0,Option_t *opt = ""); //!
-
-     TGriffinHit *GetGriffinHit(const int i); //!
-     TGRSIDetectorHit* GetHit(const Int_t idx = 0);
-     Int_t GetMultiplicity() const {return griffin_hits.size();}
-
-     static TVector3 GetPosition(int DetNbr ,int CryNbr = 5, double distance = 110.0);		//!
-     void FillData(TFragment*,TChannel*,MNEMONIC*); //!
-
-     TGriffin& operator=(const TGriffin&);  //! 
-
-     //void AddHit(TGriffinHit *hit) { griffin_hits.push_back(*hit); }
-
-   private: 
-     TGriffinData *grifdata;                 //!  Used to build GRIFFIN Hits
-     //TBGOData     *bgodata;                  //!  Used to build BGO Hits
-     std::vector <TGriffinHit> griffin_hits; //  The set of crystal hits
-
-     //static bool fSetBGOHits;		            //!  Flag that determines if BGOHits are being measured			 
-		
-     static bool fSetCoreWave;		         //!  Flag for Waveforms ON/OFF
-     //static bool fSetBGOWave;		            //!  Flag for BGO Waveforms ON/OFF
-
-     long fCycleStart;                //!  The start of the cycle
-     static long fLastPPG;                   //!  value of the last ppg
-
-     enum  GriffinFlags{kCycleStartTime,kTapeMove,kBackGround,kBeamOn,kDecay};
-     TBits fGriffinBits;
+   public:
+      TGriffin();
+      TGriffin(const TGriffin&);
+      virtual ~TGriffin();
 
    public:
-     static bool SetCoreWave()        { return fSetCoreWave;  }	//!
-     //static bool SetBGOHits()       { return fSetBGOHits;   }	//!
-     //static bool SetBGOWave()	    { return fSetBGOWave;   } //!
+      void BuildHits(TGRSIDetectorData *data =0,Option_t *opt = ""); //!
 
-     void SetTapeMove(Bool_t flag=kTRUE)   { fGriffinBits.SetBitNumber(kTapeMove,flag); }  //!
-     void SetBackground(Bool_t flag=kTRUE) { fGriffinBits.SetBitNumber(kBackGround,flag);} //!
-     void SetBeamOn(Bool_t flag=kTRUE)     { fGriffinBits.SetBitNumber(kBeamOn,flag);}     //!
-     void SetDecay(Bool_t flag=kTRUE)      { fGriffinBits.SetBitNumber(kDecay,flag);}      //!
+      TGriffinHit *GetGriffinHit(const int i); //!
+      TGRSIDetectorHit* GetHit(const Int_t idx = 0);
+      Int_t GetMultiplicity() const {return griffin_hits.size();}
 
-     bool GetTapeMove()   const { return fGriffinBits.TestBitNumber(kTapeMove);}//!
-     bool GetBackground() const { return fGriffinBits.TestBitNumber(kBackGround);}//!
-     bool GetBeamOn()     const { return fGriffinBits.TestBitNumber(kBeamOn);}//!
-     bool GetDecay()      const { return fGriffinBits.TestBitNumber(kDecay);}//!
+      static TVector3 GetPosition(int DetNbr ,int CryNbr = 5, double distance = 110.0);		//!
+      void FillData(TFragment*,TChannel*,MNEMONIC*); //!
 
-     int GetCycleTimeInMilliSeconds(long time) { return (int)((time-fCycleStart)/1e5); }//!
+      TGriffin& operator=(const TGriffin&);  //!
 
-   //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
+      //void AddHit(TGriffinHit *hit) { griffin_hits.push_back(*hit); }
+
+#ifndef __CINT__
+      void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { addback_criterion = criterion; }
+      std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() { return addback_criterion; }
+#endif
+
+      Int_t GetAddbackMultiplicity();
+      TGriffinHit* GetAddbackHit(const int i);
+
    private:
-     static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
-     void ClearStatus() { fGriffinBits.ResetAllBits(kFALSE); } //!     
+      TGriffinData *grifdata;                 //!  Used to build GRIFFIN Hits
+      //TBGOData     *bgodata;                  //!  Used to build BGO Hits
+      std::vector <TGriffinHit> griffin_hits; //  The set of crystal hits
 
-   public:         
-     virtual void Copy(TGriffin&) const;                //!
-     virtual void Clear(Option_t *opt = "all");		     //!
-     virtual void Print(Option_t *opt = "") const;		  //!
+      //static bool fSetBGOHits;		            //!  Flag that determines if BGOHits are being measured			 
+
+      static bool fSetCoreWave;		         //!  Flag for Waveforms ON/OFF
+      //static bool fSetBGOWave;		            //!  Flag for BGO Waveforms ON/OFF
+
+      long fCycleStart;                //!  The start of the cycle
+      static long fLastPPG;                   //!  value of the last ppg
+
+      enum  GriffinFlags{kCycleStartTime,kTapeMove,kBackGround,kBeamOn,kDecay};
+      TBits fGriffinBits;
+
+      std::vector <TGriffinHit> addback_hits; //! Used to create addback hits on the fly
+      std::function<bool(TGriffinHit&, TGriffinHit&)> addback_criterion;
+
+   public:
+      static bool SetCoreWave()        { return fSetCoreWave;  }	//!
+      //static bool SetBGOHits()       { return fSetBGOHits;   }	//!
+      //static bool SetBGOWave()	    { return fSetBGOWave;   } //!
+
+      void SetTapeMove(Bool_t flag=kTRUE)   { fGriffinBits.SetBitNumber(kTapeMove,flag); }  //!
+      void SetBackground(Bool_t flag=kTRUE) { fGriffinBits.SetBitNumber(kBackGround,flag);} //!
+      void SetBeamOn(Bool_t flag=kTRUE)     { fGriffinBits.SetBitNumber(kBeamOn,flag);}     //!
+      void SetDecay(Bool_t flag=kTRUE)      { fGriffinBits.SetBitNumber(kDecay,flag);}      //!
+
+      bool GetTapeMove()   const { return fGriffinBits.TestBitNumber(kTapeMove);}//!
+      bool GetBackground() const { return fGriffinBits.TestBitNumber(kBackGround);}//!
+      bool GetBeamOn()     const { return fGriffinBits.TestBitNumber(kBeamOn);}//!
+      bool GetDecay()      const { return fGriffinBits.TestBitNumber(kDecay);}//!
+
+      int GetCycleTimeInMilliSeconds(long time) { return (int)((time-fCycleStart)/1e5); }//!
+
+      //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
+   private:
+      static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
+      void ClearStatus() { fGriffinBits.ResetAllBits(kFALSE); } //!
+
+   public:
+      virtual void Copy(TGriffin&) const;                //!
+      virtual void Clear(Option_t *opt = "all");		     //!
+      virtual void Print(Option_t *opt = "") const;		  //!
 
    protected:
-     void PushBackHit(TGRSIDetectorHit* ghit);
+      void PushBackHit(TGRSIDetectorHit* ghit);
 
-   ClassDef(TGriffin,2)  // Griffin Physics structure
+      ClassDef(TGriffin,2)  // Griffin Physics structure
 
 
 };
 
 #endif
-
-

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -78,8 +78,9 @@ class TGriffinHit : public TGRSIDetectorHit {
 
       bool   InFilter(Int_t);  //!
 
-//      static bool CompareEnergy(TGriffinHit*,TGriffinHit*);  //!
-//      void Add(TGriffinHit*);    //! 
+      void SetEnergy(double en) { energy = en; }
+      static bool CompareEnergy(TGriffinHit*,TGriffinHit*);  //!
+      void Add(TGriffinHit*);    //! 
       //Bool_t BremSuppressed(TSceptarHit*);
 
 	public:

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -160,24 +160,22 @@ UInt_t TGriffinHit::SetCrystal() {
    return crystal;
 }
 
-//bool TGriffinHit::CompareEnergy(TGriffinHit *lhs, TGriffinHit *rhs)	{
-//		return(lhs->GetEnergyLow()) > rhs->GetEnergyLow();
-//}
+bool TGriffinHit::CompareEnergy(TGriffinHit *lhs, TGriffinHit *rhs)	{
+   return(lhs->GetEnergy()) > rhs->GetEnergy();
+}
 
 
 
-//void TGriffinHit::Add(TGriffinHit *hit)	{
-//   if(!CompareEnergy(this,hit)) {
-//      this->cfd    = hit->GetCfd();    
-//      this->time   = hit->GetTime();
-//      this->position = hit->GetPosition();
-//   }
-//   this->SetChargeLow(0);
-//   this->SetChargeHigh(0);
-//
-//   this->SetEnergyHigh(this->GetEnergyHigh() + hit->GetEnergyHigh());
-//   this->SetEnergyLow(this->GetEnergyLow() + hit->GetEnergyLow());
-//}
+void TGriffinHit::Add(TGriffinHit *hit)	{
+   if(!CompareEnergy(this,hit)) {
+      this->cfd    = hit->GetCfd();    
+      this->time   = hit->GetTime();
+      this->position = hit->GetPosition();
+   }
+   this->SetCharge(0);
+
+   this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
+}
 
 //Bool_t TGriffinHit::BremSuppressed(TSceptarHit* schit){
 //   return false;


### PR DESCRIPTION
I've added the possibility to use on-the-fly addback to TGriffin. The function that decides which TGriffinHits are put into one addback hit can be user-defined, the default is a simple clover addback.

I've run a quick comparison, and (always creating the same spectra), the times are
without addback: real 35s, user 33s, system 0.6s
with clover addback: real 38s, user 37s, system 0.6s
using position addback: real 44s, user 42s, system 0.6s

The last was done by calling (after each AnalysisTree->GetEntry()):
grif->SetAddbackCriterion([](TGriffinHit& one,TGriffinHit& two) {
    return ((one.GetPosition() - two.GetPosition()).Mag() < 105. &&
            (std.abs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddbackWindow()));