### PR TITLE
TPeak Upgrades

### DIFF
--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -45,6 +45,8 @@ class TGRSIFit : public TF1 {
    virtual TH1* GetHist() const { return (TH1*)(fhist.GetObject());}
    static const char* GetDefaultFitType(){ return fDefaultFitType.Data(); }
    static void SetDefaultFitType(const char* fittype){ fDefaultFitType = fittype; }
+   Bool_t AddToGlobalList(Bool_t on = kTRUE);
+   static Bool_t AddToGlobalList(TF1* func, Bool_t on = kTRUE);
 
  protected:
    Bool_t IsInitialized() const { return init_flag; }

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -6,6 +6,7 @@
 #include "TF1.h"
 #include "TFitResultPtr.h"
 #include "TFitResult.h"
+#include "TGraph.h"
 #include <string>
 #include <algorithm>
 
@@ -64,10 +65,15 @@ class TPeak : public TGRSIFit {
    Bool_t InitParams(TH1 *fithist = 0);
    TF1* Background() const { return background; } 
    void DrawBackground(Option_t *opt = "SAME") const; // *MENU*
-   void DrawResiduals() const; // *MENU*
+   void DrawResiduals(); // *MENU*
 
    static void SetLogLikelihoodFlag(Bool_t flag = true) { fLogLikelihoodFlag = flag; }
    static Bool_t GetLogLikelihoodFlag() { return fLogLikelihoodFlag; }
+
+   static Bool_t CompareEnergy(const TPeak &lhs, const TPeak &rhs)  { return lhs.GetCentroid() < rhs.GetCentroid(); }
+   static Bool_t CompareArea(const TPeak &lhs, const TPeak &rhs)    { return lhs.GetArea() < rhs.GetArea(); }
+   static Bool_t CompareEnergy(const TPeak *lhs, const TPeak *rhs)  { return lhs->GetCentroid() < rhs->GetCentroid(); }
+   static Bool_t CompareArea(const TPeak *lhs, const TPeak *rhs)    { return lhs->GetArea() < rhs->GetArea(); }
 
  public:
    virtual void Print(Option_t *opt = "") const;
@@ -84,6 +90,7 @@ class TPeak : public TGRSIFit {
    static bool fLogLikelihoodFlag; //!
 
    TF1* background;
+   TGraph* fResiduals;
 
   ClassDef(TPeak,2);
 

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -66,6 +66,9 @@ class TPeak : public TGRSIFit {
    void DrawBackground(Option_t *opt = "SAME") const; // *MENU*
    void DrawResiduals() const; // *MENU*
 
+   static void SetLogLikelihoodFlag(Bool_t flag = true) { fLogLikelihoodFlag = flag; }
+   static Bool_t GetLogLikelihoodFlag() { return fLogLikelihoodFlag; }
+
  public:
    virtual void Print(Option_t *opt = "") const;
    const char*  PrintString(Option_t *opt = "") const;
@@ -77,6 +80,8 @@ class TPeak : public TGRSIFit {
    Double_t fd_area; 
    Double_t fchi2; 
    Double_t fNdf; 
+
+   static bool fLogLikelihoodFlag;
 
    TF1* background;
 

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -81,7 +81,7 @@ class TPeak : public TGRSIFit {
    Double_t fchi2; 
    Double_t fNdf; 
 
-   static bool fLogLikelihoodFlag;
+   static bool fLogLikelihoodFlag; //!
 
    TF1* background;
 

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -72,7 +72,7 @@ class TPeak : public TGRSIFit {
  public:
    virtual void Print(Option_t *opt = "") const;
    const char*  PrintString(Option_t *opt = "") const;
-   virtual void Clear();
+   virtual void Clear(Option_t* opt = "");
 
  private: 
    //Centroid will eventually be read from parameters

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -668,8 +668,15 @@ TF1 *GCanvas::GetLastFit() {
   }
   if(!hist)
      return 0;
-  if(hist->GetListOfFunctions()->GetSize()>0) 
-     return (TF1*)(hist->GetListOfFunctions()->Last()); 
+  if(hist->GetListOfFunctions()->GetSize()>0){
+     TF1* tmpfit = (TF1*)(hist->GetListOfFunctions()->Last());
+     std::string tmpname = tmpfit->GetName();
+     while(tmpname.find("background") != std::string::npos ){
+         tmpfit = (TF1*)(hist->GetListOfFunctions()->Before(tmpfit));
+         tmpname = tmpfit->GetName();
+     }
+     return tmpfit; 
+  }
   return 0;
 }
 
@@ -908,8 +915,11 @@ bool GCanvas::PeakFit(GMarker *m1,GMarker *m2) {
 //  gfit->Delete();
   //hist->GetFunction("gaus")->Delete();
 
-  mypeak->Fit(hist);
-  mypeak->Background()->Draw("SAME");
+  mypeak->Fit(hist,"+");
+  hist->GetListOfFunctions()->Add(mypeak->Background()->Clone());
+ // hist->GetListOfFunctions()->Add(mypeak);
+  TPeak *peakfit = (TPeak*)(hist->GetListOfFunctions()->Last());
+//  mypeak->Background()->Draw("SAME");
   /*
   double param[3];
   double error[3];
@@ -981,13 +991,15 @@ bool GCanvas::PeakFitQ(GMarker *m1,GMarker *m2) {
   //hist->GetFunction("gaus")->Delete();
 
   mypeak->Fit(hist,"Q+");
+  hist->GetListOfFunctions()->Add(mypeak->Background()->Clone());
+ // hist->GetListOfFunctions()->Add(mypeak);
   TPeak *peakfit = (TPeak*)(hist->GetListOfFunctions()->Last());
   //hist->GetListOfFunctions()->Print();
   if(!peakfit) {
     printf("peakfit not found??\n");
     return false;
   }
-  mypeak->Background()->Draw("SAME");
+//  mypeak->Background()->Draw("SAME");
   mypeak->Print();
   
      

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -36,6 +36,60 @@ void TGRSIFit::Clear(Option_t *opt) {
    fDefaultFitType.Clear();
 }
 
+Bool_t TGRSIFit::AddToGlobalList(Bool_t on){
+   // Add to global list of functions (gROOT->GetListOfFunctions() )
+   // return previous status (true of functions was already in the list false if not)
+   
+   if (!gROOT) return false;
+
+   if (on )  {
+      if(gROOT->GetListOfFunctions()->FindObject(this) != nullptr){
+         return on;
+      }
+      gROOT->GetListOfFunctions()->Add(this);
+      // do I need to delete previous one with the same name ???
+      //TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(GetName()) );
+      //if (old) gROOT->GetListOfFunctions()->Remove(old);
+   }
+   else {
+      // if previous status was on and now is off
+      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(this->GetName()) );
+      if (!old) {
+         Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
+         return kFALSE;
+      }
+      gROOT->GetListOfFunctions()->Remove(this);
+   }
+   return on;
+}
+
+Bool_t TGRSIFit::AddToGlobalList(TF1* func, Bool_t on){
+   // Add to global list of functions (gROOT->GetListOfFunctions() )
+   // return previous status (true of functions was already in the list false if not)
+   
+   if (!gROOT) return false;
+
+   if (on )  {
+      if(gROOT->GetListOfFunctions()->FindObject(func) != nullptr){
+         return on;
+      }
+      gROOT->GetListOfFunctions()->Add(func);
+      // do I need to delete previous one with the same name ???
+      //TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(GetName()) );
+      //if (old) gROOT->GetListOfFunctions()->Remove(old);
+   }
+   else {
+      // if previous status was on and now is off
+      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(func->GetName()) );
+      if (!old) {
+         func->Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
+         return kFALSE;
+      }
+      gROOT->GetListOfFunctions()->Remove(func);
+   }
+   return on;
+}
+
 /*
 int TGRSIFit::FitPeak(Int_t limit1, Int_t limit2, Double_t centroid) {} // termination version
 

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -154,7 +154,7 @@ Bool_t TPeak::InitParams(TH1 *fithist){
    this->SetParameter("B",(fithist->GetBinContent(binlow) - fithist->GetBinContent(binhigh))/(xlow-xhigh));
    this->SetParameter("C",0.0000);
    this->SetParameter("bg_offset",GetParameter("centroid"));
-   this->FixParameter(8,0.00);
+//   this->FixParameter(8,0.00);
    this->FixParameter(3,GetParameter("beta"));
    this->FixParameter(4,0.00);
    SetInitialized();
@@ -323,7 +323,7 @@ Bool_t TPeak::SetHist(const char* histname){
    }
 }*/
 
-void TPeak::Clear(){
+void TPeak::Clear(Option_t *opt){
 //Clear the TPeak including functions and histogram, does not
 //currently clear inherited members such as name.
 //want to make a clear that doesn't clear everything

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -131,7 +131,7 @@ ULong64_t TPPG::GetLastStatusTime(ULong64_t time,ppg_pattern pat,bool exact_flag
             }
          }
          else{
-            printf("pat %x, ppg_it->first %lld, ppg_it->second->GetNewPPG() %x\n",pat,ppg_it->first,ppg_it->second->GetNewPPG());
+            printf("pat %x, ppg_it->first %lu, ppg_it->second->GetNewPPG() %x\n",pat,ppg_it->first,ppg_it->second->GetNewPPG());
             if(pat & ppg_it->second->GetNewPPG()){
                return ppg_it->first;
             }
@@ -161,7 +161,7 @@ void TPPG::Print(Option_t *opt) const{
       printf("           PPG STATUS        \n");
       printf("*****************************\n");
       for(ppgit = MapBegin(); ppgit != MapEnd(); ppgit++){
-         printf("%lld: ",ppgit->first); ppgit->second->Print();
+         ppgit->second->Print();
       }
    }
 }
@@ -213,7 +213,7 @@ bool TPPG::Correct(bool verbose) {
       ULong64_t diff = (*it).second->GetTimeStamp() - GetLastStatusTime((*it).second->GetTimeStamp());
       if(diff != fCycleLength) {
          if(verbose) {
-            printf("%d: found missing ppg at time %lld (%lld != %lld)\n", std::distance(MapBegin(),it),(*it).first, diff, fCycleLength);
+            printf("%ld: found missing ppg at time %lu (%lld != %lld)\n", std::distance(MapBegin(),it),(*it).first, diff, fCycleLength);
          }
          //check that the previous ppg with the same status is a multiple of fCycleLength ago and that no other ppg is in the map that was fCycleLength ago
          if(diff%fCycleLength != 0) {
@@ -365,4 +365,9 @@ void TPPG::Add(const TPPG* ppg){
          AddData(ppgit->second);
       }
    }
+   //We want to rebuild our cycle length map and this is the easiest way to do it
+   fNumberOfCycleLengths.clear();
+   fCycleLength = 0;
+   GetCycleLength();
+
 }


### PR DESCRIPTION
- Ability to turn on/off log-likelihood in TPeak.
- Shift-M/N removes background fits.
- Fixed bug in parameters of TPeak fit...can now do x^2 in background
- Removed warnings from PPG print strings
- Fixed bugs when root does it's garbage collection on TF1's. Apparently root automatically adds ALL TF1's to a global TF1 list, and deletes them from the list when .q is typed. This becomes a problem, when a class inheriting from TF1 contains a TF1, and then deletes that TF1. Root might delete these in the wrong order....