### PR TITLE
Fixed Tigress energy and charge issues

### DIFF
--- a/include/TBGOData.h
+++ b/include/TBGOData.h
@@ -39,6 +39,7 @@ class TBGOData : public TGRSIDetectorData	{
 		std::vector<Int_t>    fBGO_TimeCFD;		//!The CFD time of the hit in the BGO
 		std::vector<Double_t> fBGO_TimeLED;		//!The LED time of the hit in the BGO
 		std::vector<Double_t> fBGO_Time;		//!The time stamp of the hit in the BGO
+      std::vector<UInt_t> fBGO_Address;   //!
 
 		std::vector<std::vector<int> > fBGO_Wave;	//!The waveform collected by the BGO
 
@@ -63,10 +64,11 @@ class TBGOData : public TGRSIDetectorData	{
 		inline void SetBGOCFD(const Int_t &BGOTimeCFD)   		{fBGO_TimeCFD.push_back(BGOTimeCFD);}	//!
 		inline void SetBGOLED(const Double_t &BGOTimeLED)		{fBGO_TimeLED.push_back(BGOTimeLED);}	//!
 		inline void SetBGOTime(const Double_t &BGOTime)			{fBGO_Time.push_back(BGOTime);}		//!
+      inline void SetBGOAddress(const UInt_t &BGOAddress)   {fBGO_Address.push_back(BGOAddress);} 
 
 		inline void SetBGOWave(const std::vector<int> &BGOWave)		{fBGO_Wave.push_back(BGOWave);}		//!
 
-		inline void SetBGO(const UShort_t &BGOCloverNbr, const UShort_t &BGOCrystalNbr, const UShort_t &BGOPmNbr, const Int_t &BGOCharge, const Double_t &BGOEnergy, const Int_t &BGOTimeCFD, const Double_t &BGOTimeLED, const Double_t &BGOTime = 0)	{
+		inline void SetBGO(const UShort_t &BGOCloverNbr, const UShort_t &BGOCrystalNbr, const UShort_t &BGOPmNbr, const Int_t &BGOCharge, const Double_t &BGOEnergy, const Int_t &BGOTimeCFD, const Double_t &BGOTimeLED, const Double_t &BGOTime = 0, const UInt_t &BGOAddress = -1)	{
 			SetBGOCloverNbr(BGOCloverNbr);
 			SetBGOCrystalNbr(BGOCrystalNbr);
 			SetBGOPmNbr(BGOPmNbr);
@@ -75,6 +77,7 @@ class TBGOData : public TGRSIDetectorData	{
 			SetBGOCFD(BGOTimeCFD);
 			SetBGOLED(BGOTimeLED);
 			SetBGOTime(BGOTime);
+         SetBGOAddress(BGOAddress);
 		};	//!
 
 		inline void SetBGO(TFragment *frag,TChannel *channel,MNEMONIC *mnemonic) {
@@ -105,6 +108,7 @@ class TBGOData : public TGRSIDetectorData	{
 			SetBGOCFD(frag->Cfd.at(0));
 			SetBGOLED(frag->Led.at(0));
 			SetBGOTime(frag->Zc.at(0));
+         SetBGOAddress(frag->ChannelAddress);
 		};	
 		
 		/////////////////////           GETTERS           ////////////////////////
@@ -116,6 +120,7 @@ class TBGOData : public TGRSIDetectorData	{
 		inline Int_t    GetBGOCFD(const unsigned int &i)     {return fBGO_TimeCFD.at(i);}	//!
 		inline Double_t GetBGOLED(const unsigned int &i)     {return fBGO_TimeLED.at(i);}	//!
 		inline Double_t GetBGOTime(const unsigned int &i)    	 {return fBGO_Time.at(i);}	//!
+      inline UInt_t GetBGOAddress(const unsigned int &i)    {return fBGO_Address.at(i);}
 
 		inline std::vector<int> GetBGOWave(const unsigned int &i) {return fBGO_Wave.at(i);}	//!
 

--- a/include/TCrystalHit.h
+++ b/include/TCrystalHit.h
@@ -18,7 +18,7 @@ class TCrystalHit : public TGRSIDetectorHit	{
 		int segment;		//
 		//int charge;		  //
 
-		double local_energy;	//
+//		double local_energy;	//
       bool suppress;
 		//double time;		//
 		//double cfd;		  //
@@ -33,11 +33,11 @@ class TCrystalHit : public TGRSIDetectorHit	{
       virtual void Copy(TObject&) const;             //!
 
 		inline int    GetSegment()       { return segment;}   //!
-		inline double GetEnergy(Option_t *opt= "") const 	{ return local_energy;	}	//!
+	//	inline double GetEnergy(Option_t *opt= "") const 	{ return local_energy;	}	//!
 
       TVector3 GetPosition(Double_t dist = 0) const {return TVector3();}
 		inline void SetSegment(const int &seg) { segment = seg;   }       //!
-		inline void SetEnergy(const double &e)	{	local_energy = e;	}	//!
+//		inline void SetEnergy(const double &e)	{	local_energy = e;	}	//!
 
       inline void SetSuppress(const bool flag = true) { suppress = flag;} 
       inline bool Suppress() {return suppress;}

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -98,11 +98,11 @@ class TGRSIDetectorHit : public TObject 	{
       virtual Double_t GetTime(Option_t *opt = "") const;
       virtual Double_t GetTime(Option_t *opt = "");
       virtual UInt_t GetDetector();
-      virtual inline Int_t   GetCfd() const             {   return fcfd;      }           //!
-      inline UInt_t GetAddress()     const                  { return faddress; }         //!
-      inline Float_t GetCharge() const                       { return fcharge;} //!
-      inline TChannel *GetChannel() const                   { return TChannel::GetChannel(faddress); }  //!
-      inline std::vector<Short_t> *GetWaveform()           { return &fwaveform; } //!
+      virtual inline Int_t   GetCfd() const                          {   return fcfd;      }           //!
+      virtual inline UInt_t GetAddress()     const                   { return faddress; }         //!
+      virtual inline Float_t GetCharge() const                       { return fcharge;} //!
+      inline TChannel *GetChannel() const                            { return TChannel::GetChannel(faddress); }  //!
+      inline std::vector<Short_t> *GetWaveform()                     { return &fwaveform; } //!
     //  inline TGRSIDetector *GetParent() const               { return ((TGRSIDetector*)parent.GetObject()); } //!
       
       //The PPG is only stored in events that come out of the GRIFFIN DAQ

--- a/include/TTigressData.h
+++ b/include/TTigressData.h
@@ -25,6 +25,7 @@ class TTigressData : public TGRSIDetectorData {
 		std::vector<Double_t> fCore_Time;		//!
 		std::vector<Double_t>   fCore_TimeStamp;		//!
 		std::vector<std::vector<int> >fCore_Wave;	//!
+      std::vector<UInt_t> fCore_Address; //!
 
 
 		std::vector<UShort_t> fSeg_Clover_Nbr;		//!
@@ -36,6 +37,7 @@ class TTigressData : public TGRSIDetectorData {
 		std::vector<Double_t> fSegment_TimeLED;		//!
 		std::vector<Double_t> fSegment_Time;		//!
 		std::vector<std::vector<int> > fSegment_Wave;	//!
+      std::vector<UInt_t> fSegment_Address; //!
 
 		static bool fIsSet; //!
 
@@ -58,10 +60,12 @@ class TTigressData : public TGRSIDetectorData {
 		inline void SetCoreCFD(const Int_t &CoreTimeCFD)	       {fCore_TimeCFD.push_back(CoreTimeCFD); }	//!	
 		inline void SetCoreLED(const Double_t &CoreTimeLED)	    {fCore_TimeLED.push_back(CoreTimeLED); }	//!	
 		inline void SetCoreTimeStamp(const Long64_t    &CoreTime) {fCore_TimeStamp.push_back(CoreTime);       }	//!
+		inline void SetCoreAddress(const UInt_t    &CoreAddress)  {fCore_Address.push_back(CoreAddress);       }	//!
+      
 		
 		inline void SetCoreWave(const std::vector<int> &CoreWave) {fCore_Wave.push_back(CoreWave);} //!
 	
-		inline void SetCore(const UShort_t &CloverNbr, const UShort_t &CoreNbr, const Double_t &CrystalEnergy, const Int_t &CrystalCharge, const Int_t &CrystalTimeCFD,const Double_t &CrystalTimeLED,const Long64_t &CrystalTimeStamp)	{
+		inline void SetCore(const UShort_t &CloverNbr, const UShort_t &CoreNbr, const Double_t &CrystalEnergy, const Int_t &CrystalCharge, const Int_t &CrystalTimeCFD,const Double_t &CrystalTimeLED,const Long64_t &CrystalTimeStamp, const UInt_t &CoreAddress)	{
 
 			SetCloverNumber(CloverNbr);
 			SetCoreNumber(CoreNbr);
@@ -70,6 +74,7 @@ class TTigressData : public TGRSIDetectorData {
 			SetCoreCFD(CrystalTimeCFD);		
 			SetCoreLED(CrystalTimeLED);		
 			SetCoreTimeStamp(CrystalTimeStamp);		
+         SetCoreAddress(CoreAddress);
 
 		}	//!
 
@@ -80,7 +85,6 @@ class TTigressData : public TGRSIDetectorData {
 			  		return;
 
 				if(mnemonic->outputsensor.compare(0,1,"b")==0) {	return; }  //make this smarter.
-
 
 				UShort_t CoreNbr=5;
 				if(mnemonic->arraysubposition.compare(0,1,"B")==0)
@@ -112,6 +116,7 @@ class TTigressData : public TGRSIDetectorData {
 				SetCoreLED(frag->Led.at(0));		
 			   //SetCoreTime(frag->GetTimeStamp());		
 				SetCoreTime(frag->Zc.at(0));		
+            SetCoreAddress(frag->ChannelAddress);
 		}; //! 
 
 
@@ -123,10 +128,11 @@ class TTigressData : public TGRSIDetectorData {
 		inline void SetSegmentCFD(const Int_t &SegmentTimeCFD)	   {fSegment_TimeCFD.push_back(SegmentTimeCFD);}	//!
 		inline void SetSegmentLED(const Double_t &SegmentTimeLED)	{fSegment_TimeLED.push_back(SegmentTimeLED);}	//!
 		inline void SetSegmentTime(const Double_t &SegmentTime)		{fSegment_Time.push_back(SegmentTime);}		//!
+		inline void SetSegmentAddress(const UInt_t &SegmentAddress){fSegment_Address.push_back(SegmentAddress);}		//!
 
 		inline void SetSegmentWave(const std::vector<int> &SegWave)	{fSegment_Wave.push_back(SegWave);}		//!
 
-		inline void SetSegment(const UShort_t &SegCloverNbr, const UShort_t &SegCoreNbr, const UShort_t &SegmentNumber,const Double_t &SegmentEnergy, const Int_t &SegmentCharge, const Int_t &SegmentTimeCFD,const Double_t &SegmentTimeLED,const Double_t &SegmentTime)	{
+		inline void SetSegment(const UShort_t &SegCloverNbr, const UShort_t &SegCoreNbr, const UShort_t &SegmentNumber,const Double_t &SegmentEnergy, const Int_t &SegmentCharge, const Int_t &SegmentTimeCFD,const Double_t &SegmentTimeLED,const Double_t &SegmentTime, const UInt_t &SegmentAddress)	{
 
 			SetSegCloverNumber(SegCloverNbr);
 			SetSegCoreNumber(SegCoreNbr);
@@ -136,6 +142,7 @@ class TTigressData : public TGRSIDetectorData {
 			SetSegmentCFD(SegmentTimeCFD);
 			SetSegmentLED(SegmentTimeLED);
 			SetSegmentTime(SegmentTime);
+         SetSegmentAddress(SegmentAddress);
 		}	//!
 
 		inline void SetSegment(TFragment *frag,TChannel *channel,MNEMONIC *mnemonic)	{
@@ -170,6 +177,7 @@ class TTigressData : public TGRSIDetectorData {
 				SetSegmentLED(frag->Led.at(0));		
 			 	//SetSegmentTime(frag->GetTimeStamp());		
 				SetSegmentTime(frag->Zc.at(0));		
+            SetSegmentAddress(frag->ChannelAddress);
 		}; 
 
 
@@ -181,6 +189,7 @@ class TTigressData : public TGRSIDetectorData {
 		inline Double_t GetCoreLED(const unsigned int &i)	{return fCore_TimeLED.at(i);}	//!	
 		inline Double_t GetCoreTime(const unsigned int &i)	{return fCore_Time.at(i);}	//!
 		inline Double_t GetCoreTimeStamp(const unsigned int &i)	{return fCore_TimeStamp.at(i);}	//!
+		inline UInt_t GetCoreAddress(const unsigned int &i)	{return fCore_Address.at(i);}	//!
 
 		inline std::vector<int> GetCoreWave(const unsigned int &i)	{return fCore_Wave.at(i);}	//!
 
@@ -191,7 +200,8 @@ class TTigressData : public TGRSIDetectorData {
 		inline Float_t  GetSegmentCharge(const unsigned int &i)   {return fSegment_Chg.at(i);}	//!
 		inline Int_t    GetSegmentCFD(const unsigned int &i)      {return fSegment_TimeCFD.at(i);}//!
 		inline Double_t GetSegmentLED(const unsigned int &i)      {return fSegment_TimeLED.at(i);}//!
-		inline Double_t GetSegmentTime(const unsigned int &i)	    {return fSegment_Time.at(i);}	//!
+      inline Double_t GetSegmentTime(const unsigned int &i)	    {return fSegment_Time.at(i);}	//!
+		inline UInt_t GetSegmentAddress(const unsigned int &i)	 {return fSegment_Address.at(i);}	//!
 	
 		inline std::vector<int> GetSegmentWave(const unsigned int &i) {return fSegment_Wave.at(i);} //!
 

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -29,7 +29,7 @@ class TTigressHit : public TGRSIDetectorHit {
 		UShort_t first_segment;        
 		Float_t    first_segment_charge; //!
 
-      Double_t fEnergy;
+  //    Double_t fEnergy;
 
 		TCrystalHit core;
 		//std::vector<TCrystalHit> segment;
@@ -50,7 +50,7 @@ class TTigressHit : public TGRSIDetectorHit {
 	public:
       void SetHit() {}
 		/////////////////////////		/////////////////////////////////////
-		void SetCore(TCrystalHit &temp)		  { core = temp;	} 					//!
+		void SetCore(const TCrystalHit &temp)		  { core = temp;	} 					//!
 		void AddSegment(TCrystalHit &temp);	  //{ segment.push_back(temp);	}		//!
 		void AddBGO(TCrystalHit &temp);		  //{ bgo.push_back(temp);	}			//!
 
@@ -67,10 +67,13 @@ class TTigressHit : public TGRSIDetectorHit {
 		int GetCrystal() const;	          //{	return crystal;			}		//!
 		inline int GetInitialHit()		               {	return first_segment;	}			//!
 	
-		inline int GetCharge()			                  {	return core.GetCharge();	}		//!
+		inline Float_t GetCharge()	const	               {  return core.GetCharge();	}		//!
 		inline double GetEnergy(Option_t *opt ="")const	{	return core.GetEnergy();	}		//!
 		inline double GetTime(Option_t *opt ="") const	{	return core.GetTime();		}		//!
-		inline double GetTimeCFD()                      {  return core.GetCfd(); } //!
+		inline double GetTimeCFD() const                {  return core.GetCfd(); } //!
+      inline UInt_t GetAddress() const                {  return core.GetAddress(); }
+      ULong_t GetTimeStamp(Option_t *opt="")   const  {  return core.GetTimeStamp();   }  // Returns a time value to the nearest nanosecond!
+      UInt_t GetDetector()   const                    {  return core.GetDetector();   }  // Returns a time value to the nearest nanosecond!
 		//inline double   GetDoppler()	       {	return doppler;				}		//!
 
 

--- a/libraries/TGRSIAnalysis/TTigress/TCrystalHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TCrystalHit.cxx
@@ -16,7 +16,7 @@ TCrystalHit::TCrystalHit(): suppress(false)	{
 TCrystalHit::TCrystalHit(const TCrystalHit &rhs)
   : TGRSIDetectorHit() {
    //Class()->IgnoreTObjectStreamer(true);
-   ((TCrystalHit&)rhs).Copy(*this);
+   rhs.Copy(*this);
 
 }
 

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -71,6 +71,7 @@ void TTigress::AddAddBackHit(const TTigressHit& temp) {
 
 
 void TTigress::Print(Option_t *opt)	const {
+   printf("Tigress Hits: %d\n",GetMultiplicity());
   //printf("not yet written...\n");
   //printf(DYELLOW "TTigress::beta  =  %.04f" RESET_COLOR  "\n",beta);
   return;
@@ -125,6 +126,7 @@ void	TTigress::BuildHits(TDetectorData *data,Option_t *opt)	{
 		TTigressHit corehit;
 		temp_crystal.Clear();
 
+		temp_crystal.SetAddress(tdata->GetCoreAddress(i));
 		temp_crystal.SetCharge(tdata->GetCoreCharge(i));
       temp_crystal.SetEnergy(tdata->GetCoreEnergy(i));
       temp_crystal.SetTime(tdata->GetCoreTime(i));
@@ -137,6 +139,7 @@ void	TTigress::BuildHits(TDetectorData *data,Option_t *opt)	{
 		corehit.SetCore(temp_crystal);	
 		corehit.SetDetector((UInt_t)tdata->GetCloverNumber(i));
       corehit.SetCrystal();  //tdata->GetCoreNumber(i));
+
 		//tigress_hits.push_back(corehit);
 		AddTigressHit(corehit);
 	}
@@ -150,6 +153,7 @@ void	TTigress::BuildHits(TDetectorData *data,Option_t *opt)	{
 					continue;
 			
            temp_crystal.Clear();
+           temp_crystal.SetAddress(tdata->GetSegmentAddress(j));
            temp_crystal.SetSegment(tdata->GetSegmentNumber(j));
            temp_crystal.SetCharge(tdata->GetSegmentCharge(j));
            temp_crystal.SetEnergy(tdata->GetSegmentEnergy(j));
@@ -173,6 +177,7 @@ void	TTigress::BuildHits(TDetectorData *data,Option_t *opt)	{
           temp_crystal.SetEnergy(bdata->GetBGOEnergy(j));
           temp_crystal.SetTime(bdata->GetBGOTime(j));
           temp_crystal.SetCfd(bdata->GetBGOCFD(j));
+          temp_crystal.SetAddress(bdata->GetBGOAddress(j));
           //if(TTigress::SetBGOWave()) {
           //  temp_crystal.SetWaveForm(bdata->GetBGOWave(j));
           //}			
@@ -482,7 +487,6 @@ void TTigress::BuildAddBack(Option_t *opt)	{
     	return;
 
 	addback_hits.Clear();
-
    AddAddBackHit((TTigressHit&)(*(this->GetTigressHit(0))));
   
 	if(this->GetMultiplicity() == 1) {
@@ -492,7 +496,6 @@ void TTigress::BuildAddBack(Option_t *opt)	{
 		//addback_hits.push_back(*(this->GetTigressHit(0)));
 		//addback_hits.At(0)->SumHit((TTigressHit*)addback_hits.At(0));
       GetAddBackHit(0)->SumHit(GetAddBackHit(0));
-
 
 		for(int i = 1; i<(int)(this->GetMultiplicity()); i++)   {
 		 	bool used = false;
@@ -524,7 +527,8 @@ void TTigress::BuildAddBack(Option_t *opt)	{
 		 	}
 			 if(!used) {
             AddAddBackHit(*GetTigressHit(i));
-            GetAddBackHit(addback_hits.GetEntries())->SumHit(GetAddBackHit(addback_hits.GetEntries()));
+         //NOT SURE WHY THIS IS HERE (BELOW) COMMENTED OUT BECUASE WE DIDNT THINK IT MADE SENSE.
+        //    GetAddBackHit(addback_hits.GetEntries())->SumHit(GetAddBackHit(addback_hits.GetEntries()));
 		 	   //addback_hits.push_back(*(this->GetTigressHit(i)));
 		     	//addback_hits.back().Add(&(addback_hits.back()));
 			 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigressData.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressData.cxx
@@ -28,6 +28,7 @@ void TTigressData::Clear(Option_t *opt)	{
 	fCore_TimeLED.clear();
 	fCore_Time.clear();
 	fCore_TimeStamp.clear();
+   fCore_Address.clear();
 
 	fCore_Wave.clear();
 
@@ -39,6 +40,7 @@ void TTigressData::Clear(Option_t *opt)	{
 	fSegment_TimeCFD.clear();
 	fSegment_TimeLED.clear();
 	fSegment_Time.clear();
+   fSegment_Address.clear();
 
 	fSegment_Wave.clear();
 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -56,6 +56,7 @@ void TTigressHit::Clear(Option_t *opt) {
 void TTigressHit::Copy(TObject &rhs) const {
   TGRSIDetectorHit::Copy(rhs);
   segment.Copy(static_cast<TTigressHit&>(rhs).segment);
+  core.Copy(static_cast<TTigressHit&>(rhs).core);
   bgo.Copy(static_cast<TTigressHit&>(rhs).bgo);
   (static_cast<TTigressHit&>(rhs)).crystal = crystal;
   (static_cast<TTigressHit&>(rhs)).first_segment = first_segment;


### PR DESCRIPTION
- Was that the core was being ignored.
- About to change the charge data member to be an Int_t rather than a Float_t and fix associated issues with this
- Currently in possession of a new Tigress format that will get rid of the need for special subclasses of bgos and segments instead making them separate DetectorHits within the tigress_hits. 