### PR TITLE
TRF Dict fix, plus hist TChannel Support

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -176,6 +176,7 @@ class TChannel : public TNamed	{
 	void DestroyTIMECal();
 	void DestroyEFFCal();
 
+	static Int_t ReadCalFromCurrentFile(Option_t *opt="overwrite");
 	static Int_t ReadCalFromTree(TTree*,Option_t *opt="overwrite");
 	static Int_t ReadCalFile(const char *filename = "");
 	static Int_t ParseInputData(const char *inputdata = "",Option_t *opt = "");

--- a/libraries/TGRSIAnalysis/TRF/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TRF/LinkDef.h
@@ -1,4 +1,4 @@
-//TRF.h
+//TRF.h TRFFitter.h
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -7,6 +7,7 @@
 #pragma link C++ nestedclasses;
 
 #pragma link C++ class TRF+;
+#pragma link C++ class TRFFitter+;
 
 #endif
 

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -651,6 +651,29 @@ void TChannel::WriteCalBuffer(Option_t *opt) {
    return;
 }
 
+Int_t TChannel::ReadCalFromCurrentFile(Option_t *opt) {
+
+   if(!gFile)
+      return 0;
+
+   TFile *tempf = gFile->CurrentFile();
+   TList *list =  tempf->GetListOfKeys();
+   TIter iter(list);
+
+   //while(TObject *obj = ((TKey*)(iter.Next()))->ReadObj()) {
+   while(TKey *key = (TKey*)(iter.Next())) {
+      if(!key || strcmp(key->GetClassName(),"TChannel"))
+         continue;
+      //TObject *  obj = key->ReadObj();
+      //if(obj && !obj->InheritsFrom("TChannel"))
+      //   continue;
+      //TChannel *c = (TChannel*)obj;
+      //TChannel *c = (TChannel*)key->ReadObj();
+		key->ReadObj();
+      return GetNumberOfChannels();
+   }
+     return 0;
+}
 
 Int_t TChannel::ReadCalFromTree(TTree *tree,Option_t *opt) {
 //Reads the TChannel information from a Tree if it has already been written to that Tree.

--- a/libraries/TGRSIFormat/TFragmentSelector.cxx
+++ b/libraries/TGRSIFormat/TFragmentSelector.cxx
@@ -126,4 +126,21 @@ void TFragmentSelector::Terminate()
 	if(obj->InheritsFrom("TH1"))
 		obj->Write();
    }
+
+   f.cd();
+	TChannel *chan = TChannel::GetDefaultChannel();//new TChannel(iter->second);
+	if(chan != NULL) {
+      chan->SetNameTitle(Form("TChannels[%i]",TChannel::GetNumberOfChannels()),
+                         Form("%i TChannels.",TChannel::GetNumberOfChannels()));
+                           // using the write command on any TChannel will now write all 
+      chan->WriteToRoot(); // the TChannels to a root file.  additionally reading a TChannel
+                           // from a rootfile will read all the channels saved to it.  TChannels
+                           // are now saved as a text buffer to the root file.  pcb.
+	                        // update. (3/9/2015) the WriteToRoot function should now 
+                           // corretcly save the TChannels even if the came from the odb(i.e. internal 
+                           // data buffer not set.)  pcb.
+   } else {
+		printf("Failed to get default channel, not going to write TChannel information!\n");
+	}
+   
 }

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -378,7 +378,10 @@ void TGRSIRootIO::MakeUserHistsFromFragmentTree() {
 
    TProofLite *proof = (TProofLite*)TProofLite::Open("");
    proof->ClearCache();
-   proof->Exec("gSystem->Load(\"libTGRSIFormat.so\")");
+  // proof->Exec("gSystem->Load(\"libTGRSIFormat.so\")");
+   const char* pPath = getenv("GRSISYS");
+   gSystem->AddDynamicPath(pPath);
+   gSystem->Load("libTGRSIFormat.so");
    proof->SetProgressDialog(TGRSIOptions::ProgressDialog());
    //Going to get run number from file name. This will allow us to chain->chop off the subrun numbers
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -96,7 +96,8 @@ void TGRSIint::ApplyOptions() {
       printf("\tfile %s opened as _file%i\n",file->GetName(),x);
       TGRSIRootIO::Get()->LoadRootFile(file);
    }
-   if(TGRSIOptions::GetInputRoot().size() > 0 && !fAutoSort && !fFragmentSort) {
+  // if(TGRSIOptions::GetInputRoot().size() > 0 && !fAutoSort && !fFragmentSort) {
+   if(TGRSIOptions::GetInputRoot().size() > 0 && !fAutoSort) {
       if(TGRSIOptions::GetInputRoot().at(0).find("fragment") != std::string::npos){
          Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(FragmentTree)");
          printf("Read calibration info for %d channels from \"%s\" FragmentTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str()); 
@@ -106,6 +107,11 @@ void TGRSIint::ApplyOptions() {
          Int_t chans_read = ProcessLine("TChannel::ReadCalFromTree(AnalysisTree)");    
          printf("Read calibration info for %d channels from \"%s\" AnalysisTree\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str());
          TGRSIRunInfo::ReadInfoFromFile();
+      }
+      if(TGRSIOptions::GetInputRoot().at(0).find("hists") != std::string::npos){ 
+         Int_t chans_read = ProcessLine("TChannel::ReadCalFromCurrentFile()");    
+         printf("Read calibration info for %d channels from \"%s\" HistFile\n",chans_read,TGRSIOptions::GetInputRoot().at(0).c_str());
+        // TGRSIRunInfo::ReadInfoFromFile(); Not implemented yet
       }
    }
 


### PR DESCRIPTION
- TRFFitter was not being generated, lead to linking error
- Not sure if this was meant to be removed

- This is commonly used for gain matching so it's frustrating to load cal file
- Shouldn't affect anything else

This is to help work being done by @AndrewMac1 and @mrdunlop