### PR TITLE
Various bug fixes and improvements.

### DIFF
--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -16,6 +16,7 @@
 #include "TROOT.h"
 #include <utility>
 #include "TRef.h"
+#include "TString.h"
 
 using namespace TGRSIFunctions;
 
@@ -42,6 +43,9 @@ class TGRSIFit : public TF1 {
    Bool_t IsGoodFit() const { return goodfit_flag; }
    virtual void SetHist(TH1* hist){fhist = hist;} //fHistogram is a member of TF1. I'm not sure this does anything proper right now
    virtual TH1* GetHist() const { return (TH1*)(fhist.GetObject());}
+   static const char* GetDefaultFitType(){ return fDefaultFitType.Data(); }
+   static void SetDefaultFitType(const char* fittype){ fDefaultFitType = fittype; }
+
  protected:
    Bool_t IsInitialized() const { return init_flag; }
    void SetInitialized(Bool_t flag = true) {init_flag = flag;}
@@ -51,10 +55,11 @@ class TGRSIFit : public TF1 {
    Bool_t init_flag;
    Bool_t goodfit_flag; //This doesn't do anything yet
    TRef fhist;
+   static TString fDefaultFitType;
 
  public:  
    virtual void Print(Option_t *opt = "") const;
-   virtual void Clear();
+   virtual void Clear(Option_t* opt = "" );
 
    ClassDef(TGRSIFit,0);
 };

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -90,6 +90,12 @@ class TGRSIRunInfo : public TObject {
       static inline int  RunNumber() { return fGRSIRunInfo->fRunNumber; }
       static inline int  SubRunNumber() { return fGRSIRunInfo->fSubRunNumber; }
 
+      static inline void   SetRunStart(double tmp) { fGRSIRunInfo->fRunStart = tmp; }
+      static inline void   SetRunStop(double tmp) { fGRSIRunInfo->fRunStop = tmp; }
+
+      static inline double RunStart() { return fGRSIRunInfo->fRunStart; }
+      static inline double RunStop() { return fGRSIRunInfo->fRunStop; }
+
       static inline void SetMajorIndex(const char *tmpstr) { fGRSIRunInfo->fMajorIndex.assign(tmpstr); }
       static inline void SetMinorIndex(const char *tmpstr) { fGRSIRunInfo->fMinorIndex.assign(tmpstr); }
 
@@ -171,6 +177,9 @@ class TGRSIRunInfo : public TObject {
       int fRunNumber;                     //The current run number
       int fSubRunNumber;                  //The current sub run number
 
+      double fRunStart;                      //The start of the current run in seconds
+      double fRunStop;                       //The stop  of the current run in seconds
+
       int fNumberOfTrueSystems;           //The number of detection systems in the array
 
       static std::string fGRSIVersion;    //The version of GRSISort that generated the file
@@ -237,7 +246,7 @@ class TGRSIRunInfo : public TObject {
       void Print(Option_t *opt = "") const;
       void Clear(Option_t *opt = "");
 
-   ClassDef(TGRSIRunInfo,3);  //Contains the run-dependent information.
+   ClassDef(TGRSIRunInfo,4);  //Contains the run-dependent information.
 };
 
 #endif

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -90,6 +90,7 @@ class TPPG : public TObject	{
     std::size_t PPGSize() const {return fPPGStatusMap->size()- 1;}
    
     bool Correct();
+    ULong64_t GetCycleLength();
 
     TPPGData* const Next();
     TPPGData* const Previous();
@@ -106,7 +107,9 @@ class TPPG : public TObject	{
 
   private:
     PPGMap_t *fPPGStatusMap;
+   ULong64_t fCycleLength;
+   std::map<ULong64_t, int> fNumberOfCycleLengths;
 
-    ClassDef(TPPG,1) //Contains PPG information
+    ClassDef(TPPG,2) //Contains PPG information
 };
 #endif

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -43,12 +43,8 @@ class TSceptar : public TGRSIDetector {
       
      static bool fSetWave;		                                                //  Flag for Waveforms ON/OFF
 
-     bool beta;                                                               //   Is there a sceptar hit?
-
    public:
      static bool SetWave()      { return fSetWave;  }	                        //!
-     void SetBeta(bool flag = true) { beta = flag; }                          //!
-     bool Beta()                {return beta;}                                //!  
 
    private:
      static TVector3 gPaddlePosition[21];                                     //!  Position of each Paddle

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -2,6 +2,8 @@
 
 ClassImp(TGRSIFit);
 
+TString TGRSIFit::fDefaultFitType("");
+
 TGRSIFit::TGRSIFit(){
    this->Clear();
 }
@@ -28,9 +30,10 @@ void TGRSIFit::Print(Option_t *opt) const {
    }
 }
 
-void TGRSIFit::Clear() {
+void TGRSIFit::Clear(Option_t *opt) {
    init_flag = false;
    goodfit_flag = false;
+   fDefaultFitType.Clear();
 }
 
 /*

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -231,6 +231,7 @@ Int_t TGriffin::GetAddbackMultiplicity() {
    if(addback_hits.size() == 0) {
       // use the first griffin hit as starting point for the addback hits
       addback_hits.push_back(griffin_hits[0]);
+      faddback_frags.push_back(1);
 
       // loop over remaining griffin hits
       size_t i, j;

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -132,7 +132,6 @@ void TSceptar::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
 
    //Clear("");
    sceptar_hits.reserve(gdata->GetMultiplicity());
-  // TSceptar::SetBeta(false);
    
    for(int i=0;i<gdata->GetMultiplicity();i++)	{
       TSceptarHit dethit;
@@ -163,7 +162,6 @@ void TSceptar::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
    //   dethit.SetPosition(TSceptar::GetPosition(gdata->GetDetNumber(i)));
    
       AddHit(&dethit);
-//     TSceptar::SetBeta();
    }
 }
 

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -58,6 +58,10 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    TObject::Streamer(b);  
    {Int_t  R__int ; b >> R__int;  fRunNumber = R__int;}
    {Int_t  R__int ; b >> R__int;  fSubRunNumber = R__int;}
+   if(R__v>3) {
+     {Double_t  R__double ; b >> R__double;  fRunStart = R__double;}
+     {Double_t  R__double ; b >> R__double;  fRunStop  = R__double;}
+   }
    if(R__v>2) {
      {Int_t  R__int ; b >> R__int;  fHPGeArrayPosition = R__int;}
      {Int_t  R__int ; b >> R__int;  fBuildWindow = R__int;}
@@ -96,6 +100,8 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    TObject::Streamer(b);  
    {Int_t R__int = fRunNumber;    b << R__int;}
    {Int_t R__int = fSubRunNumber; b << R__int;}
+   {Double_t R__double = fRunStart;  b << R__double;}
+   {Double_t R__double = fRunStop ;  b << R__double;}
    {Int_t R__int = fHPGeArrayPosition; b << R__int;}
    {Int_t R__int = fBuildWindow;       b << R__int;}
    {Double_t R__double = fAddBackWindow;  b << R__double;}
@@ -171,6 +177,8 @@ void TGRSIRunInfo::Print(Option_t *opt) const {
       printf("\tTGRSIRunInfo Status:\n");
       printf("\t\tRunNumber:    %05i\n",TGRSIRunInfo::Get()->fRunNumber);
       printf("\t\tSubRunNumber: %03i\n",TGRSIRunInfo::Get()->fSubRunNumber);
+      printf("\t\tRunStart:     %.0f\n",TGRSIRunInfo::Get()->fRunStart);
+      printf("\t\tRunStop:      %.0f\n",TGRSIRunInfo::Get()->fRunStop);
       printf("\t\tTIGRESS:      %s\n", Tigress() ? "true" : "false");
       printf("\t\tSHARC:        %s\n", Sharc() ? "true" : "false");
       printf("\t\tTRIFOIL:      %s\n", TriFoil() ? "true" : "false");

--- a/util/AddToChannelNumber.cxx
+++ b/util/AddToChannelNumber.cxx
@@ -1,0 +1,42 @@
+#include "TChannel.h"
+#include <map>
+
+int main(int argc, char **argv) {
+   if(argc != 3){
+      printf("Usage: AddOneToChannel <int to add> <calfile.cal>\n");
+      return 0;
+   }
+
+   int num_to_add = atoi(argv[1]);
+
+   printf("Adding %d to all channels\n",num_to_add);
+
+   //Read Cal file
+   TChannel::ReadCalFile(argv[2]);
+   std::map<unsigned int, TChannel*>::iterator it;
+   std::map<unsigned int, TChannel*> * chanmap = TChannel::GetChannelMap();
+
+   if(!chanmap){
+      printf("can't find channel map\n");
+      return 0;
+   }
+   
+   std::vector<TChannel*> chanlist;
+
+   for(it = chanmap->begin(); it != chanmap->end(); ++it){
+      TChannel* chan = it->second;
+      TChannel *newchan = new TChannel(chan);
+      chanlist.push_back(newchan);
+      newchan->SetNumber(newchan->GetNumber() + num_to_add);
+   }
+
+   TChannel::DeleteAllChannels();
+
+   for(int i =0; i<chanlist.size();++i){
+      TChannel::AddChannel(chanlist.at(i));
+   }
+
+   TChannel::WriteCalFile(argv[2]);
+
+   return 1;
+}

--- a/util/makefile
+++ b/util/makefile
@@ -35,7 +35,7 @@ endif
 
 CXXTARGET = Root2Rad
 #ROOTTARGET = MakeMatrices MakeTimeDiffSpec Make1DChargeHistograms offsetadd offsetfind offsetfix offsetfindtree bufferclean ExamineMidasFile timeloop EnergyCal EfficCal LeanMatrices
-ROOTTARGET = MakeTimeDiffSpec Make1DChargeHistograms offsetadd offsetfind offsetfix offsetfindtree bufferclean ExamineMidasFile timeloop EnergyCal EfficCal gadd
+ROOTTARGET = MakeTimeDiffSpec Make1DChargeHistograms offsetadd offsetfind offsetfix offsetfindtree bufferclean ExamineMidasFile timeloop EnergyCal EfficCal gadd AddToChannelNumber
 
 CFLAGS += -fPIC -O2
 CFLAGS += -std=c++0x -O2 -I$(PWD)/include -g `root-config --cflags --libs`


### PR DESCRIPTION
- TPPG can now calculate the cycle length: it creates a map with the time difference between consecutive ppg events of the same status and uses the time difference with the maximum counts as cycle length (so far we've seen a loss of about 7% of our ppg events)
- TGRSIRunInfo now includes a run start and stop time in s. For this the fragment trees GetMinimum and GetMaximum is used on the TMidasTimeStamp. This allows us to determine the length of a sub-run without being influenced by "buffer dumps"
- the counting of the fragments in a GRIFFIN addback missed the starting entry, causing it to crash
- Ryan started on adding the option to select a fit function to TGRSIFit
- the LeanMatrices script has been updated for the August 2015 Cd/In decay experiments