### PR TITLE
Changed TPPG::Print and removed printf formatting warnings

### DIFF
--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -108,7 +108,7 @@ class TPPG : public TObject	{
     const TPPGData* First();
     const TPPGData* Last();
 
-    virtual void Print(Option_t *opt = "") const;
+    virtual void Print(Option_t *opt = "");
     virtual void Clear(Option_t *opt = "");
 
   private:

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -151,18 +151,32 @@ uint16_t TPPG::GetStatus(ULong64_t time) const {
    return (uint16_t)((--(fPPGStatusMap->upper_bound(time)))->second->GetNewPPG());
 }
 
-void TPPG::Print(Option_t *opt) const{
-   if(MapIsEmpty()){
+void TPPG::Print(Option_t *opt) {
+   if(MapIsEmpty()) {
       printf("Empty\n");
-   }
-   else{
-      PPGMap_t::iterator ppgit;
-      printf("*****************************\n");
-      printf("           PPG STATUS        \n");
-      printf("*****************************\n");
-      for(ppgit = MapBegin(); ppgit != MapEnd(); ppgit++){
-         ppgit->second->Print();
-      }
+   } else {
+		if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
+			//print all ppg data
+			PPGMap_t::iterator ppgit;
+			printf("*****************************\n");
+			printf("           PPG STATUS        \n");
+			printf("*****************************\n");
+			for(ppgit = MapBegin(); ppgit != MapEnd(); ppgit++) {
+				ppgit->second->Print();
+			}
+		} else {
+			//print only an overview of the ppg
+			//first calculate how often each different status occured
+			std::map<uint16_t, int> status;
+			for(auto it = MapBegin(); it != MapEnd(); ++it) {
+				status[it->second->GetNewPPG()]++;
+			}
+			printf("Cycle length is %lld in 10 ns units = %.3lf seconds.\n", GetCycleLength(), GetCycleLength()/1e8);
+			printf("Got %ld PPG words:\n", fPPGStatusMap->size() - 1);
+			for(auto it = status.begin(); it != status.end(); ++it) {
+				printf("\tfound status 0x%04x %d times\n", it->first, it->second);
+			}
+		}
    }
 }
 

--- a/util/offsetfind.cxx
+++ b/util/offsetfind.cxx
@@ -315,7 +315,11 @@ void GetRoughTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
 
    printf("*****  Rough time shifts *******\n");
    for(mapit = TEventTime::digmap.begin(); mapit != TEventTime::digmap.end(); mapit++){
+#ifdef OS_DARWIN
       printf("0x%04x:\t %lld\n",mapit->first,correction[mapit->second]);
+#else
+      printf("0x%04x:\t %ld\n",mapit->first,correction[mapit->second]);
+#endif
    }
    printf("********************\n");
 
@@ -402,7 +406,11 @@ void GetTimeDiff(std::vector<TEventTime*> *eventQ, int64_t *correction){
    
    printf("*****  Final time shifts *******\n");
    for(mapit = TEventTime::digmap.begin(); mapit != TEventTime::digmap.end(); mapit++){
+#ifdef OS_DARWIN
       printf("0x%04x:\t %lld\n",mapit->first,correction[mapit->second]);
+#else
+      printf("0x%04x:\t %ld\n",mapit->first,correction[mapit->second]);
+#endif
    }
    printf("********************\n");
         

--- a/util/offsetfix.cxx
+++ b/util/offsetfix.cxx
@@ -454,7 +454,11 @@ void GetRoughTimeDiff(std::vector<TEventTime*> *eventQ){
       if(cit->first == TEventTime::GetBestDigitizer())
          printf("0x%04x:\t BEST\n",cit->first);
       else
-         printf("0x%04x:\t %lld\n",cit->first,cit->second);
+#ifdef OS_DARWIN
+			printf("0x%04x:\t %lld\n",cit->first,cit->second);
+#else
+		   printf("0x%04x:\t %ld\n",cit->first,cit->second);
+#endif
    }
    printf("********************\n");
 
@@ -547,7 +551,11 @@ void GetTimeDiff(std::vector<TEventTime*> *eventQ){
       if(cit->first == TEventTime::GetBestDigitizer())
          printf("0x%04x:\t BEST\n",cit->first);
       else
-         printf("0x%04x:\t %lld\n",cit->first,cit->second);
+#ifdef OS_DARWIN
+			printf("0x%04x:\t %lld\n",cit->first,cit->second);
+#else
+		   printf("0x%04x:\t %ld\n",cit->first,cit->second);
+#endif
         // printf("0x%04x:\t %lld\n",mapit->first,correction[mapit->second]);
    }
    printf("********************\n");


### PR DESCRIPTION
Changed TPPG::Print to print (short) overview of the ppg, use all as options to print all ppg data. Also changed printf formatting warning in offsetfix/offsetfind, keeping the old format for OS_DARWIN.