### PR TITLE
Updated to TDataParser, added rate scalers

### DIFF
--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -81,7 +81,7 @@ class TDataParser { //: public TObject {
     static bool SetPPGHighTimeStamp(uint32_t,TPPGData*);
 	 static bool SetScalerNetworkPacket(uint32_t, TScalerData*);
 	 static bool SetScalerLowTimeStamp(uint32_t, TScalerData*);
-	 static bool SetScalerHighTimeStamp(uint32_t, TScalerData*);
+	 static bool SetScalerHighTimeStamp(uint32_t, TScalerData*, int&);
 	 static bool SetScalerValue(int, uint32_t, TScalerData*);
 
     static void FillStats(TFragment*);

--- a/include/TGRSILoop.h
+++ b/include/TGRSILoop.h
@@ -48,7 +48,8 @@ class TGRSILoop : public TObject {
       int fFragsReadFromMidas;
       int fFragsSentToTree;
 		int fBadFragsSentToTree;
-		int fScalersSentToTree;
+		int fDeadtimeScalersSentToTree;
+		int fRateScalersSentToTree;
  
    #ifndef __CINT__
       std::thread *fMidasThread;

--- a/include/TGRSIRootIO.h
+++ b/include/TGRSIRootIO.h
@@ -33,15 +33,16 @@ class TGRSIRootIO : public TObject {
       TTree *fFragmentTree;
       TTree *fBadFragmentTree;
       TTree *fEpicsTree;
-      TTree *fScalerTree;
+      TTree *fDeadtimeScalerTree;
+      TTree *fRateScalerTree;
       TPPG *fPPG;
-		TScaler* fScaler;
 
       TFile *foutfile;
       int fTimesFillCalled;
       int fTimesBadFillCalled;
       int fTimesPPGCalled;
-      int fTimesScalerCalled;
+      int fTimesDeadtimeScalerCalled;
+      int fTimesRateScalerCalled;
       int fEPICSTimesFillCalled;
 
       std::vector<TFile*> finfiles;
@@ -51,7 +52,8 @@ class TGRSIRootIO : public TObject {
       TEpicsFrag *fEXBufferFrag;
       TChannel   *fBufferChannel;
 
-		TScalerData* fScalerData;
+		TScalerData* fDeadtimeScalerData;
+		TScalerData* fRateScalerData;
 
    public:
       bool SetUpRootOutFile(int,int);
@@ -85,11 +87,14 @@ class TGRSIRootIO : public TObject {
       void FinalizePPG();
       int GetTimesPPGCalled()  { return fTimesPPGCalled;  }
 
-      void SetUpScalerTree();
-      TTree *GetScalerTree()  { return fScalerTree;  }
-      void FillScalerTree(TScalerData*);
-      void FinalizeScalerTree();
-      int GetTimesScalerCalled()  { return fTimesScalerCalled;  }
+      void SetUpScalerTrees();
+      TTree *GetDeadtimeScalerTree()  { return fDeadtimeScalerTree;  }
+      TTree *GetRateScalerTree()  { return fRateScalerTree;  }
+      void FillDeadtimeScalerTree(TScalerData*);
+      void FillRateScalerTree(TScalerData*);
+      void FinalizeScalerTrees();
+      int GetTimesDeadtimeScalerCalled()  { return fTimesDeadtimeScalerCalled;  }
+      int GetTimesRateScalerCalled()  { return fTimesRateScalerCalled;  }
 
       void SetUpEpicsTree();
       TTree *GetEpicsTree()  { return fEpicsTree;  }

--- a/include/TScaler.h
+++ b/include/TScaler.h
@@ -41,16 +41,14 @@ class TScalerData : public TObject {
 	
 	void SetAddress(UInt_t address) { fAddress = address; }
 	void SetNetworkPacketId(UInt_t network_id) { fNetworkPacketId = network_id; }
-	void SetLowTimeStamp(UInt_t low_time) { fLowTimeStamp = low_time; SetTimeStamp(); }
-	void SetHighTimeStamp(UInt_t high_time) { fHighTimeStamp = high_time; SetTimeStamp();}
+	void SetLowTimeStamp(UInt_t low_time) { fLowTimeStamp = low_time; }
+	void SetHighTimeStamp(UInt_t high_time) { fHighTimeStamp = high_time; }
 	void SetScaler(size_t index, UInt_t scaler) { 
 		if(index < fScaler.size()) 
 		 fScaler[index] = scaler;
 		else
 		 std::cout<<"Failed to set scaler "<<scaler<<", index "<<index<<" is out of range 0 - "<<fScaler.size()<<std::endl;
 	}
-
-	void SetTimeStamp();
 
 	UInt_t GetAddress() const { return fAddress; }
 	UInt_t GetNetworkPacketId() const { return fNetworkPacketId; }
@@ -64,13 +62,23 @@ class TScalerData : public TObject {
 		 return 0; 
 	}
 
-	ULong64_t GetTimeStamp() const { return fTimeStamp; }
+	ULong64_t GetTimeStamp() const { 
+      ULong64_t time = GetHighTimeStamp();
+      time  = time << 28;
+      time |= GetLowTimeStamp() & 0x0fffffff;
+      return time;
+   }
+
+   void ResizeScaler(size_t newSize = 1) {
+      fScaler.resize(newSize);
+   }
+
 
 	void Print(Option_t *opt = "") const;
 	void Clear(Option_t *opt = "");
 
  private:
-	ULong64_t fTimeStamp;
+	//ULong64_t fTimeStamp;
 	UInt_t fNetworkPacketId;
 	UInt_t fAddress;
 	std::vector<UInt_t> fScaler;

--- a/include/TScalerQueue.h
+++ b/include/TScalerQueue.h
@@ -16,19 +16,19 @@
 
 #include "TScaler.h"
 
-class TScalerQueue : public TObject {
+class TDeadtimeScalerQueue : public TObject {
 	
 	public:
-		static TScalerQueue* Get(); //Returns the Queue
-		virtual ~TScalerQueue();
+		static TDeadtimeScalerQueue* Get(); //Returns the Queue
+		virtual ~TDeadtimeScalerQueue();
 
       int ScalersInQueue() { return fScalersInQueue;   }
 
 	private:
-      TScalerQueue();
-		static TScalerQueue* fScalerQueueClassPointer; //Pointer to the scaler Q singleton
+      TDeadtimeScalerQueue();
+		static TDeadtimeScalerQueue* fDeadtimeScalerQueueClassPointer; //Pointer to the scaler Q singleton
 
-		std::queue<TScalerData*> fScalerQueue; //The scaler Queue itself
+		std::queue<TScalerData*> fDeadtimeScalerQueue; //The scaler Queue itself
 		int fScalersInQueue;	//The current number of scalers in the Q
 
 		void StatusUpdate();
@@ -76,13 +76,68 @@ class TScalerQueue : public TObject {
 
       void Print(Option_t *opt = "") const;
 		void Clear(Option_t *opt = "");
-		
-		ClassDef(TScalerQueue,0); //The Class used to hold scalers when building events
 };
 
+class TRateScalerQueue : public TObject {
+	
+	public:
+		static TRateScalerQueue* Get(); //Returns the Queue
+		virtual ~TRateScalerQueue();
+
+      int ScalersInQueue() { return fScalersInQueue;   }
+
+	private:
+      TRateScalerQueue();
+		static TRateScalerQueue* fRateScalerQueueClassPointer; //Pointer to the scaler Q singleton
+
+		std::queue<TScalerData*> fRateScalerQueue; //The scaler Queue itself
+		int fScalersInQueue;	//The current number of scalers in the Q
+
+		void StatusUpdate();
+		bool fStatusUpdateOn; //flag that determines whether the Q status should be read out
+
+		bool fStop;
+		
+		int fScalersIn; 		
+		int fScalersOut;
+
+		TStopwatch* fStopwatch; //The stop watch used for timing in the status
+		void ResetRateCounter();
+
+		unsigned int fTotalScalersIn;
+		unsigned int fTotalScalersOut;	
+
+		static std::map<int,int> fScalerIdMap;	
 
 
+#ifndef __CINT__
+#ifndef NO_MUTEX
+	public:
+		static std::mutex All;
+		static std::mutex Sorted;
+#endif
+#endif
 
+	public:
+		void Add(TScalerData*);
+	
+		void Pop();
+		TScalerData* PopScaler();
 
+		int Size() const;
+
+		void StartStatusUpdate();
+		void StopStatusUpdate();
+		void CheckStatus() const;
+
+		unsigned int GetTotalScalersIn()  { return fTotalScalersIn;}
+		unsigned int GetTotalScalersOut() {	return fTotalScalersOut;}
+
+		bool Running() { return !fStop;}
+		void Stop() { fStop = true;}
+
+      void Print(Option_t *opt = "") const;
+		void Clear(Option_t *opt = "");
+};
 
 #endif

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -27,7 +27,8 @@
 #pragma link C++ class std::map<ULong64_t,TPPGData*>;
 #pragma link C++ class TScaler+;
 #pragma link C++ class TScalerData+;
-#pragma link C++ class TScalerQueue+;
+//#pragma link C++ class TDeadtimeScalerQueue+;
+//#pragma link C++ class TRateScalerQueue+;
 #pragma link C++ class std::map<UInt_t, std::map<ULong64_t, TScalerData*> >;
 #pragma link C++ class std::map<ULong64_t, TScalerData*>;
 

--- a/libraries/TGRSIFormat/TScaler.cxx
+++ b/libraries/TGRSIFormat/TScaler.cxx
@@ -17,7 +17,6 @@ TScalerData::TScalerData(const TScalerData& rhs) : TObject() {
 }
 
 void TScalerData::Copy(TObject &rhs) const {
-  ((TScalerData&)rhs).fTimeStamp       =  fTimeStamp;      
   ((TScalerData&)rhs).fAddress         =  fAddress;      
   ((TScalerData&)rhs).fScaler          =  fScaler;        
   ((TScalerData&)rhs).fNetworkPacketId =  fNetworkPacketId;        
@@ -25,17 +24,9 @@ void TScalerData::Copy(TObject &rhs) const {
   ((TScalerData&)rhs).fHighTimeStamp   =  fHighTimeStamp;  
 }
 
-void TScalerData::SetTimeStamp() {
-   Long64_t time = GetHighTimeStamp();
-   time  = time << 28;
-   time |= GetLowTimeStamp() & 0x0fffffff;
-   fTimeStamp = time;
-}
-
 void TScalerData::Clear(Option_t* opt) {
 //Clears the TScalerData and leaves it a "junk" state. By junk, I just mean default
 //so that we can tell that this Scaler is no good.
-   fTimeStamp        =  0;
 	fAddress          =  0;
    fLowTimeStamp     =  0;
    fHighTimeStamp    =  0;

--- a/libraries/TGRSILoop/TGRSILoop.cxx
+++ b/libraries/TGRSILoop/TGRSILoop.cxx
@@ -165,22 +165,41 @@ void TGRSILoop::FillFragmentTree(TMidasFile *midasfile) {
 }
 
 void TGRSILoop::FillScalerTree() {
-   fScalersSentToTree = 0;
+   fDeadtimeScalersSentToTree = 0;
+   fRateScalersSentToTree = 0;
    TScalerData* scalerData = 0;
-   while(TScalerQueue::Get()->ScalersInQueue() != 0 || 
+   while(TDeadtimeScalerQueue::Get()->ScalersInQueue() != 0 || 
+         TRateScalerQueue::Get()->ScalersInQueue() != 0 || 
          fMidasThreadRunning) {
-		scalerData = TScalerQueue::Get()->PopScaler();
-		if(scalerData) {
-         TGRSIRootIO::Get()->FillScalerTree(scalerData);
- 	      delete scalerData;
-         fScalersSentToTree++;
-      }
+      if(TDeadtimeScalerQueue::Get()->ScalersInQueue() > 0) {
+		   scalerData = TDeadtimeScalerQueue::Get()->PopScaler();
+		   if(scalerData) {
+            TGRSIRootIO::Get()->FillDeadtimeScalerTree(scalerData);
+ 	         delete scalerData;
+            fDeadtimeScalersSentToTree++;
+         }
 
-      if(!fMidasThreadRunning && TScalerQueue::Get()->ScalersInQueue()%5000==0) {
-         printf(DYELLOW HIDE_CURSOR " \t%i" RESET_COLOR "/"
-                DBLUE   "%i"   RESET_COLOR
-                "     scalers left to write to tree/frags written to tree.        " SHOW_CURSOR "\r",
-                TScalerQueue::Get()->ScalersInQueue(),fScalersSentToTree);
+         if(!fMidasThreadRunning && TDeadtimeScalerQueue::Get()->ScalersInQueue()%5000==0) {
+            printf(DYELLOW HIDE_CURSOR " \t%i" RESET_COLOR "/"
+                  DBLUE   "%i"   RESET_COLOR
+                  "     deadtime scalers left to write to tree/frags written to tree.        " SHOW_CURSOR "\r",
+                  TDeadtimeScalerQueue::Get()->ScalersInQueue(),fDeadtimeScalersSentToTree);
+         }
+      }
+      if(TRateScalerQueue::Get()->ScalersInQueue() > 0) {
+		   scalerData = TRateScalerQueue::Get()->PopScaler();
+		   if(scalerData) {
+            TGRSIRootIO::Get()->FillRateScalerTree(scalerData);
+ 	         delete scalerData;
+            fRateScalersSentToTree++;
+         }
+
+         if(!fMidasThreadRunning && TRateScalerQueue::Get()->ScalersInQueue()%5000==0) {
+            printf(DYELLOW HIDE_CURSOR " \t%i" RESET_COLOR "/"
+                  DBLUE   "%i"   RESET_COLOR
+                  "     rate scalers left to write to tree/frags written to tree.        " SHOW_CURSOR "\r",
+                  TRateScalerQueue::Get()->ScalersInQueue(),fRateScalersSentToTree);
+         }
       }
    }
 
@@ -569,7 +588,8 @@ void TGRSILoop::Finalize() {
    printf("in finalization phase.\n");   
    printf(DMAGENTA "successfully sorted " DBLUE "%0d" DMAGENTA "/" 
           DCYAN "%0d" DMAGENTA "  ---> " DYELLOW " %.2f" DMAGENTA " percent passed." 
-          RESET_COLOR "\n",fFragsSentToTree+PPGEvents+fScalersSentToTree,fFragsReadFromMidas,((double)(fFragsSentToTree+PPGEvents+fScalersSentToTree)/(double)fFragsReadFromMidas)*100.);
+          RESET_COLOR "\n",fFragsSentToTree+PPGEvents+fDeadtimeScalersSentToTree+fRateScalersSentToTree,fFragsReadFromMidas,
+          ((double)(fFragsSentToTree+PPGEvents+fDeadtimeScalersSentToTree+fRateScalersSentToTree)/(double)fFragsReadFromMidas)*100.);
 }
 
 

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -267,8 +267,8 @@ void TGRSIRootIO::FinalizeScalerTrees() {
   if(!fDeadtimeScalerTree || !fRateScalerTree || !foutfile)
       return;
    foutfile->cd();
-   fDeadtimeScalerTree->Write();
-   fRateScalerTree->Write();
+   if(fDeadtimeScalerTree->GetEntries()>0) fDeadtimeScalerTree->Write();
+   if(fRateScalerTree->GetEntries()>0) fRateScalerTree->Write();
 	return;
 }
 

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -25,7 +25,8 @@ TGRSIRootIO::TGRSIRootIO() {
   fFragmentTree    = 0;
   fBadFragmentTree =0;
   fEpicsTree    = 0;
-  fScalerTree   = 0;
+  fDeadtimeScalerTree   = 0;
+  fRateScalerTree   = 0;
   fPPG          = 0;
 
   foutfile = 0; //new TFile("test_out.root","recreate");
@@ -99,17 +100,22 @@ void TGRSIRootIO::SetUpPPG() {
 }
 
 
-void TGRSIRootIO::SetUpScalerTree() {
+void TGRSIRootIO::SetUpScalerTrees() {
    if(TGRSIOptions::IgnoreScaler()) 
      return;
    if(foutfile)
       foutfile->cd();
-   fTimesScalerCalled = 0;
-   fScalerTree = new TTree("ScalerTree","ScalerTree");
-	fScalerData = NULL;
-   fScalerTree->Branch("TScalerData","TScalerData",&fScalerData);//,128000,99);
-	fScalerTree->BranchRef();
-	printf("Scaler-Tree set up.\n");
+   fTimesDeadtimeScalerCalled = 0;
+   fDeadtimeScalerTree = new TTree("ScalerTree","ScalerTree");
+	fDeadtimeScalerData = NULL;
+   fDeadtimeScalerTree->Branch("TScalerData","TScalerData",&fDeadtimeScalerData);//,128000,99);
+	fDeadtimeScalerTree->BranchRef();
+   fTimesRateScalerCalled = 0;
+   fRateScalerTree = new TTree("RateScalerTree","RateScalerTree");
+	fRateScalerData = NULL;
+   fRateScalerTree->Branch("TScalerData","TScalerData",&fRateScalerData);//,128000,99);
+	fRateScalerTree->BranchRef();
+	printf("Scaler-Trees set up.\n");
 }
 
 void TGRSIRootIO::SetUpEpicsTree() {
@@ -158,14 +164,24 @@ void TGRSIRootIO::FillPPG(TPPGData* data) {
    ++fTimesPPGCalled;
 }
 
-void TGRSIRootIO::FillScalerTree(TScalerData *scalerData) {
+void TGRSIRootIO::FillDeadtimeScalerTree(TScalerData *scalerData) {
   if(TGRSIOptions::IgnoreScaler()) 
     return;
-   *fScalerData = *scalerData;
-   int bytes =  fScalerTree->Fill();
+   *fDeadtimeScalerData = *scalerData;
+   int bytes =  fDeadtimeScalerTree->Fill();
    if(bytes < 1)
       printf("\n fill failed with bytes = %i\n",bytes);
-   fTimesScalerCalled++;
+   fTimesDeadtimeScalerCalled++;
+}
+
+void TGRSIRootIO::FillRateScalerTree(TScalerData *scalerData) {
+  if(TGRSIOptions::IgnoreScaler()) 
+    return;
+   *fRateScalerData = *scalerData;
+   int bytes =  fRateScalerTree->Fill();
+   if(bytes < 1)
+      printf("\n fill failed with bytes = %i\n",bytes);
+   fTimesRateScalerCalled++;
 }
 
 void TGRSIRootIO::FillEpicsTree(TEpicsFrag *EXfrag) {
@@ -245,13 +261,14 @@ void TGRSIRootIO::FinalizeEpicsTree() {
 	return;
 }
 
-void TGRSIRootIO::FinalizeScalerTree() {
+void TGRSIRootIO::FinalizeScalerTrees() {
   if(TGRSIOptions::IgnoreScaler()) 
     return;
-  if(!fScalerTree || !foutfile)
+  if(!fDeadtimeScalerTree || !fRateScalerTree || !foutfile)
       return;
    foutfile->cd();
-   fScalerTree->Write();
+   fDeadtimeScalerTree->Write();
+   fRateScalerTree->Write();
 	return;
 }
 
@@ -276,7 +293,7 @@ bool TGRSIRootIO::SetUpRootOutFile(int runnumber, int subrunnumber) {
    SetUpFragmentTree();
    SetUpBadFragmentTree();
    SetUpPPG();
-	SetUpScalerTree();
+	SetUpScalerTrees();
    SetUpEpicsTree();
 
    return true;
@@ -294,7 +311,7 @@ void TGRSIRootIO::CloseRootOutFile()   {
    
    FinalizeFragmentTree();
    FinalizePPG();
-	FinalizeScalerTree();
+	FinalizeScalerTrees();
    FinalizeEpicsTree();
 
    if(TGRSIRunInfo::GetNumberOfSystems()>0) {


### PR DESCRIPTION
- we now throw out events if we see an extra header
- if we encounter an odd number of charge/cfd words we search for the next trailer and throw the error there (effectively throwing out the following fragment which has a corrupt address)
- added a new tree for rate scalers