### PR TITLE
Fixes error in exceptions on pre c++11 stds

### DIFF
--- a/include/Globals.h
+++ b/include/Globals.h
@@ -147,7 +147,7 @@ struct exit_exception : public std::exception
 {
    public:
       exit_exception(int c,const char *msg = "") : code(c), message(msg){}
-      ~exit_exception() {}
+      virtual ~exit_exception() throw() {}
  /*     virtual const char* what() const throw {
          //  LOG(what); // write to log file
          return what.c_str();


### PR DESCRIPTION
If someone could test this and let me know that would be great.