### PR TITLE
Fixed incorrect parentheses placement in CompareEnergy function

### DIFF
--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -118,7 +118,7 @@ UInt_t TGriffinHit::SetCrystal(char color) {
 }
 
 bool TGriffinHit::CompareEnergy(const TGriffinHit *lhs, const TGriffinHit *rhs)	{
-   return(lhs->GetEnergy()) > rhs->GetEnergy();
+   return(lhs->GetEnergy() > rhs->GetEnergy());
 }
 
 void TGriffinHit::Add(const TGriffinHit *hit)	{


### PR DESCRIPTION
This would impact the position, time, and address assignments for addback events.