### PR TITLE
Fixes position recalculation of GRSIDetectorHits

### DIFF
--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -36,11 +36,12 @@ class TDescantHit : public TGRSIDetectorHit {
    //   inline void SetPosition(TVector3 x)          { position = x; }   //!
 
       inline void SetWaveform(std::vector<Short_t> x) {
+         std::vector<Short_t> *waveform = GetWaveform();
          if(x.size() <= 8) {
             return;
          }
          size_t length = x.size() - (x.size()%8);
-         fwaveform.resize(length-8);
+         waveform->resize(length-8);
          for(size_t i = 0; i < length; ++i) {
             // reorder so that samples 0-7 are: 7,6,1,0,3,2,5,4
             //                                  0,1,2,3,4,5,6,7
@@ -48,15 +49,15 @@ class TDescantHit : public TGRSIDetectorHit {
             // 67,01,32,45: shift all by +2, except for the last pair which need to be shifted by -6
             Int_t reordered = i-2;
             reordered = reordered+1-2*(reordered%2);
-            if(reordered >= (Int_t) fwaveform.size()) {
+            if(reordered >= (Int_t) waveform->size()) {
                continue;
             }
             if(reordered%8 < 6) {
                //std::cout<<i<<" => "<<reordered+2<<std::endl;
-               fwaveform[reordered+2] = x[i];
+               waveform->at(reordered+2) = x[i];
             } else {
                //std::cout<<i<<" => "<<reordered-6<<std::endl;
-               fwaveform[reordered-6] = x[i];
+               waveform->at(reordered-6) = x[i];
             }
          }
       } //!
@@ -67,7 +68,6 @@ class TDescantHit : public TGRSIDetectorHit {
       inline Int_t    GetZc()                  { return zc;      }  //!
       inline Int_t    GetCcShort()             { return ccShort;      }  //!
       inline Int_t    GetCcLong()              { return ccLong;      }  //!
-      TVector3 GetPosition(Double_t dist = 0) const; //!
 //      inline std::vector<Short_t> GetWaveform() { return waveform; }  //!
 
       Int_t CalculateCfd(double attenuation, unsigned int delay, int halfsmoothingwindow, int interpolation_steps); //!
@@ -89,6 +89,9 @@ class TDescantHit : public TGRSIDetectorHit {
       void Copy(TObject&) const;        //!
 		void Clear(Option_t *opt = "");		                    //!
 		void Print(Option_t *opt = "") const;		                    //!
+
+   private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!
 
 	ClassDef(TDescantHit,4)
 };

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -80,17 +80,16 @@ class TGRSIDetectorHit : public TObject 	{
       inline void SetCharge(const Float_t &temp_charge)            { fcharge = temp_charge;} //!
   //    inline void SetParent(TGRSIDetector *fParent)               { parent = (TObject*)fParent ; } //!
       virtual inline void SetCfd(const Int_t &x)                  { fcfd    = x;   }                  //!
-      inline void SetWaveform(std::vector<Short_t> x)             { fwaveform = x;    } //!
+      inline void SetWaveform(const std::vector<Short_t> &x)             { fwaveform = x;    } //!
       virtual inline void SetTimeStamp(const ULong_t &x)               { ftimestamp   = x;   }                  //! Maybe make this abstract?
 
       virtual TVector3 SetPosition(Double_t temp_pos = 0);
-      void SetEnergy(double en) { fenergy = en; SetFlag(kIsEnergySet,true);}
-      virtual UInt_t SetDetector(UInt_t det);
-      void SetTime(Double_t time) {ftime = time; SetFlag(kIsTimeSet,true); }
+      void SetEnergy(const double &en) { fenergy = en; SetFlag(kIsEnergySet,true);}
+      virtual UInt_t SetDetector(const UInt_t &det);
+      void SetTime(const Double_t &time) {ftime = time; SetFlag(kIsTimeSet,true); }
 
-      //Abstract methods. These are required in all derived classes
-		virtual TVector3 GetPosition(Double_t dist = 0) const; //!
-      virtual TVector3 GetPosition(Double_t dist = 0);
+		TVector3 GetPosition(Double_t dist = 0) const; //!
+      TVector3 GetPosition(Double_t dist = 0);
       virtual double GetEnergy(Option_t *opt="") const;
       virtual double GetEnergy(Option_t *opt="");
       virtual UInt_t GetDetector() const;
@@ -103,7 +102,7 @@ class TGRSIDetectorHit : public TObject 	{
       inline UInt_t GetAddress()     const                  { return faddress; }         //!
       inline Float_t GetCharge() const                       { return fcharge;} //!
       inline TChannel *GetChannel() const                   { return TChannel::GetChannel(faddress); }  //!
-      inline std::vector<Short_t> GetWaveform() const       { return fwaveform; } //!
+      inline std::vector<Short_t> *GetWaveform()           { return &fwaveform; } //!
     //  inline TGRSIDetector *GetParent() const               { return ((TGRSIDetector*)parent.GetObject()); } //!
       
       //The PPG is only stored in events that come out of the GRIFFIN DAQ
@@ -111,6 +110,9 @@ class TGRSIDetectorHit : public TObject 	{
       uint16_t GetPPGStatus();
       uint16_t GetCycleTimeStamp() const;
       uint16_t GetCycleTimeStamp();
+
+   private:
+      virtual TVector3 GetChannelPosition(Double_t dist = 0) const { AbstractMethod("GetChannelPosition"); return TVector3(0.0,0.0,0.0); }
 
      // unsigned int GetHighestBitSet(UChar_t flag);
 
@@ -123,25 +125,26 @@ class TGRSIDetectorHit : public TObject 	{
       Bool_t IsTimeSet() const {return (fbitflags & kIsTimeSet); }
       void SetFlag(enum Ebitflag,Bool_t set);
 
-   protected:
+   private:
       UInt_t   faddress;    //address of the the channel in the DAQ.
       Float_t  fcharge;     //charge collected from the hit
       Int_t    fcfd;        // CFD time of the Hit
       ULong_t  ftimestamp; // Timestamp given to hit
       Double_t ftime;      //! Calibrated Time of the hit
       UInt_t   fdetector;   //! Detector Number
-      TVector3 fposition;   //! Position of hit detector.
+ //     TVector3 fposition;   //! Position of hit detector.
       Double_t fenergy;     //! Energy of the Hit.
    //   TRef      parent;   // pointer to the mother class;
-     std::vector<Short_t> fwaveform;  //
+      std::vector<Short_t> fwaveform;  //
       //Bool_t fHitSet;    //!
       uint16_t fPPGStatus; //! 
       ULong_t  fCycleTimeStamp; //!
 
+   protected:
       static TPPG* fPPG;
-
+      TVector3 fposition;   //! Position of hit detector.
+   private:
    //flags   
-   protected:  
       UChar_t fbitflags;
       
       //Bool_t fDetectorSet;//!

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -75,7 +75,7 @@ class TGRSIDetectorHit : public TObject 	{
       //We need a common function for all detectors in here
 		//static bool Compare(TGRSIDetectorHit *lhs,TGRSIDetectorHit *rhs); //!
 
-      inline void SetPosition(const TVector3& temp_pos)           { fposition = temp_pos; }    //!
+      inline void SetPosition(const TVector3& temp_pos)           { fposition = temp_pos; SetFlag(kIsEnergySet,true); }    //!
       inline void SetAddress(const UInt_t &temp_address)          { faddress = temp_address; } //!
       inline void SetCharge(const Float_t &temp_charge)            { fcharge = temp_charge;} //!
   //    inline void SetParent(TGRSIDetector *fParent)               { parent = (TObject*)fParent ; } //!

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -132,7 +132,7 @@ class TGRSIDetectorHit : public TObject 	{
       ULong_t  ftimestamp; // Timestamp given to hit
       Double_t ftime;      //! Calibrated Time of the hit
       UInt_t   fdetector;   //! Detector Number
- //     TVector3 fposition;   //! Position of hit detector.
+      TVector3 fposition;   //! Position of hit detector.
       Double_t fenergy;     //! Energy of the Hit.
    //   TRef      parent;   // pointer to the mother class;
       std::vector<Short_t> fwaveform;  //
@@ -142,7 +142,7 @@ class TGRSIDetectorHit : public TObject 	{
 
    protected:
       static TPPG* fPPG;
-      TVector3 fposition;   //! Position of hit detector.
+
    private:
    //flags   
       UChar_t fbitflags;

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -43,8 +43,6 @@ class TGriffinHit : public TGRSIDetectorHit {
 		/////////////////////////  Setters	/////////////////////////////////////
       inline void SetFilterPattern(const int &x)   { fFilter = x;   }                  //! 
 
-      TVector3 GetPosition(Double_t dist = 110.0) const; //!
-
 		/////////////////////////  Getters	/////////////////////////////////////
       inline Int_t    GetFilterPattern() const         {   return fFilter;   }          //!
 
@@ -84,6 +82,7 @@ class TGriffinHit : public TGRSIDetectorHit {
       virtual void Copy(TObject&) const;        //!
 
    private:
+      TVector3 GetChannelPosition(Double_t dist = 110.0) const; //!
       void SetGriffinFlag(enum EGriffinHitBits,Bool_t set);
 	
       ClassDef(TGriffinHit,5); //Information about a GRIFFIN Hit

--- a/include/TPacesHit.h
+++ b/include/TPacesHit.h
@@ -26,8 +26,6 @@ class TPacesHit : public TGRSIDetectorHit {
       inline void SetFilterPattern(const int &x)   { filter = x;   }                  //! 
       //void SetHit();
 
-      TVector3 GetPosition(Double_t dist = 0.0) const; //!
-
 		/////////////////////////  Getters	/////////////////////////////////////
       inline Int_t    GetFilterPattern() const         {   return filter;   }          //!
 
@@ -38,6 +36,9 @@ class TPacesHit : public TGRSIDetectorHit {
 		virtual void Clear(Option_t *opt = "");		 //!
 		virtual void Print(Option_t *opt = "") const; //!
       virtual void Copy(TObject&) const;        //!
+
+   private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!
 
 	ClassDef(TPacesHit,3);
 };

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -29,11 +29,12 @@ class TSceptarHit : public TGRSIDetectorHit {
    //   inline void SetPosition(TVector3 x)          { position = x; }   //!
 
       inline void SetWaveform(std::vector<Short_t> x) {
+         std::vector<Short_t> *waveform = GetWaveform();
          if(x.size() <= 8) {
             return;
          }
          size_t length = x.size() - (x.size()%8);
-         fwaveform.resize(length-8);
+         waveform->resize(length-8);
          for(size_t i = 0; i < length; ++i) {
             // reorder so that samples 0-7 are: 7,6,1,0,3,2,5,4
             //                                  0,1,2,3,4,5,6,7
@@ -41,22 +42,21 @@ class TSceptarHit : public TGRSIDetectorHit {
             // 67,01,32,45: shift all by +2, except for the last pair which need to be shifted by -6
             Int_t reordered = i-2;
             reordered = reordered+1-2*(reordered%2);
-            if(reordered >= (Int_t) fwaveform.size()) {
+            if(reordered >= (Int_t) waveform->size()) {
                continue;
             }
             if(reordered%8 < 6) {
                //std::cout<<i<<" => "<<reordered+2<<std::endl;
-               fwaveform[reordered+2] = x[i];
+               waveform->at(reordered+2) = x[i];
             } else {
                //std::cout<<i<<" => "<<reordered-6<<std::endl;
-               fwaveform[reordered-6] = x[i];
+               waveform->at(reordered-6) = x[i];
             }
          }
       } //!
 
 		/////////////////////////		/////////////////////////////////////
       inline Int_t    GetFilterPattern()    const     { return filter;   }  //!
-      TVector3 GetPosition(Double_t dist = 0) const; //!
   //    inline std::vector<Short_t> GetWaveform() 		{ return waveform; }  //!
 
       Int_t CalculateCfd(double attenuation, int delay, int halfsmoothingwindow, int interpolation_steps); //!
@@ -74,6 +74,9 @@ class TSceptarHit : public TGRSIDetectorHit {
 		void Clear(Option_t *opt = "");		                    //!
 		void Print(Option_t *opt = "") const;		                    //!
       virtual void Copy(TObject&) const;        //!
+
+   private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!
 
 	ClassDef(TSceptarHit,2) //Stores the information for a SceptarHit
 };

--- a/include/TSharcHit.h
+++ b/include/TSharcHit.h
@@ -22,7 +22,7 @@
 //
 //  This is the updated sharc-hit storage class, designed to better work with 
 //  the GRSISort Inheritied class method.  A lot has changed, but the main function
-//  stays the same.  Sense two physial wire hits are needed to make one sharc hit,
+//  stays the same.  Since two physial wire hits are needed to make one sharc hit,
 //  and the "front" side will always have better resolution/timing properties, we 
 //  will make the inherited charge/time derive from the front.  So we do not lose the 
 //  back information, the class additionally holds a TGRSIDetector for the back and
@@ -80,8 +80,6 @@ class TSharcHit : public TGRSIDetectorHit {
 
     inline Double_t GetEnergy(Option_t *opt = "") { return GetFront()->GetEnergy() + GetPad()->GetEnergy(); }
     inline Double_t GetTime(Option_t *opt = "")   { return GetFront()->GetTime(); }
-
-    TVector3 GetPosition(Double_t dist = 0) const;
    
     Double_t GetThetaDeg(double Xoff = 0.0, double Yoff = 0.0, double Zoff = 0.0) { return GetTheta(Xoff,Yoff,Zoff)*TMath::RadToDeg(); } ; //! 
     Double_t GetTheta(double Xoff = 0.0, double Yoff = 0.0, double Zoff = 0.0); //! 
@@ -96,6 +94,9 @@ class TSharcHit : public TGRSIDetectorHit {
     void SetFront(const TFragment &frag); //!  
     void SetBack (const TFragment &frag); //!
     void SetPad  (const TFragment &frag); //!
+
+  private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!
     
 
   ClassDef(TSharcHit,6)

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -71,7 +71,6 @@ class TTigressHit : public TGRSIDetectorHit {
 		inline double GetEnergy(Option_t *opt ="")const	{	return core.GetEnergy();	}		//!
 		inline double GetTime(Option_t *opt ="") const	{	return core.GetTime();		}		//!
 		inline double GetTimeCFD()                      {  return core.GetCfd(); } //!
-      TVector3 GetPosition(Double_t dist = 110.0) const; //!
 		//inline double   GetDoppler()	       {	return doppler;				}		//!
 
 
@@ -106,6 +105,9 @@ class TTigressHit : public TGRSIDetectorHit {
 		virtual void Clear(Option_t *opt = "");		                      //!
 		virtual void Copy(TObject&) const;                             //!
       virtual void Print(Option_t *opt = "") const;       		                //!
+
+   private:
+    TVector3 GetChannelPosition(Double_t dist=110.0) const;
 
 	ClassDef(TTigressHit,1)
 };

--- a/include/TTipHit.h
+++ b/include/TTipHit.h
@@ -36,7 +36,6 @@ class TTipHit : public TGRSIDetectorHit {
 
     inline Int_t    GetFiterPatter()           { return filter;   }  //!
     inline Double_t GetPID()                   { return fPID;      }  //!
-    TVector3 GetPosition(Double_t dist=0) const   { return TVector3();}
 
     bool   InFilter(Int_t);                                         //!
 
@@ -44,6 +43,9 @@ class TTipHit : public TGRSIDetectorHit {
     void Clear(Option_t *opt = "");                        //!
     void Print(Option_t *opt = "") const;                  //!
     virtual void Copy(TObject&) const;                     //!
+
+  private:
+    TVector3 GetChannelPosition(Double_t dist=0) const   { return TVector3();}
 
     ClassDef(TTipHit,1);
 

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -215,7 +215,7 @@ void TDescant::BuildHits(TDetectorData *data,Option_t *opt)	{
             //printf("Warning, TDescant::SetWave() set, but data waveform size is zero!\n");
          }
          dethit.SetWaveform(gdata->GetDetWave(i));
-         if(dethit.GetWaveform().size() > 0) {
+         if(dethit.GetWaveform()->size() > 0) {
             printf("Analyzing waveform, current cfd = %d, psd = %d\n",dethit.GetCfd(),dethit.GetPsd());
             bool analyzed = dethit.AnalyzeWaveform();
             printf("%s analyzed waveform, cfd = %d, psd = %d\n",analyzed ? "successfully":"unsuccessfully",dethit.GetCfd(),dethit.GetPsd());

--- a/libraries/TGRSIAnalysis/TGRSIDetector/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/LinkDef.h
@@ -8,7 +8,7 @@
 
 //#pragma link C++ class std::vector<Short_t>+;
 
-#pragma link C++ class TGRSIDetectorHit+;
+#pragma link C++ class TGRSIDetectorHit-;
 #pragma link C++ class std::vector<TGRSIDetectorHit>+;
 #pragma link C++ class std::vector<TGRSIDetectorHit*>+;
 #pragma link C++ class TGRSIDetector+;

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -60,7 +60,7 @@ void TGriffinHit::Print(Option_t *opt) const	{
    printf("Griffin hit TV3 theta: %.2f\tphi%.2f\n",GetPosition().Theta() *180/(3.141597),GetPosition().Phi() *180/(3.141597));
 }
 
-TVector3 TGriffinHit::GetPosition(Double_t dist) const{
+TVector3 TGriffinHit::GetChannelPosition(Double_t dist) const{
    //Returns the Position of the crystal of the current Hit.
 	return TGriffin::GetPosition(GetDetector(),GetCrystal(),dist);
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
@@ -38,7 +38,6 @@ bool TPacesHit::InFilter(Int_t wantedfilter) {
 void TPacesHit::Clear(Option_t *opt)	{
    TGRSIDetectorHit::Clear(opt);    // clears the base (address, position and waveform)
    filter          =  0;
-   fdetector       =  0xFFFF;
 }
 
 
@@ -48,6 +47,8 @@ void TPacesHit::Print(Option_t *opt) const	{
 	printf("Paces hit time:   %f\n",GetTime());
 }
 
-TVector3 TPacesHit::GetPosition(Double_t dist) const{
+TVector3 TPacesHit::GetChannelPosition(Double_t dist) const{
+   //This should not be called by a user. Instead use
+   //TGRSIDetectorHit::GetPosition.
 	return TPaces::GetPosition(GetDetector());
 }

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -149,7 +149,7 @@ void TSceptar::BuildHits(TDetectorData *data,Option_t *opt)	{
             printf("Warning, TSceptar::SetWave() set, but data waveform size is zero!\n");
          }
          dethit.SetWaveform(gdata->GetDetWave(i));
-         if(dethit.GetWaveform().size() > 0) {
+         if(dethit.GetWaveform()->size() > 0) {
 //            printf("Analyzing waveform, current cfd = %d\n",dethit.GetCfd());
             dethit.AnalyzeWaveform();
 //            printf("%s analyzed waveform, cfd = %d\n",analyzed ? "successfully":"unsuccessfully",dethit.GetCfd());

--- a/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
@@ -55,9 +55,10 @@ void TSharcHit::Print(Option_t *options) const {
   //printf( DGREEN "=	=	=	=	=	=	=	" RESET_COLOR "\n");
 }
 
-TVector3 TSharcHit::GetPosition(Double_t dist) const {
-  return  fposition; // returned from this -> i.e front...
-  //return TSharc::GetPosition(detectornumber,front_strip,back_strip,TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());  //! 
+TVector3 TSharcHit::GetChannelPosition(Double_t dist) const {
+ // return  fposition; // returned from this -> i.e front...
+   //PC BENDER PLEASE LOOK AT THIS.
+  return TSharc::GetPosition(detectornumber,front_strip,back_strip,TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());  //! 
 }
 
 Double_t TSharcHit::GetTheta(double Xoff, double Yoff, double Zoff) {

--- a/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
@@ -64,7 +64,7 @@ TVector3 TSharcHit::GetChannelPosition(Double_t dist) const {
 Double_t TSharcHit::GetTheta(double Xoff, double Yoff, double Zoff) {
   TVector3 posoff; 
   posoff.SetXYZ(Xoff,Yoff,Zoff);
-  return (fposition+posoff).Theta();
+  return (GetPosition()+posoff).Theta();
 }
 
 

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -105,7 +105,7 @@ void TTigressHit::SumHit(TTigressHit *hit) {
 }
 
 
-TVector3 TTigressHit::GetPosition(Double_t dist) const {
+TVector3 TTigressHit::GetChannelPosition(Double_t dist) const {
    //Returns the Position of the crystal of the current Hit.
 	return TTigress::GetPosition(GetDetector(),GetCrystal(),dist);
 }


### PR DESCRIPTION
- This makes GRSIDetectorHit members private. I fixed other code that did not assume that.
- Fixes position calls so that they do not recalculate
This works by forcing the user to call GetPosition of the GRSIDetectorHit, which then calls the private virtual GetChannelPosition of the derived detector hit. GetPosition SHOULD NEVER BE OVERRIDDEN for this method to work properly. One can make their own sub-detector checks in their detector classes if they wish.
- @pcbend I was not sure what to do for the sharc position. I am not sure it was ever working. All it did was return fposition which may not have been set. Can you please take a look at this and fix it?
