### PR TITLE
Updated Makefile for Html Docs

### DIFF
--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -50,9 +50,6 @@ class TGriffin : public TGRSIDetector {
       void FillData(TFragment*,TChannel*,MNEMONIC*); //!
 
       TGriffin& operator=(const TGriffin&);  //!
-
-      //void AddHit(TGriffinHit *hit) { griffin_hits.push_back(*hit); }
-
       
 #ifndef __CINT__
       void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { fAddback_criterion = criterion; }
@@ -76,8 +73,7 @@ class TGriffin : public TGRSIDetector {
       //static bool fSetBGOWave;		            //!  Flag for BGO Waveforms ON/OFF
 
       long fCycleStart;                //!  The start of the cycle
-
-      UChar_t fGriffinBits;
+      UChar_t fGriffinBits;            // Transient member flags
 
       std::vector <TGriffinHit> fAddback_hits; //! Used to create addback hits on the fly
       std::vector <UShort_t> fAddback_frags; //! Number of crystals involved in creating in the addback hit
@@ -87,7 +83,6 @@ class TGriffin : public TGRSIDetector {
       //static bool SetBGOHits()       { return fSetBGOHits;   }	//!
       //static bool SetBGOWave()	    { return fSetBGOWave;   } //!
 
-      //  void AddHit(TGRSIDetectorHit *hit,Option_t *opt="");//!
    private:
       static TVector3 gCloverPosition[17];               //! Position of each HPGe Clover
       void ClearStatus() { fGriffinBits = 0; } //!

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -34,9 +34,9 @@ class TGriffinHit : public TGRSIDetectorHit {
 		virtual ~TGriffinHit();
 
 	private:
-      Int_t fFilter;
-		UChar_t fGriffinHitBits;
-      UInt_t fCrystal; //!
+      Int_t fFilter;             //  The Filter Word
+		UChar_t fGriffinHitBits;   //  Transient Member Flags
+      UInt_t fCrystal;           //! Crystal Number       
 
 	public:
 		/////////////////////////  Setters	/////////////////////////////////////

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -61,6 +61,7 @@ TVector3 TGriffin::gCloverPosition[17] = {
 
 
 TGriffin::TGriffin() : TGRSIDetector(),grifdata(0) { //  ,bgodata(0)	{
+//Default ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -68,6 +69,7 @@ TGriffin::TGriffin() : TGRSIDetector(),grifdata(0) { //  ,bgodata(0)	{
 }
 
 TGriffin::TGriffin(const TGriffin& rhs) {
+//Copy ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -75,6 +77,7 @@ TGriffin::TGriffin(const TGriffin& rhs) {
 }
 
 void TGriffin::Copy(TGriffin &rhs) const {
+  //Copy function.
   TGRSIDetector::Copy((TGRSIDetector&)rhs);
 
   ((TGriffin&)rhs).grifdata     = 0;
@@ -88,11 +91,6 @@ void TGriffin::Copy(TGriffin &rhs) const {
   ((TGriffin&)rhs).fCycleStart         = fCycleStart;
   ((TGriffin&)rhs).fGriffinBits        = fGriffinBits;
 
-   //((TGriffin&)rhs).fSetBGOWave         = fSetBGOWave;
-  //((TGriffin&)rhs).ftapemove           = ftapemove;
-  //((TGriffin&)rhs).fbackground         = fbackground;
-  //((TGriffin&)rhs).fbeamon             = fbeamon;      
-  //((TGriffin&)rhs).fdecay              = fdecay;       
   return;                                      
 }                                       
 
@@ -104,34 +102,6 @@ TGriffin::~TGriffin()	{
    }
    //if(bgodata)  delete bgodata;
 }
-
-//void TGriffin::InitCloverPositions() {
-   ////Initiallizes the HPGe Clover positions as per the wiki <https://www.triumf.info/wiki/tigwiki/index.php/HPGe_Coordinate_Table>
-   //gCloverPosition[0].SetMagThetaPhi(1.0,TMath::DegToRad()*(0.0),TMath::DegToRad()*(0.0));
-//
-   ////Downstream lampshade
-   //gCloverPosition[1].SetMagThetaPhi(1.0,TMath::DegToRad()*(45.0),TMath::DegToRad()*(67.5));
-   //gCloverPosition[2].SetMagThetaPhi(1.0,TMath::DegToRad()*(45.0),TMath::DegToRad()*(157.5));
-   //gCloverPosition[3].SetMagThetaPhi(1.0,TMath::DegToRad()*(45.0),TMath::DegToRad()*(247.5));
-   //gCloverPosition[4].SetMagThetaPhi(1.0,TMath::DegToRad()*(45.0),TMath::DegToRad()*(337.5));
-//
-   ////Corona
-   //gCloverPosition[5].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(22.5));
-   //gCloverPosition[6].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(67.5));
-   //gCloverPosition[7].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(112.5));
-   //gCloverPosition[8].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(157.5));
-   //gCloverPosition[9].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(202.5));
-   //gCloverPosition[10].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(247.5));
-   //gCloverPosition[11].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(292.5));
-   //gCloverPosition[12].SetMagThetaPhi(1.0,TMath::DegToRad()*(90.0),TMath::DegToRad()*(337.5));
-//
-   ////Upstream lampshade
-   //gCloverPosition[13].SetMagThetaPhi(1.0,TMath::DegToRad()*(135.0),TMath::DegToRad()*(67.5));
-   //gCloverPosition[14].SetMagThetaPhi(1.0,TMath::DegToRad()*(135.0),TMath::DegToRad()*(157.5));
-   //gCloverPosition[15].SetMagThetaPhi(1.0,TMath::DegToRad()*(135.0),TMath::DegToRad()*(247.5));
-   //gCloverPosition[16].SetMagThetaPhi(1.0,TMath::DegToRad()*(135.0),TMath::DegToRad()*(337.5));
-      //
-//}
 
 void TGriffin::Clear(Option_t *opt)	{
    //Clears the mother, all of the hits and any stored data
@@ -151,7 +121,7 @@ void TGriffin::Clear(Option_t *opt)	{
 
 void TGriffin::Print(Option_t *opt) const {
   //Prints out TGriffin members, currently does nothing.
-  printf("grifdata = 0x%p\n",grifdata);
+  printf("grifdata = %p\n",grifdata);
   if(grifdata) grifdata->Print();
   //printf("bgodata  = 0x%p\n",bgodata);
   //if(bgodata) bgodata->Print();
@@ -214,7 +184,7 @@ TGriffinHit* TGriffin::GetGriffinHit(const int i) {
 }
 
 Int_t TGriffin::GetAddbackMultiplicity() {
-   // Automatically builds the addback hits using the addback_criterion (if the size of the addback_hits vector is zero) and return the number of addback hits
+   // Automatically builds the addback hits using the addback_criterion (if the size of the addback_hits vector is zero) and return the number of addback hits.
    if(griffin_hits.size() == 0) {
       return 0;
    }
@@ -444,6 +414,7 @@ UShort_t TGriffin::GetNAddbackFrags(int idx) const{
 }
 
 void TGriffin::SetBitNumber(enum EGriffinBits bit,Bool_t set){
+   //Used to set the flags that are stored in TGriffin.
    if(set)
       fGriffinBits |= bit;
    else

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -6,6 +6,7 @@
 ClassImp(TGriffinHit)
 
 TGriffinHit::TGriffinHit():TGRSIDetectorHit()	{	
+   //Default Ctor. Ignores TObject Streamer in ROOT < 6.
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -13,6 +14,7 @@ TGriffinHit::TGriffinHit():TGRSIDetectorHit()	{
 }
 
 TGriffinHit::TGriffinHit(const TGriffinHit &rhs)	{	
+   //Copy Ctor. Ignores TObject Streamer in ROOT < 6.
 	Clear();
    ((TGriffinHit&)rhs).Copy(*this);
 }
@@ -36,16 +38,18 @@ bool TGriffinHit::InFilter(Int_t wantedfilter) {
 
 
 void TGriffinHit::Clear(Option_t *opt)	{
+   //Clears the information stored in the TGriffinHit.
    TGRSIDetectorHit::Clear(opt);    // clears the base (address, position and waveform)
    fFilter          =  0;
    fGriffinHitBits  =  0;
-   fCrystal         = 0xFFFF;
+   fCrystal         =  0xFFFF;
    fPPG             =  0;
 
 }
 
 
 void TGriffinHit::Print(Option_t *opt) const	{
+   //Prints the Detector Number, Crystal Number, Energy, Time and Angle.
    printf("Griffin Detector: %i\n",GetDetector());
 	printf("Griffin Crystal:  %i\n",GetCrystal());
    printf("Griffin Energy:   %lf\n",GetEnergy());
@@ -54,10 +58,12 @@ void TGriffinHit::Print(Option_t *opt) const	{
 }
 
 TVector3 TGriffinHit::GetPosition(Double_t dist) const{
+   //Returns the Position of the crystal of the current Hit.
 	return TGriffin::GetPosition(GetDetector(),GetCrystal(),dist);
 }
 
 UInt_t TGriffinHit::GetCrystal() const { 
+   //Returns the Crystal Number of the Current hit.
    if(IsCrystalSet())
       return fCrystal;
 
@@ -81,6 +87,7 @@ UInt_t TGriffinHit::GetCrystal() const {
 }
 
 UInt_t TGriffinHit::GetCrystal() {
+   //Returns the Crystal Number of the Current hit.
    if(IsCrystalSet())
       return fCrystal;
 

--- a/makefile
+++ b/makefile
@@ -145,6 +145,13 @@ $(foreach lib,$(LIBRARY_DIRS),$(eval $(call library_template,$(lib))))
 
 -include $(shell find .build -name '*.d' 2> /dev/null)
 
+html: all
+	@printf " ${COM_COLOR}Building      ${OBJ_COLOR} HTML Documentation ${NO_COLOR}\n"
+	@cp -r include grsisort
+	@grsisort -q -l --work_harder util/html_generator.C #>/dev/null
+	@$(RM) -r grsisort
+	@$(RM) tempfile.out
+
 clean:
 	@printf "\nCleaning up\n\n"
 	@-$(RM) -rf .build


### PR DESCRIPTION
Once can make the html docs in the directory using `make html`. This might be bad practice... but html has the "all" target meaning the entire program and all scripts must be compiled before the docs are built. The THtml class uses the libraries of the classes, so this needs to take place before the docs are made.

I have also cleaned up Griffin a bit in terms of outdated, commented, code. And I added a couple more html comments into Griffin.