### PR TITLE
TSCLRTree and Parser added for Griffin SCLR events.

### DIFF
--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -41,6 +41,7 @@ class TDataParser { //: public TObject {
     static int GriffinDataToFragment(uint32_t *data, int size, int *iter, int bank, unsigned int midasserialnumber = 0, time_t midastime = 0);
    
     static int EPIXToScalar(float *data,int size,unsigned int midasserialnumber = 0,time_t midastime = 0);
+    static int SCLRToScalar(uint32_t *data,int size,unsigned int midasserialnumber = 0,time_t midastime = 0);
 	 static int EightPIDataToFragment(uint32_t stream,uint32_t* data,
                                      int size,unsigned int midasserialnumber = 0, time_t midastime = 0);
     static int FifoToFragment(unsigned short *data,int size,bool zerobuffer=false,

--- a/include/TEpicsFrag.h
+++ b/include/TEpicsFrag.h
@@ -44,4 +44,45 @@ class TEpicsFrag : public TObject	{
     
     ClassDef(TEpicsFrag,1);  // Event Fragments
 };
+
+
+
+class TSCLRFrag : public TObject	{
+  public:
+    TSCLRFrag(); 
+    ~TSCLRFrag(); 
+
+    time_t   MidasTimeStamp;       //  Timestamp of the MIDAS event  
+    Int_t    MidasId;              //  MIDAS ID
+
+    static void SetAddressMap(int*,int);           //!  // done once per run.
+    static std::vector<Int_t >      AddressMap; //!
+    
+    std::vector<UInt_t >     Address;
+    std::vector<UInt_t>      Data1;
+    std::vector<UInt_t>      Data2;
+    std::vector<UInt_t>      Data3;
+    std::vector<UInt_t>      Data4;
+
+    int GetSize() { return Data1.size(); }
+    inline UInt_t GetData1(const unsigned int &i) { return Data1.at(i); }
+    inline UInt_t GetData2(const unsigned int &i) { return Data2.at(i); }
+    inline UInt_t GetData3(const unsigned int &i) { return Data3.at(i); }
+    inline UInt_t GetData4(const unsigned int &i) { return Data4.at(i); }
+    
+    virtual void Clear(Option_t *opt = ""); //!
+    virtual void Print(Option_t *opt = "") const; //!
+    virtual void Copy(const TSCLRFrag&); 
+
+    ClassDef(TSCLRFrag,1);  // Event Fragments
+};
+
+
+
+
+
+
+
+
+
 #endif // TEPICSFRAG_H

--- a/include/TGRSILoop.h
+++ b/include/TGRSILoop.h
@@ -40,6 +40,9 @@ class TGRSILoop : public TObject {
       bool fTestMode;
       bool fOffline;   
 
+      bool fIamTigress;
+      bool fIamGriffin;
+
       TXMLOdb *fOdb;
 
       int fFragsReadFromMidas;
@@ -68,6 +71,7 @@ class TGRSILoop : public TObject {
       bool Process8PI(uint32_t stream,uint32_t *ptr,int &dsize,TMidasEvent *mevent=0,TMidasFile *mfile=0);
       bool ProcessEPICS(float *ptr,int &dsize,TMidasEvent *mevent=0,TMidasFile *mfile=0);
       //bool ProcessEPICS(double *ptr,int &dsize,TMidasEvent *mevent=0,TMidasFile *mfile=0);
+      bool ProcessSCLR(uint32_t *ptr,int &dsize,TMidasEvent *mevent=0,TMidasFile *mfile=0);
 
       void SetFileOdb(char *data,int size);
       void SetTIGOdb();

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -32,6 +32,7 @@ namespace TGRSIOptions {
       extern bool fReadingMaterial;
       extern bool fIgnoreFileOdb;
       extern bool fIgnoreEpics;
+      extern bool fIgnoreSCLR;
       extern bool fWriteBadFrags;
 
       }
@@ -61,6 +62,9 @@ namespace TGRSIOptions {
 
       void SetIgnoreEpics(bool flag=true);
       bool IgnoreEpics();
+      
+      void SetIgnoreSCLR(bool flag=true);
+      bool IgnoreSCLR();
 
       void SetLogErrors(bool flag=true);      
       bool LogErrors();			

--- a/include/TGRSIRootIO.h
+++ b/include/TGRSIRootIO.h
@@ -31,16 +31,19 @@ class TGRSIRootIO : public TObject {
       TTree *fFragmentTree;
       TTree *fBadFragmentTree;
       TTree *fEpicsTree;
+      TTree *fSCLRTree;
       TFile *foutfile;
       int fTimesFillCalled;
       int fTimesBadFillCalled;
       int fEPICSTimesFillCalled;
+      int fSCLRTimesFillCalled;
 
       std::vector<TFile*> finfiles;
 
       TFragment  *fBufferFrag;
       TFragment  *fBadBufferFrag;
       TEpicsFrag *fEXBufferFrag;
+      TSCLRFrag  *fSBufferFrag;
       TChannel   *fBufferChannel;
 
    public:
@@ -73,6 +76,13 @@ class TGRSIRootIO : public TObject {
       TTree *GetEpicsTree()  { return fEpicsTree;  }
       void FillEpicsTree(TEpicsFrag*);
       void FinalizeEpicsTree();
+
+      void SetUpSCLRTree();
+      TTree *GetSCLRTree()  { return fSCLRTree;  }
+      void FillSCLRTree(TSCLRFrag*);
+      void FinalizeSCLRTree();
+
+
 
       void MakeUserHistsFromFragmentTree();
       void WriteRunStats();

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -926,6 +926,38 @@ int TDataParser::EPIXToScalar(float *data,int size,unsigned int midasserialnumbe
    return NumFragsFound;
 }
 
+int TDataParser::SCLRToScalar(uint32_t *data,int size,unsigned int midasserialnumber,time_t midastime) {
+
+   int NumFragsFound = 1;
+   TSCLRFrag *Sfrag = new TSCLRFrag;
+
+   Sfrag->MidasTimeStamp = midastime;
+   Sfrag->MidasId        = midasserialnumber;	 
+
+   //printf("\nsclr unpacked called with size = %i\n\n",size);
+  
+
+   if((size%4) != 0) {
+      //make some error mode
+      //printf("here 1 \n");
+      TGRSIRootIO::Get()->FillSCLRTree(Sfrag); // fill the tree so at least there is a record of it's timestamp.
+      return 0;
+   }
+   for(int x=0;x<size;x=x+4) {
+      Sfrag->Data1.push_back((UInt_t)data[x+0]);
+      Sfrag->Data2.push_back((UInt_t)data[x+1]);
+      Sfrag->Data3.push_back((UInt_t)data[x+2]);
+      Sfrag->Data4.push_back((UInt_t)data[x+3]);
+   }
+   for(int x=0;x<TSCLRFrag::AddressMap.size();x++) {Sfrag->Address.push_back(TSCLRFrag::AddressMap.at(x)); }
+   //Sfrag->Print();
+
+   TGRSIRootIO::Get()->FillSCLRTree(Sfrag);
+   delete Sfrag;
+   Sfrag = 0;
+   //printf("[%i]  frag deleted, return.\n\n\n",midasserialnumber);
+   return NumFragsFound;
+}
 
 
 

--- a/libraries/TGRSIFormat/TEpicsFrag.cxx
+++ b/libraries/TGRSIFormat/TEpicsFrag.cxx
@@ -5,11 +5,13 @@
 
 #include <time.h>
 
+#include <TChannel.h>
+
 ////////////////////////////////////////////////////////////////
 //                                                            //
-// TEpicsFrag                                                 //
+// TEpicsFrag   TSCLRFrag                                     //
 //                                                            //
-// This Class should contain all the information found in     //
+// These Classes should contain all the information found in  //
 // NOT typeid 1 midas events.                                 //
 //                                                            //
 //                                                            //
@@ -56,4 +58,93 @@ void TEpicsFrag::Print(Option_t *opt) const {
       std::cout << "\n";
     }
 } 
+
+ClassImp(TSCLRFrag) 
+
+std::vector<Int_t > TSCLRFrag::AddressMap; 
+
+
+TSCLRFrag::TSCLRFrag()  {
+  Clear();
+}
+
+TSCLRFrag::~TSCLRFrag() { }
+
+
+
+void TSCLRFrag::Clear(Option_t *opt) {
+  MidasTimeStamp =  0;   
+  MidasId        = -1;         
+
+  if(!strcmp(opt,"ALL"))
+     AddressMap.clear();
+
+  Address.clear();
+  Data1.clear();  
+  Data2.clear();  
+  Data3.clear();  
+  Data4.clear();  
+} 
+
+void TSCLRFrag::Print(Option_t *opt) const { 
+   printf("------ SCLR %i Unique Counters Found ------\n",Data1.size());
+
+   char buff[20];
+   ctime(&MidasTimeStamp);
+   struct tm * timeinfo = localtime(&MidasTimeStamp);
+   strftime(buff,20,"%b %d %H:%M:%S",timeinfo);
+
+   printf("  MidasTimeStamp: %s\n",buff);
+   printf("  MidasId:    	  %i\n", MidasId);
+
+   if(!strcmp(opt,"LITE")) {
+     printf("\tAddress[%i] at 0x%08x\n",Address.size(),&Address);
+     printf("\tData1[%i] at 0x%08x\t%i\n",Data1.size(),&Data1,Data1.at(0));
+     printf("\tData2[%i] at 0x%08x\n",Data2.size(),&Data2);
+     printf("\tData3[%i] at 0x%08x\n",Data3.size(),&Data3);
+     printf("\tData4[%i] at 0x%08x\n",Data4.size(),&Data4);
+     return;
+   }
+
+   for(int i=0;i<Data1.size();i++) {
+      TChannel *channel = 0;
+      if(Address.size()>i) channel = TChannel::GetChannel(Address.at(i));
+      printf("[%i]\t",i);
+      if(channel) {
+        printf("%s\t",channel->GetName());
+      }
+      printf("%lu\t",Data1.at(i));
+      printf("%lu\t",Data2.at(i));
+      printf("%lu\t",Data3.at(i));
+      printf("%lu\n",Data4.at(i));
+
+   }
+} 
+
+void TSCLRFrag::SetAddressMap(int *array, int size) { 
+  //once we find where in the odb the order of the sclr is,
+  //we need to write this function.  called in grsiloop so
+  //we have access to the odb. 
+  printf("TSCLRFrag::SetAddressMap() called,\n");
+  return;
+}
+
+
+void TSCLRFrag::Copy(const TSCLRFrag &rhs) {
+  Clear();
+  ((TSCLRFrag&)(*this)).MidasTimeStamp = rhs.MidasTimeStamp;   
+  ((TSCLRFrag&)(*this)).MidasId        = rhs.MidasId;         
+  
+
+
+  for(int x=0;x<rhs.Address.size();x++) { 
+    (*((TSCLRFrag*)this)).Address.push_back(rhs.Address.at(x));
+  }
+  for(int x=0;x<rhs.Data1.size();x++) {
+    ((TSCLRFrag&)(*this)).Data1.push_back(rhs.Data1.at(x));
+    ((TSCLRFrag&)(*this)).Data2.push_back(rhs.Data1.at(x));
+    ((TSCLRFrag&)(*this)).Data3.push_back(rhs.Data1.at(x));
+    ((TSCLRFrag&)(*this)).Data4.push_back(rhs.Data1.at(x));
+  }
+}
 

--- a/libraries/TGRSIFormat/TGRSIFormatLinkDef.h
+++ b/libraries/TGRSIFormat/TGRSIFormatLinkDef.h
@@ -13,6 +13,7 @@
 #pragma link C++ class TFragment+;
 
 #pragma link C++ class TEpicsFrag+;
+#pragma link C++ class TSCLRFrag+;
 #pragma link C++ class TChannel-;
 #pragma link C++ class TGRSIRunInfo-;
 

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -22,9 +22,10 @@ TGRSIRootIO *TGRSIRootIO::Get()  {
 TGRSIRootIO::TGRSIRootIO() { 
    //printf("TGRSIRootIO has been created.\n");
 
-  fFragmentTree = 0;
+  fFragmentTree    = 0;
   fBadFragmentTree =0;
-  fEpicsTree    = 0;
+  fEpicsTree       = 0;
+  fSCLRTree        = 0;
 
   foutfile = 0; //new TFile("test_out.root","recreate");
 
@@ -73,9 +74,6 @@ void TGRSIRootIO::SetUpBadFragmentTree() {
 
 }
 
-
-
-
 void TGRSIRootIO::SetUpEpicsTree() {
    if(TGRSIOptions::IgnoreEpics()) 
      return;
@@ -86,8 +84,25 @@ void TGRSIRootIO::SetUpEpicsTree() {
    fEXBufferFrag = 0;
    fEpicsTree->Bronch("TEpicsFrag","TEpicsFrag",&fEXBufferFrag,128000,99);
 	printf("EPICS-Tree set up.\n");
+}
+
+
+void TGRSIRootIO::SetUpSCLRTree() {
+   if(TGRSIOptions::IgnoreSCLR()) 
+     return;
+   if(foutfile)
+      foutfile->cd();
+   fSCLRTimesFillCalled = 0;
+   fSCLRTree = new TTree("SCLRTree","SCLRTree");
+   fSBufferFrag = 0;
+   fSCLRTree->Bronch("TSCLRFrag","TSCLRFrag",&fSBufferFrag,128000,99);
+	printf("SCLR-Tree set up.\n");
 
 }
+
+
+
+
 
 //void TGRSIRootIO::FillChannelTree(TChannel *chan) {
 //   if(!fTChannelTree)
@@ -120,12 +135,35 @@ void TGRSIRootIO::FillBadFragmentTree(TFragment *frag) {
 void TGRSIRootIO::FillEpicsTree(TEpicsFrag *EXfrag) {
   if(TGRSIOptions::IgnoreEpics()) 
     return;
+  if(!fEpicsTree)
+     return;
    *fEXBufferFrag = *EXfrag;
    int bytes =  fEpicsTree->Fill();
    if(bytes < 1)
-      printf("\n fill failed with bytes = %i\n",bytes);
+      printf("\n [EPIX] fill failed with bytes = %i\n",bytes);
    fEPICSTimesFillCalled++;
 }
+
+void TGRSIRootIO::FillSCLRTree(TSCLRFrag *Sfrag) {
+  //printf("\tSfrag = 0x%08x\n");
+  //printf("\tfill called with Sfrag->MidasId  %i\n",Sfrag->MidasId);
+  if(TGRSIOptions::IgnoreSCLR()) 
+    return;
+  if(!fSCLRTree || !Sfrag)
+     return;
+  fSBufferFrag->Copy(*Sfrag);
+  //if(fSCLRTree->GetEntries()) {
+  //  fSCLRTree->Show(fSCLRTree->GetEntries()-1);
+  //}
+  //fSBufferFrag->Print("LITE");
+  int bytes =  fSCLRTree->Fill();
+  fSBufferFrag->Clear();
+  if(bytes < 1)
+     printf("\n [SCLR] fill failed with bytes = %i\n",bytes);
+  fSCLRTimesFillCalled++;
+}
+
+
 
 
 //void TGRSIRootIO::FinalizeChannelTree() {
@@ -183,6 +221,17 @@ void TGRSIRootIO::FinalizeEpicsTree() {
 	return;
 }
 
+void TGRSIRootIO::FinalizeSCLRTree() {
+  if(TGRSIOptions::IgnoreSCLR()) 
+    return;
+  if(!fSCLRTree || !foutfile)
+      return;
+   foutfile->cd();
+   fSCLRTree->AutoSave(); //Write();
+	return;
+}
+
+
 
 void TGRSIRootIO::SetUpRootOutFile(int runnumber, int subrunnumber) {
   
@@ -217,6 +266,7 @@ void TGRSIRootIO::CloseRootOutFile()   {
    
    FinalizeFragmentTree(); 
    FinalizeEpicsTree();
+   FinalizeSCLRTree();
 
    if(TGRSIRunInfo::GetNumberOfSystems()>0) {
       printf(DMAGENTA " Writing RunInfo with " DYELLOW "%i " DMAGENTA " systems to file." RESET_COLOR "\n",TGRSIRunInfo::GetNumberOfSystems());

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -15,6 +15,7 @@ namespace TGRSIOptions {
   bool fReadingMaterial = false;
   bool fIgnoreFileOdb  = false;
   bool fIgnoreEpics    = false;
+  bool fIgnoreSCLR     = false;
   bool fCloseAfterSort = false;
   bool fWriteBadFrags  = false;
 
@@ -62,6 +63,9 @@ bool IgnoreFileOdb()             { return fIgnoreFileOdb; }
 
 void SetIgnoreEpics(bool flag) { fIgnoreEpics=flag; }
 bool IgnoreEpics()             { return fIgnoreEpics; }
+
+void SetIgnoreSCLR(bool flag) { fIgnoreSCLR=flag; }
+bool IgnoreSCLR()             { return fIgnoreSCLR; }
 
 void SetCloseAfterSort(bool flag) { fCloseAfterSort=flag; }
 bool CloseAfterSort()                  { return fCloseAfterSort; }

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -330,6 +330,12 @@ void TGRSIint::GetOptions(int *argc, char **argv) {
        } else if(temp.compare("ignore_odb")==0) { 
           // useful when dealing with midas file that have corrupt odbs in them .
           TGRSIOptions::SetIgnoreFileOdb(true);          
+       } else if(temp.compare("ignore_epics")==0) { 
+          // useful when dealing with midas file that have corrupt odbs in them .
+          TGRSIOptions::SetIgnoreEpics(true);          
+       } else if(temp.compare("ignore_sclr")==0) { 
+          // useful when dealing with midas file that have corrupt odbs in them .
+          TGRSIOptions::SetIgnoreSCLR(true);          
        } else {
           printf(DBLUE  "    option: " DYELLOW "%s " DBLUE "passed but not understood." RESET_COLOR "\n",temp.c_str());
        }


### PR DESCRIPTION
* Added a TSCLRFrag, the class def is done TEpicsFrag.  Contains five UInt_t arrays.  4 four griffin scalars one for the data's associated address. Each Entry also contains a MidasTimStamp and MidasId (MidasSerialNumber).
* Added a SCLR bank parser for event type 2 coming for the griffin experiment type.  Parse the input into 4 UInt_t chucks stored in the TSCLRFrag.
* Added  a TSCLRTree to hold the TSCLRFrag.  Data is in parallel to the TFragments (same as epics).