### PR TITLE
Mac OS and ROOT 6 compatibility

### DIFF
--- a/include/TAnalysisTreeBuilder.h
+++ b/include/TAnalysisTreeBuilder.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <string>
 #include <queue>
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #define _GLIBCXX_USE_NANOSLEEP 1
    #include <thread>
    #include <mutex>
@@ -73,7 +73,7 @@ class TEventQueue : public TObject {
 	int Size_Instance();
       
 	std::queue<std::vector<TFragment>*> fEventQueue;
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 	std::mutex m_event;
 #endif 
 	bool elock;
@@ -102,7 +102,7 @@ class TWriteQueue {
       int Size_Instance();
       
       std::queue<std::map<std::string, TDetector*>*> fWriteQueue;
-      #ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
       std::mutex m_write;
       #endif
       bool wlock;         
@@ -171,7 +171,7 @@ class TAnalysisTreeBuilder : public TObject {
       static int fAnalysisIn;
       static int fAnalysisOut;
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
       bool fSortFragmentDone;
       bool fPrintStatus;
       std::thread *fReadThread;                             //The thread used to read fragments out of the fragment tree

--- a/include/TBGOData.h
+++ b/include/TBGOData.h
@@ -10,7 +10,7 @@
 #include "TFragment.h"
 #include "TChannel.h"
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TGRSIDetectorData.h"
 #else
 class TGRSIDetectorData;

--- a/include/TCSM.h
+++ b/include/TCSM.h
@@ -7,7 +7,7 @@
 #include <cstdio>
 #include <map>
 #include <iostream>
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include <tuple>
 #include <iterator>
 #include <algorithm>
@@ -19,7 +19,7 @@
 #include "TFragment.h"
 #include "TChannel.h"
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TCSMData.h"
 #else
 class TCSMData;

--- a/include/TDecay.h
+++ b/include/TDecay.h
@@ -28,7 +28,7 @@ class TDecayFit : public TF1 {
    //TDecayFit(const char* name, void* fcn, Double_t xmin, Double_t xmax, Int_t npar) : TF1(name, fcn,xmin,xmax,npar){}
    TDecayFit(const char* name, ROOT::Math::ParamFunctor f, Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0) : TF1(name,f,xmin,xmax,npar),fDecay(0){DefaultGraphs(); }
    //TDecayFit(const char* name, void* ptr, Double_t xmin, Double_t xmax, Int_t npar, const char* className) : TF1(name,ptr, xmin, xmax, npar, className){ }
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
    TDecayFit(const char *name, Double_t (*fcn)(Double_t *, Double_t *), Double_t xmin=0, Double_t xmax=1, Int_t npar=0) : TF1(name,fcn,xmin,xmax,npar),fDecay(0){DefaultGraphs(); }
    TDecayFit(const char *name, Double_t (*fcn)(const Double_t *, const Double_t *), Double_t xmin=0, Double_t xmax=1, Int_t npar=0) : TF1(name,fcn,xmin,xmax,npar),fDecay(0){DefaultGraphs(); }
 #endif

--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #include "TDescantHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TDescantData.h"
 #else
 class TDescantData;

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -7,11 +7,8 @@
 #include <vector>
 #include "TVector3.h"
 
-#ifndef __CINT__
-#endif
-
 #include "TObject.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TDetectorData.h"
 #else
 class TDetectorData;

--- a/include/TDetectorData.h
+++ b/include/TDetectorData.h
@@ -1,7 +1,7 @@
 #ifndef TDetectorDATA_H
 #define TDetectorDATA_H
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 /*****************************************************************************
  *

--- a/include/TFragmentQueue.h
+++ b/include/TFragmentQueue.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <map>
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #define _GLIBCXX_USE_NANOSLEEP 1
 #include <thread>
 #include <mutex>
@@ -50,7 +50,7 @@ class TFragmentQueue : public TObject {
 		static std::map<int,int> fragment_id_map;	
 
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #ifndef NO_MUTEX
 	public:
 		static std::mutex All;

--- a/include/TGRSIDetector.h
+++ b/include/TGRSIDetector.h
@@ -7,11 +7,11 @@
 #include <vector>
 #include "TVector3.h"
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #endif
 
 #include "TObject.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TGRSIDetectorData.h"
 #include "TDetectorData.h"
 #else

--- a/include/TGRSIDetectorData.h
+++ b/include/TGRSIDetectorData.h
@@ -1,7 +1,7 @@
 #ifndef TGRSIDetectorDATA_H
 #define TGRSIDetectorDATA_H
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 /*****************************************************************************
  *

--- a/include/TGRSILoop.h
+++ b/include/TGRSILoop.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <fstream>
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include <thread>
 #endif
 
@@ -51,7 +51,7 @@ class TGRSILoop : public TObject {
 		int fDeadtimeScalersSentToTree;
 		int fRateScalersSentToTree;
  
-   #ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
       std::thread *fMidasThread;
       std::thread *fFillTreeThread;
       std::thread *fFillScalerThread;

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -10,7 +10,7 @@
 #include <TBits.h>
 
 #include "TGriffinHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TGriffinData.h"
 #else
 class TGriffinData;
@@ -51,7 +51,7 @@ class TGriffin : public TGRSIDetector {
 
       TGriffin& operator=(const TGriffin&);  //!
       
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
       void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { fAddback_criterion = criterion; }
       std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return fAddback_criterion; }
 #endif
@@ -60,7 +60,7 @@ class TGriffin : public TGRSIDetector {
       TGriffinHit* GetAddbackHit(const int& i);
 
    private:
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
       static std::function<bool(TGriffinHit&, TGriffinHit&)> fAddback_criterion;
 #endif
       TGriffinData *grifdata;                 //!  Used to build GRIFFIN Hits

--- a/include/TGriffinData.h
+++ b/include/TGriffinData.h
@@ -1,7 +1,7 @@
 #ifndef TGRIFFINDATA_H
 #define TGRIFFINDATA_H
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include <cstdlib>
 #include <cstdio>

--- a/include/TPaces.h
+++ b/include/TPaces.h
@@ -9,7 +9,7 @@
 #include <TBits.h>
 
 #include "TPacesHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TPacesData.h"
 #else
 class TPacesData;

--- a/include/TRF.h
+++ b/include/TRF.h
@@ -9,7 +9,7 @@
 #include "TDetector.h"
 
 #include "TFragment.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TRFFitter.h"
 #else
 class TRFFitter;

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -4,7 +4,7 @@
 #include "TDetector.h"
 #include <iostream>
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TS3Data.h"
 #else
 class TS3Data;

--- a/include/TScalerQueue.h
+++ b/include/TScalerQueue.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <map>
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #define _GLIBCXX_USE_NANOSLEEP 1
 #include <thread>
 #include <mutex>
@@ -48,7 +48,7 @@ class TDeadtimeScalerQueue : public TObject {
 		static std::map<int,int> fScalerIdMap;	
 
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #ifndef NO_MUTEX
 	public:
 		static std::mutex All;
@@ -110,7 +110,7 @@ class TRateScalerQueue : public TObject {
 		static std::map<int,int> fScalerIdMap;	
 
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #ifndef NO_MUTEX
 	public:
 		static std::mutex All;

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #include "TSceptarHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TSceptarData.h"
 #else
 class TSceptarData;

--- a/include/TSceptarData.h
+++ b/include/TSceptarData.h
@@ -1,7 +1,7 @@
 #ifndef TSCEPTARDATA_H
 #define TSCEPTARDATA_H
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include <cstdlib>
 #include <cstdio>

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -7,7 +7,7 @@
 
 #include "TDetector.h"
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TSiLiData.h"
 #else
 class TSiLiData;
@@ -34,7 +34,7 @@ class TSiLi: public TDetector  {
     TVector3 GetPosition(int segment);
 
   private:
-    #ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
     TSiLiData *data;    //! 
     #endif
     std::vector<TSiLiHit> sili_hits;

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 #include "TTigressHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TTigressData.h"
 #include "TBGOData.h"
 #else

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -3,7 +3,7 @@
 
 #include <cstdio>
 #include <cmath>
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include <tuple>
 #endif
 
@@ -45,9 +45,9 @@ class TTigressHit : public TGRSIDetectorHit {
 
 		//need to do sudo tracking to build addback.
 		TVector3 lasthit;                //!
-		#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 		std::tuple<int,int,int> lastpos; //!
-		#endif
+#endif
 
       static TVector3 beam;
 
@@ -107,9 +107,9 @@ class TTigressHit : public TGRSIDetectorHit {
 		
 		void SumHit(TTigressHit*);                                        //!
 		TVector3 GetLastHit()	{return lasthit;}                      //!
-		#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 		inline std::tuple<int,int,int> GetLastPosition() {return lastpos;} //!
-		#endif                         
+#endif                         
 
 	public:
 		virtual void Clear(Option_t *opt = "");		                      //!

--- a/include/TTip.h
+++ b/include/TTip.h
@@ -10,7 +10,7 @@
 #include <stdio.h>
 
 #include "TTipHit.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TTipData.h"
 #else
 class TTipData;

--- a/include/TTipData.h
+++ b/include/TTipData.h
@@ -1,7 +1,7 @@
 #ifndef TTIPDATA_H
 #define TTIPDATA_H
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include <cstdlib>
 #include <cstdio>

--- a/include/TTriFoil.h
+++ b/include/TTriFoil.h
@@ -9,7 +9,7 @@
 #include "TDetector.h"
 
 #include "TFragment.h"
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 #include "TTriFoilData.h"
 #else
 class TTriFoilData;

--- a/libraries/TGRSIAnalysis/TDetector/TDetectorData.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetectorData.cxx
@@ -1,5 +1,5 @@
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include "TDetectorData.h"
 #include <TClass.h>

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorData.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorData.cxx
@@ -1,5 +1,5 @@
 
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include "TGRSIDetectorData.h"
 #include <TClass.h>

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinData.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinData.cxx
@@ -1,4 +1,4 @@
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include "TGriffinData.h"
 

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptarData.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptarData.cxx
@@ -1,4 +1,4 @@
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include "TSceptarData.h"
 

--- a/libraries/TGRSIAnalysis/TTip/TTipData.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipData.cxx
@@ -1,4 +1,4 @@
-#ifndef __CINT__
+#if !defined (__CINT__) && !defined (__CLING__)
 
 #include "TTip.h"
 #include "TTipData.h"


### PR DESCRIPTION
The error we had using ROOT 6 on Mac OS was due to the fact that __CINT__ isn't defined anymore in ROOT 6 which made the std::tuple lines in TTigressHit.h visible to rootcint/rootcling. For some reason this is no issue on Linux, but on Mac OS it crashes rootcint. 
So I've replaced the 
#ifndef __CINT__
lines with
#if !defined(__CINT__) && !defined(__CLING__)
Now the code not only compiles on Mac OS, but runs as well. Note that changing the lines in all files might have removed more code from dictionaries when using ROOT 6 than strictly necessary (changing the two lines with std::tuple in TTigressHit.h would have been enough), but this way it's consistent.