### PR TITLE
Read RunInfo from file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ examples
 .deps
 .nfs*
 G__auto*
+*.log

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -57,6 +57,7 @@
 #include <TObject.h>
 #include <TTree.h>
 #include <TFile.h>
+#include <TKey.h>
 
 #include "TChannel.h"
 
@@ -71,7 +72,8 @@ class TGRSIRunInfo : public TObject {
                         // order to write this class to a tree.
                         // pcb.
       
-      static void ReadInfoFromFile(TGRSIRunInfo *temp);
+      static void SetRunInfo(TGRSIRunInfo *temp);
+      static Bool_t ReadInfoFromFile(TFile *tempf = 0);
 
       static const char* GetGRSIVersion() { return fGRSIVersion.c_str(); } 
       static void ClearGRSIVersion() { fGRSIVersion.clear(); } 

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -148,11 +148,43 @@ TGRSIRunInfo *TGRSIRunInfo::Get() {
    return fGRSIRunInfo;
 }
 
-void TGRSIRunInfo::ReadInfoFromFile(TGRSIRunInfo *tmp) {
+void TGRSIRunInfo::SetRunInfo(TGRSIRunInfo *tmp) {
    //Sets the TGRSIRunInfo to the info passes as tmp.
    if(fGRSIRunInfo)
       delete fGRSIRunInfo;
    fGRSIRunInfo = tmp;
+}
+
+Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile *tempf){
+
+   TDirectory *savdir = gDirectory;
+   if(tempf)
+      tempf->cd();
+
+   if (!(gDirectory->GetFile())){
+      printf("File does not exist\n");
+      savdir->cd();
+      return false;
+   }
+
+   tempf = gDirectory->GetFile();
+
+   TList *list =  tempf->GetListOfKeys();
+   TIter iter(list);
+
+   TGRSIRunInfo *tmpinfo;
+
+   //while(TObject *obj = ((TKey*)(iter.Next()))->ReadObj()) {
+   while(TKey *key = (TKey*)(iter.Next())) {
+      if(!key || strcmp(key->GetClassName(),"TGRSIRunInfo"))
+         continue;
+      TGRSIRunInfo::SetRunInfo((TGRSIRunInfo*)key->ReadObj());
+      savdir->cd();
+      return true;
+   }
+     savdir->cd();
+     return false;
+
 }
 
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -117,7 +117,7 @@ void TGRSIint::ApplyOptions() {
 
    // read in TGRSIRunInfo  
    if(TGRSIOptions::GetInputRoot().size() > 0) {
-      ProcessLine("TGRSIRunInfo->Get();");
+      ProcessLine("TGRSIRunInfo::ReadInfoFromFile()");
    }
 
    if(TGRSIOptions::WorkHarder()) {

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -102,10 +102,12 @@ void TGRSIint::ApplyOptions() {
       if(TGRSIOptions::GetInputRoot().at(0).find("fragment") != std::string::npos){
          Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(FragmentTree)");
          printf("Read calibration info for %d channels from \"%s\" FragmentTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str()); 
+         TGRSIRunInfo::ReadInfoFromFile();
       }   
       if(TGRSIOptions::GetInputRoot().at(0).find("analysis") != std::string::npos){ 
          Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(AnalysisTree)");    
          printf("Read calibration info for %d channels from \"%s\" AnalysisTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str());
+         TGRSIRunInfo::ReadInfoFromFile();
       }
    }
 
@@ -113,11 +115,6 @@ void TGRSIint::ApplyOptions() {
       for(int i =0; i<TGRSIOptions::GetInputCal().size();++i){
          TChannel::ReadCalFile(TGRSIOptions::GetInputCal().at(i).c_str());
       }
-   }
-
-   // read in TGRSIRunInfo  
-   if(TGRSIOptions::GetInputRoot().size() > 0) {
-      ProcessLine("TGRSIRunInfo::ReadInfoFromFile()");
    }
 
    if(TGRSIOptions::WorkHarder()) {


### PR DESCRIPTION
This is written in order to read the run info from the gDirectory if there is run info in the gDirectory. You can also pass a pointer to a file, such as `TGRSIRunInfo::ReadRunInfo(_file1);` The old function that @SmithJK changed has been changed to `SetRunInfo(TGRSIRunInfo*);`

I believe the last fragment, or analysis file processed is the RunInfo that is automatically loaded. It works the same as the TChannels except that you never "load in" the run info into a standard session as it is mostly used during sorting time. I'm not sure which run info would be loaded if you put a few analysis files on the command line, and then also sorted a fragment tree. However, I think that in that scenario you can print the runinfo and see which run it is using. Also I don't think it would ever be useful to do the above, so it may be a bug we just live with because it might always be nonsense.

@SmithJK, you seem to use the .info files more than me, so maybe you have some ideas to try and break this, my testing of this is pretty limited.