### PR TITLE
Changed to always calculating transient members on the fly... :(

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -69,18 +69,18 @@ class TGRSIDetectorHit : public TObject 	{
       
       //Abstract methods. These are required in all derived classes
 		virtual TVector3 GetPosition(Double_t dist = 0) const; //!
-      virtual TVector3 GetPosition(Double_t dist = 0);
+  //    virtual TVector3 GetPosition(Double_t dist = 0);
       virtual double GetEnergy(Option_t *opt="") const;
-      virtual double GetEnergy(Option_t *opt="");
+ //     virtual double GetEnergy(Option_t *opt="");
       virtual UInt_t GetDetector() const;
-      virtual UInt_t GetDetector();
+ //     virtual UInt_t GetDetector();
       virtual double GetTime(Option_t *opt="")   const      {return 0.0; } //AbstractMethod("GetTime()"); return 0.00;   }  // Returns a time value to the nearest nanosecond!
       virtual inline Int_t   GetCfd() const             {   return cfd;      }           //!
       inline UInt_t GetAddress()     const                  { return address; }         //!
       inline Double_t GetCharge() const                       { return charge;} //!
       inline TChannel *GetChannel() const                   { return TChannel::GetChannel(address); }  //!
       inline std::vector<Short_t> GetWaveform() const       { return waveform; } //!
-   //   inline TGRSIDetector *GetParent() const               { return ((TGRSIDetector*)parent.GetObject()); } //!
+    //  inline TGRSIDetector *GetParent() const               { return ((TGRSIDetector*)parent.GetObject()); } //!
       //virtual void SetHit() { AbstractMethod("SetHit()");}
       //We need a common function for all detectors in here
 		//static bool Compare(TGRSIDetectorHit *lhs,TGRSIDetectorHit *rhs); //!

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -38,8 +38,8 @@ class TSceptar : public TGRSIDetector {
      TSceptar& operator=(const TSceptar&);  //!
 
    private: 
-     TSceptarData *sceptardata;                                               //!  Used to build GRIFFIN Hits
-     std::vector <TSceptarHit> sceptar_hits;                                  //   The set of crystal hits
+     TSceptarData *sceptardata;                                               //!  Used to build SCEPTAR Hits
+     std::vector <TSceptarHit> sceptar_hits;                                  //   The set of sceptar hits
       
      static bool fSetWave;		                                                //  Flag for Waveforms ON/OFF
 

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -76,7 +76,7 @@ class TSceptarHit : public TGRSIDetectorHit {
 		void Print(Option_t *opt = "") const;		                    //!
       virtual void Copy(TSceptarHit&) const;        //!
 
-	ClassDef(TSceptarHit,1)
+	ClassDef(TSceptarHit,1) //Stores the information for a SceptarHit
 };
 
 #endif

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -41,6 +41,8 @@ Bool_t TGainMatch::CoarseMatch(TH1* hist, Int_t chanNum, Double_t energy1, Doubl
 //for gain matching purposes.
    if(!hist) return false;
 
+   fhist = hist;
+
    //I might want to do a clear of the gainmatching parameters at this point.
 
    //Check to see that the histogram isn't empty
@@ -96,9 +98,9 @@ Bool_t TGainMatch::CoarseMatch(TH1* hist, Int_t chanNum, Double_t energy1, Doubl
 
    //We now want to create a peak for each one we found (2) and fit them.
    for(int x=0; x<2; x++){
-      TPeak tmpPeak(foundbin[x],foundbin[x] - 20./binWidth, foundbin[x] + 20./binWidth);
+      TPeak tmpPeak(foundbin[x],foundbin[x] - 10./binWidth, foundbin[x] + 10./binWidth);
       tmpPeak.SetName(Form("GM_Cent_%lf",foundbin[x]));//Change the name of the TPeak to know it's origin
-      tmpPeak.Fit(hist,"M+");
+      tmpPeak.Fit(hist,"+");
       this->SetPoint(x,tmpPeak.GetParameter("centroid"),engvec[x]);
    }
 
@@ -355,7 +357,8 @@ Bool_t TGainMatch::CoarseMatchAll(TCalManager* cm, TH2 *mat, Double_t energy1, D
          badlist.push_back(chan);
          continue;
       }
-      cm->AddToManager(gm);
+      gm->SetName(Form("gm_chan_%d",chan));
+      cm->AddToManager(gm,chan);
    }
    if(badlist.size())
       printf("The following channels did not gain match properly: ");

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -36,7 +36,7 @@ TGRSIDetectorHit::~TGRSIDetectorHit()	{
 //Default destructor
 }
 
-double TGRSIDetectorHit::GetEnergy(Option_t *opt) const{
+double TGRSIDetectorHit::GetEnergy(Option_t *opt) const {
    if(is_energy_set)
       return energy;
 
@@ -47,10 +47,11 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt) const{
    }
       return chan->CalibrateENG(GetCharge());
 }
-
+/* non const version
 double TGRSIDetectorHit::GetEnergy(Option_t *opt){
-   if(is_energy_set)
+   if(is_energy_set){
       return energy;
+   }
 
    TChannel *chan = GetChannel();
    if(!chan){
@@ -61,7 +62,7 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt){
       return energy;
 
 }
-
+*/
 void TGRSIDetectorHit::Copy(TGRSIDetectorHit &rhs) const {
   TObject::Copy((TObject&)rhs);
   ((TGRSIDetectorHit&)rhs).address  = address;
@@ -72,9 +73,9 @@ void TGRSIDetectorHit::Copy(TGRSIDetectorHit &rhs) const {
   ((TGRSIDetectorHit&)rhs).charge   = charge;
   ((TGRSIDetectorHit&)rhs).detector = detector;
   ((TGRSIDetectorHit&)rhs).energy   = energy;
-  ((TGRSIDetectorHit&)rhs).is_energy_set   = is_energy_set;
-  ((TGRSIDetectorHit&)rhs).is_det_set      = is_det_set;
-  ((TGRSIDetectorHit&)rhs).is_pos_set      = is_pos_set;
+  ((TGRSIDetectorHit&)rhs).is_energy_set   = false;
+  ((TGRSIDetectorHit&)rhs).is_det_set      = false;
+  ((TGRSIDetectorHit&)rhs).is_pos_set      = false;
 
 //  ((TGRSIDetectorHit&)rhs).parent  = parent;  
 }
@@ -113,7 +114,7 @@ UInt_t TGRSIDetectorHit::GetDetector() const {
    ParseMNEMONIC(channel->GetChannelName(),&mnemonic);
    return mnemonic.arrayposition;
 }
-
+/* non const version
 UInt_t TGRSIDetectorHit::GetDetector() {
    if(is_det_set)
       return detector;
@@ -128,7 +129,7 @@ UInt_t TGRSIDetectorHit::GetDetector() {
    ParseMNEMONIC(channel->GetChannelName(),&mnemonic);
    return SetDetector(mnemonic.arrayposition);
 }
-
+*/
 
 UInt_t TGRSIDetectorHit::SetDetector(UInt_t det) {
    detector = det;
@@ -145,13 +146,13 @@ TVector3 TGRSIDetectorHit::GetPosition(Double_t dist) const{
    if(is_pos_set)
       return position;
 
-   if(is_det_set)
+   //if(is_det_set)// Dont necessarily need this (job of derived)
       return GetPosition(dist); //Calls the derivative GetPosition function
 
    return TVector3(0,0,1);
 
 }
-
+/* non const version
 TVector3 TGRSIDetectorHit::GetPosition(Double_t dist) {
    if(is_pos_set)
       return position;
@@ -162,7 +163,7 @@ TVector3 TGRSIDetectorHit::GetPosition(Double_t dist) {
    return TVector3(0,0,1);
 
 }
-
+*/
 bool TGRSIDetectorHit::CompareEnergy(TGRSIDetectorHit *lhs, TGRSIDetectorHit *rhs) {
    return (lhs->GetEnergy() > rhs->GetEnergy());
 }

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -61,6 +61,7 @@ TSceptar::~TSceptar()	{
 }
 
 TSceptar::TSceptar(const TSceptar& rhs) {
+   //Copy Contructor
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -68,7 +69,8 @@ TSceptar::TSceptar(const TSceptar& rhs) {
 }
 
 void TSceptar::Clear(Option_t *opt)	{
-//Clears all of the hits and data
+//Clears all of the hits
+//The Option "all" clears the base class and data.
    if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
       TGRSIDetector::Clear(opt);
       if(sceptardata) sceptardata->Clear();
@@ -78,6 +80,7 @@ void TSceptar::Clear(Option_t *opt)	{
 }
 
 void TSceptar::Copy(TSceptar &rhs) const {
+   //Copies a TSceptar
   TGRSIDetector::Copy((TGRSIDetector&)rhs);
 
   ((TSceptar&)rhs).sceptardata     = 0;
@@ -92,7 +95,7 @@ TSceptar& TSceptar::operator=(const TSceptar& rhs) {
 }
 
 void TSceptar::Print(Option_t *opt) const	{
-  //Prints out TSceptar members, currently does little.
+  //Prints out TSceptar Multiplicity, currently does little.
   printf("sceptardata = 0x%p\n",sceptardata);
   if(sceptardata) sceptardata->Print();
   printf("%lu sceptar_hits\n",sceptar_hits.size());
@@ -112,8 +115,9 @@ void TSceptar::FillData(TFragment *frag, TChannel *channel, MNEMONIC *mnemonic) 
 }
 
 void TSceptar::PushBackHit(TGRSIDetectorHit *schit) {
-  sceptar_hits.push_back(*((TSceptarHit*)schit));
-  return;
+   //Adds a Hit to the list of TSceptar Hits
+   sceptar_hits.push_back(*((TSceptarHit*)schit));
+   return;
 }
 
 void TSceptar::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
@@ -164,6 +168,7 @@ void TSceptar::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
 }
 
 TGRSIDetectorHit* TSceptar::GetHit(const Int_t idx){
+   //Gets the TSceptarHit at index idx. 
    if(idx < GetMultiplicity())
       return &(sceptar_hits.at(idx));
    else 

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
@@ -7,7 +7,17 @@
 
 ClassImp(TSceptarHit)
 
-TSceptarHit::TSceptarHit()	{	
+////////////////////////////////////////////////////////////////
+//                                                            //
+// TSceptarHit                                                //
+//                                                            //
+// This is class that contains the information about a sceptar//
+// hit. This class is used to find energy, time, etc.         //
+//                                                            //
+////////////////////////////////////////////////////////////////
+
+TSceptarHit::TSceptarHit()	{
+   //Default Constructor
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -18,6 +28,7 @@ TSceptarHit::TSceptarHit()	{
 TSceptarHit::~TSceptarHit()	{	}
 
 TSceptarHit::TSceptarHit(const TSceptarHit &rhs)	{	
+   //Copy Constructor
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -26,6 +37,7 @@ TSceptarHit::TSceptarHit(const TSceptarHit &rhs)	{
 }
 
 void TSceptarHit::Copy(TSceptarHit &rhs) const {
+   //Copies a TSceptarHit
   TGRSIDetectorHit::Copy((TGRSIDetectorHit&)rhs);
 	((TSceptarHit&)rhs).filter = filter;
 }                                       
@@ -52,6 +64,8 @@ void TSceptarHit::SetHit(){
 */
 
 TVector3 TSceptarHit::GetPosition(double dist) const {
+   //Gets the position of the current TSceptarHit
+   //This position returns is of the center of the paddle
 	return TSceptar::GetPosition(detector);
 }
 
@@ -62,15 +76,21 @@ bool TSceptarHit::InFilter(Int_t wantedfilter) {
 }
 
 double TSceptarHit::GetTime(Option_t *opt) const {
+   //Returns the Time of the Sceptar Hit.
    return (double)time;
 }
 
 void TSceptarHit::Clear(Option_t *opt)	{
+   //Clears the SceptarHit
    filter = 0;
    TGRSIDetectorHit::Clear();
 }
 
 void TSceptarHit::Print(Option_t *opt) const	{
+   //Prints the SceptarHit. Returns:
+   //Detector
+   //Energy
+   //Time
    printf("Sceptar Detector: %i\n",GetDetector());
 	printf("Sceptar hit energy: %.2f\n",GetEnergy());
 	printf("Sceptar hit time:   %.lf\n",GetTime());
@@ -109,6 +129,7 @@ Double_t TSceptarHit::GetEnergy() const {
 */
 
 bool TSceptarHit::AnalyzeWaveform() {
+   //Calculates the cfd time from the waveform
    bool error = false;
    std::vector<Int_t> baseline_corrections (8, 0);
    std::vector<Short_t> smoothedwaveform;
@@ -137,7 +158,7 @@ bool TSceptarHit::AnalyzeWaveform() {
 }
 
 Int_t TSceptarHit::CalculateCfd(double attenuation, int delay, int halfsmoothingwindow, int interpolation_steps) {
-
+   //Used when calculating the CFD from the waveform
    std::vector<Short_t> monitor;
 
    return CalculateCfdAndMonitor(attenuation, delay, halfsmoothingwindow, interpolation_steps, monitor);
@@ -145,6 +166,7 @@ Int_t TSceptarHit::CalculateCfd(double attenuation, int delay, int halfsmoothing
 }
 
 Int_t TSceptarHit::CalculateCfdAndMonitor(double attenuation, int delay, int halfsmoothingwindow, int interpolation_steps, std::vector<Short_t> &monitor) {
+   //Used when calculating the CFD from the waveform
 
    Short_t monitormax = 0;
 
@@ -203,6 +225,7 @@ Int_t TSceptarHit::CalculateCfdAndMonitor(double attenuation, int delay, int hal
 }
 
 std::vector<Short_t> TSceptarHit::CalculateSmoothedWaveform(unsigned int halfsmoothingwindow) {
+   //Used when calculating the CFD from the waveform
 
    std::vector<Short_t> smoothedwaveform(std::max((size_t)0, waveform.size()-2*halfsmoothingwindow), 0);
 
@@ -219,6 +242,7 @@ std::vector<Short_t> TSceptarHit::CalculateSmoothedWaveform(unsigned int halfsmo
 }
 
 std::vector<Short_t> TSceptarHit::CalculateCfdMonitor(double attenuation, int delay, int halfsmoothingwindow) {
+   //Used when calculating the CFD from the waveform
 
    std::vector<Short_t> monitor(std::max((size_t)0, waveform.size()-delay), 0);
    std::vector<Short_t> smoothedwaveform;


### PR DESCRIPTION
- Data is reused by trees to save time.
- our flags become useless in this mode.
- I have left the relevant code commented out in case we do want to use it in the future
- Maybe we can convince the rooters that this is a good idea?