### PR TITLE
Added new limits for halflives

### DIFF
--- a/include/TDecay.h
+++ b/include/TDecay.h
@@ -206,6 +206,7 @@ class TDecay : public TVirtualDecay {
    TDecayChain* GetChain(UInt_t idx);
 
    void SetHalfLife(Int_t Id, Double_t halflife);
+   void SetHalfLifeLimits(Int_t Id, Double_t low, Double_t high);
    TFitResultPtr Fit(TH1* fithist, Option_t *opt = "");
 
    void Print(Option_t* opt = "") const;

--- a/libraries/TGRSIAnalysis/TGRSIFit/TDecay.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TDecay.cxx
@@ -666,6 +666,20 @@ void TDecay::SetHalfLife(Int_t Id, Double_t halflife){
 
 }
 
+void TDecay::SetHalfLifeLimits(Int_t Id, Double_t low, Double_t high){
+  auto it = fDecayMap.find(Id);
+   if(it == fDecayMap.end()){
+      printf("Could not find Id = : %d\n",Id);
+      return;
+   }
+   for(int i=0; i<it->second.size(); ++i){
+      it->second.at(i)->SetHalfLifeLimits(low,high);
+      it->second.at(i)->SetTotalDecayParameters();
+   }
+
+}
+
+
 void TDecay::Print(Option_t *opt) const{
    printf("Background: %lf +/- %lf\n\n", GetBackground(),GetBackgroundError());
    for(auto it = fDecayMap.begin(); it!=fDecayMap.end();++it){


### PR DESCRIPTION
These can be used in TDecay and a specific Id. For example a TDecay named decay can have all of it's id = 3 decays to  a halflife of 19.1->19.5 set like:

```c++
decay->SetHalfLife(3, 19.3); //Anything between 19.1 and 19.5 will do here.
decay->SetHalfLifeLimits(3,19.1,19.5);
```
FYI @mrdunlop