### PR TITLE
Added ability to get PPG status and Timestamp in cycle for hits

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -13,6 +13,8 @@
 #include "TObject.h" 
 #include "TRef.h"
 #include "Rtypes.h"
+#include "TPPG.h"
+#include "TFile.h"
 
 class TGRSIDetector;
 
@@ -48,7 +50,7 @@ class TGRSIDetectorHit : public TObject 	{
       kIsEnergySet   = 1<<1,
       kIsPositionSet = 1<<2,
       kIsSubDetSet   = 1<<3,
-		kBit4          = 1<<4,
+		kIsPPGSet      = 1<<4,
 		kBit5          = 1<<5,
 		kBit6          = 1<<6,
 		kBit7          = 1<<7,
@@ -101,13 +103,19 @@ class TGRSIDetectorHit : public TObject 	{
       inline std::vector<Short_t> GetWaveform() const       { return waveform; } //!
     //  inline TGRSIDetector *GetParent() const               { return ((TGRSIDetector*)parent.GetObject()); } //!
       
+      //The PPG is only stored in events that come out of the GRIFFIN DAQ
+      uint16_t GetPPGStatus() const;
+      uint16_t GetPPGStatus();
+      uint16_t GetCycleTimeStamp() const;
+      uint16_t GetCycleTimeStamp();
+
+
    protected:
       Bool_t IsDetSet() const {return (fbitflags & kIsDetSet);}
       Bool_t IsPosSet() const {return (fbitflags & kIsPositionSet);}
       Bool_t IsEnergySet() const {return (fbitflags & kIsEnergySet);} 
       Bool_t IsSubDetSet() const {return (fbitflags & kIsSubDetSet);}
-
-      Bool_t IsCrystalSet() const {return IsSubDetSet();}
+      Bool_t IsPPGSet() const {return (fbitflags & kIsPPGSet);}
 
       void SetFlag(enum Ebitflag,Bool_t set);
 
@@ -122,7 +130,11 @@ class TGRSIDetectorHit : public TObject 	{
    //   TRef      parent;   // pointer to the mother class;
      std::vector<Short_t> waveform;  //
       //Bool_t fHitSet;    //!
- 
+      uint16_t fPPGStatus; //! 
+      ULong_t  fCycleTimeStamp; //!
+
+      static TPPG* fPPG;
+
    //flags   
    protected:  
       UChar_t fbitflags;
@@ -131,7 +143,7 @@ class TGRSIDetectorHit : public TObject 	{
       //Bool_t fPosSet;//!
       //Bool_t fEnergySet;//!
 
-	ClassDef(TGRSIDetectorHit,3) //Stores the information for a detector hit
+	ClassDef(TGRSIDetectorHit,4) //Stores the information for a detector hit
 };
 
 

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -87,8 +87,6 @@ class TGriffin : public TGRSIDetector {
       //static bool SetBGOHits()       { return fSetBGOHits;   }	//!
       //static bool SetBGOWave()	    { return fSetBGOWave;   } //!
 
-      int GetCycleTimeInMilliSeconds(long time) { return (int)((time-fCycleStart)/1e5); }//!
-
       //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
    private:
       static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
@@ -106,7 +104,7 @@ class TGriffin : public TGRSIDetector {
    protected:
       void PushBackHit(TGRSIDetectorHit* ghit);
 
-      ClassDef(TGriffin,2)  // Griffin Physics structure
+      ClassDef(TGriffin,3)  // Griffin Physics structure
 
 
 };

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -19,7 +19,7 @@ class TGriffinHit : public TGRSIDetectorHit {
 	public:
 		enum EGriffinHitBits {
 			kCrystalSet = 1<<0,
-			kPPGSet     = 1<<1,
+			kBit1       = 1<<1,
 			kBit2       = 1<<2,
 			kBit3       = 1<<3,
 			kBit4       = 1<<4,
@@ -37,7 +37,6 @@ class TGriffinHit : public TGRSIDetectorHit {
       Int_t fFilter;
 		UChar_t fGriffinHitBits;
       UInt_t fCrystal; //!
-		Int_t fPPG; //!
 
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////
@@ -57,6 +56,7 @@ class TGriffinHit : public TGRSIDetectorHit {
       UInt_t GetCrystal();
       UInt_t SetCrystal(char color);
       UInt_t SetCrystal(UInt_t crynum);
+      Bool_t IsCrystalSet() const {return IsSubDetSet();}
 
 		/////////////////////////		/////////////////////////////////////
 
@@ -74,7 +74,7 @@ class TGriffinHit : public TGRSIDetectorHit {
 		virtual void Print(Option_t *opt = "") const; //!
       virtual void Copy(TGriffinHit&) const;        //!
 
-	ClassDef(TGriffinHit,2);
+	ClassDef(TGriffinHit,3);
 };
 
 

--- a/include/TPaces.h
+++ b/include/TPaces.h
@@ -46,32 +46,12 @@ class TPaces : public TGRSIDetector {
 		
      static bool fSetCoreWave;		         //!  Flag for Waveforms ON/OFF
 
-     static long fCycleStart;                //!  The start of the cycle
-     static long fLastPPG;                   //!  value of the last ppg
-
-     enum  PacesFlags{kCycleStartTime,kTapeMove,kBackGround,kBeamOn,kDecay};
-     TBits fPacesBits;
-
    public:
      static bool SetCoreWave()        { return fSetCoreWave;  }	//!
-
-     void SetTapeMove(Bool_t flag=kTRUE)   { fPacesBits.SetBitNumber(kTapeMove,flag); }  //!
-     void SetBackground(Bool_t flag=kTRUE) { fPacesBits.SetBitNumber(kBackGround,flag);} //!
-     void SetBeamOn(Bool_t flag=kTRUE)     { fPacesBits.SetBitNumber(kBeamOn,flag);}     //!
-     void SetDecay(Bool_t flag=kTRUE)      { fPacesBits.SetBitNumber(kDecay,flag);}      //!
-
-     bool GetTapeMove()   const { return fPacesBits.TestBitNumber(kTapeMove);}//!
-     bool GetBackground() const { return fPacesBits.TestBitNumber(kBackGround);}//!
-     bool GetBeamOn()     const { return fPacesBits.TestBitNumber(kBeamOn);}//!
-     bool GetDecay()      const { return fPacesBits.TestBitNumber(kDecay);}//!
-
-     static int GetCycleTimeInMilliSeconds(long time) { return (int)((time-fCycleStart)/1e5); }//!
-
 
    //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
    private:
     // static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
-     void ClearStatus() { fPacesBits.ResetAllBits(kFALSE); } //!     
 
    public:         
      virtual void Copy(TPaces&) const;                //!
@@ -81,7 +61,7 @@ class TPaces : public TGRSIDetector {
    protected:
      void PushBackHit(TGRSIDetectorHit* phit);
 
-   ClassDef(TPaces,2)  // Paces Physics structure
+   ClassDef(TPaces,3)  // Paces Physics structure
 
 
 };

--- a/include/TPacesData.h
+++ b/include/TPacesData.h
@@ -26,8 +26,6 @@ class TPacesData : public TGRSIDetectorData {
     std::vector<Int_t>        fCore_NbrHits; //!
     std::vector<Int_t>        fCore_MidasId; //!
 
-   std::vector<Int_t>         fPPG; //!
-
     static bool fIsSet; //!
 
   public:
@@ -53,8 +51,6 @@ class TPacesData : public TGRSIDetectorData {
     
     inline void SetCoreWave(const std::vector<Short_t> &CoreWave)	{fCore_Wave.push_back(CoreWave);} //!
 
-    inline void SetPPG(const Int_t &ppg)                 {fPPG.push_back(ppg);               }  //!
-    
     inline void SetCore(TFragment *frag,TChannel *channel,MNEMONIC *mnemonic)	{
 	      if(!frag || !channel || !mnemonic) return;
 
@@ -67,7 +63,6 @@ class TPacesData : public TGRSIDetectorData {
           //core.fCore_IsHighGain = false;
           SetIsHighGain(false);
 
-         SetPPG(frag->PPG);
           //core.fCore_Address = frag->ChannelAddress;
           SetCoreAddress(frag->ChannelAddress);
 
@@ -92,8 +87,6 @@ class TPacesData : public TGRSIDetectorData {
       inline Long_t GetCoreTime(const unsigned int &i) const       {return fCore_Time.at(i);}	//!
 
       inline Bool_t GetIsHighGain(const unsigned int &i) const       {return fCore_IsHighGain.at(i);} //!
-
-      inline Int_t GetPPG(const unsigned int &i) const               {return fPPG.at(i);} //!
 
       inline std::vector<Short_t> GetCoreWave(const unsigned int &i) const {return fCore_Wave.at(i);}	//!
 

--- a/include/TPacesHit.h
+++ b/include/TPacesHit.h
@@ -20,19 +20,16 @@ class TPacesHit : public TGRSIDetectorHit {
 
 	private:
       Int_t filter;
-      Int_t ppg;
 
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////
       inline void SetFilterPattern(const int &x)   { filter = x;   }                  //! 
-      inline void SetPPG(const int &x)             { ppg = x;   }                     //! 
       //void SetHit();
 
       TVector3 GetPosition(Double_t dist = 0.0) const; //!
 
 		/////////////////////////  Getters	/////////////////////////////////////
       inline Int_t    GetFilterPattern() const         {   return filter;   }          //!
-      inline Int_t    GetPPG() const                  {   return ppg;   }             //!
 
 		/////////////////////////  TChannel Helpers /////////////////////////////////////
       bool   InFilter(Int_t);  //!
@@ -42,7 +39,7 @@ class TPacesHit : public TGRSIDetectorHit {
 		virtual void Print(Option_t *opt = "") const; //!
       virtual void Copy(TPacesHit&) const;        //!
 
-	ClassDef(TPacesHit,2);
+	ClassDef(TPacesHit,3);
 };
 
 

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -59,6 +59,7 @@ class TTigressHit : public TGRSIDetectorHit {
 		//void SetDetectorNumber(const int &i) { detector = i;	} 				//!
 		void SetCrystal()	                   { crystal = GetCrystal(); SetFlag(TGRSIDetectorHit::kIsSubDetSet,true); }		//!
 		void SetInitalHit(const int &i)		 { first_segment = i; }				//!
+      Bool_t IsCrystalSet() const {return IsSubDetSet();}
 
 //		void SetPosition(const TVector3 &p)  { position = p;	}					//!
 		//void SetDoppler(const double &d)	   { doppler = d;	}					//!

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -17,9 +17,6 @@ ClassImp(TPaces)
 
 bool TPaces::fSetCoreWave = false;
 
-long TPaces::fCycleStart  = 0;
-long TPaces::fLastPPG     = 0;
-
 TPaces::TPaces() : TGRSIDetector(),pacesdata(0) {
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
@@ -41,7 +38,6 @@ void TPaces::Copy(TPaces &rhs) const {
 
   ((TPaces&)rhs).paces_hits          = paces_hits;
   ((TPaces&)rhs).fSetCoreWave        = fSetCoreWave;
-  ((TPaces&)rhs).fPacesBits          = fPacesBits;
   return;                                      
 }                                       
 
@@ -56,7 +52,6 @@ void TPaces::Clear(Option_t *opt)	{
    if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
      TGRSIDetector::Clear(opt);
      if(pacesdata) pacesdata->Clear();
-     ClearStatus();
    }
 	paces_hits.clear();
 }
@@ -127,13 +122,6 @@ void TPaces::BuildHits(TGRSIDetectorData *data,Option_t *opt)	{
          corehit.SetWaveform(pdata->GetCoreWave(i));
       }
  */
-      corehit.SetPPG(pdata->GetPPG(i));
-
-      if((pdata->GetPPG(i) == 0xd000 && pdata->GetPPG(i) != fLastPPG) || fCycleStart == 0.) { //this is a background event
-         fCycleStart = corehit.GetTime();
-      }
-      fLastPPG = pdata->GetPPG(i);
-      //fCycleStartTime = fCycleStart;
 
       //temp_hits.push_back(corehit);  
       AddHit(&corehit);

--- a/libraries/TGRSIAnalysis/TPaces/TPacesData.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPacesData.cxx
@@ -29,8 +29,6 @@ void TPacesData::Clear(Option_t *opt)	{
 	fCore_TimeCFD.clear();
 	fCore_Time.clear();
 
-   fPPG.clear();
-
 
 	for(int x=0;x<fCore_Wave.size();x++)	{
 		fCore_Wave[x].clear();

--- a/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
@@ -25,7 +25,6 @@ TPacesHit::~TPacesHit()  {	}
 void TPacesHit::Copy(TPacesHit &rhs) const {
   TGRSIDetectorHit::Copy((TGRSIDetectorHit&)rhs);
   ((TPacesHit&)rhs).filter          = filter;
-  ((TPacesHit&)rhs).ppg             = ppg;
   return;                                      
 }                                       
 
@@ -39,7 +38,6 @@ bool TPacesHit::InFilter(Int_t wantedfilter) {
 void TPacesHit::Clear(Option_t *opt)	{
    TGRSIDetectorHit::Clear(opt);    // clears the base (address, position and waveform)
    filter          =  0;
-   ppg             =  0;
    detector        = 0xFFFF;
 }
 


### PR DESCRIPTION
- Took away PPG from any mother classes that had them
- removed ppg data member from a few classes which should save completely unused data space
- This works by loading the gDirectory version of "TPPG". I couldn't think of a better way to do this, so this is how it currently is. If someone else has a better idea of where the static TPPG pointer of TGRSIDetectorHit should point, please let me know. 
- There is also currently no direct functionality to change where this pointer points to once it has been set. This can be changed, but for this version I don't really see a reason to do it. If it stops someone from doing something that they want to do, a static SetPPGPtr function can easily be created.