### PR TITLE
Added error reporting script

### DIFF
--- a/util/ErrorReport.sh
+++ b/util/ErrorReport.sh
@@ -1,0 +1,19 @@
+# Source this script to help report Errors in GRSISort
+# Author by Ryan Dunlop, 22/10/2015
+echo SYSTEM       = `uname`
+echo GRSISYS      = $GRSISYS
+echo ROOTSYS      = $ROOTSYS
+
+echo ROOT Version = `root-config --version`
+
+cd ${GRSISYS}
+echo GRSISort Branch = `git rev-parse --abbrev-ref HEAD`
+echo 'Last Commit: \n' 
+
+git log -1
+
+echo '\nPut Error Here:\n\n\n\n'
+
+echo 'Last Working Commit: Put commit here\n\n'
+
+echo 'What I have tried so far\n\n\n'

--- a/util/ErrorReport.sh
+++ b/util/ErrorReport.sh
@@ -5,10 +5,11 @@ echo GRSISYS      = $GRSISYS
 echo ROOTSYS      = $ROOTSYS
 
 echo ROOT Version = `root-config --version`
+echo '\nComputer and Path to File that failed: \n'
 
 cd ${GRSISYS}
 echo GRSISort Branch = `git rev-parse --abbrev-ref HEAD`
-echo 'Last Commit: \n' 
+echo '\nLast Commit: ' 
 
 git log -1
 


### PR DESCRIPTION
This script will help us to find the error you are reporting on the issue tracker. Just use `sh $GRSISYS/util/ErrorReport.sh` We could maybe make this into something that could be executed in grsi-config, I just wanted something quick and dirt for now. When the script is run you get an output like this:

```
SYSTEM = Darwin
GRSISYS = /Users/rdunlop/Programs/GRSISort
ROOTSYS = /usr/local/root_v5.34.30
ROOT Version = 5.34/30

Computer and Path to File that failed:

GRSISort Branch = master

Last Commit:
commit 479204ae1385a874abda8f32bc41eef354e0f20e
Author: Ryan Dunlop <rdunlop@uoguelph.ca>
Date:   Wed Oct 21 11:04:20 2015 -0400

    Fixed error reporting script

Put Error Here:




Last Working Commit: Put commit here


What I have tried so far




```
This will help us identify easy to solve problems, and will remove the 5 or 6 emails we always spend trying to sort minor details out. Please feel free to adapt this file as necessary, I just wanted something out there.