### PR TITLE
Can now read Calfile from command line always.

### DIFF
--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -98,7 +98,7 @@ void TGRSIint::ApplyOptions() {
       printf("\tfile %s opened as _file%i\n",file->GetName(),x);
       TGRSIRootIO::Get()->LoadRootFile(file);
    }
-   if(TGRSIOptions::GetInputRoot().size() > 0) {
+   if(TGRSIOptions::GetInputRoot().size() > 0 && !fAutoSort && !fFragmentSort) {
       if(TGRSIOptions::GetInputRoot().at(0).find("fragment") != std::string::npos){
          Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(FragmentTree)");
          printf("Read calibration info for %d channels from \"%s\" FragmentTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str()); 
@@ -108,8 +108,14 @@ void TGRSIint::ApplyOptions() {
          printf("Read calibration info for %d channels from \"%s\" AnalysisTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str());
       }
    }
+
+   if(TGRSIOptions::GetInputCal().size() > 0){
+      for(int i =0; i<TGRSIOptions::GetInputCal().size();++i){
+         TChannel::ReadCalFile(TGRSIOptions::GetInputCal().at(i).c_str());
+      }
+   }
   
-  if(TGRSIOptions::WorkHarder()) {
+   if(TGRSIOptions::WorkHarder()) {
       for(int x=0;x<TGRSIOptions::GetMacroFile().size();x++) {
          gROOT->Macro(TGRSIOptions::GetMacroFile().at(x).c_str());  
        // gROOT->ProcessLineSync(Form(".x %s",TGRSIOptions::GetMacroFile().at(x).c_str()));

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ $(SUBDIRS): print
 grsisort: src libraries users print bin config
 	@mv $</$@ bin/$@
 
-config: print
+config: print bin
 	@cp util/grsi-config bin/
 	@find libraries/*/ users/ -name "*.pcm" -exec cp {} libraries/ \;
 


### PR DESCRIPTION
- All calfiles are read in
- Order of cal reading is Trees, cal files left-to-right
- Each successive cal file overwrites the information it holds of the channel to the "left"
- The tree still sorts and automatically writes the **FIRST** cal file input on the command line. The rest of the cal files are loaded after the sort.
- All of the cal files are read before the `--work_harder` flag is called.
- This goes as far as being able to make a `grsisort mycal.cal` call and it will load the TChannels into the current sesh.
- This solves #378 .