### PR TITLE
added users/ to be searched for dictionaries that need to be copied t…

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,7 +91,7 @@ grsisort: src libraries users print bin config
 
 config: print
 	@cp util/grsi-config bin/
-	@find libraries/*/ -name "*.pcm" -exec cp {} libraries/ \;
+	@find libraries/*/ users/ -name "*.pcm" -exec cp {} libraries/ \;
 
 bin:
 ifeq ($(wildcard ./bin),) 


### PR DESCRIPTION
…o libraries/ for root 6. This copies TUserSortInfoDict_rdict.pcm to a place root 6 can find it.