### PR TITLE
Fixed a mistake in TGriffinHit.cxx

### DIFF
--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -102,12 +102,16 @@ UInt_t TGriffinHit::SetCrystal(char color) {
    switch(color) {
       case 'B':
          fCrystal = 0;
+         break;
       case 'G':
          fCrystal = 1;
+         break;
       case 'R':
          fCrystal = 2;
+         break;
       case 'W':
          fCrystal = 3;  
+         break;
    };
    SetFlag(TGRSIDetectorHit::kIsSubDetSet,true);
    return fCrystal;


### PR DESCRIPTION
There were no breaks in the SetCrystal switch statement. This caused the crystals to always be set as white.