### PR TITLE
Added custom exception for more transparent error handling

### DIFF
--- a/include/Globals.h
+++ b/include/Globals.h
@@ -62,6 +62,7 @@ typedef char int8_t;
 #include <stdint.h> 
 #endif
 
+#include <stdexcept>
 #include <string>
 #include <cstdio>
 #include <cstdlib>
@@ -141,5 +142,19 @@ static void ClearMNEMONIC(MNEMONIC *mnemonic) {
 
 
 const std::string &ProgramName(void);
+
+struct exit_exception : public std::exception
+{
+   public:
+      exit_exception(int c,const char *msg = "") : code(c), message(msg){}
+      ~exit_exception() {}
+ /*     virtual const char* what() const throw {
+         //  LOG(what); // write to log file
+         return what.c_str();
+      }*/
+
+      const int code;
+      const char* message;
+};
 
 #endif

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -57,7 +57,7 @@ class TGriffin : public TGRSIDetector {
 #endif
 
       Int_t GetAddbackMultiplicity();
-      TGriffinHit* GetAddbackHit(const int i);
+      TGriffinHit* GetAddbackHit(const int& i);
 
    private:
 #ifndef __CINT__

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -157,6 +157,7 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -2,6 +2,7 @@
 #include "TGriffin.h"
 #include <TRandom.h>
 #include <TMath.h>
+#include "TCint.h"
 
 #include <TGRSIRunInfo.h>
 
@@ -178,10 +179,12 @@ TGRSIDetectorHit* TGriffin::GetHit(const Int_t& idx) {
 
 TGriffinHit* TGriffin::GetGriffinHit(const int& i) {
    try{
-      return &griffin_hits.at(i);   
+      return &(griffin_hits.at(i));   
    }
    catch (const std::out_of_range& oor){
-      std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      std::cerr << ClassName() << " Hits are out of range: " << oor.what() << std::endl;
+      if(!gInterpreter)
+         throw exit_exception(1);
    }
    return 0;
 }
@@ -222,10 +225,12 @@ Int_t TGriffin::GetAddbackMultiplicity() {
    return fAddback_hits.size();
 }
 
-TGriffinHit* TGriffin::GetAddbackHit(const int i) {
+TGriffinHit* TGriffin::GetAddbackHit(const int& i) {
    if(i < GetAddbackMultiplicity()) {
       return &fAddback_hits.at(i);
    } else {
+      std::cerr << "Addback hits are out of range" << std::endl;
+      throw exit_exception(1);
       return NULL;
    }
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -95,6 +95,7 @@ TPacesHit* TPaces::GetPacesHit(const int& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -101,6 +101,7 @@ TS3Hit *TS3::GetS3Hit(const int& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }  

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -175,6 +175,7 @@ TSceptarHit* TSceptar::GetSceptarHit(const int& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -253,6 +253,7 @@ TSharcHit* TSharc::GetSharcHit(const int& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -60,6 +60,7 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }  

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -104,6 +104,7 @@ TTipHit* TTip::GetTipHit(const int& i) {
    }
    catch (const std::out_of_range& oor){
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw exit_exception(1);
    }
    return 0;
 }

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -229,6 +229,7 @@ void TGRSIRunInfo::Print(Option_t *opt) const {
       printf("\t\tCSM:          %s\n", CSM() ? "true" : "false");
       printf("\t\tSPICE:        %s\n", Spice() ? "true" : "false");
       printf("\t\tS3:           %s\n", S3() ? "true" : "false");
+      printf("\t\tRF:           %s\n", RF() ? "true" : "false");
       printf("\t\tGRIFFIN:      %s\n", Griffin() ? "true" : "false");
       printf("\t\tSCEPTAR:      %s\n", Sceptar() ? "true" : "false");
       printf("\t\tPACES:        %s\n", Paces() ? "true" : "false");

--- a/src/grsisort.cxx
+++ b/src/grsisort.cxx
@@ -4,6 +4,8 @@
 #include <string>
 #include <sys/stat.h>
 #include <netdb.h>
+#include <stdexcept>
+#include <iostream>
 
 #include "TEnv.h"
 #include "TPluginManager.h"
@@ -49,21 +51,26 @@ static void SetDisplay();
 
 
 int main(int argc, char **argv) {
-   //Find the grsisort environment variable so that we can read in .grsirc
-   SetDisplay();
-   SetGRSIEnv();
-   SetGRSIPluginHandlers();
-   TGRSIint *input = 0;
+   try{
+      //Find the grsisort environment variable so that we can read in .grsirc
+      SetDisplay();
+      SetGRSIEnv();
+      SetGRSIPluginHandlers();
+      TGRSIint *input = 0;
    
-   //Create an instance of the grsi interpreter so that we can run root-like interpretive mode
-   input = TGRSIint::instance(argc,argv);
-   //input->GetOptions(&argc,argv);
-   //Run the code!
-   input->Run("true");
-   //Be polite when you leave.
-   printf("\nbye,bye\n");
+      //Create an instance of the grsi interpreter so that we can run root-like interpretive mode
+      input = TGRSIint::instance(argc,argv);
+      //input->GetOptions(&argc,argv);
+      //Run the code!
+      input->Run("true");
+      //Be polite when you leave.
+      printf("\nbye,bye\n");
+   } catch(exit_exception& e) {
+      std::cerr << e.message << std::endl;
+      //Close files and clean up properly here
+   }
 
-   return 0;
+      return 0;
 }
 
 


### PR DESCRIPTION
@pcbend and @VinzenzBildstein can you let me know what you think about this? What I have done is to create an exit exception that should be thrown when we want to quit the program. If you want to exit any compiled script safely you should put a try block around your entire main function code. You can then throw an exit exception whenever you feel like you should abort, catch that in the main, and then choose to do things like close TFiles etc using gROOT. This forces the code to also call the proper dtors as it moves backwards and to clear the heap at the very end. 

The exit_exception I have added checks to see if you have searched beyond the end of your hit vector. You really want to know if you did this because you could have bad results if you do so, so this is not a case of just catch and move on. So in that case, I display a warning and throw an exit exception. One can also choose to only throw if in non-interpreted mode using (!gInterpreter) since the interpreter does a good job of warning and recovering. It's unlikely you will be doing anything over the top in interpreted mode, so this exception is only thrown outside of the interpreter.

I have the exception defined in Globals.h, but if we feel like moving it I am fine with that. I think this is going to make some errors more transparent especially as we move forward. I'll leave this here for you guys to comment on and potentially merge if you think it is a good idea.