### PR TITLE
Added subdetector bit, ie crystal in Griffin and Tigress

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -40,11 +40,12 @@ class TGRSIDetectorHit : public TObject 	{
                            
    // 5. The waveform.       Since we are dealing with digital daqs, a waveform is a fairly common thing to have.  It
    //                        may not allows be present, put it is echoed enough that the storage for it belongs here.
+   public:
    enum Ebitflag {
       kIsDetSet      = 0x1,
       kIsEnergySet   = 0x2,
       kIsPositionSet = 0x4,
-      //Room for 0x8
+      kIsSubDetSet   = 0x8,
       //Room for 0x10
       //Room for 0x20
       //Room for 0x40
@@ -102,6 +103,9 @@ class TGRSIDetectorHit : public TObject 	{
       Bool_t IsDetSet() const {return (fbitflags & kIsDetSet);}
       Bool_t IsPosSet() const {return (fbitflags & kIsPositionSet);}
       Bool_t IsEnergySet() const {return (fbitflags & kIsEnergySet);} 
+      Bool_t IsSubDetSet() const {return (fbitflags * kIsSubDetSet);}
+
+      Bool_t IsCrystalSet() const {return IsSubDetSet();}
 
       void SetFlag(enum Ebitflag,Bool_t set);
 

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -26,10 +26,6 @@ class TGriffinHit : public TGRSIDetectorHit {
       Int_t ppg;
       UInt_t crystal; //!
 
-   //flags
-   private:
-      Bool_t is_crys_set; //
-
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////
       inline void SetFilterPattern(const int &x)   { filter = x;   }                  //! 

--- a/include/TPacesHit.h
+++ b/include/TPacesHit.h
@@ -22,10 +22,6 @@ class TPacesHit : public TGRSIDetectorHit {
       Int_t filter;
       Int_t ppg;
 
-   //flags
-   private:
-      Bool_t is_crys_set; //!
-
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////
       inline void SetFilterPattern(const int &x)   { filter = x;   }                  //! 

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -30,7 +30,6 @@ class TTigressHit : public TGRSIDetectorHit {
 		UInt_t   crystal;              //!
 		UShort_t first_segment;        
 		Float_t    first_segment_charge; //!
-      Bool_t is_crys_set;            //!
 
       Double_t fEnergy;
 
@@ -58,7 +57,7 @@ class TTigressHit : public TGRSIDetectorHit {
 		void AddBGO(TCrystalHit &temp);		  //{ bgo.push_back(temp);	}			//!
 
 		//void SetDetectorNumber(const int &i) { detector = i;	} 				//!
-		void SetCrystal()	                   { crystal = GetCrystal(); }		//!
+		void SetCrystal()	                   { crystal = GetCrystal(); SetFlag(TGRSIDetectorHit::kIsSubDetSet,true); }		//!
 		void SetInitalHit(const int &i)		 { first_segment = i; }				//!
 
 //		void SetPosition(const TVector3 &p)  { position = p;	}					//!

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -23,7 +23,6 @@ void TGriffinHit::Copy(TGriffinHit &rhs) const {
   TGRSIDetectorHit::Copy((TGRSIDetectorHit&)rhs);
   ((TGriffinHit&)rhs).filter          = filter;
   ((TGriffinHit&)rhs).ppg             = ppg;
-  ((TGriffinHit&)rhs).is_crys_set     = false;
   return;                                      
 }                                       
 
@@ -92,8 +91,6 @@ void TGriffinHit::Clear(Option_t *opt)	{
    ppg             =  0;
    crystal         = 0xFFFF;
 
-   is_crys_set     = false;
-
 }
 
 
@@ -130,7 +127,7 @@ TVector3 TGriffinHit::GetPosition(Double_t dist) const{
 }
 
 UInt_t TGriffinHit::GetCrystal() const { 
-   if(is_crys_set)
+   if(IsCrystalSet())
       return crystal;
 
    TChannel *chan = GetChannel();
@@ -153,7 +150,7 @@ UInt_t TGriffinHit::GetCrystal() const {
 }
 
 UInt_t TGriffinHit::GetCrystal() {
-   if(is_crys_set)
+   if(IsCrystalSet())
       return crystal;
 
    TChannel *chan = GetChannel();
@@ -167,7 +164,6 @@ UInt_t TGriffinHit::GetCrystal() {
 
 UInt_t TGriffinHit::SetCrystal(UInt_t crynum) {
    crystal = crynum;
-   is_crys_set = true;
    return crystal;
 }
 
@@ -182,7 +178,7 @@ UInt_t TGriffinHit::SetCrystal(char color) {
       case 'W':
          crystal = 3;  
    };
-   is_crys_set = true;
+   SetFlag(TGRSIDetectorHit::kIsSubDetSet,true);
    return crystal;
 }
 

--- a/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
@@ -41,11 +41,6 @@ void TPacesHit::Clear(Option_t *opt)	{
    filter          =  0;
    ppg             =  0;
    detector        = 0xFFFF;
-
-   is_crys_set     = false;
-
-   //I think we want to make sure the entire Hit is cleared including the BASE.
-   TGRSIDetectorHit::Clear();
 }
 
 

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -40,8 +40,6 @@ void TTigressHit::Clear(Option_t *opt)	{
 	crystal  = -1;
 	first_segment = 0;
 	first_segment_charge = 0.0;
-   is_crys_set     = false;
-
 	core.Clear();
 	//for(int x=0;x<segment.size();x++) { 
 	//	segment[x].Clear();
@@ -112,7 +110,7 @@ TVector3 TTigressHit::GetPosition(Double_t dist) { return TTigress::GetPosition(
 
 
 int TTigressHit::GetCrystal() {
-   if(is_crys_set)
+   if(IsCrystalSet())
       return crystal;
 
    TChannel *chan = GetChannel();


### PR DESCRIPTION
So we have 4 allocated bits in the TGRSIDetectorHit. My gut feeling is that the rest of the 4 bits should be open to individual detectors. We can write the enum to have the last 4 bits be called kOBitFlag1, kOBitFlag2 etc. and then have the derived classes set these bits themselves with functions that have sensible names for whatever that detector needs. This also has opened up the required 4 bits for ppg (although we technically only need two and some smartness) on a per hit level...just sayin' that this is now an option... 

Should be last pull request for today...sorry for the emails!