### PR TITLE
Adding check for charge/cfd word PAIR

### DIFF
--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -526,17 +526,18 @@ int TDataParser::GriffinDataToFragment(uint32_t *data, int size, int *iter, int 
          
  		   default:				
 	      	if((packet & 0x80000000) == 0x00000000) {
-            if(x+1 < size) {
-              EventFrag->KValue.push_back( (*(data+x) & 0x7c000000) >> 21 );
-              EventFrag->Charge.push_back((*(data+x) & 0x03ffffff));	
-              ++x;
-              EventFrag->KValue.back() |= (*(data+x) & 0x7c000000) >> 26;
-              EventFrag->Cfd.push_back( (*(data+x) & 0x03ffffff));
-            } else {
-               *iter += x;
-               return -x;
-	          }
-          }
+               //check that there is another word and that it is also a charge/cfd word
+               if(x+1 < size && (*(data+x+1) & 0x80000000) == 0x0) {
+                  EventFrag->KValue.push_back( (*(data+x) & 0x7c000000) >> 21 );
+                  EventFrag->Charge.push_back((*(data+x) & 0x03ffffff));	
+                  ++x;
+                  EventFrag->KValue.back() |= (*(data+x) & 0x7c000000) >> 26;
+                  EventFrag->Cfd.push_back( (*(data+x) & 0x03ffffff));
+               } else {
+                  *iter += x;
+                  return -x;
+	            }
+            }
    	      break;
 		};
 	}


### PR DESCRIPTION
Currently, the code only checks for the first word (charge) and assumes the second word is present. One error mode is to have an odd number of charge/cfd words.

-Vinzenz, Jenna