### PR TITLE
Fixed order of --no-as-needed linker flag to work on all distros

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ else
 export __LINUX__:= 1
 CPP        = g++
 CFLAGS     += -Wl,--no-as-needed
-LINKFLAGS_SUFFIX += -Wl,--no-as-needed
+LINKFLAGS_PREFIX += -Wl,--no-as-needed
 SHAREDSWITCH = -shared -Wl,-soname,# NO ENDING SPACE
 endif
 


### PR DESCRIPTION
- Didn't work on linux mint because order of --no-as-needed matters... sometimes....

http://stackoverflow.com/questions/45135/why-does-the-order-in-which-libraries-are-linked-sometimes-cause-errors-in-gcc