### PR TITLE
Fixed some bugs with the global TF1 list

### DIFF
--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -17,6 +17,7 @@
 #include <utility>
 #include "TRef.h"
 #include "TString.h"
+#include "Globals.h"
 
 using namespace TGRSIFunctions;
 
@@ -45,8 +46,17 @@ class TGRSIFit : public TF1 {
    virtual TH1* GetHist() const { return (TH1*)(fhist.GetObject());}
    static const char* GetDefaultFitType(){ return fDefaultFitType.Data(); }
    static void SetDefaultFitType(const char* fittype){ fDefaultFitType = fittype; }
+
+   //These are only to be called in the Dtor of classes to protect from ROOT's insane garbage collection system
+   //They can be called anywhere though as long as new classes are carefully destructed. 
    Bool_t AddToGlobalList(Bool_t on = kTRUE);
    static Bool_t AddToGlobalList(TF1* func, Bool_t on = kTRUE);
+
+   void operator delete(void *ptr);
+
+ protected:
+   void* operator new[](size_t sz) ;
+   void* operator new[](size_t sz, void* vp) ;
 
  protected:
    Bool_t IsInitialized() const { return init_flag; }

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -13,6 +13,7 @@ TGRSIFit::TGRSIFit(const TGRSIFit &copy) : TF1(copy){
 }
 
 TGRSIFit::~TGRSIFit(){
+   this->AddToGlobalList(kFALSE);
 }
 
 void TGRSIFit::Copy(TObject &obj) const{
@@ -44,23 +45,25 @@ Bool_t TGRSIFit::AddToGlobalList(Bool_t on){
 
    if (on )  {
       if(gROOT->GetListOfFunctions()->FindObject(this) != nullptr){
-         return on;
+         return true;
       }
       gROOT->GetListOfFunctions()->Add(this);
       // do I need to delete previous one with the same name ???
       //TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(GetName()) );
       //if (old) gROOT->GetListOfFunctions()->Remove(old);
+      return false;
    }
    else {
       // if previous status was on and now is off
-      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(this->GetName()) );
+      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(this) );
       if (!old) {
-         Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
-         return kFALSE;
+         //Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
+         return false;
       }
       gROOT->GetListOfFunctions()->Remove(this);
+      return true;
    }
-   return on;
+   return true;
 }
 
 Bool_t TGRSIFit::AddToGlobalList(TF1* func, Bool_t on){
@@ -71,168 +74,50 @@ Bool_t TGRSIFit::AddToGlobalList(TF1* func, Bool_t on){
 
    if (on )  {
       if(gROOT->GetListOfFunctions()->FindObject(func) != nullptr){
-         return on;
+         return true;
       }
       gROOT->GetListOfFunctions()->Add(func);
       // do I need to delete previous one with the same name ???
       //TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(GetName()) );
       //if (old) gROOT->GetListOfFunctions()->Remove(old);
+      return false;
    }
    else {
       // if previous status was on and now is off
-      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(func->GetName()) );
+      TF1 * old = dynamic_cast<TF1*>( gROOT->GetListOfFunctions()->FindObject(func) );
       if (!old) {
-         func->Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
-         return kFALSE;
+         //func->Warning("AddToGlobalList","Function is supposed to be in the global list but it is not present");
+         return false;
       }
       gROOT->GetListOfFunctions()->Remove(func);
+      return true;
    }
-   return on;
+   return true;
 }
 
-/*
-int TGRSIFit::FitPeak(Int_t limit1, Int_t limit2, Double_t centroid) {} // termination version
-
-Double_t TGRSIFitter::Fit(TPeak *peak, Option_t *opt){
-//This is the algorithm used if a TPeak is passed to the fitter
-//It returns the chi2 of the fit or a negative number for an error
-//Errors: "-1": the TPeak* passed was empty
-   Bool_t verbosity = false;
-   if(strchr(opt,'v') != NULL){
-      verbosity = true;
-   }
-   if(peak = 0){
-      printf("Empty TPeak, please try again\n");
-      return -1;
-   }
-   
-   //Should figure out a way to send default parameters to the fitter. rd
-   TF1* fitfunc = peak->GetFitFunction();
-   //fitfunc->Print();
-   return 0;
+//This delete is here because we want things to be removed from the global list when we delete them. 
+//However, the delete[] operator does not work, so one might cause a seg fault when they use a dynamic array
+//of TGRSIFits. So don't do it until this is sorted out. Make a vector or something instead.
+void TGRSIFit::operator delete(void *ptr){
+      //operator delete
+      (static_cast<TGRSIFit*>(ptr))->AddToGlobalList(kFALSE);
+      TF1::operator delete(ptr);
 }
-*/
 
-
-
-
-
-/*
-TFitResultPtr TGRSIFitter::FitPhotoPeak(Double_t *par, TH1 *h, Float_t &area, Float_t &darea, Double_t *energy, Bool_t verbosity){
-
-   //I should come up with something smarter to return from this function. If I return a smart pointer to the fitresult it should be good enough (I think).
-
-   //Change the bin width to the bin containing the centroid
-   Double_t binWidth = h->GetXaxis()->GetBinWidth(1000);//Need to find the bin widths so that the integral makes sense
-   Int_t rw = binWidth*120;  //This number may change depending on the source used   
-   //Set the number of iterations. The code is pretty quick, so having a lot isn't an issue	
-   TVirtualFitter::SetMaxIterations(10000);
-   Int_t xp = par[1];
-   Int_t yp = par[0];
-   Int_t A = par[6];
-   //Define the fit function and the range of the fit
-   TF1 *pp = new TF1("photopeak","gaus",xp-rw,xp+rw,10);
-
-   //Name the parameters so it is easy to see what the code is doing
-   pp->SetParName(0,"Height");
-   pp->SetParName(1,"centroid");
-   pp->SetParName(2,"sigma");
-   pp->SetParName(3,"beta");
-   pp->SetParName(4,"R");
-   pp->SetParName(5,"step");
-   pp->SetParName(6,"A");
-   pp->SetParName(7,"B");
-   pp->SetParName(8,"C");
-   pp->SetParName(9,"bg offset");
-
-   //Set some physical limits for parameters
-   pp->SetParLimits(0,0.5*yp, 2*yp);
-   pp->SetParLimits(1,xp-rw,xp+rw);
- //  pp->SetParLimits(2,4,12);
-   pp->SetParLimits(3,0.000,10);
-   pp->SetParLimits(4,0,500);
-   pp->SetParLimits(6,0,A*1.4);
-   pp->SetParLimits(5,0,1000000);
-   pp->SetParLimits(9,xp-40,xp+40);
-   //Actually set the parameters in the photopeak function
-   pp->SetParameters(par);
-  //Fixing has to come after setting
-  pp->FixParameter(8,0);
-  // pp->FixParameter(4,0);
- //  pp->FixParameter(7,0);
-//   pp->FixParameter(4,0);
-  // pp->FixParameter(5,1);
-
-   std::string optionstring;
-
-   if(verbosity)
-      optionstring = "RFSM0+";
-   else
-      optionstring = "RFSM0Q+";
- 
-   const char * options = optionstring.c_str();
-
-   pp->SetNpx(1000); //Draws a nice smooth function on the graph
-   TFitResultPtr fitres = h->Fit("photopeak",options); 
-//   pp->Draw("same");      
-   
-   if(fitres->ParError(2) != fitres->ParError(2)){ //Check to see if nan
-      if(fitres->Parameter(3) < 1){
-         pp->FixParameter(4,0);
-         pp->FixParameter(3,1);
-         std::cout << "Beta may have broken the fit, retrying with R=0" << std::endl;
-         fitres = h->Fit("photopeak",options);
-         pp->ReleaseParameter(4);
-         pp->SetParLimits(4,0,500);
-         fitres = h->Fit("photopeak",options);
-         pp->ReleaseParameter(3);
-         pp->SetParLimits(3,0.000,10);
-         fitres = h->Fit("photopeak",options);
-      }
-   }
-   
-
-   pp->GetParameters(&par[0]); 
-   TF1 *photopeak = new TF1("photopeak",PhotoPeak,xp-rw,xp+rw,10);//I Think this is supposed to be just a gaussian maybe.
-   photopeak->SetParameters(par);
-
-   Double_t integral = photopeak->Integral(xp-rw,xp+rw)/binWidth;
-
-   if(verbosity){
-      std::cout << "FIT RESULT CHI2 " << fitres->Chi2() << std::endl;
-      std::cout << "FWHM = " << 2.35482*fitres->Parameter(2)/binWidth <<"(" << fitres->ParError(2)/binWidth << ")" << std::endl;
-      std::cout << "NDF: " << fitres->Ndf() << std::endl;
-   }
-   std::cout << "X sq./v = " << fitres->Chi2()/fitres->Ndf() << std::endl;
-
-   TVirtualFitter *fitter = TVirtualFitter::GetFitter();
-
-   assert(fitter != 0); //make sure something was actually fit
-   TMatrixDSym covMatrix = fitres->GetCovarianceMatrix(); //This allows us to find the uncertainty in the integral
-
-   Double_t sigma_integral = photopeak->IntegralError(xp-rw,xp+rw)/binWidth;
-
-   std::cout << "Integral = " << integral << " +/- " << sigma_integral << std::endl;
-
-   area = integral;
-   darea = sigma_integral;
-   *energy = fitres->Parameter(1);
-
-	delete photopeak;
-	delete pp;
-   if(fitres->Chi2()/fitres->Ndf() > 5.0){
-      std::cout << "THIS FIT WAS NOT GOOD (Reduced Chi2 = " << fitres->Chi2()/fitres->Ndf() << " )" << std::endl;
-      return false;
-   }
-
-   return fitres;
-
-//   myFitResult.fIntegral = integral;
-
-
- //  return photopeak;
-
+void* TGRSIFit::operator new[](size_t sz){
+      //operator delete. You must use delete[] to free the array before program completion
+      // Otherwise ROOT will try to delete the array using a normal delete call which is
+      //bad news bears and will result in a segmentation violation.
+      printf(DRED"It is DANGEROUS allocate dynamic arrays of TGRSIFits, use delete[] on the array before program completion, otherwise you will get a segfault.\n" RESET_COLOR);
+      return TF1::operator new[](sz);
 }
-*/
+
+void* TGRSIFit::operator new[](size_t sz, void* vp){
+      //operator delete. You must use delete[] to free the array before program completion
+      // Otherwise ROOT will try to delete the array using a normal delete call which is
+      //bad news bears and will result in a segmentation violation.
+      printf(DRED"It is DANGEROUS allocate dynamic arrays of TGRSIFits, use delete[] on the array before program completion, otherwise you will get a segfault.\n" RESET_COLOR);
+      return TF1::operator new[](sz,vp);
+}
 
 

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -50,7 +50,7 @@ TPeak::TPeak(Double_t cent, Double_t xlow, Double_t xhigh, Option_t* type) : TGR
    this->background->SetNpx(1000);
    this->background->SetLineStyle(2);
    this->background->SetLineColor(kBlack);
-   TGRSIFit::AddToGlobalList(background,kFALSE);
+//   TGRSIFit::AddToGlobalList(background,kFALSE);
 
    this->fResiduals = new TGraph;
 }
@@ -64,16 +64,20 @@ TPeak::TPeak() : TGRSIFit("photopeakbg",TGRSIFunctions::PhotoPeakBG,0,1000,10){
    background->SetNpx(1000);
    background->SetLineStyle(2);
    background->SetLineColor(kBlack);
-   TGRSIFit::AddToGlobalList(background,kFALSE);
+//   TGRSIFit::AddToGlobalList(background,kFALSE);
 
    fResiduals = new TGraph;
 }
 
 TPeak::~TPeak(){
-   if(background) delete background;
+   this->AddToGlobalList(kFALSE); //Remvoe from global list in case it is part of another class.
+
+   if(background){
+      if(TGRSIFit::AddToGlobalList(background,kFALSE)){   
+         delete background;
+      }
+   }
    if(fResiduals) delete fResiduals;
-   background = 0;
-   fResiduals  = 0;
 }
 
 void TPeak::InitNames(){
@@ -105,13 +109,12 @@ void TPeak::Copy(TObject &obj) const {
 
    ((TPeak&)obj).fchi2 = fchi2;
    ((TPeak&)obj).fNdf  = fNdf;
-   ((TPeak&)obj).background->Copy(*background);
+   *(((TPeak&)obj).background) = *background;
    *(((TPeak&)obj).fResiduals) = *fResiduals;
 
    ((TPeak&)obj).SetHist(GetHist());
 
 }
-
 
 void TPeak::SetType(Option_t * type){
 // This sets the style of gaussian fit function to use for the fitted peak. 
@@ -130,7 +133,6 @@ void TPeak::SetType(Option_t * type){
    }
 
 //   fpeakfit = new TF1("photopeak","gauss",fxlow,fxhigh);  
-
 }
 
 Bool_t TPeak::InitParams(TH1 *fithist){


### PR DESCRIPTION
- overwrote delete statement to check the list and remove the current TGRSIFit
- overwrote new[] operator because apparantly the new[] operator on TF1's cause root to die on .q unless one calls delete[] on that TF1 array first. The new[] statment has all of the old functionality with the addition that it yells at you in red to tell you to call delete[].