### PR TITLE
Added a static SetUseCalFileIntegration to change all channels

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -128,6 +128,7 @@ class TChannel : public TNamed	{
 	double GetEFFChi2()  { return EFFChi2;} 
 
 	void SetUseCalFileIntegration(bool flag=true) {usecalfileint=flag;}
+   static void SetUseCalFileIntegration(std::string mnemonic,bool flag);
 	bool UseCalFileIntegration() { return usecalfileint; }
 
 	std::vector<Float_t> GetENGCoeff() { return ENGCoefficients;}

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -473,6 +473,19 @@ double TChannel::CalibrateEFF(double energy) {
    return 1.0;
 }
 
+void TChannel::SetUseCalFileIntegration(std::string mnemonic,bool flag){
+   //Writes this CalFile to all channels in the current TChannel Map 
+   //That starts with the mnemonic. Use "" to write to ALL channels
+   //WARNING: This is case sensitive!
+   std::map<unsigned int,TChannel*>::iterator mapit;
+   std::map<unsigned int,TChannel*> *chanmap = TChannel::GetChannelMap();
+   for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++){
+      if(!mnemonic.size() || !strncmp(mapit->second->GetChannelName(),mnemonic.c_str(),mnemonic.size())){
+         mapit->second->SetUseCalFileIntegration(flag);
+      }
+   }
+}
+
 void TChannel::Print(Option_t *opt) const {
    //Prints out the current TChannel.
    std::cout <<  channelname << "\t{\n";  //,channelname.c_str();


### PR DESCRIPTION
- Usage for all channels `TChannel::SetUseCalFileIntegration("",true);`
- Usage for a particular mnemonic `TChannel::SetUseCalFileIntegration("TIG",true)` which would set all tigress detectors
or 
`TChannel::SetUseCalFileIntegration("TIG02",true);` which would only due tigress 2
or 
`TChannel::SetUseCalFileIntegration("TIG1",true);` which would only due tigress 10 through 19,
Basically it changes anything with that string within it's mnemonic. It is also strictly case sensitive.