### PR TITLE
Fixed bug where SetPosition(TVector) set energy flag

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -75,7 +75,7 @@ class TGRSIDetectorHit : public TObject 	{
       //We need a common function for all detectors in here
 		//static bool Compare(TGRSIDetectorHit *lhs,TGRSIDetectorHit *rhs); //!
 
-      inline void SetPosition(const TVector3& temp_pos)           { fposition = temp_pos; SetFlag(kIsEnergySet,true); }    //!
+      inline void SetPosition(const TVector3& temp_pos)           { fposition = temp_pos; SetFlag(kIsPositionSet,true); }    //!
       inline void SetAddress(const UInt_t &temp_address)          { faddress = temp_address; } //!
       inline void SetCharge(const Float_t &temp_charge)            { fcharge = temp_charge;} //!
   //    inline void SetParent(TGRSIDetector *fParent)               { parent = (TObject*)fParent ; } //!

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -94,9 +94,7 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt) const {
 }
 
 double TGRSIDetectorHit::GetEnergy(Option_t *opt){
-   printf("GetEnergy\n");
    if(IsEnergySet()){
-   printf("GetEnergy is set\n");
       return fenergy;
    }
 
@@ -106,7 +104,6 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt){
       return 0.00;
    }
       SetEnergy(chan->CalibrateENG(GetCharge()));
-   printf("SetEnergy\n");
       return fenergy;
 
 }

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -94,7 +94,9 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt) const {
 }
 
 double TGRSIDetectorHit::GetEnergy(Option_t *opt){
+   printf("GetEnergy\n");
    if(IsEnergySet()){
+   printf("GetEnergy is set\n");
       return fenergy;
    }
 
@@ -104,6 +106,7 @@ double TGRSIDetectorHit::GetEnergy(Option_t *opt){
       return 0.00;
    }
       SetEnergy(chan->CalibrateENG(GetCharge()));
+   printf("SetEnergy\n");
       return fenergy;
 
 }


### PR DESCRIPTION
- The next little bit we should work on getting the flags forced to 0
- We also need to change the position calls in the hits. This may have been done in a parallel PR, I just haven't looked at it yet.
- This fix only works if the transient members are not being set during build (as per the first bullet point)