### PR TITLE
Updates made during 128,129,130,131,132Cd run

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -27,7 +27,7 @@ class TGRSIDetector;
 ////////////////////////////////////////////////////////////////
 
 class TGRSIDetectorHit : public TObject 	{
-   // The bare bones; stuff all detecotors need.  
+   // The bare bones; stuff all detectors need.  
    // 1. An address.         The whoami for the detector. This is the value used by TChannel::GetChannel(address);
    // 2. An "Energy value."  What this is left the parent class, but it is going to return a double.
    // 3. A   Time  value.     This should be a time value common for detectors (derived from the timestamp)

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -90,11 +90,13 @@ class TGRSIRunInfo : public TObject {
       static inline int  RunNumber() { return fGRSIRunInfo->fRunNumber; }
       static inline int  SubRunNumber() { return fGRSIRunInfo->fSubRunNumber; }
 
-      static inline void   SetRunStart(double tmp) { fGRSIRunInfo->fRunStart = tmp; }
-      static inline void   SetRunStop(double tmp) { fGRSIRunInfo->fRunStop = tmp; }
+      static inline void   SetRunStart(double tmp)  { fGRSIRunInfo->fRunStart = tmp; }
+      static inline void   SetRunStop(double tmp)   { fGRSIRunInfo->fRunStop = tmp; }
+      static inline void   SetRunLength(double tmp) { fGRSIRunInfo->fRunLength = tmp; }
 
-      static inline double RunStart() { return fGRSIRunInfo->fRunStart; }
-      static inline double RunStop() { return fGRSIRunInfo->fRunStop; }
+      static inline double RunStart()  { return fGRSIRunInfo->fRunStart; }
+      static inline double RunStop()   { return fGRSIRunInfo->fRunStop; }
+      static inline double RunLength() { return fGRSIRunInfo->fRunLength; }
 
       static inline void SetMajorIndex(const char *tmpstr) { fGRSIRunInfo->fMajorIndex.assign(tmpstr); }
       static inline void SetMinorIndex(const char *tmpstr) { fGRSIRunInfo->fMinorIndex.assign(tmpstr); }
@@ -170,6 +172,9 @@ class TGRSIRunInfo : public TObject {
       inline void SetHPGeArrayPosition(const int arr_pos) { fHPGeArrayPosition = arr_pos; }
       static inline int  HPGeArrayPosition()  { return Get()->fHPGeArrayPosition; }
 
+      Long64_t Merge(TCollection *list);
+      void Add(TGRSIRunInfo* runinfo) { fRunStart = 0.; fRunStop = 0.; fRunLength += runinfo->RunLength(); }
+
    private:
       static TGRSIRunInfo *fGRSIRunInfo; //Static pointer to TGRSIRunInfo
       //TGRSIRunInfo();
@@ -177,8 +182,9 @@ class TGRSIRunInfo : public TObject {
       int fRunNumber;                     //The current run number
       int fSubRunNumber;                  //The current sub run number
 
-      double fRunStart;                      //The start of the current run in seconds
-      double fRunStop;                       //The stop  of the current run in seconds
+      double fRunStart;                      //The start  of the current run in seconds
+      double fRunStop;                       //The stop   of the current run in seconds
+      double fRunLength;                     //The length of the current run in seconds
 
       int fNumberOfTrueSystems;           //The number of detection systems in the array
 
@@ -246,7 +252,7 @@ class TGRSIRunInfo : public TObject {
       void Print(Option_t *opt = "") const;
       void Clear(Option_t *opt = "");
 
-   ClassDef(TGRSIRunInfo,4);  //Contains the run-dependent information.
+   ClassDef(TGRSIRunInfo,5);  //Contains the run-dependent information.
 };
 
 #endif

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -24,6 +24,7 @@
 
 #include "TObject.h"
 #include "Globals.h"
+#include "TCollection.h"
 
 class TPPGData : public TObject {
     public:
@@ -88,8 +89,11 @@ class TPPG : public TObject	{
     ULong64_t GetLastStatusTime(ULong64_t time, ppg_pattern pat = kJunk, bool exact_flag = false );
     Bool_t MapIsEmpty() const;
     std::size_t PPGSize() const {return fPPGStatusMap->size()- 1;}
+    Long64_t Merge(TCollection *list);
+    void Add(const TPPG* ppg);
+    void operator+=(const TPPG& rhs);                           
    
-    bool Correct();
+    bool Correct(bool verbose = false);
     ULong64_t GetCycleLength();
 
     TPPGData* const Next();
@@ -107,8 +111,8 @@ class TPPG : public TObject	{
 
   private:
     PPGMap_t *fPPGStatusMap;
-   ULong64_t fCycleLength;
-   std::map<ULong64_t, int> fNumberOfCycleLengths;
+    ULong64_t fCycleLength;
+    std::map<ULong64_t, int> fNumberOfCycleLengths;
 
     ClassDef(TPPG,2) //Contains PPG information
 };

--- a/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
+++ b/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
@@ -735,7 +735,7 @@ void TAnalysisTreeBuilder::CloseAnalysisFile() {
    fCurrentRunInfo->Write();
    if(fCurrentPPG){
       printf("Writing PPG Data\n");
-      fCurrentPPG->Write();
+      fCurrentPPG->Write("TPPG",TObject::kSingleKey);
    }
    //TChannel::DeleteAllChannels();
 

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -62,6 +62,9 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
      {Double_t  R__double ; b >> R__double;  fRunStart = R__double;}
      {Double_t  R__double ; b >> R__double;  fRunStop  = R__double;}
    }
+   if(R__v>4) {
+     {Double_t  R__double ; b >> R__double;  fRunLength = R__double;}
+   }
    if(R__v>2) {
      {Int_t  R__int ; b >> R__int;  fHPGeArrayPosition = R__int;}
      {Int_t  R__int ; b >> R__int;  fBuildWindow = R__int;}
@@ -102,6 +105,7 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    {Int_t R__int = fSubRunNumber; b << R__int;}
    {Double_t R__double = fRunStart;  b << R__double;}
    {Double_t R__double = fRunStop ;  b << R__double;}
+   {Double_t R__double = fRunLength ;  b << R__double;}
    {Int_t R__int = fHPGeArrayPosition; b << R__int;}
    {Int_t R__int = fBuildWindow;       b << R__int;}
    {Double_t R__double = fAddBackWindow;  b << R__double;}
@@ -179,6 +183,7 @@ void TGRSIRunInfo::Print(Option_t *opt) const {
       printf("\t\tSubRunNumber: %03i\n",TGRSIRunInfo::Get()->fSubRunNumber);
       printf("\t\tRunStart:     %.0f\n",TGRSIRunInfo::Get()->fRunStart);
       printf("\t\tRunStop:      %.0f\n",TGRSIRunInfo::Get()->fRunStop);
+      printf("\t\tRunLength:    %.0f\n",TGRSIRunInfo::Get()->fRunLength);
       printf("\t\tTIGRESS:      %s\n", Tigress() ? "true" : "false");
       printf("\t\tSHARC:        %s\n", Sharc() ? "true" : "false");
       printf("\t\tTRIFOIL:      %s\n", TriFoil() ? "true" : "false");
@@ -426,3 +431,16 @@ void TGRSIRunInfo::trim(std::string * line, const std::string & trimChars) {
    return;
 }
 
+Long64_t TGRSIRunInfo::Merge(TCollection *list){
+   //Loop through the TCollection of TGRSISortLists, and add each entry to the original TGRSISort List
+   TIter it(list);
+   //The TCollection will be filled by something like hadd. Each element in the list will be a TGRSISortList from
+   //An individual file that was submitted to hadd.
+   TGRSIRunInfo *runinfo = 0;
+
+   while ((runinfo = (TGRSIRunInfo *)it.Next()) != NULL){
+      //Now we want to loop through each TGRSISortList and find the TGRSISortInfo's stored in there.    
+      this->Add(runinfo);
+   }
+   return 0;
+}

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -206,7 +206,7 @@ void TGRSIRootIO::FinalizePPG(){
    foutfile->cd();
    if(fPPG->PPGSize()){
       printf("Writing PPG\n");
-      fPPG->Write();
+      fPPG->Write("TPPG",TObject::kSingleKey);
    }
    return;
 }
@@ -266,7 +266,8 @@ void TGRSIRootIO::CloseRootOutFile()   {
       //get run start and stop (in seconds) from the fragment tree
       TGRSIRunInfo::Get()->SetRunStart(fFragmentTree->GetMinimum("MidasTimeStamp"));
       TGRSIRunInfo::Get()->SetRunStop( fFragmentTree->GetMaximum("MidasTimeStamp"));
-      printf("set run start to %.0f (%.0f), and stop to %.0f (%0.f)\n",TGRSIRunInfo::Get()->RunStart(),fFragmentTree->GetMinimum("MidasTimeStamp"),TGRSIRunInfo::Get()->RunStop(),fFragmentTree->GetMaximum("MidasTimeStamp"));
+      TGRSIRunInfo::Get()->SetRunLength(fFragmentTree->GetMaximum("MidasTimeStamp") - fFragmentTree->GetMinimum("MidasTimeStamp"));
+      printf("set run start to %.0f, and stop to %.0f (run length %.0f)\n",TGRSIRunInfo::Get()->RunStart(),TGRSIRunInfo::Get()->RunStop(),TGRSIRunInfo::Get()->RunLength());
       TGRSIRunInfo::Get()->Write();
    }
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -359,8 +359,10 @@ void TGRSIint::GetOptions(int *argc, char **argv) {
              printf("file %s has size 0, skipping\n", dir);
           }
        } else {
-          //file does not exist... assuming output file.
-          FileAutoDetect(argv[i],-1);
+          //file does not exist... complain to the user about this
+          if(!FileAutoDetect(argv[i],-1)) {
+            printf(DRED "File %s does not exist, ignoring it!" RESET_COLOR "\n",argv[i]);
+          }
           argv[i] = null;
        }   
     }
@@ -389,39 +391,40 @@ bool TGRSIint::FileAutoDetect(std::string filename, long filesize) {
    //first search for extensions.
    std::string ext = filename.substr(filename.find_last_of('.')+1);
    //printf("\text = %s\n",ext.c_str());
-   if(ext.compare("root")==0) {
+   if(ext.compare("root")==0 && filesize > 0) {
       //printf("\tFound root file: %s\n",filename.c_str());
       //fInputRootFile->push_back(filename);
       TGRSIOptions::AddInputRootFile(filename);
       return true;
-   } else if(ext.compare("mid")==0 || ext.compare("bz2")==0) {
+   } else if((ext.compare("mid")==0 || ext.compare("bz2")==0) && filesize > 0) {
       //printf("\tFound midas file: %s\n",filename.c_str());
       //fInputMidasFile->push_back(filename);
       TGRSIOptions::AddInputMidasFile(filename);
       fAutoSort = true;
       return true;
-   } else if(ext.compare("cal")==0) { 
+   } else if(ext.compare("cal")==0 && filesize > 0) { 
       //printf("\tFound custom calibration file: %s\n",filename.c_str());
       //fInputCalFile->push_back(filename);
       TGRSIOptions::AddInputCalFile(filename);
       return true;
-   } else if(ext.compare("info")==0) { 
+   } else if(ext.compare("info")==0 && filesize > 0) { 
       if(TGRSIRunInfo::ReadInfoFile(filename.c_str()))
          return true;
       else {
          printf("Problem reading run-info file %s\n",filename.c_str());
          return false;
       }
-   } else if(ext.compare("xml")==0) { 
+   } else if(ext.compare("xml")==0 && filesize > 0) { 
       //fInputOdbFile->push_back(filename);
       TGRSIOptions::AddInputOdbFile(filename);
       //printf("\tFound xml odb file: %s\n",filename.c_str());
       return true;
-   } else if(ext.compare("odb")==0) { 
+   } else if(ext.compare("odb")==0 && filesize > 0) { 
       //printf("\tFound c-like odb file: %s\n",filename.c_str());
       printf("c-like odb structures can't be read yet.\n");
       return false;
    } else if((ext.compare("c")==0) || (ext.compare("C")==0) || (ext.compare("c+")==0) || (ext.compare("C+")==0)) {
+      //scripts are the only files that don't have to exist, they may also be found in the macro-paths
       TGRSIOptions::AddMacroFile(filename);
       return true;
    } else {

--- a/util/grsi-config
+++ b/util/grsi-config
@@ -45,7 +45,7 @@ utildir=$GRSISYS/etc
 
 
 grsilibs="-lGRSIDetector -lGRSIFormat -lNucleus -lKinematics -lSRIM -lBetaDecay -lTGRSIFit -lTCal -lGROOT"
-detlibs="-lTigress -lGriffin -lSharc -lTriFoil -lCSM -lSceptar -lPaces -lDescant -lTip"
+detlibs="-lTigress -lGriffin -lSharc -lTriFoil -lSceptar -lPaces -lDescant -lTip"
 grsimore="-lMidasFormat -lDataParser -lGRSILoop -lTGRSIint -lGRSIRootIO -lAnalysisTreeBuilder"
 
 cflags="-std=c++0x -I$incdir"


### PR DESCRIPTION
- Added run start,stop and length to TGRSIRunInfo
- Added TGRSIRunInfo Merge function to calculated entire run length for summed up matrix files
- Added PPG Merge and Add functions for summed up matrix files
- Fixed bugs in TPPG Copy, Clear, and dtor
- Added TPPG::Correct function to fix missing and bad PPG words
- Fixed File autodetect to warn of missing input files
- Updated LeanMatrices to work with addback
- PPG in fragment tree currently needs to look for PPG in fragment tree subrun -1 unless it is subrun 0. This might get annoying, and might get changed.
- Removed CSM from grsi-config until CSM makes it into leangrsi