### PR TITLE
Fixed flags to write to 0, always. and Made IsFlagSet functions public

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -115,14 +115,15 @@ class TGRSIDetectorHit : public TObject 	{
       virtual TVector3 GetChannelPosition(Double_t dist = 0) const { AbstractMethod("GetChannelPosition"); return TVector3(0.0,0.0,0.0); }
 
      // unsigned int GetHighestBitSet(UChar_t flag);
-
-   protected:
+   public:
       Bool_t IsDetSet() const {return (fbitflags & kIsDetSet);}
       Bool_t IsPosSet() const {return (fbitflags & kIsPositionSet);}
       Bool_t IsEnergySet() const {return (fbitflags & kIsEnergySet);} 
       Bool_t IsSubDetSet() const {return (fbitflags & kIsSubDetSet);}
       Bool_t IsPPGSet() const {return (fbitflags & kIsPPGSet);}
       Bool_t IsTimeSet() const {return (fbitflags & kIsTimeSet); }
+
+   protected:
       void SetFlag(enum Ebitflag,Bool_t set);
 
    private:

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -127,7 +127,7 @@ void TGRSIDetectorHit::Copy(TObject &rhs) const {
   static_cast<TGRSIDetectorHit&>(rhs).fenergy         = fenergy;
   static_cast<TGRSIDetectorHit&>(rhs).ftime           = ftime;
 
-  static_cast<TGRSIDetectorHit&>(rhs).fbitflags       =  fbitflags;
+  static_cast<TGRSIDetectorHit&>(rhs).fbitflags       =  0;
   static_cast<TGRSIDetectorHit&>(rhs).fPPGStatus      =  fPPGStatus;
   static_cast<TGRSIDetectorHit&>(rhs).fCycleTimeStamp =  fCycleTimeStamp;
 

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -87,9 +87,8 @@ void TGriffin::Copy(TObject &rhs) const {
   static_cast<TGriffin&>(rhs).fAddback_hits        = fAddback_hits;
   static_cast<TGriffin&>(rhs).fAddback_frags      = fAddback_frags;
   static_cast<TGriffin&>(rhs).fSetCoreWave        = fSetCoreWave;
-  static_cast<TGriffin&>(rhs).fGriffinBits        = fGriffinBits;
   static_cast<TGriffin&>(rhs).fCycleStart         = fCycleStart;
-  static_cast<TGriffin&>(rhs).fGriffinBits        = fGriffinBits;
+  static_cast<TGriffin&>(rhs).fGriffinBits        = 0;
    
 
   return;                                      
@@ -276,6 +275,7 @@ void TGriffin::BuildHits(TDetectorData *data,Option_t *opt)	{
       corehit.SetCharge(gdata->GetCoreCharge(i));
       corehit.SetNPileUps((UChar_t)(gdata->GetCoreNbrHits(i)));
       corehit.SetPUHit((UChar_t)(gdata->GetCorePUHit(i)));
+      corehit.SetEnergy(100);
 /*
       if(TGriffin::SetCoreWave()){
          corehit.SetWaveform(gdata->GetCoreWave(i));

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -25,7 +25,7 @@ TGriffinHit::~TGriffinHit()  {	}
 void TGriffinHit::Copy(TObject &rhs) const {
   TGRSIDetectorHit::Copy(rhs);
   static_cast<TGriffinHit&>(rhs).fFilter                = fFilter;
-  static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = fGriffinHitBits;
+  static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = 0;
   static_cast<TGriffinHit&>(rhs).fCrystal               = fCrystal;
   static_cast<TGriffinHit&>(rhs).fPPG                   = fPPG;
   static_cast<TGriffinHit&>(rhs).fBremSuppressed_flag   = fBremSuppressed_flag;//! Bremsstrahlung Suppression flag.


### PR DESCRIPTION
- Makes it so we can't screw up the transient flags.
- IsFlagsSet are const functions and making them public makes debugging easier.