### PR TITLE
Added SFU CsI pulse-shape analysis code to TPulseAnalyzer

### DIFF
--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -30,6 +30,8 @@ namespace TGRSIFunctions {
    Double_t SkewedGaus2(Double_t *dim, Double_t *par);
    Double_t MultiSkewedGausWithBG2(Double_t *dim, Double_t *par);
 
+// CSI FIT FUNCTION
+   Double_t CsIFitFunction(Double_t *i,Double_t *p);
 
 	 static int  npeaks = 0;
 	 static int  GetNumberOfPeaks() { return npeaks;}

--- a/include/TPulseAnalyzer.h
+++ b/include/TPulseAnalyzer.h
@@ -2,6 +2,7 @@
 #define TPULSE_ANALYZER_H
 
 #include "TFragment.h"
+#include "TGRSIFunctions.h"
 #include <vector>
 #include <TNamed.h>
 #include <Rtypes.h>
@@ -84,6 +85,22 @@ class TPulseAnalyzer {
 	  double C;
 	}SinPar;
 	
+	typedef struct
+	{
+	  double chisq;
+	  int    ndf;
+	  int    type;
+	  long double t[5]; //decay constants for the fits
+	  long double am[5]; //associated aplitudes for the decay constants
+	  double rf[5];
+
+	  //new stuff necessary for compiliation of Kris' waveform analyzer changes
+	  long double chisq_ex;
+	  long double chisq_f;
+	  int    ndf_ex;
+	  int    ndf_f;
+	  
+	}ShapePar;
 	
   public:
     TPulseAnalyzer();
@@ -103,13 +120,20 @@ class TPulseAnalyzer {
     void      DrawT0fit();
     void      DrawRFFit();
 
+	// CsI functions:
+	double    CsIPID();
+	double	  CsIt0();
+	void 	  DrawCsIExclusion();
+	void	  DrawCsIFit();
+
   private:
 	  
        bool   		set;
-int 			N;
+	   int 			N;
        WaveFormPar*	wpar;
        SinPar*		spar;
        TFragment* 	frag;
+	   ShapePar*	shpar;
 
 	//pulse fitting parameters
 	int FILTER; //integration region for noise reduction (in samples)
@@ -122,9 +146,20 @@ int 			N;
 	long double lineq_vector[20];
 	long double lineq_solution[20];
 	long double copy_matrix[20][20];  
+		
+	// CsI functions
+	void GetCsIExclusionZone();	
+	double GetCsITau(int);
+	double GetCsIt0();
+	int GetCsIShape();
 	
-	
-       //internal methods       
+	bool CsISet;
+	double EPS;
+
+	void SetCsI(bool option="true") { CsISet = option; }
+	bool CsIIsSet()				  	{ return CsISet; }
+
+    //internal methods       
 	int solve_lin_eq();
 	long double  determinant(int);
 	
@@ -156,6 +191,14 @@ int 			N;
 	const static int PIN_BASELINE_RANGE=16; //minimum ticks before max for a valid signal
 	const static int BAD_BASELINE_RANGE =-1024-11;
 	const static int MAX_SAMPLES= 4096;	
+
+	const static int CSI_BASELINE_RANGE = 50;
+	const static int NOISE_LEVEL_CSI = 100;
+	const static int NSHAPE = 5;
+
+	const static int BADCHISQ_T0 = -1024-7;
+	const static int BADCHISQ_NEG = -1024-1;
+	const static int BADCHISQ_AMPL = -1024-6;
 
     ClassDef(TPulseAnalyzer,2);
 };

--- a/include/TTipHit.h
+++ b/include/TTipHit.h
@@ -28,6 +28,8 @@ class TTipHit : public TGRSIDetectorHit {
     Double_t slow_amplitude;
     Double_t gamma_amplitude;
    
+	bool	csi_flag;
+
 	Int_t	 tip_channel;
 
     Double_t    time_fit;
@@ -36,7 +38,6 @@ class TTipHit : public TGRSIDetectorHit {
   public:
     /////////////////////////    /////////////////////////////////////
     inline void SetFilterPattern(const int &x)    { filter   = x; }   //! 
-    inline void SetPID(Double_t x)                { fPID = x;     }   //!
 	inline void SetTipChannel(const int x)		  { tip_channel = x; } //!
 
     inline Int_t    GetFiterPatter()           { return filter;   }  //!
@@ -44,6 +45,9 @@ class TTipHit : public TGRSIDetectorHit {
 	inline Double_t GetFitTime()			   { return time_fit;	} //!
 	inline Double_t GetSignalToNoise()		   { return sig2noise;	} //!
 	inline Int_t	GetTipChannel()			   { return tip_channel; } //!
+
+	inline bool   IsCsI()								{return csi_flag; }
+	inline void	  SetCsI(bool flag="true")   { csi_flag = flag; }
 
     bool   InFilter(Int_t);                                         //!
 
@@ -60,9 +64,13 @@ class TTipHit : public TGRSIDetectorHit {
 										  ClearMNEMONIC(&mnemonic);
 										  ParseMNEMONIC(channel->GetChannelName(),&mnemonic); 
 										  Int_t tmp = (int16_t)atoi(mnemonic.arraysubposition.c_str()); 
-										  SetTipChannel((Int_t)(10*mnemonic.arrayposition + tmp)); }
+										  SetTipChannel((Int_t)(10*mnemonic.arrayposition + tmp)); 
+										  if(mnemonic.subsystem.compare("W")==0 || mnemonic.subsystem.compare("C")==0)
+											SetCsI(); 
+										  }
 
-    void SetWavefit(TFragment&);
+	void SetWavefit(TFragment&);
+    void SetPID(TFragment&);
 
   public:
     void Clear(Option_t *opt = "");                        //!

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -16,6 +16,29 @@ NamespaceImp(TGRSIFunctions)
 #define PI 3.14159265
 //TGRSIFunctions::SetNumberOfPeaks(0);
 
+Double_t TGRSIFunctions::CsIFitFunction(Double_t *i,Double_t *p)
+{
+  Double_t x,s,e;
+
+  /* 
+     p[0]-p[4] are t0, tRC, tF, TS, TGamma
+     p[5]-p[8] are baseline, AF, AS, AGamma
+  */
+
+  x=i[0]-p[0];
+  e=exp(-x/p[1]);
+  if(x<=0) 
+    return p[5];
+  else
+    {   
+      s=p[5];
+      s+=p[6]*(1-exp(-x/p[2]))*e;
+      s+=p[7]*(1-exp(-x/p[3]))*e;
+      s+=p[8]*(1-exp(-x/p[4]))*e;
+      return s;
+    }
+}
+
 Double_t TGRSIFunctions::PolyBg(Double_t *x, Double_t *par,Int_t order) {
 //Polynomial function of the form SUM(par[i]*(x - shift)^i). The shift is done to match parameters with Radware output. 
 

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -83,13 +83,14 @@ void TTip::BuildHits(TDetectorData *data,Option_t *opt)	{
 
       dethit.SetVariables(tmp);
 
-	  if(TGRSIRunInfo::IsWaveformFitting()) 
-      	dethit.SetWavefit(tmp);
-
 	  TChannel chan = TChannel::GetChannel(dethit.GetAddress());
-	  dethit.SetUpNumbering(chan);
+	  dethit.SetUpNumbering(chan); // Need to do this before PID
 
-      //dethit.SetPID(gdata->GetPID(i));
+	  // Only fit what is needed to speed things up
+	  if(TGRSIRunInfo::IsWaveformFitting() && !dethit.IsCsI()) // If we're doing wavefitting, but with an S3 or the PIN diode array, we'll just use the regular t0 fitter
+      	dethit.SetWavefit(tmp);
+	  else if(TGRSIRunInfo::IsWaveformFitting() && dethit.IsCsI())  // If we're doing wavefitting with the CsI wall OR the CsI ball, we'll use the proper CsI fitting algorithm
+		dethit.SetPID(tmp);
 
       tip_hits.push_back(dethit);
    }

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -64,3 +64,11 @@ void TTipHit::SetWavefit(TFragment &frag)   {
 	}
 }
 
+void TTipHit::SetPID(TFragment &frag)	{
+	TPulseAnalyzer pulse(frag);
+	if(pulse.IsSet()){
+		fPID = pulse.CsIPID();
+		time_fit = pulse.CsIt0();
+	}
+}
+


### PR DESCRIPTION
Added SFU CsI pulse-shape analysis code to TPulseAnalyzer and set up TTip sensibly so as not to duplicate expensive waveform fitting unnecessarily. Added the CsIFitFunction to TGRSIFunctions so we can draw the fit when needed. Fitting works well and gives lovely PID plots, see below (for a single channel):

![pid_grsisort](https://cloud.githubusercontent.com/assets/10636847/10948003/27c5fc08-82e0-11e5-956e-802f28d01d14.png)
