### PR TITLE
Bug fixes for addback.

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -65,6 +65,7 @@ class TGRSIDetectorHit : public TObject 	{
  
       void SetPosition(Double_t temp_pos = 0);
       Double_t SetEnergy(Option_t *opt="");
+      void SetEnergy(double en) { energy = en; is_energy_set = true; }
       virtual UInt_t SetDetector();
       
       //Abstract methods. These are required in all derived classes

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -45,7 +45,7 @@ class TGriffin : public TGRSIDetector {
 
 #ifndef __CINT__
       void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { addback_criterion = criterion; }
-      std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() { return addback_criterion; }
+      std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return addback_criterion; }
 #endif
 
       Int_t GetAddbackMultiplicity();
@@ -68,7 +68,7 @@ class TGriffin : public TGRSIDetector {
       TBits fGriffinBits;
 
       std::vector <TGriffinHit> addback_hits; //! Used to create addback hits on the fly
-      std::function<bool(TGriffinHit&, TGriffinHit&)> addback_criterion;
+      static std::function<bool(TGriffinHit&, TGriffinHit&)> addback_criterion;
 
    public:
       static bool SetCoreWave()        { return fSetCoreWave;  }	//!

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -78,7 +78,6 @@ class TGriffinHit : public TGRSIDetectorHit {
 
       bool   InFilter(Int_t);  //!
 
-      void SetEnergy(double en) { energy = en; }
       static bool CompareEnergy(TGriffinHit*,TGriffinHit*);  //!
       void Add(TGriffinHit*);    //! 
       //Bool_t BremSuppressed(TSceptarHit*);

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -33,6 +33,8 @@ TGRSIDetectorHit::~TGRSIDetectorHit()	{
 }
 
 double TGRSIDetectorHit::GetEnergy(Option_t *opt) const{
+   if(is_energy_set)
+      return energy;
    TChannel *chan = GetChannel();
    if(!chan){
       printf("no TChannel set for this address\n");

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -59,15 +59,16 @@ TVector3 TGriffin::gCloverPosition[17] = {
    TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(135.0)))
 };
 
+std::function<bool(TGriffinHit&, TGriffinHit&)> TGriffin::addback_criterion = [](TGriffinHit& one, TGriffinHit& two) { 
+   return ((one.GetDetector() == two.GetDetector()) && 
+	   (std::abs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow())); 
+};
+
 
 TGriffin::TGriffin() : TGRSIDetector(),grifdata(0) { //  ,bgodata(0)	{
    Class()->IgnoreTObjectStreamer(kTRUE);
    fGriffinBits.Class()->IgnoreTObjectStreamer(kTRUE);
    Clear();
-   addback_criterion = [](TGriffinHit& one, TGriffinHit& two) { 
-      return ((one.GetDetector() == two.GetDetector()) && 
-	      (std::abs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow())); 
-   };
 }
 
 TGriffin::TGriffin(const TGriffin& rhs) {

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -401,8 +401,8 @@ double TChannel::CalibrateENG(double charge) {
    //integration parameter.
    if(ENGCoefficients.size()==0)
       return charge;
-   double cal_chg = 0.0;
-   for(int i=0;i<ENGCoefficients.size();i++){
+   double cal_chg = ENGCoefficients[0];
+   for(int i=1;i<ENGCoefficients.size();i++){
       cal_chg += ENGCoefficients[i] * pow((charge),i);
    }
    return cal_chg;


### PR DESCRIPTION
- added SetEnergy(double) to TGRSIDetectorHit, this function sets the energy directly and also sets is_energy_set to true
- modified TGRSIDetectorHit::GetEnergy so that in case is_energy_set is true, it returns the energy instead of re-calculating it from the charge
- made addback_criterion static
- TChannel::CalibrateENG(double charge): instead of calculating charge^0 the return value is set to ENGCoefficients[0] and then all other coefficients are added inside a loop from 1.