### PR TITLE
TS3 and TSiLi manual merge and changes

### DIFF
--- a/include/TRFFitter.h
+++ b/include/TRFFitter.h
@@ -3,8 +3,8 @@
 
 #include <vector>
 
-#include <TNamed.h>
-#include <Rtypes.h>
+#include "TNamed.h"
+#include "Rtypes.h"
 
 class TFragment;
 

--- a/include/TRFFitter.h
+++ b/include/TRFFitter.h
@@ -3,8 +3,8 @@
 
 #include <vector>
 
-#include "TNamed.h"
-#include "Rtypes.h"
+#include <TNamed.h>
+#include <Rtypes.h>
 
 class TFragment;
 

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -3,27 +3,36 @@
 
 #include <iostream>
 
-#include "TDetector.h"
+#include "TGRSIDetector.h"
 #include "TS3Hit.h"
 
-class TS3 : public TDetector {
+class TS3 : public TGRSIDetector {
 	public:
 		TS3();
-		~TS3();
+		TS3(const TS3&);
+		virtual  ~TS3();
 
-		void AddFragment(TFragment*, MNEMONIC*);
-		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+		virtual void AddFragment(TFragment*, MNEMONIC*);
+		virtual void BuildHits();
 
+		TGRSIDetectorHit* GetHit(const int& idx =0);
 		TS3Hit* GetS3Hit(const int& i);  
-		Short_t GetMultiplicity() { return fS3Hits.size(); }
+		Short_t GetMultiplicity() const { return fS3Hits.size(); }
+		void PushBackHit(TGRSIDetectorHit* deshit);
 
-		TVector3 GetPosition(int front, int back);
+		static TVector3 GetPosition(int ring, int sector);
 
-      virtual void Clear(Option_t *opt = "all");		     //!
-      virtual void Print(Option_t *opt = "") const;		  //!
+		void Copy(TObject&) const;
+		TS3& operator=(const TS3&);  // 
+		virtual void Clear(Option_t *opt = "all");		     //!
+		virtual void Print(Option_t *opt = "") const;		  //!
+		
+		
 
 	private:
 		std::vector<TS3Hit> fS3Hits;
+		std::vector<TFragment*> fS3_RingFragment;
+		std::vector<TFragment*> fS3_SectorFragment;
 
 		///for geometery
 		static int fRingNumber;          //!
@@ -34,7 +43,7 @@ class TS3 : public TDetector {
 		static double fInnerDiameter;    //!
 		static double fTargetDistance;   //!
 
-		ClassDef(TS3,2)
+		ClassDef(TS3,4)
 };
 
 #endif

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -31,8 +31,8 @@ class TS3 : public TGRSIDetector {
 
 	private:
 		std::vector<TS3Hit> fS3Hits;
-		std::vector<TFragment*> fS3_RingFragment;
-		std::vector<TFragment*> fS3_SectorFragment;
+		std::vector<TFragment*> fS3_RingFragment; //! 
+		std::vector<TFragment*> fS3_SectorFragment; //! 
 
 		///for geometery
 		static int fRingNumber;          //!

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -43,7 +43,7 @@ class TS3 : public TGRSIDetector {
 		static double fInnerDiameter;    //!
 		static double fTargetDistance;   //!
 
-		ClassDef(TS3,4)
+		ClassDef(TS3,5)
 };
 
 #endif

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -9,32 +9,40 @@
 class TS3Hit : public TGRSIDetectorHit {
    public:
     TS3Hit();
-    ~TS3Hit();
+    TS3Hit(TFragment &);
+    virtual ~TS3Hit();
+    TS3Hit(const TS3Hit&);
 
-    Double_t GetLed()          { return fLed;     }
-    Short_t  GetRingNumber()   { return fRing;   }
-    Short_t  GetSectorNumber() { return fSector; }
+    Double_t GetLed()   const  { return fLed;    }
+    Short_t  GetRing()  const  { return fRing;   }
+    Short_t  GetSector() const { return fSector; }
 
   public:
+    void Copy(TObject&) const;        //!
     void Print(Option_t* opt="") const;
     void Clear(Option_t* opt="");
 
+    void SetVariables(TFragment &frag) {  fLed    = frag.GetLed(); }
     void SetRingNumber(Short_t rn)     { fRing = rn;   }
     void SetSectorNumber(Short_t sn)   { fSector = sn; }
-    void SetVariables(TFragment& frag) { 
-			 SetCfd(frag.GetCfd());
-			 SetCharge(frag.GetCharge());
-			 SetTimeStamp(frag.GetTimeStamp()); 
-			 fLed  = frag.GetLed(); 
-	 }
+    
+    void SetRingNumber(TFragment &frag)     { fRing = GetMnemonicSegment(frag);   }
+    void SetSectorNumber(TFragment &frag)   { fSector =GetMnemonicSegment(frag) ; }
+    
+    Short_t GetMnemonicSegment(TFragment &frag);//could be added to TGRSIDetectorHit base class
 	 
 
   private:
+     TVector3 GetChannelPosition(Double_t dist = 0) const; //!
+      
+      
+      
+      
     Double_t fLed;
     Short_t  fRing;   //front
     Short_t  fSector; //back
 
-  ClassDef(TS3Hit,4);
+  ClassDef(TS3Hit,6);
 };
 
 #endif

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -42,7 +42,7 @@ class TS3Hit : public TGRSIDetectorHit {
     Short_t  fRing;   //front
     Short_t  fSector; //back
 
-  ClassDef(TS3Hit,6);
+  ClassDef(TS3Hit,5);
 };
 
 #endif

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -4,28 +4,36 @@
 #include <cstdio>
 #include <iostream>
 
-#include "TDetector.h"
+#include "TGRSIDetector.h"
 #include "TSiLiHit.h"
 
-class TSiLi: public TDetector  {
+class TSiLi: public TGRSIDetector  {
 	public:
 		TSiLi();
-		~TSiLi();
+		TSiLi(const TSiLi&);
+		virtual ~TSiLi();
+		
+     
 
 		void AddFragment(TFragment*, MNEMONIC*);
 		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
 
+		TSiLi& operator=(const TSiLi&);  // 
+
+		void Copy(TObject&) const;
+		void Clear(Option_t *opt="");   
 		void Print(Option_t *opt="") const;
-		void Clear(Option_t *opt="");
+		void PushBackHit(TGRSIDetectorHit* deshit);
 
 		Short_t GetMultiplicity() const { return fSiLiHits.size(); }
-		TSiLiHit *GetSiLiHit(const int& i);
-
-		TVector3 GetPosition(int segment);
+		TGRSIDetectorHit* GetHit(const Int_t& idx =0);
+		TSiLiHit* GetSiLiHit(const Int_t& idx = 0);
+		
+		static TVector3 GetPosition(int segment);
 
 	private:
 		std::vector<TSiLiHit> fSiLiHits;
 
-		ClassDef(TSiLi,2);
+		ClassDef(TSiLi,5);
 };
 #endif

--- a/include/TSiLiHit.h
+++ b/include/TSiLiHit.h
@@ -12,42 +12,36 @@
 class TSiLiHit : public TGRSIDetectorHit {
 	public:
 		TSiLiHit();
-		~TSiLiHit();
-
+		TSiLiHit(TFragment &);	
+		virtual ~TSiLiHit();
+		TSiLiHit(const TSiLiHit&);
+		
+		void Copy(TObject&) const;        //!
 		void Clear(Option_t *opt="");
 		void Print(Option_t *opt="") const;
 
-		Double_t GetLed()       { return fLed;      }
-		Short_t  GetSegment()   { return fSegment;  }
-		Double_t GetSig2Noise() { return fSig2Noise;}    
-		Int_t    GetRing()      { return fRing;     }
-		Int_t    GetSector()    { return fSector;   }
-		Int_t    GetPreamp()    { return fPreamp;   }
+		Double_t GetLed()      const { return fLed;      }
+		Short_t  GetSegment()  const { return fSegment;  }
+		Double_t GetSig2Noise()const { return fSig2Noise;}    
+		Int_t GetRing()        const {  return 9-(fSegment/12); }
+		Int_t GetSector()      const {  return fSegment%12; }
+		Int_t GetPreamp()      const {  return  ((GetSector()/3)*2)+(((GetSector()%3)+GetRing())%2); }
 		Double_t GetTimeFit()   { return fTimeFit;  }
 
-		void SetSegment(Short_t seg) {
-				fSegment = seg; 
-				fRing    = 9-(fSegment/12);
-				fSector  = fSegment%12;
-				fPreamp  = ((GetSector()/3)*2)+(((GetSector()%3)+GetRing())%2);
-		}
-		void SetVariables(TFragment &frag) { 
-				SetCfd(frag.GetCfd());
-				SetCharge(frag.GetCharge());
-				SetTimeStamp(frag.GetTimeStamp()); 
-				fLed    = frag.GetLed();
-		}
+		void SetSegment(Short_t seg)       { fSegment = seg;	}
+		void SetSegment(TFragment &frag);
+		void SetVariables(TFragment &frag) { fLed    = frag.GetLed();
+							SetSegment(frag); }
 		void SetWavefit(TFragment&);
 
 	private:
+		TVector3 GetChannelPosition(Double_t dist = 0) const; //!  
+      
 		Double_t    fLed;
 		Short_t  fSegment;
-		Short_t  fRing;
-		Short_t  fSector;
-		Short_t  fPreamp;
 		Double_t    fTimeFit;
 		Double_t    fSig2Noise;
 
-		ClassDef(TSiLiHit,6);
+		ClassDef(TSiLiHit,8);
 };
 #endif

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -13,17 +13,27 @@ double TS3::fInnerDiameter;
 double TS3::fTargetDistance;
 
 TS3::TS3() {
-  fRingNumber=24;
-  fSectorNumber=32;
-
-  fOffsetPhi=15*TMath::Pi()/180.; // according to dave.
-  fOuterDiameter=70.;
-  fInnerDiameter=22.;
-  fTargetDistance=21.;
+   Clear();	
 }
 
 TS3::~TS3()  { 
 }
+
+
+TS3& TS3::operator=(const TS3& rhs) {
+   rhs.Copy(*this);
+   return *this;
+}
+
+TS3::TS3(const TS3& rhs) : TGRSIDetector() {
+  rhs.Copy(*this);
+}
+
+void TS3::Copy(TObject &rhs) const {
+  TGRSIDetector::Copy(rhs);
+  static_cast<TS3&>(rhs).fS3Hits    = fS3Hits;
+  return;                                      
+}  
 
 void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	///this function takes a fragment and either adds it to an existing hit (if it's a ring for a matching sector or vice versa)
@@ -32,61 +42,68 @@ void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 		return;
 	}
 
-	for(size_t i = 0; i < fS3Hits.size(); ++i) {
-		if(static_cast<UInt_t>(mnemonic->arrayposition) == fS3Hits[i].GetDetector()) { //same detector
-			if(mnemonic->collectedcharge.compare(0,1,"P")==0) { //front  (ring)
-				//this means we've already found a sector of this detector
-				//so we set the ring number and all other variables from this ring
-				fS3Hits[i].SetRingNumber(mnemonic->segment);
-				fS3Hits[i].SetVariables(*frag);
-				TVector3 tmppos = GetPosition(fS3Hits[i].GetRingNumber(),fS3Hits[i].GetSectorNumber());
-				fS3Hits[i].SetPosition(tmppos);
-				return; //we've filled the data of the current fragment into the hits so we're done 
-			} else { //back (sector)
-				//this means we've already found a ring of this detector
-				//so we set the sector number from this sector (all other variables are set by the front)
-				fS3Hits[i].SetSectorNumber(mnemonic->segment);
-				//fS3Hits[i].SetVariables(*frag);
-				TVector3 tmppos = GetPosition(fS3Hits[i].GetRingNumber(),fS3Hits[i].GetSectorNumber());
-				fS3Hits[i].SetPosition(tmppos);
-				return; //we've filled the data of the current fragment into the hits so we're done 
-			}
-		}
-	}
-	//if we reach here we haven't found a detector before so we create a new hit
-  TS3Hit hit;
-  
-  if(mnemonic->collectedcharge.compare(0,1,"P")==0) { //front  (ring)
-	  //this means we've already found a sector of this detector
-	  //so we set the ring number and all other variables from this ring
-	  hit.SetRingNumber(mnemonic->segment);
-	  hit.SetVariables(*frag);
-  } else { //back (sector)
-	  //this means we've already found a ring of this detector
-	  //so we set the sector number from this sector (all other variables are set by the front)
-	  hit.SetSectorNumber(mnemonic->segment);
-	  //hit.SetVariables(*frag);
-  }
-
-  fS3Hits.push_back(hit);
+	if(mnemonic->collectedcharge.compare(0,1,"P")==0) { //front  (ring)	
+			fS3_RingFragment.push_back(frag);
+	}else{
+			fS3_SectorFragment.push_back(frag);
+	}	
 }
+
+
+void TS3::BuildHits()  {
+  
+  for(size_t i = 0; i < fS3_RingFragment.size(); ++i) {
+    for(size_t i = 0; i < fS3_SectorFragment.size(); ++i) {
+
+	    //mnemonic->arrayposition
+      //if(sdata->GetRing_Detector(i) == sdata->GetSector_Detector(j))     {
+
+        //Set the base data     
+        TS3Hit dethit(*fS3_RingFragment[i]);
+	dethit.SetVariables(*fS3_RingFragment[i]);	
+	
+        dethit.SetRingNumber(*fS3_RingFragment[i]);
+        dethit.SetSectorNumber(*fS3_SectorFragment[i]);
+		
+        fS3Hits.push_back(dethit);
+     // }
+    }
+  }
+  
+  
+  fS3_RingFragment.clear();
+  fS3_SectorFragment.clear();
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 TVector3 TS3::GetPosition(int ring, int sector)  {
   TVector3 position;
-
   double ring_width=(fOuterDiameter-fInnerDiameter)*0.5/fRingNumber; // 24 rings   radial width!
   double inner_radius=fInnerDiameter/2.0;
-
-  
   double correctedsector = 6+sector; //moe is currently checking.
-
   double phi     =  2.*TMath::Pi()/fSectorNumber * (correctedsector + 0.5);   //the phi angle....
   double radius =  inner_radius + ring_width * (ring + 0.5) ;
-  
   position.SetMagThetaPhi(sqrt(radius*radius + fTargetDistance*fTargetDistance),atan((radius/fTargetDistance)),phi+fOffsetPhi);
 
-
   return position;
+}
+
+TGRSIDetectorHit* TS3::GetHit(const int& idx){
+   return GetS3Hit(idx);
 }
 
 TS3Hit *TS3::GetS3Hit(const int& i) {  
@@ -99,12 +116,27 @@ TS3Hit *TS3::GetS3Hit(const int& i) {
    return 0;
 }  
 
+void TS3::PushBackHit(TGRSIDetectorHit *deshit) {
+  fS3Hits.push_back(*((TS3Hit*)deshit));
+  return;
+}
+
+
 void TS3::Print(Option_t *opt) const {
    printf("%s\tnot yet written.\n",__PRETTY_FUNCTION__);
 }
 
 void TS3::Clear(Option_t *opt) {
+  TGRSIDetector::Clear(opt);
   fS3Hits.clear();
+  fS3_RingFragment.clear();
+  fS3_SectorFragment.clear();
+  fRingNumber=24;
+  fSectorNumber=32;
+  fOffsetPhi=15*TMath::Pi()/180.; // according to dave.
+  fOuterDiameter=70.;
+  fInnerDiameter=22.;
+  fTargetDistance=21.;
 }
 
 

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -53,7 +53,7 @@ void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 void TS3::BuildHits()  {
   
   for(size_t i = 0; i < fS3_RingFragment.size(); ++i) {
-    for(size_t i = 0; i < fS3_SectorFragment.size(); ++i) {
+    for(size_t j = 0; j < fS3_SectorFragment.size(); ++j) {
 
 	    //mnemonic->arrayposition
       //if(sdata->GetRing_Detector(i) == sdata->GetSector_Detector(j))     {
@@ -63,7 +63,7 @@ void TS3::BuildHits()  {
 	dethit.SetVariables(*fS3_RingFragment[i]);	
 	
         dethit.SetRingNumber(*fS3_RingFragment[i]);
-        dethit.SetSectorNumber(*fS3_SectorFragment[i]);
+        dethit.SetSectorNumber(*fS3_SectorFragment[j]);
 		
         fS3Hits.push_back(dethit);
      // }

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -35,7 +35,7 @@ void TS3Hit::Clear(Option_t *opt)	{
 
 Short_t TS3Hit::GetMnemonicSegment(TFragment &frag){//could be added to TGRSIDetectorHit base class
 	MNEMONIC mnemonic;
-	TChannel *channel = GetChannel();
+	TChannel *channel = TChannel::GetChannel(frag.ChannelAddress);
 	if(!channel){
 		Error("SetDetector","No TChannel exists for address %u",GetAddress());
 		return 0;

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -1,12 +1,30 @@
 #include "TS3Hit.h"
+#include "TS3.h"
 
 ClassImp(TS3Hit)
 
 TS3Hit::TS3Hit()	{
 	Clear();
 }
+TS3Hit::TS3Hit(TFragment &frag)	: TGRSIDetectorHit(frag) {}
 
-TS3Hit::~TS3Hit()	{	}
+TS3Hit::~TS3Hit()	{}
+
+TS3Hit::TS3Hit(const TS3Hit &rhs) : TGRSIDetectorHit() {
+   Clear();
+   ((TS3Hit&)rhs).Copy(*this);
+}
+
+
+void TS3Hit::Copy(TObject &rhs) const {
+   TGRSIDetectorHit::Copy(rhs);
+
+	static_cast<TS3Hit&>(rhs).fLed = fLed;
+	static_cast<TS3Hit&>(rhs).fRing = fRing;
+	static_cast<TS3Hit&>(rhs).fSector = fSector;
+   return;
+}
+
 
 void TS3Hit::Clear(Option_t *opt)	{
    TGRSIDetectorHit::Clear(opt);
@@ -15,6 +33,22 @@ void TS3Hit::Clear(Option_t *opt)	{
    fSector         = -1;
 }
 
+Short_t TS3Hit::GetMnemonicSegment(TFragment &frag){//could be added to TGRSIDetectorHit base class
+	MNEMONIC mnemonic;
+	TChannel *channel = GetChannel();
+	if(!channel){
+		Error("SetDetector","No TChannel exists for address %u",GetAddress());
+		return 0;
+	}
+	ClearMNEMONIC(&mnemonic);
+	ParseMNEMONIC(channel->GetChannelName(),&mnemonic);
+	return mnemonic.segment;
+}
+
+
+TVector3 TS3Hit::GetChannelPosition(double dist) const {
+	return TS3::GetPosition(GetRing(),GetSector());
+}
 
 void TS3Hit::Print(Option_t *opt) const	{
 	printf("================\n");

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -5,40 +5,37 @@
 ClassImp(TSiLi)
 
 TSiLi::TSiLi() {
+   Clear();	
 }
 
 TSiLi::~TSiLi()  {
 }
 
+void TSiLi::Copy(TObject &rhs) const {
+  TGRSIDetector::Copy(rhs);
+  static_cast<TSiLi&>(rhs).fSiLiHits     = fSiLiHits;
+  return;                                      
+} 
+
+TSiLi::TSiLi(const TSiLi& rhs) : TGRSIDetector() {
+  rhs.Copy(*this);
+} 
+
 void TSiLi::Clear(Option_t *opt)  {
   fSiLiHits.clear();
 }
 
+TSiLi& TSiLi::operator=(const TSiLi& rhs) {
+   rhs.Copy(*this);
+   return *this;
+}
+
 void TSiLi::Print(Option_t *opt) const  {  
-  printf("===============\n");
-  printf("not yet written\n");
-  printf("===============\n");
+  printf("%lu sili_hits\n",fSiLiHits.size());
 }
 
-void TSiLi::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
-  if(frag == NULL || mnemonic == NULL) {
-	 return;
-  }
-  TSiLiHit hit;
-  hit.SetSegment(mnemonic->segment);
-  TVector3 tmppos = GetPosition(mnemonic->segment);
-  hit.SetPosition(tmppos);
-  hit.SetVariables(*frag);
-  if(TGRSIRunInfo::IsWaveformFitting()) 
-	 hit.SetWavefit(*frag);
-
-  fSiLiHits.push_back(hit);
-}
-
-TVector3 TSiLi::GetPosition(int seg)  {
-  TVector3 position;
-  position.SetXYZ(0,0,-1);
-  return position;
+TGRSIDetectorHit* TSiLi::GetHit(const Int_t& idx){
+   return GetSiLiHit(idx);
 }
 
 TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {  
@@ -51,3 +48,27 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
    }
    return 0;
 }  
+
+void TSiLi::PushBackHit(TGRSIDetectorHit *deshit) {
+  fSiLiHits.push_back(*((TSiLiHit*)deshit));
+  return;
+}
+
+void TSiLi::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
+  if(frag == NULL || mnemonic == NULL) {
+	 return;
+  }
+
+  TSiLiHit hit(*frag);
+  
+  if(TGRSIRunInfo::IsWaveformFitting())
+	  hit.SetWavefit(*frag);
+    
+  fSiLiHits.push_back(hit);
+}
+
+TVector3 TSiLi::GetPosition(int seg)  {
+  TVector3 position;
+  position.SetXYZ(0,0,-1);
+  return position;
+}

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
@@ -29,7 +29,7 @@ void TSiLiHit::Copy(TObject &rhs) const {
 
 
 void TSiLiHit::SetSegment(TFragment &frag){
-      TChannel *channel=GetChannel();
++	TChannel *channel = TChannel::GetChannel(frag.ChannelAddress);
       if(!channel)  return;
       
       char seg[5]; 

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
@@ -3,18 +3,46 @@
 
 ClassImp(TSiLiHit)
 
-TSiLiHit::TSiLiHit()  {  }
+TSiLiHit::TSiLiHit()  {    Clear(); }
+
+TSiLiHit::TSiLiHit(TFragment &frag)	: TGRSIDetectorHit(frag) {
+	SetVariables(frag);
+}
 
 TSiLiHit::~TSiLiHit()  {  }
+
+TSiLiHit::TSiLiHit(const TSiLiHit &rhs) : TGRSIDetectorHit() {
+   Clear();
+   ((TSiLiHit&)rhs).Copy(*this);
+}
+
+void TSiLiHit::Copy(TObject &rhs) const {
+   TGRSIDetectorHit::Copy(rhs);
+
+	static_cast<TSiLiHit&>(rhs).fLed = fLed;
+	static_cast<TSiLiHit&>(rhs).fSegment = fSegment;
+	static_cast<TSiLiHit&>(rhs).fTimeFit = fTimeFit;
+	static_cast<TSiLiHit&>(rhs).fSig2Noise = fSig2Noise;
+
+   return;
+}
+
+
+void TSiLiHit::SetSegment(TFragment &frag){
+      TChannel *channel=GetChannel();
+      if(!channel)  return;
+      
+      char seg[5]; 
+      strncpy(seg,channel->GetChannelName()+7,3);
+      fSegment=strtol(seg, NULL, 16);
+}
+
 
 
 void TSiLiHit::Clear(Option_t *opt)  {
    TGRSIDetectorHit::Clear(opt);
 	fLed       = -1;
 	fSegment   = -1;
-	fRing      = -1;
-	fSector    = -1;
-	fPreamp    = -1; 
 	fTimeFit   = -1;
 	fSig2Noise = -1;
 }
@@ -25,6 +53,10 @@ void TSiLiHit::SetWavefit(TFragment &frag)   {
 		fTimeFit = pulse.fit_newT0();
 		fSig2Noise = pulse.get_sig2noise();
 	}
+}
+
+TVector3 TSiLiHit::GetChannelPosition(double dist) const {
+	return TSiLi::GetPosition(GetSegment());
 }
 
 


### PR DESCRIPTION
This brings TS3 and TSiLi up to date with the changes I made on the master branch.

However TS3 is currently using a building method that may not be approved, but they previous way of doing it on the multiset branch doesnt work.

I am all in favour of getting rid of the data classes, but TS3 cant be built in the AddFragment(), at least not in the way it had been implemented. That way didnt allow for double hits correctly.
As you need to have loaded all fragments before doing even construction I have had to move some of the code back into BuildHits()
I'm collecting the fragments in TS3 members 	std::vector<TFragment*> fS3_RingFragment
and std::vector<TFragment*> fS3_SectorFragment 
I'm doing it with pointers to save on needless copying but I dont know enough about event construction to know if there is a danger of the fragments going out of scope between AddFragment() and BuildHits().
Also those are wiped after they are used do they dont get written to the tree.
