### PR TITLE
Added waveform fitting to Tigress and Tip, added fitting option to runinfo

### DIFF
--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -259,7 +259,7 @@ class TGRSIRunInfo : public TObject {
       void Print(Option_t *opt = "") const;
       void Clear(Option_t *opt = "");
 
-   ClassDef(TGRSIRunInfo,6);  //Contains the run-dependent information.
+   ClassDef(TGRSIRunInfo,7);  //Contains the run-dependent information.
 };
 
 #endif

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -165,6 +165,9 @@ class TGRSIRunInfo : public TObject {
       inline void SetBuildWindow(const long int t_bw)    { fBuildWindow = t_bw; } 
       inline void SetAddBackWindow(const double   t_abw) { fAddBackWindow = t_abw; } 
 
+	  inline void SetWaveformFitting(const bool flag)	 {fWaveformFitting = flag; }
+	  static inline bool IsWaveformFitting()			 {return Get()->fWaveformFitting; }
+
       inline void SetMovingWindow(const bool flag)       {fIsMovingWindow = flag; }
       static inline bool IsMovingWindow()                { return Get()->fIsMovingWindow; }
 
@@ -247,6 +250,8 @@ class TGRSIRunInfo : public TObject {
       double   fAddBackWindow;        // Time used to build Addback-Ge-Events for TIGRESS/GRIFFIN.   (default =150 ns (15.0))
       bool     fIsMovingWindow;       // if set to true the event building window moves. Static otherwise.
       
+	  bool 	   fWaveformFitting;	  // If true, waveform fitting with SFU algorithm will be performed
+
       double  fHPGeArrayPosition;        // Position of the HPGe Array (default = 110.0 mm );
   
 

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -29,12 +29,12 @@ class TS3Hit : public TGRSIDetectorHit {
     void SetSectorNumber(Short_t sn)   { sector = sn; }
 //    void SetDetectorNumber(Short_t dn) { detectornumber = dn; }
 //    void SetPosition(TVector3 &vec)    { fposition = vec; }
-    void SetVariables(TFragment &frag) { SetEnergy(frag.GetEnergy());
+    void SetVariables(TFragment &frag) { //SetEnergy(frag.GetEnergy());
                                          SetCfd(frag.GetCfd());
                                          SetCharge(frag.GetCharge());
                                          SetTimeStamp(frag.GetTimeStamp()); 
-                                         SetTime(frag.GetZCross());
-					 led    = frag.GetLed(); }
+                                         //SetTime(frag.GetZCross());
+					 					 led    = frag.GetLed(); }
  
 
   private:

--- a/include/TSiLiHit.h
+++ b/include/TSiLiHit.h
@@ -32,14 +32,12 @@ class TSiLiHit : public TGRSIDetectorHit {
 					}
 //     using TGRSIDetectorHit::SetPosition; //This is here to fix warnings. Will leave when lean-ness occurs
 //     void SetPosition(TVector3 &vec)    { fposition = vec; }
-    void SetVariables(TFragment &frag) { SetEnergy(frag.GetEnergy());
+    void SetVariables(TFragment &frag) { //SetEnergy(frag.GetEnergy());
                                          SetCfd(frag.GetCfd());
                                          SetCharge(frag.GetCharge());
                                          SetTimeStamp(frag.GetTimeStamp()); 
-                                         SetTime(frag.GetZCross());
-					 
-					 led    = frag.GetLed();
-				        }
+                                         //SetTime(frag.GetZCross());
+										 led    = frag.GetLed(); }
     void SetWavefit(TFragment&);
 
 //     Double_t fit_time(TFragment &);

--- a/include/TTigressData.h
+++ b/include/TTigressData.h
@@ -39,6 +39,8 @@ class TTigressData : public TGRSIDetectorData {
 		std::vector<std::vector<int> > fSegment_Wave;	//!
       std::vector<UInt_t> fSegment_Address; //!
 
+		std::vector<TFragment> fCore_Frag;
+
 		static bool fIsSet; //!
 
 	public:
@@ -61,7 +63,7 @@ class TTigressData : public TGRSIDetectorData {
 		inline void SetCoreLED(const Double_t &CoreTimeLED)	    {fCore_TimeLED.push_back(CoreTimeLED); }	//!	
 		inline void SetCoreTimeStamp(const Long64_t    &CoreTime) {fCore_TimeStamp.push_back(CoreTime);       }	//!
 		inline void SetCoreAddress(const UInt_t    &CoreAddress)  {fCore_Address.push_back(CoreAddress);       }	//!
-      
+      	inline void SetCoreFragment(const TFragment &frag)		 {fCore_Frag.push_back(frag);				}//!
 		
 		inline void SetCoreWave(const std::vector<int> &CoreWave) {fCore_Wave.push_back(CoreWave);} //!
 	
@@ -110,6 +112,8 @@ class TTigressData : public TGRSIDetectorData {
 //				printf("energy;  %.02f\n",channel->CalibrateENG(frag->Charge.at(0)));
 //				printf("============================================================\n");
             	SetCoreTimeStamp(frag->GetTimeStamp());
+
+				SetCoreFragment(*frag);
 
 				SetCoreCharge(frag->GetCharge(0));
 				SetCoreCFD(frag->Cfd.at(0));		
@@ -177,10 +181,11 @@ class TTigressData : public TGRSIDetectorData {
 				SetSegmentLED(frag->Led.at(0));		
 			 	//SetSegmentTime(frag->GetTimeStamp());		
 				SetSegmentTime(frag->Zc.at(0));		
-            SetSegmentAddress(frag->ChannelAddress);
+            	SetSegmentAddress(frag->ChannelAddress);
 		}; 
 
 
+		inline TFragment GetCoreFragment(const unsigned int &i)	{return fCore_Frag.at(i);}
 		inline UShort_t GetCloverNumber(const unsigned int &i)	{return fClover_Nbr.at(i);}	//!
 		inline UShort_t GetCoreNumber(const unsigned int &i)	{return fCore_Nbr.at(i);}	//!
 		inline Double_t GetCoreEnergy(const unsigned int &i)	{return fCore_Eng.at(i);}	//!

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -10,6 +10,7 @@
 #include "TFragment.h"
 #include "TChannel.h"
 #include "TCrystalHit.h"
+#include "TPulseAnalyzer.h"
 
 #include "TMath.h"
 #include "TVector3.h"
@@ -28,14 +29,17 @@ class TTigressHit : public TGRSIDetectorHit {
 		UInt_t   crystal;              //!
 		UShort_t first_segment;        
 		Float_t    first_segment_charge; //!
+		
+	    Double_t    time_fit;
+	    Double_t    sig2noise;
 
   //    Double_t fEnergy;
 
 		TCrystalHit core;
 		//std::vector<TCrystalHit> segment;
-      TClonesArray segment;
+      	TClonesArray segment;
 		//std::vector<TCrystalHit> bgo;
-      TClonesArray bgo;
+      	TClonesArray bgo;
 
 		//double doppler;
 
@@ -57,7 +61,7 @@ class TTigressHit : public TGRSIDetectorHit {
 		//void SetDetectorNumber(const int &i) { detector = i;	} 				//!
 		void SetCrystal()	                   { crystal = GetCrystal(); SetFlag(TGRSIDetectorHit::kIsSubDetSet,true); }		//!
 		void SetInitalHit(const int &i)		 { first_segment = i; }				//!
-      Bool_t IsCrystalSet() const {return IsSubDetSet();}
+      	Bool_t IsCrystalSet() const {return IsSubDetSet();}
 
 //		void SetPosition(const TVector3 &p)  { position = p;	}					//!
 		//void SetDoppler(const double &d)	   { doppler = d;	}					//!
@@ -71,11 +75,14 @@ class TTigressHit : public TGRSIDetectorHit {
 		inline double GetEnergy(Option_t *opt ="")const	{	return core.GetEnergy();	}		//!
 		inline double GetTime(Option_t *opt ="") const	{	return core.GetTime();		}		//!
 		inline double GetTimeCFD() const                {  return core.GetCfd(); } //!
-      inline UInt_t GetAddress() const                {  return core.GetAddress(); }
-      ULong_t GetTimeStamp(Option_t *opt="")   const  {  return core.GetTimeStamp();   }  // Returns a time value to the nearest nanosecond!
-      UInt_t GetDetector()   const                    {  return core.GetDetector();   }  // Returns a time value to the nearest nanosecond!
+      	inline UInt_t GetAddress() const                {  return core.GetAddress(); }
+      	ULong_t GetTimeStamp(Option_t *opt="")   const  {  return core.GetTimeStamp();   }  // Returns a time value to the nearest nanosecond!
+      	UInt_t GetDetector()   const                    {  return core.GetDetector();   }  // Returns a time value to the nearest nanosecond!
 		//inline double   GetDoppler()	       {	return doppler;				}		//!
 
+    	void SetWavefit(TFragment&);
+		inline Double_t GetSignalToNoise()		   { return sig2noise;	} //!
+		inline Double_t GetFitTime()			   { return time_fit;	} //!
 
 		inline double GetDoppler(double beta,TVector3 *vec=0) { 
 			if(vec==0) {

--- a/include/TTip.h
+++ b/include/TTip.h
@@ -49,7 +49,7 @@ class TTip : public TGRSIDetector {
     TTipData *tipdata;                                               //!  Used to build TIP Hits
     std::vector <TTipHit> tip_hits;                                  //   The set of detector hits
 
-  private:
+  /*private:
     //  SFU CsI waveform fitting routines.
     typedef struct WaveFormPar {
       //parameters for baseline
@@ -109,7 +109,7 @@ class TTip : public TGRSIDetector {
 
     WaveFormPar GetExclusionZone();
     WaveShapPar GetShape(WaveFormPar&);
-
+	*/
 
   public:
 

--- a/include/TTipData.h
+++ b/include/TTipData.h
@@ -18,6 +18,7 @@ class TTipData : public TGRSIDetectorData {
   private:
     std::vector <TFragment> fTip_Frag;  //!
     std::vector <std::string> fTip_Name; //!
+	std::vector <UInt_t> fTip_Address;	
 
     static bool fIsSet;      //!
    public:
@@ -34,16 +35,19 @@ class TTipData : public TGRSIDetectorData {
 
     inline void SetTipFragment(const TFragment &Frag)       {fTip_Frag.push_back(Frag);        }  //!  
     inline void SetTipName(const char *Name)                {fTip_Name.push_back(std::string(Name));        }  //!  
+	inline void SetTipAddress(const UInt_t Address)			{fTip_Address.push_back(Address);	}
 
   public:
     void SetDet(TFragment *frag,TChannel *channel,MNEMONIC *mnemonic)  {
       if(!frag || !channel || !mnemonic) return;
       SetTipFragment(*frag);
       SetTipName(channel->GetChannelName());
+	  SetTipAddress(frag->ChannelAddress);
     }; //! 
 
     inline TFragment   GetTipFragment(const unsigned int &i)   {return fTip_Frag.at(i);}  //!
     inline std::string GetTipName(const unsigned int &i)       {return fTip_Name.at(i);}  //!
+	inline UInt_t 	   GetTipAddress(const unsigned int &i)	   {return fTip_Address.at(i);} //!
 
     inline unsigned int GetMultiplicity()    {return fTip_Frag.size();}                   //!
     

--- a/include/TTipHit.h
+++ b/include/TTipHit.h
@@ -7,6 +7,7 @@
 #include "TFragment.h"
 #include "TChannel.h"
 #include "TCrystalHit.h"
+#include "TPulseAnalyzer.h"
 
 #include "TVector3.h"
 
@@ -27,17 +28,41 @@ class TTipHit : public TGRSIDetectorHit {
     Double_t slow_amplitude;
     Double_t gamma_amplitude;
    
-    Double_t fit_time;
+	Int_t	 tip_channel;
+
+    Double_t    time_fit;
+    Double_t    sig2noise;
 
   public:
     /////////////////////////    /////////////////////////////////////
-    inline void SetFilterPattern(const int &x)   { filter   = x; }   //! 
+    inline void SetFilterPattern(const int &x)    { filter   = x; }   //! 
     inline void SetPID(Double_t x)                { fPID = x;     }   //!
+	inline void SetTipChannel(const int x)		  { tip_channel = x; } //!
 
     inline Int_t    GetFiterPatter()           { return filter;   }  //!
     inline Double_t GetPID()                   { return fPID;      }  //!
+	inline Double_t GetFitTime()			   { return time_fit;	} //!
+	inline Double_t GetSignalToNoise()		   { return sig2noise;	} //!
+	inline Int_t	GetTipChannel()			   { return tip_channel; } //!
 
     bool   InFilter(Int_t);                                         //!
+
+    void SetVariables(TFragment &frag) { SetCfd(frag.GetCfd());
+                                         SetCharge(frag.GetCharge());
+                                         SetTimeStamp(frag.GetTimeStamp()); }
+
+	void SetUpNumbering(TChannel &chan) { MNEMONIC mnemonic;
+										  TChannel *channel = GetChannel();
+										  if(!channel){
+										    Error("SetDetector","No TChannel exists for address %u",GetAddress());
+										    return;
+										  }
+										  ClearMNEMONIC(&mnemonic);
+										  ParseMNEMONIC(channel->GetChannelName(),&mnemonic); 
+										  Int_t tmp = (int16_t)atoi(mnemonic.arraysubposition.c_str()); 
+										  SetTipChannel((Int_t)(10*mnemonic.arrayposition + tmp)); }
+
+    void SetWavefit(TFragment&);
 
   public:
     void Clear(Option_t *opt = "");                        //!

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -414,7 +414,7 @@ double  TPulseAnalyzer::fit_newT0(){
 
 	chisq[0]=get_smooth_T0(); memcpy(&w[0],wpar,swp);	
 	chisq[1]=get_parabolic_T0(); memcpy(&w[1],wpar,swp);	
-	chisq[2]=get_linear_T0();// memcpy(&w[2],wpar,swp);	
+	chisq[2]=get_linear_T0(); memcpy(&w[2],wpar,swp);	
 
 	chimin=LARGECHISQ;
 	imin=0;

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -1,5 +1,6 @@
 
 #include "TSiLi.h"
+#include <TGRSIRunInfo.h>
 
 ClassImp(TSiLi)
 
@@ -41,7 +42,9 @@ void TSiLi::BuildHits(TDetectorData *data,Option_t *opt)  {
      hit.SetPosition(tmppos);
      TFragment tmp = sdata->GetFragment(i);
      hit.SetVariables(tmp);
-     hit.SetWavefit(tmp);
+
+	 if(TGRSIRunInfo::IsWaveformFitting()) 
+     	hit.SetWavefit(tmp);
   
      sili_hits.push_back(hit);
   }

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -128,18 +128,24 @@ void	TTigress::BuildHits(TDetectorData *data,Option_t *opt)	{
 
 		temp_crystal.SetAddress(tdata->GetCoreAddress(i));
 		temp_crystal.SetCharge(tdata->GetCoreCharge(i));
-      //temp_crystal.SetEnergy(tdata->GetCoreEnergy(i));
-      //temp_crystal.SetTime(tdata->GetCoreTime(i));
-      temp_crystal.SetCfd(tdata->GetCoreCFD(i));
-	  temp_crystal.SetTimeStamp(tdata->GetCoreTime(i));
+      	//temp_crystal.SetEnergy(tdata->GetCoreEnergy(i));
+      	//temp_crystal.SetTime(tdata->GetCoreTime(i));
+      	temp_crystal.SetCfd(tdata->GetCoreCFD(i));
+	  	temp_crystal.SetTimeStamp(tdata->GetCoreTime(i));
 
 		//if(TTigress::SetCoreWave())	{
-      //  	temp_crystal.SetWaveForm(tdata->GetCoreWave(i));
+      	//  	temp_crystal.SetWaveForm(tdata->GetCoreWave(i));
 		//}
+
+		TFragment tmp = tdata->GetCoreFragment(i);
+
+		if(TGRSIRunInfo::IsWaveformFitting()) 
+			corehit.SetWavefit(tmp);
+		
 		
 		corehit.SetCore(temp_crystal);	
 		corehit.SetDetector((UInt_t)tdata->GetCloverNumber(i));
-      corehit.SetCrystal();  //tdata->GetCoreNumber(i));
+      	corehit.SetCrystal();  //tdata->GetCoreNumber(i));
 
 		//tigress_hits.push_back(corehit);
 		AddTigressHit(corehit);

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -61,6 +61,8 @@ void TTigressHit::Copy(TObject &rhs) const {
   (static_cast<TTigressHit&>(rhs)).crystal = crystal;
   (static_cast<TTigressHit&>(rhs)).first_segment = first_segment;
   (static_cast<TTigressHit&>(rhs)).first_segment_charge = first_segment_charge;
+  static_cast<TTigressHit&>(rhs).time_fit		= time_fit;
+  static_cast<TTigressHit&>(rhs).sig2noise		= sig2noise;  
   lasthit.Copy(static_cast<TTigressHit&>(rhs).lasthit);
 }
 
@@ -133,4 +135,12 @@ int TTigressHit::GetCrystal() const {
    };
    return -1;  
 
+}
+
+void TTigressHit::SetWavefit(TFragment &frag)   { 
+	TPulseAnalyzer pulse(frag);	    
+	if(pulse.IsSet()){
+		time_fit = pulse.fit_newT0();
+		sig2noise= pulse.get_sig2noise();
+	}
 }

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -3,6 +3,8 @@
 #include <TRandom.h>
 #include <TMath.h>
 #include <TClass.h>
+#include <TGRSIRunInfo.h>
+
 
 ////////////////////////////////////////////////////////////
 //                    
@@ -57,7 +59,7 @@ void TTip::FillData(TFragment *frag, TChannel *channel, MNEMONIC *mnemonic) {
    if(!tipdata)   
       tipdata = new TTipData();
 
-   //tipdata->SetDet(frag,channel,mnemonic);
+   tipdata->SetDet(frag,channel,mnemonic);
    TTipData::Set();
 }
 
@@ -75,12 +77,17 @@ void TTip::BuildHits(TDetectorData *data,Option_t *opt)	{
    for(size_t i=0;i<gdata->GetMultiplicity();i++) {
       TTipHit dethit;
 
-      //dethit.SetAddress(gdata->GetDetAddress(i));
+      dethit.SetAddress(gdata->GetTipAddress(i));
       
-      //dethit.SetCharge(gdata->GetDetCharge(i));
+	  TFragment tmp = gdata->GetTipFragment(i);
 
-      //dethit.SetTime(gdata->GetDetTime(i));
-      //dethit.SetCfd(gdata->GetDetCFD(i));
+      dethit.SetVariables(tmp);
+
+	  if(TGRSIRunInfo::IsWaveformFitting()) 
+      	dethit.SetWavefit(tmp);
+
+	  TChannel chan = TChannel::GetChannel(dethit.GetAddress());
+	  dethit.SetUpNumbering(chan);
 
       //dethit.SetPID(gdata->GetPID(i));
 

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -27,8 +27,11 @@ TTipHit::TTipHit(const TTipHit &rhs) : TGRSIDetectorHit() {
 
 void TTipHit::Copy(TObject &rhs) const {
    TGRSIDetectorHit::Copy(rhs);
-   static_cast<TTipHit&>(rhs).filter  = filter;
-   static_cast<TTipHit&>(rhs).fPID     = fPID;
+   static_cast<TTipHit&>(rhs).filter  		= filter;
+   static_cast<TTipHit&>(rhs).fPID     		= fPID;
+   static_cast<TTipHit&>(rhs).tip_channel 	= tip_channel;
+   static_cast<TTipHit&>(rhs).time_fit		= time_fit;
+   static_cast<TTipHit&>(rhs).sig2noise		= sig2noise;
 }                                       
 
 bool TTipHit::InFilter(Int_t wantedfilter) {
@@ -38,8 +41,10 @@ bool TTipHit::InFilter(Int_t wantedfilter) {
 }
 
 void TTipHit::Clear(Option_t *opt) {
-   filter = 0;
-   fPID   = 0;
+   filter 		= 0;
+   fPID   		= 0;
+   tip_channel 	= 0;
+   time_fit		= 0;
    //position.SetXYZ(0,0,1);
 
   // waveform.clear();
@@ -49,5 +54,13 @@ void TTipHit::Print(Option_t *opt) const {
    printf("Tip Detector: %i\n",GetDetector());
    printf("Tip hit energy: %.2f\n",GetEnergy());
    printf("Tip hit time:   %.f\n",GetTime());
+}
+
+void TTipHit::SetWavefit(TFragment &frag)   { 
+	TPulseAnalyzer pulse(frag);	    
+	if(pulse.IsSet()){
+		time_fit = pulse.fit_newT0();
+		sig2noise= pulse.get_sig2noise();
+	}
 }
 

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -77,6 +77,9 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    if(R__v>4) {
      {Bool_t R__bool; b >> R__bool; fIsMovingWindow = R__bool;}
    }
+   if(R__v>6) {
+     {Bool_t R__bool; b >> R__bool; fWaveformFitting = R__bool;}
+   }
    {Bool_t R__bool; b >> R__bool; fTigress = R__bool;   }
    {Bool_t R__bool; b >> R__bool; fSharc = R__bool;     }
    {Bool_t R__bool; b >> R__bool; fTriFoil = R__bool;   }
@@ -116,6 +119,7 @@ void TGRSIRunInfo::Streamer(TBuffer &b) {
    {Long_t R__long = fBuildWindow;       b << R__long;}
    {Double_t R__double = fAddBackWindow;  b << R__double;}
    {Bool_t R__bool = fIsMovingWindow; b << R__bool;}
+   {Bool_t R__bool = fWaveformFitting; b << R__bool;}
    {Bool_t R__bool = fTigress;    b << R__bool;}
    {Bool_t R__bool = fSharc;      b << R__bool;}
    {Bool_t R__bool = fTriFoil;    b << R__bool;}

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -203,6 +203,7 @@ TGRSIRunInfo::TGRSIRunInfo() : fRunNumber(0),fSubRunNumber(-1) {
    fBuildWindow       = 200;  
    fAddBackWindow     = 15.0;
    fIsMovingWindow    = true;
+   fWaveformFitting	  = false;
 
    //printf("run info created.\n");
 
@@ -239,6 +240,7 @@ void TGRSIRunInfo::Print(Option_t *opt) const {
       printf(DBLUE"\tMoving Window  = " DRED "%s"    RESET_COLOR "\n",TGRSIRunInfo::IsMovingWindow() ? "TRUE" : "FALSE");
       printf(DBLUE"\tAddBack Window = " DRED "%.01f" RESET_COLOR "\n",TGRSIRunInfo::AddBackWindow());
       printf(DBLUE"\tArray Position = " DRED "%i"    RESET_COLOR "\n",TGRSIRunInfo::HPGeArrayPosition());
+	  printf(DBLUE"\tWaveform fitting = " DRED "%s"  RESET_COLOR "\n",TGRSIRunInfo::IsWaveformFitting() ? "TRUE" : "FALSE");
       printf("\n");
       printf("\t==============================\n");
    }
@@ -427,6 +429,10 @@ Bool_t TGRSIRunInfo::ParseInputData(const char *inputdata,Option_t *opt) {
         std::istringstream ss(line);
         long int temp_bw; ss >> temp_bw;
         Get()->SetBuildWindow(temp_bw);
+      } else if( type.compare("WF")==0 || type.compare("WAVEFORMFIT")==0) {
+        std::istringstream ss(line);
+        bool temp_wff; ss >> temp_wff;
+        Get()->SetWaveformFitting(temp_wff);
       } else if( type.compare("MW")==0 || type.compare("MOVINGWINDOW")==0) {
         std::istringstream ss(line);
         bool temp_mw; ss >> temp_mw;
@@ -452,6 +458,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char *inputdata,Option_t *opt) {
      printf(DBLUE"\tMoving Window  = " DRED "%s"    RESET_COLOR "\n",TGRSIRunInfo::IsMovingWindow() ? "TRUE" : "FALSE");
      printf(DBLUE"\tAddBack Window = " DRED "%.01f" RESET_COLOR "\n",TGRSIRunInfo::AddBackWindow());
      printf(DBLUE"\tArray Position = " DRED "%i"    RESET_COLOR "\n",TGRSIRunInfo::HPGeArrayPosition());
+     printf(DBLUE"\tWaveform Fitting  = " DRED "%s"    RESET_COLOR "\n",TGRSIRunInfo::IsWaveformFitting() ? "TRUE" : "FALSE");
    }
    return true;
 }


### PR DESCRIPTION
I've added the SFU waveform fitting to both Tigress and Tip, as needed for the upcoming Tip experiment. I also updated the Tip format (required for it to work) into what I think is the nominal style - hits are now predominantly constructed from the TFragment, rather than the DetData, in the same style as TS3 and TSiLi.

Since the fitting is such a slow process, I have made it optional in the runinfo (default: false). It can be set to be true (or explicitly false) with:
WaveformFit:  1  (or 0)

I also removed a couple of SetEnergy and SetTime functions in the TSiLiHit and TS3Hit classes which were screwing things up.