### PR TITLE
Changed TBits to UChar for PPG status

### DIFF
--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -24,6 +24,17 @@ class TGriffinData;
 
 class TGriffin : public TGRSIDetector {
 
+   enum EPPG {
+      kTapeMove      = 0x1,
+      kBackGround    = 0x2,
+      kBeamOn        = 0x4,
+      kDecay         = 0x8,
+      kCycleStartTime= 0x10,
+      //Room for 0x20
+      //Room for 0x40
+      //Room for 0x80
+   };
+
    public:
       TGriffin();
       TGriffin(const TGriffin&);
@@ -69,8 +80,7 @@ class TGriffin : public TGRSIDetector {
       long fCycleStart;                //!  The start of the cycle
       static long fLastPPG;                   //!  value of the last ppg
 
-      enum  GriffinFlags{kCycleStartTime,kTapeMove,kBackGround,kBeamOn,kDecay};
-      TBits fGriffinBits;
+      UChar_t fGriffinBits;
 
       std::vector <TGriffinHit> addback_hits; //! Used to create addback hits on the fly
       std::vector <UShort_t> faddback_frags; //! Number of crystals involved in creating in the addback hit
@@ -80,22 +90,24 @@ class TGriffin : public TGRSIDetector {
       //static bool SetBGOHits()       { return fSetBGOHits;   }	//!
       //static bool SetBGOWave()	    { return fSetBGOWave;   } //!
 
-      void SetTapeMove(Bool_t flag=kTRUE)   { fGriffinBits.SetBitNumber(kTapeMove,flag); }  //!
-      void SetBackground(Bool_t flag=kTRUE) { fGriffinBits.SetBitNumber(kBackGround,flag);} //!
-      void SetBeamOn(Bool_t flag=kTRUE)     { fGriffinBits.SetBitNumber(kBeamOn,flag);}     //!
-      void SetDecay(Bool_t flag=kTRUE)      { fGriffinBits.SetBitNumber(kDecay,flag);}      //!
+      void SetTapeMove(Bool_t flag=kTRUE)   { SetBitNumber(kTapeMove,flag); }  //!
+      void SetBackground(Bool_t flag=kTRUE) { SetBitNumber(kBackGround,flag);} //!
+      void SetBeamOn(Bool_t flag=kTRUE)     { SetBitNumber(kBeamOn,flag);}     //!
+      void SetDecay(Bool_t flag=kTRUE)      { SetBitNumber(kDecay,flag);}      //!
 
-      bool GetTapeMove()   const { return fGriffinBits.TestBitNumber(kTapeMove);}//!
-      bool GetBackground() const { return fGriffinBits.TestBitNumber(kBackGround);}//!
-      bool GetBeamOn()     const { return fGriffinBits.TestBitNumber(kBeamOn);}//!
-      bool GetDecay()      const { return fGriffinBits.TestBitNumber(kDecay);}//!
+      bool GetTapeMove()   const { return TestBitNumber(kTapeMove);}//!
+      bool GetBackground() const { return TestBitNumber(kBackGround);}//!
+      bool GetBeamOn()     const { return TestBitNumber(kBeamOn);}//!
+      bool GetDecay()      const { return TestBitNumber(kDecay);}//!
 
       int GetCycleTimeInMilliSeconds(long time) { return (int)((time-fCycleStart)/1e5); }//!
 
       //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
    private:
       static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
-      void ClearStatus() { fGriffinBits.ResetAllBits(kFALSE); } //!
+      void ClearStatus() { fGriffinBits = 0; } //!
+      void SetBitNumber(enum EPPG ppg,Bool_t set);
+      Bool_t TestBitNumber(enum EPPG ppg) const {return (ppg & fGriffinBits);}
 
    public:
       virtual void Copy(TGriffin&) const;                //!

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -28,7 +28,7 @@ class TGriffinHit : public TGRSIDetectorHit {
 
    //flags
    private:
-      Bool_t is_crys_set; //!
+      Bool_t is_crys_set; //
 
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -103,6 +103,8 @@ void TGriffin::Copy(TGriffin &rhs) const {
   ((TGriffin&)rhs).fSetCoreWave        = fSetCoreWave;
   ((TGriffin&)rhs).fGriffinBits        = fGriffinBits;
   ((TGriffin&)rhs).fCycleStart         = fCycleStart;
+  ((TGriffin&)rhs).fGriffinBits        = fGriffinBits;
+
    //((TGriffin&)rhs).fSetBGOWave         = fSetBGOWave;
   //((TGriffin&)rhs).ftapemove           = ftapemove;
   //((TGriffin&)rhs).fbackground         = fbackground;
@@ -519,4 +521,11 @@ UShort_t TGriffin::GetNAddbackFrags(int idx) const{
       return faddback_frags.at(idx);   
    else
       return 0;
+}
+
+void TGriffin::SetBitNumber(enum EPPG ppg,Bool_t set){
+   if(set)
+      fGriffinBits |= ppg;
+   else
+      fGriffinBits &= (~ppg);
 }

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -23,6 +23,7 @@ void TGriffinHit::Copy(TGriffinHit &rhs) const {
   TGRSIDetectorHit::Copy((TGRSIDetectorHit&)rhs);
   ((TGriffinHit&)rhs).filter          = filter;
   ((TGriffinHit&)rhs).ppg             = ppg;
+  ((TGriffinHit&)rhs).is_crys_set     = false;
   return;                                      
 }                                       
 


### PR DESCRIPTION
This drops (a particular) analysis tree file size down from 744 MB to 622 MB. There is still some clean up to do with the PPG (like how to implement it), but we will figure that out once it is figured out ont he hardware side.