### PR TITLE
Initial Push of TMultiPeak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ examples
 *User*
 .deps
 .nfs*
+G__auto*

--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -52,12 +52,6 @@ class TGRSIFit : public TF1 {
    Bool_t AddToGlobalList(Bool_t on = kTRUE);
    static Bool_t AddToGlobalList(TF1* func, Bool_t on = kTRUE);
 
-   void operator delete(void *ptr);
-
- protected:
-   void* operator new[](size_t sz) ;
-   void* operator new[](size_t sz, void* vp) ;
-
  protected:
    Bool_t IsInitialized() const { return init_flag; }
    void SetInitialized(Bool_t flag = true) {init_flag = flag;}
@@ -72,6 +66,7 @@ class TGRSIFit : public TF1 {
  public:  
    virtual void Print(Option_t *opt = "") const;
    virtual void Clear(Option_t* opt = "" );
+   virtual void ClearParameters(Option_t *opt = "");
 
    ClassDef(TGRSIFit,0);
 };

--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -16,6 +16,7 @@ namespace TGRSIFunctions {
    Double_t StepFunction(Double_t *dim, Double_t *par);
    Double_t PhotoPeak(Double_t *dim, Double_t *par);
    Double_t PhotoPeakBG(Double_t *dim, Double_t *par);
+   Double_t MultiPhotoPeakBG(Double_t *dim, Double_t *par);
    Double_t Gaus(Double_t *dim, Double_t *par);
    Double_t SkewedGaus(Double_t *dim, Double_t *par);
    Double_t MultiSkewedGausWithBG(Double_t *dim, Double_t *par);

--- a/include/TMultiPeak.h
+++ b/include/TMultiPeak.h
@@ -1,0 +1,68 @@
+#ifndef TMULTIPEAK_H
+#define TMULTIPEAK_H
+
+#include "TGRSIFunctions.h"
+#include "TGRSIFit.h"
+#include "TF1.h"
+#include "TPeak.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <stdarg.h>
+#include "TGraph.h"
+#include "Math/Minimizer.h"
+#include "Math/Factory.h"
+#include "Math/Functor.h"
+
+
+////////////////////////////////////////////////////////////////
+//                                                            //
+// TMultiPeak                                                 //
+//                                                            //
+// This Class is used to represent fitted data that is        //
+// Gaussian like in nature (ie centroid and area).            //
+//                                                            //
+////////////////////////////////////////////////////////////////
+
+class TMultiPeak : public TGRSIFit {
+ public: 
+   //ctors and dtors
+   virtual ~TMultiPeak();
+   //TMultiPeak(int n, ...);
+  // TMultiPeak(double xlow, double xhigh, int n, ...);
+   TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t> &centroids, Option_t *type = "gsc");
+   TMultiPeak(Double_t cent, Double_t xlow, Double_t xhigh, Option_t* type="gsc");
+   TMultiPeak(const TMultiPeak &copy);
+   TMultiPeak(); //I might make it so if you call this ctor, the TPeak yells at you since it's a fairly useless call anyway
+   
+ protected:
+   void InitNames();
+
+ public:
+   Bool_t Fit(TH1* fithist,Option_t *opt = "");
+   bool InitParams(TH1* hist);
+   void SortPeaks(Bool_t (*SortFunction)(const TPeak* ,const TPeak* ) = TPeak::CompareEnergy);
+   TPeak* GetPeak(UInt_t idx);
+
+   static void SetLogLikelihoodFlag(bool flag){ fLogLikelihoodFlag = flag; }
+   static bool GetLogLikelihoodFlag() { return fLogLikelihoodFlag; }
+  
+   virtual void Copy(TObject &obj) const;
+   virtual void Print(Option_t *opt = "") const;
+   virtual void Clear(Option_t *opt = "");
+   virtual const char* PrintString(Option_t *opt = "") const;
+
+ private:
+   static bool fLogLikelihoodFlag; //!
+   std::vector<TPeak*> fPeakVec;
+   TF1* background;
+
+   static Double_t MultiPhotoPeakBG(Double_t *dim, Double_t *par); 
+
+  ClassDef(TMultiPeak,2);
+
+};
+
+#endif

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -23,6 +23,7 @@ using namespace TGRSIFunctions;
 ////////////////////////////////////////////////////////////////
 
 class TPeak : public TGRSIFit {
+   friend class TMultiPeak;
  public: 
    //ctors and dtors
    virtual ~TPeak();
@@ -60,6 +61,8 @@ class TPeak : public TGRSIFit {
    void SetArea(Double_t a){farea = a;}
    void SetAreaErr(Double_t d_a){fd_area = d_a;}
    void SetArea(Double_t a, Double_t d_a){SetArea(a);SetAreaErr(d_a);}
+   void SetChi2(Double_t chi2)   { fchi2 = chi2;}
+   void SetNdf(Double_t Ndf)     { fNdf  = Ndf; } 
 
  public:
    Bool_t InitParams(TH1 *fithist = 0);

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -36,6 +36,12 @@ void TGRSIFit::Clear(Option_t *opt) {
    fDefaultFitType.Clear();
 }
 
+void TGRSIFit::ClearParameters(Option_t *opt){
+   for(int i =0; i< GetNpar();++i){
+      SetParameter(i,0);
+   }
+}
+
 Bool_t TGRSIFit::AddToGlobalList(Bool_t on){
    // Add to global list of functions (gROOT->GetListOfFunctions() )
    // return previous status (true of functions was already in the list false if not)

--- a/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -1,0 +1,402 @@
+#include "TMultiPeak.h"
+
+ClassImp(TMultiPeak)
+
+Bool_t TMultiPeak::fLogLikelihoodFlag = false;
+
+
+TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t> &centroids, Option_t *opt) : TGRSIFit("multipeakbg",MultiPhotoPeakBG,xlow,xhigh,centroids.size()*6 +5){
+   this->Clear();
+
+   for(int i=0; i<centroids.size(); i++){
+      Bool_t out_of_range_flag = false;
+      Double_t cent = centroids.at(i);
+      if(cent > xhigh){
+         printf("centroid %lf is higher than range\n",cent);
+         out_of_range_flag = true;
+      }
+      else if (cent < xlow){
+         printf("centroid %lf is lower than range\n", cent);
+         out_of_range_flag = true;
+      }
+      if(out_of_range_flag){
+         printf("ignoring peak at %lf, make a new multi peak with the corrected energy\n",cent);
+      }
+      else{
+         TPeak* peak = new TPeak(cent,xlow,xhigh);
+         peak->AddToGlobalList(kFALSE);
+         fPeakVec.push_back(peak);
+      }
+   }
+   this->SetRange(xlow,xhigh);
+
+   this->SetName(Form("MultiPeak_%d_to_%d",(Int_t)(xlow),(Int_t)(xhigh))); //Gives a default name to the peak
+   this->SortPeaks();//Defaults to sorting by TPeak::CompareEnergy
+   this->InitNames();
+
+   background = new TF1(Form("MPbackground_%d_to_%d",(Int_t)(xlow),(Int_t)(xhigh)),TGRSIFunctions::StepBG,xlow,xhigh,10);
+   background->SetNpx(1000);
+   background->SetLineStyle(2);
+   background->SetLineColor(kBlack);
+   TGRSIFit::AddToGlobalList(background,kFALSE);
+   
+}
+
+TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg",MultiPhotoPeakBG,0,1000,10){
+   this->InitNames();
+   background = new TF1("background",TGRSIFunctions::StepBG,0,1000,10);
+   background->SetNpx(1000);
+   background->SetLineStyle(2);
+   background->SetLineColor(kBlack);
+   TGRSIFit::AddToGlobalList(background,kFALSE);
+}
+
+TMultiPeak::~TMultiPeak(){
+   if(background){ 
+      delete background;
+   }
+   
+   for(int i=0; i<fPeakVec.size(); ++i){
+      if(fPeakVec.at(i)){
+            delete fPeakVec.at(i);
+      }
+   }
+
+}
+
+void TMultiPeak::SortPeaks(Bool_t (*SortFunction)(const TPeak* ,const TPeak* )) { 
+   std::sort( fPeakVec.begin(), fPeakVec.end(), SortFunction);
+}
+
+
+void TMultiPeak::InitNames(){
+   this->SetParName(0,"N_Peaks");
+   this->SetParName(1,"A");
+   this->SetParName(2,"B");
+   this->SetParName(3,"C");
+   this->SetParName(4,"bg_offset");
+
+   for(int i=0; i<fPeakVec.size();++i){
+      Int_t cent = static_cast<Int_t>(fPeakVec.at(i)->GetCentroid());
+
+      this->SetParName(6*i+5,Form("Height_%i",i));
+      this->SetParName(6*i+6,Form("Centroid_%i",i));
+      this->SetParName(6*i+7,Form("Sigma_%i",i));
+      this->SetParName(6*i+8,Form("Beta_%i",i));
+      this->SetParName(6*i+9,Form("R_%i",i));
+      this->SetParName(6*i+10,Form("Step_%i",i));
+   }
+   this->FixParameter(0,fPeakVec.size());
+}
+
+
+TMultiPeak::TMultiPeak(const TMultiPeak &copy) : background(0) {
+   ((TMultiPeak&)copy).Copy(*this);
+}
+
+void TMultiPeak::Copy(TObject &obj) const {
+   TGRSIFit::Copy(obj);
+   TMultiPeak *mpobj = (TMultiPeak*)(&obj);
+   if(!(mpobj->background)) 
+      mpobj->background = new TF1(*(background));
+   else
+      *(mpobj->background) = *background;
+
+   TGRSIFit::AddToGlobalList(background,kFALSE);
+
+   //Copy all of the TPeaks.
+   for(int i=0; i<fPeakVec.size();++i){
+      TPeak* peak = new TPeak(*(fPeakVec.at(i)));
+      peak->AddToGlobalList(kFALSE);
+      mpobj->fPeakVec.push_back(peak);
+   }
+
+}
+
+Bool_t TMultiPeak::InitParams(TH1 *fithist){
+//Makes initial guesses at parameters for the fit. Uses the histogram to make the initial guesses
+   if(!fithist && GetHist()) 
+      fithist = GetHist();
+
+   if(!fithist){
+      printf("No histogram is associated yet, no initial guesses made\n");
+      return false;
+   }
+
+   this->FixParameter(0,fPeakVec.size());
+   //This is the range for the fit.
+   Double_t xlow,xhigh;
+   GetRange(xlow,xhigh);
+   Int_t binlow = fithist->GetXaxis()->FindBin(xlow);
+   Int_t binhigh = fithist->GetXaxis()->FindBin(xhigh);
+   Double_t binWidth = fithist->GetBinWidth(xhigh);
+
+   //Initialize background
+   this->SetParLimits(1,0.0,fithist->GetBinContent(binlow)*100.0);
+   this->SetParameter("A",fithist->GetBinContent(binlow));
+   this->SetParameter("B",(fithist->GetBinContent(binlow) - fithist->GetBinContent(binhigh))/(xlow-xhigh));
+   this->SetParameter("C",0.0000);
+   this->SetParameter("bg_offset",(xhigh+xlow)/2.0);
+
+   //We need to initialize parameters for every peak in the fit
+   for(int i=0; i<fPeakVec.size();++i){
+      Int_t bin = fithist->GetXaxis()->FindBin(fPeakVec.at(i)->GetCentroid());
+      printf("BIN: %d\n",bin);
+      this->SetParLimits(6*i+5,-fithist->GetBinContent(bin),fithist->GetBinContent(bin)*5.);
+      this->SetParLimits(6*i+6,bin-4,bin+4);
+      this->SetParLimits(6*i+7,0.1,xhigh-xlow);//This will be linked to other peaks eventually.
+      this->SetParLimits(6*i+8,0.000001,10);
+      this->SetParLimits(6*i+9,0.000001,100);
+      this->SetParLimits(6*i+10,0.0,1.0E2);
+      //Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+
+      //Now set the actual paramter to start the fit from these points
+      this->SetParameter(Form("Height_%i",i),fithist->GetBinContent(bin));
+      this->SetParameter(Form("Centroid_%i",i),bin);
+      //  this->SetParameter("sigma",(xhigh-xlow)*0.5); // slightly more robust starting value for sigma -JKS
+      //  this->SetParameter("sigma",1.0/binWidth); // slightly more robust starting value for sigma -JKS
+      this->SetParameter(Form("Sigma_%i",i),TMath::Sqrt(9.0 + 4.*GetParameter(Form("Centroid_%i",i))/1000.));
+      this->SetParameter(Form("Beta_%i",i),GetParameter(Form("Sigma_%i",i))/2.0);
+      this->SetParameter(Form("R_%i",i), 1.0);
+      this->SetParameter(Form("Step_%i",i),1.0);
+
+      //Fix beta and R. These will be released if they are needed (or can be asked to be released).
+      this->FixParameter(6*i+8,GetParameter(Form("Beta_%i",i)));
+      this->FixParameter(6*i+9,0.00);
+      TF1::Print();
+
+   }
+
+   SetInitialized();
+   return true;
+}
+
+Bool_t TMultiPeak::Fit(TH1* fithist,Option_t *opt){
+   TString optstr = opt;
+   if(!fithist && !GetHist()){
+      printf("No hist passed, trying something...");
+      fithist = fHistogram;
+   }
+   if(!fithist){
+      printf("No histogram associated with Peak\n");
+      return false;
+   }
+   if(!IsInitialized()) 
+      InitParams(fithist);
+
+   TVirtualFitter::SetMaxIterations(100000);
+   ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2","Combination");
+   SetHist(fithist);
+
+   TString options(opt); bool print_flag = true;
+   if(options.Contains("Q"))
+     print_flag = false;
+
+   //Now that it is initialized, let's fit it.
+
+   TFitResultPtr fitres;
+   //Log likelihood is the proper fitting technique UNLESS the data is a result of an addition or subtraction.
+   if(GetLogLikelihoodFlag()){
+      fitres = fithist->Fit(this,Form("%sLRS",opt));//The RS needs to always be there
+   }
+   else{
+      fitres = fithist->Fit(this,Form("%sRS",opt));//The RS needs to always be there
+   }
+
+   //After performing this fit I want to put something here that takes the fit result (good,bad,etc)
+   //for printing out. RD
+
+   Int_t fitStatus = fitres; //This returns a fit status from the TFitResult Ptr
+   //This removes the background parts of the fit form the integral error, while maintaining the covariance between the fits and the background.
+   TMatrixDSym CovMat = fitres->GetCovarianceMatrix();
+   CovMat(0,0) = 0.0;
+   CovMat(1,1) = 0.0;
+   CovMat(2,2) = 0.0;
+   CovMat(3,3) = 0.0;
+   CovMat(4,4) = 0.0;
+//   printf("covmat ");CovMat.Print();
+
+   //We now make a copy of the covariance matrix that has completel 0 diagonals so that we can remove the other peaks form the integral error.
+   //This is done by adding back the peak of interest on the diagonal when it is integrated.
+   TMatrixDSym emptyCovMat = CovMat;
+   for(int i =0; i<fPeakVec.size();++i){
+      emptyCovMat(6*i+5,6*i+5) = 0.0;
+      emptyCovMat(6*i+6,6*i+6) = 0.0;
+      emptyCovMat(6*i+7,6*i+7) = 0.0;
+      emptyCovMat(6*i+8,6*i+8) = 0.0;
+      emptyCovMat(6*i+9,6*i+9) = 0.0;
+      emptyCovMat(6*i+10,6*i+10) = 0.0;
+ //  printf("empt covmat ");emptyCovMat.Print();
+   }
+
+/*
+   if(fitres->ParError(2) != fitres->ParError(2)){ //Check to see if nan
+      if(fitres->Parameter(3) < 1){
+         InitParams(fithist);
+         FixParameter(4,0);
+         FixParameter(3,1);
+         std::cout << "Beta may have broken the fit, retrying with R=0" << std::endl;
+   	 // Leaving the log-likelihood argument out so users are not constrained to just using that. - JKS
+         fithist->GetListOfFunctions()->Last()->Delete();
+         if(GetLogLikelihoodFlag()){
+            fitres = fithist->Fit(this,Form("%sLRS",opt));//The RS needs to always be there
+         }
+         else{
+            fitres = fithist->Fit(this,Form("%sRS",opt));
+         }
+      }
+   }*/
+/*   if(fitres->Parameter(5) < 0.0){
+      FixParameter(5,0);
+      std::cout << "Step < 0. Retrying fit with stp = 0" << std::endl;
+      fitres = fithist->Fit(this,Form("%sRSML",opt));
+   }
+*/
+   /*
+*/
+   if(print_flag) printf("Chi^2/NDF = %lf\n",fitres->Chi2()/fitres->Ndf());
+   //We will now set the parameters of each of the peaks based on the fits.
+   for(int i=0; i< fPeakVec.size();++i){
+      TMultiPeak *tmpMp = new TMultiPeak(*this);
+      tmpMp->ClearParameters();//We need to clear all of the parameters so that we can add the ones we want back in
+      Double_t binWidth = fithist->GetBinWidth(GetParameter(Form("Centroid_%i",i)));
+      TPeak *peak = fPeakVec.at(i);
+      TMatrixDSym tmpCovMat = emptyCovMat;
+      peak->SetParameter("Height",GetParameter(Form("Height_%i",i)));
+      peak->SetParameter("centroid",GetParameter(Form("Centroid_%i",i)));
+      peak->SetParameter("sigma",GetParameter(Form("Sigma_%i",i)));
+      peak->SetParameter("beta",GetParameter(Form("Beta_%i",i)));
+      peak->SetParameter("R",GetParameter(Form("R_%i",i)));
+      peak->SetParameter("step",0.0);
+      peak->SetParameter("A",0.0);
+      peak->SetParameter("B",0.0);
+      peak->SetParameter("C",0.0);
+      peak->SetParameter("bg_offset",0.0);
+      peak->SetChi2(fitres->Chi2());  
+      peak->SetNdf(fitres->Ndf());
+     // printf("tmp cov mat: ");tmpCovMat.Print();
+
+      //Set the important diagonals for the integral of the covariance matrix
+      tmpCovMat(6*i+5,6*i+5) = CovMat(6*i+5,6*i+5);
+      tmpCovMat(6*i+6,6*i+6) = CovMat(6*i+6,6*i+6);
+      tmpCovMat(6*i+7,6*i+7) = CovMat(6*i+7,6*i+7);
+      tmpCovMat(6*i+8,6*i+8) = CovMat(6*i+8,6*i+8);
+      tmpCovMat(6*i+9,6*i+9) = CovMat(6*i+9,6*i+9);
+      
+      tmpMp->SetParameter("N_Peaks",GetParameter("N_Peaks"));
+      tmpMp->SetParameter(Form("Height_%i",i),GetParameter(Form("Height_%i",i)));
+      tmpMp->SetParameter(Form("Centroid_%i",i),GetParameter(Form("Centroid_%i",i)));
+      tmpMp->SetParameter(Form("Sigma_%i",i),GetParameter(Form("Sigma_%i",i)));
+      tmpMp->SetParameter(Form("Beta_%i",i),GetParameter(Form("Beta_%i",i)));
+      tmpMp->SetParameter(Form("R_%i",i),GetParameter(Form("R_%i",i)));
+ //     peak->SetParameter("step",GetParameter(Form("Step_%i",i)));
+
+   
+      Double_t width = this->GetParameter(Form("Sigma_%i",i));
+      Double_t xlow,xhigh;
+      Double_t int_low, int_high; 
+      this->GetRange(xlow,xhigh);
+      int_low = xlow - 5.*width; // making the integration bounds a bit smaller, but still large enough. -JKS
+      int_high = xhigh + 5.*width;
+
+      //Make a function that does not include the background
+      //Intgrate the background.
+      tmpMp->SetRange(int_low,int_high);//This will help get the true area of the gaussian 200 ~ infinity in a gaus
+   //   peak->SetName("tmppeak");
+      
+      //This is where we will do integrals and stuff.
+      peak->SetArea((tmpMp->Integral(int_low,int_high))/binWidth);
+      peak->SetAreaErr((tmpMp->IntegralError(int_low,int_high,tmpMp->GetParameters(),tmpCovMat.GetMatrixArray())) /binWidth);
+      peak->SetParameter("centroid",GetParameter(Form("Centroid_%i",i)));
+      peak->SetParError(peak->GetParNumber("centroid"),GetParError(GetParNumber(Form("Centroid_%i",i))));
+      peak->SetParameter("sigma",GetParameter(GetParNumber(Form("Sigma_%i",i))));
+      peak->SetParError(peak->GetParNumber("sigma"),GetParError(GetParNumber(Form("Sigma_%i",i))));
+   if(print_flag) printf("Integral: %lf +/- %lf\n",peak->GetArea(),peak->GetAreaErr());
+   }
+
+   //Set the background for drawing later
+ //  background->SetParameters(this->GetParameters());
+  //To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix
+  // Copy(*fithist->GetListOfFunctions()->Last());
+  // if(optstr.Contains("+"))
+  //    Copy(*fithist->GetListOfFunctions()->Before(fithist->GetListOfFunctions()->Last()));
+  
+ //     peak->SetParameter("step",GetParameter(Form("Step_%i",i)));
+//   delete tmppeak;
+   return true;
+}
+
+
+void TMultiPeak::Clear(Option_t* opt){
+   TGRSIFit::Clear(opt);
+   for(int i =0; i<fPeakVec.size(); ++i){
+      if(fPeakVec.at(i)){
+         delete fPeakVec.at(i);
+         fPeakVec.at(i) = 0;
+      }
+   }
+   fPeakVec.clear();
+
+}
+
+void TMultiPeak::Print(Option_t *opt) const {
+//Prints TMultiPeak properties. To see More properties use the option "+"
+   printf("Name:        %s \n", this->GetName()); 
+   printf("Number of Peaks: %lu\n",fPeakVec.size());
+   TF1::Print();
+   for(int i=0; i<fPeakVec.size(); ++i){
+      printf("Peak: %i\n",i);
+      fPeakVec.at(i)->Print(opt);
+      printf("\n");
+
+   }
+}
+
+const char * TMultiPeak::PrintString(Option_t *opt) const {
+//Prints TMultiPeak properties to a string, returns the string.
+   /*
+   std::string temp;
+   temp.assign("Name:        ");temp.append(this->GetName()); temp.append("\n");
+   temp.append("Centroid:    ");temp.append(Form("%lf",this->GetParameter("centroid")));
+                                temp.append(" +/- ");
+                                temp.append(Form("%lf",this->GetParError(GetParNumber("centroid")))); temp.append("\n");
+   temp.append("Area: 	     ");temp.append(Form("%lf",farea)); 
+                                temp.append(" +/- ");
+                                temp.append(Form("%lf",fd_area));    temp.append("\n"); 
+   temp.append("Chi^2/NDF:   ");temp.append(Form("%lf",fchi2/fNdf)); temp.append("\n");
+   //if(strchr(opt,'+') != NULL){
+   //   TF1::Print();
+   //   TGRSIFit::Print(opt); //Polymorphise this a bit better
+   //}
+   return temp.c_str();*/
+   return "b";
+}
+
+
+Double_t TMultiPeak::MultiPhotoPeakBG(Double_t *dim, Double_t *par) {
+  // Limits need to be imposed or error states may occour.
+  //
+   //General background.
+   int npeaks = (int)(par[0]+0.5);
+	double result = TGRSIFunctions::PolyBg(dim,&par[1],2); // polynomial background. uses par[1->4]
+	for(int i=0;i<npeaks;i++){// par[0] is number of peaks
+		Double_t tmp_par[6];
+  	   tmp_par[0]   = par[6*i+5]; //height of photopeak
+  	   tmp_par[1]   = par[6*i+6]; //Peak Centroid of non skew gaus
+  	   tmp_par[2]   = par[6*i+7]; //standard deviation  of gaussian
+  	   tmp_par[3]   = par[6*i+8]; //"skewedness" of the skewed gaussian
+  	   tmp_par[4]   = par[6*i+9]; //relative height of skewed gaussian
+      tmp_par[5]   = par[6*i+10]; //Size of step in background
+		result += TGRSIFunctions::PhotoPeak(dim,tmp_par) + TGRSIFunctions::StepFunction(dim,tmp_par);
+	}
+	return result;
+}
+
+TPeak* TMultiPeak::GetPeak(UInt_t idx){
+   if(idx < fPeakVec.size())
+      return fPeakVec.at(idx);
+   else
+      printf("No matching peak at index %u\n",idx);
+
+   return 0;
+}

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -201,9 +201,9 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
 
    SetHist(fithist);
 
-   TString options(opt); bool Print = true;
+   TString options(opt); bool print_flag = true;
    if(options.Contains("Q"))
-     Print = false;
+     print_flag = false;
 
    //Now that it is initialized, let's fit it.
    //Just in case the range changed, we should reset the centroid and bg energy limits
@@ -248,7 +248,7 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
 */
    Double_t binWidth = fithist->GetBinWidth(GetParameter("centroid"));
    Double_t width = this->GetParameter("sigma");
-   if(Print) printf("Chi^2/NDF = %lf\n",fitres->Chi2()/fitres->Ndf());
+   if(print_flag) printf("Chi^2/NDF = %lf\n",fitres->Chi2()/fitres->Ndf());
    fchi2 = fitres->Chi2();  fNdf = fitres->Ndf();
    Double_t xlow,xhigh;
    Double_t int_low, int_high; 
@@ -274,15 +274,15 @@ Bool_t TPeak::Fit(TH1* fithist,Option_t *opt){
    farea = (tmppeak->Integral(int_low,int_high))/binWidth;
    //Set the background values in the covariance matrix to 0, while keeping their covariance errors
    TMatrixDSym CovMat = fitres->GetCovarianceMatrix();
-   //CovMat(5,5) = 0.0;
+   CovMat(5,5) = 0.0;
    CovMat(6,6) = 0.0;
    CovMat(7,7) = 0.0;
    CovMat(8,8) = 0.0;
    CovMat(9,9) = 0.0;
-
+   CovMat.Print();
    fd_area = (tmppeak->IntegralError(int_low,int_high,tmppeak->GetParameters(),CovMat.GetMatrixArray())) /binWidth;
 
-   if(Print) printf("Integral: %lf +/- %lf\n",farea,fd_area);
+   if(print_flag) printf("Integral: %lf +/- %lf\n",farea,fd_area);
    //Set the background for drawing later
    background->SetParameters(this->GetParameters());
    //To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix

--- a/libraries/TGRSIAnalysis/TGRSIFit/makefile
+++ b/libraries/TGRSIAnalysis/TGRSIFit/makefile
@@ -1,5 +1,5 @@
 
-OBJECTS = TGRSIFunctions.o TGRSIFunctionsDict.o TGRSIFit.o TGRSIFitDict.o TPeak.o TPeakDict.o 
+OBJECTS = TGRSIFunctions.o TGRSIFunctionsDict.o TGRSIFit.o TGRSIFitDict.o TPeak.o TPeakDict.o TMultiPeak.o TMultiPeakDict.o
 NAME = TGRSIFit
 
 -include ../../../make.rules

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ export CFLAGS += -DOS_DARWIN -DHAVE_ZLIB #-lz
 export CFLAGS += -I/opt/X11/include -Qunused-arguments
 export LFLAGS = -dynamiclib -undefined dynamic_lookup -single_module -Wl,-install_name,'@executable_path/../libraries/$$@'
 export SHAREDSWITCH = -install_name # ENDING SPACE
-export CPP = clang++ 
+export CPP = clang++
 export CXX = clang++
 else
 export __LINUX__:= 1	


### PR DESCRIPTION
- Can fit multiple peaks at the same time.
- Uses a vector of centroids as input.
- One can clear all of the parameters of a TGRSIFit using `TGRSIFit::ClearParameters()`. Note that `TGRSIFit::Clear()` nor `TF1::Clear()` do this for you.

Future work:
- Will add a draw that will show deconvolution of the various peaks and background.
- will add a "click-click-(click*n_peaks)-fit" or search fit function
- Will add a residuals draw drop down option
The above will make TPeak more of a container than the actual fitter like we have been using it (although that functionality will remain).