### PR TITLE
Added TLMFitter

### DIFF
--- a/include/TLMFitter.h
+++ b/include/TLMFitter.h
@@ -27,8 +27,6 @@
 ////////////////////////////////////////////////////////////////
 // Vector Types
 
-typedef double DP;
-
 //Overloaded complex operations to handle mixed float and double
 //This takes care of e.g. 1.0/z, z complex<float>
 
@@ -377,14 +375,14 @@ typedef NRVec<unsigned long> Vec_ULNG, Vec_O_ULNG, Vec_IO_ULNG;
 typedef const NRVec<float> Vec_I_SP;
 typedef NRVec<float> Vec_SP, Vec_O_SP, Vec_IO_SP;
 
-typedef const NRVec<DP> Vec_I_DP;
-typedef NRVec<DP> Vec_DP, Vec_O_DP, Vec_IO_DP;
+typedef const NRVec<double> Vec_I_double;
+typedef NRVec<double> Vec_double, Vec_O_double, Vec_IO_double;
 
 typedef const NRVec<std::complex<float> > Vec_I_CPLX_SP;
 typedef NRVec<std::complex<float> > Vec_CPLX_SP, Vec_O_CPLX_SP, Vec_IO_CPLX_SP;
 
-typedef const NRVec<std::complex<DP> > Vec_I_CPLX_DP;
-typedef NRVec<std::complex<DP> > Vec_CPLX_DP, Vec_O_CPLX_DP, Vec_IO_CPLX_DP;
+typedef const NRVec<std::complex<double> > Vec_I_CPLX_double;
+typedef NRVec<std::complex<double> > Vec_CPLX_double, Vec_O_CPLX_double, Vec_IO_CPLX_double;
 
 // Matrix Types
 
@@ -412,24 +410,24 @@ typedef NRMat<unsigned long> Mat_ULNG, Mat_O_ULNG, Mat_IO_ULNG;
 typedef const NRMat<float> Mat_I_SP;
 typedef NRMat<float> Mat_SP, Mat_O_SP, Mat_IO_SP;
 
-typedef const NRMat<DP> Mat_I_DP;
-typedef NRMat<DP> Mat_DP, Mat_O_DP, Mat_IO_DP;
+typedef const NRMat<double> Mat_I_double;
+typedef NRMat<double> Mat_double, Mat_O_double, Mat_IO_double;
 
 typedef const NRMat<std::complex<float> > Mat_I_CPLX_SP;
 typedef NRMat<std::complex<float> > Mat_CPLX_SP, Mat_O_CPLX_SP, Mat_IO_CPLX_SP;
 
-typedef const NRMat<std::complex<DP> > Mat_I_CPLX_DP;
-typedef NRMat<std::complex<DP> > Mat_CPLX_DP, Mat_O_CPLX_DP, Mat_IO_CPLX_DP;
+typedef const NRMat<std::complex<double> > Mat_I_CPLX_double;
+typedef NRMat<std::complex<double> > Mat_CPLX_double, Mat_O_CPLX_double, Mat_IO_CPLX_double;
 
 // 3D Matrix Types
 
-typedef const NRMat3d<DP> Mat3D_I_DP;
-typedef NRMat3d<DP> Mat3D_DP, Mat3D_O_DP, Mat3D_IO_DP;
+typedef const NRMat3d<double> Mat3D_I_double;
+typedef NRMat3d<double> Mat3D_double, Mat3D_O_double, Mat3D_IO_double;
 
 // Miscellaneous Types
 
 typedef NRVec<unsigned long *> Vec_ULNG_p;
-typedef NRVec<NRMat<DP> *> Vec_Mat_DP_p;
+typedef NRVec<NRMat<double> *> Vec_Mat_double_p;
 typedef NRVec<std::fstream *> Vec_FSTREAM_p;
 
 
@@ -497,7 +495,6 @@ class TLMFitter : public TObject{
       int fRangeMin;
       int fRangeMax;
 
-      typedef double DP;
    public:
       template <class T> class NRVec;
       template <class T> class NRMat;
@@ -517,18 +514,18 @@ class TLMFitter : public TObject{
 		   exit(1);
 	   }
    
-      void funcs(const DP &x, Vec_IO_DP &a, DP &y, Vec_O_DP &dyda);
-      void mrqmin(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
-            Vec_I_BOOL &ia, Mat_O_DP &covar, Mat_O_DP &alpha, DP &chisq, Vec_I_DP &W,
-            DP &alamda);
+      void funcs(const double &x, Vec_IO_double &a, double &y, Vec_O_double &dyda);
+      void mrqmin(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_IO_double &a,
+            Vec_I_BOOL &ia, Mat_O_double &covar, Mat_O_double &alpha, double &chisq, Vec_I_double &W,
+            double &alamda);
 
-      void mrqcof(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
-            Vec_I_BOOL &ia, Mat_O_DP &alpha, Vec_O_DP &beta, DP &chisq, Vec_I_DP &W,
-               DP &chisqexp);
-      void gaussj(Mat_IO_DP &a, Mat_IO_DP &b);
-      void covsrt(Mat_IO_DP &covar, Vec_I_BOOL &ia, const int mfit);
-      int  integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
-			   Vec_IO_DP &a, Vec_DP &dyda, int chisqnumber, const double &bin_width, Vec_DP &yfit, const int &bin);
+      void mrqcof(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_IO_double &a,
+            Vec_I_BOOL &ia, Mat_O_double &alpha, Vec_O_double &beta, double &chisq, Vec_I_double &W,
+               double &chisqexp);
+      void gaussj(Mat_IO_double &a, Mat_IO_double &b);
+      void covsrt(Mat_IO_double &covar, Vec_I_BOOL &ia, const int mfit);
+      int  integrator(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_I_double &W,
+			   Vec_IO_double &a, Vec_double &dyda, int chisqnumber, const double &bin_width, Vec_double &yfit, const int &bin);
 
    public:
 

--- a/include/TLMFitter.h
+++ b/include/TLMFitter.h
@@ -55,24 +55,27 @@ template <class T>
 NRVec<T>::NRVec() : nn(0), v(0) {}
 
 template <class T>
-NRVec<T>::NRVec(int n) : nn(n), v(new T[n]) {}
+NRVec<T>::NRVec(int n) : nn(n), v(new T[n]()) {
+   for(int i=0; i<n; ++i)
+      v[i] = 0.0;
+}
 
 template <class T>
-NRVec<T>::NRVec(const T& a, int n) : nn(n), v(new T[n])
+NRVec<T>::NRVec(const T& a, int n) : nn(n), v(new T[n]())
 {
 	for(int i=0; i<n; i++)
 		v[i] = a;
 }
 
 template <class T>
-NRVec<T>::NRVec(const T *a, int n) : nn(n), v(new T[n])
+NRVec<T>::NRVec(const T *a, int n) : nn(n), v(new T[n]())
 {
 	for(int i=0; i<n; i++)
 		v[i] = *a++;
 }
 
 template <class T>
-NRVec<T>::NRVec(const NRVec<T> &rhs) : nn(rhs.nn), v(new T[nn])
+NRVec<T>::NRVec(const NRVec<T> &rhs) : nn(rhs.nn), v(new T[nn]())
 {
 	for(int i=0; i<nn; i++)
 		v[i] = rhs[i];
@@ -155,18 +158,24 @@ template <class T>
 NRMat<T>::NRMat() : nn(0), mm(0), v(0) {}
 
 template <class T>
-NRMat<T>::NRMat(int n, int m) : nn(n), mm(m), v(new T*[n])
+NRMat<T>::NRMat(int n, int m) : nn(n), mm(m), v(new T*[n]())
 {
-	v[0] = new T[m*n];
+	v[0] = new T[m*n]();
 	for (int i=1; i< n; i++)
 		v[i] = v[i-1] + m;
+
+   for(int i=0; i<n;++i){
+      for(int j=0;j<m;++j){
+         v[i][j] = 0.0;
+      }
+   }
 }
 
 template <class T>
-NRMat<T>::NRMat(const T &a, int n, int m) : nn(n), mm(m), v(new T*[n])
+NRMat<T>::NRMat(const T &a, int n, int m) : nn(n), mm(m), v(new T*[n]())
 {
 	int i,j;
-	v[0] = new T[m*n];
+	v[0] = new T[m*n]();
 	for (i=1; i< n; i++)
 		v[i] = v[i-1] + m;
 	for (i=0; i< n; i++)
@@ -175,10 +184,10 @@ NRMat<T>::NRMat(const T &a, int n, int m) : nn(n), mm(m), v(new T*[n])
 }
 
 template <class T>
-NRMat<T>::NRMat(const T *a, int n, int m) : nn(n), mm(m), v(new T*[n])
+NRMat<T>::NRMat(const T *a, int n, int m) : nn(n), mm(m), v(new T*[n]())
 {
 	int i,j;
-	v[0] = new T[m*n];
+	v[0] = new T[m*n]();
 	for (i=1; i< n; i++)
 		v[i] = v[i-1] + m;
 	for (i=0; i< n; i++)
@@ -187,10 +196,10 @@ NRMat<T>::NRMat(const T *a, int n, int m) : nn(n), mm(m), v(new T*[n])
 }
 
 template <class T>
-NRMat<T>::NRMat(const NRMat &rhs) : nn(rhs.nn), mm(rhs.mm), v(new T*[nn])
+NRMat<T>::NRMat(const NRMat &rhs) : nn(rhs.nn), mm(rhs.mm), v(new T*[nn]())
 {
 	int i,j;
-	v[0] = new T[mm*nn];
+	v[0] = new T[mm*nn]();
 	for (i=1; i< nn; i++)
 		v[i] = v[i-1] + mm;
 	for (i=0; i< nn; i++)
@@ -477,7 +486,7 @@ inline const std::complex<float> operator/(const std::complex<float> &a,
 
 class TLMFitter : public TObject{
    public:
-      TLMFitter(): fIntegrationSteps(1000), fInitChi2Number(3){};
+      TLMFitter(): fIntegrationSteps(100), fInitChi2Number(3){};
       ~TLMFitter(){};
 
    private:
@@ -485,6 +494,8 @@ class TLMFitter : public TObject{
       TH1* fHist;
       TF1* fFunction;
       int fInitChi2Number;
+      int fRangeMin;
+      int fRangeMax;
 
       typedef double DP;
    public:
@@ -495,13 +506,15 @@ class TLMFitter : public TObject{
       void Fit(TH1* hist, TF1* function);
 
    protected:
+      void SetFitterRange(int min, int max) {fRangeMin = min; fRangeMax = max;}
+
 	   inline void nrerror(const std::string error_text)
-	   // Numerical Recipes standard error handler
+	    //Numerical Recipes standard error handler
 	   {
-		   //cerr << "Numerical Recipes run-time error..." << endl;
-		   //cerr << error_text << endl;
-		   //cerr << "...now exiting to system..." << endl;
-		   //exit(1);
+         std::cerr << "Numerical Recipes run-time error..." << std::endl;
+         std::cerr << error_text << std::endl;
+         std::cerr << "...now exiting to system..." << std::endl;
+		   exit(1);
 	   }
    
       void funcs(const DP &x, Vec_IO_DP &a, DP &y, Vec_O_DP &dyda);

--- a/include/TLMFitter.h
+++ b/include/TLMFitter.h
@@ -1,0 +1,525 @@
+// Author: Ryan Dunlop    11/15
+
+#ifndef TLMFITTER_H
+#define TLMFITTER_H
+
+#include "Globals.h"
+
+#include <vector>
+#include <complex>
+#include <iostream>
+#include <fstream>
+
+#include "Rtypes.h"
+#include "TObject.h"
+#include "TH1.h"
+#include "TF1.h"
+
+////////////////////////////////////////////////////////////////
+//                                                            //
+// TLMFitter                                                  //
+//                                                            //
+// This Class can be used to fit weighted-poisson distributed //
+// data. It is originally from Numerical recipes, and adapted //
+// by G.F Grinyer. It is based on the non-linear 
+// Levenberg-Marquardt minimization algorithm.
+//                                                            //
+////////////////////////////////////////////////////////////////
+// Vector Types
+
+typedef double DP;
+
+//Overloaded complex operations to handle mixed float and double
+//This takes care of e.g. 1.0/z, z complex<float>
+
+template <class T>
+class NRVec {
+private:
+	int nn;	// size of array. upper index is nn-1
+	T *v;
+public:
+	NRVec();
+	explicit NRVec(int n);		// Zero-based array
+	NRVec(const T &a, int n);	//initialize to constant value
+	NRVec(const T *a, int n);	// Initialize to array
+	NRVec(const NRVec &rhs);	// Copy constructor
+	NRVec & operator=(const NRVec &rhs);	//assignment
+	NRVec & operator=(const T &a);	//assign a to every element
+	inline T & operator[](const int i);	//i'th element
+	inline const T & operator[](const int i) const;
+	inline int size() const;
+	~NRVec();
+};
+
+template <class T>
+NRVec<T>::NRVec() : nn(0), v(0) {}
+
+template <class T>
+NRVec<T>::NRVec(int n) : nn(n), v(new T[n]) {}
+
+template <class T>
+NRVec<T>::NRVec(const T& a, int n) : nn(n), v(new T[n])
+{
+	for(int i=0; i<n; i++)
+		v[i] = a;
+}
+
+template <class T>
+NRVec<T>::NRVec(const T *a, int n) : nn(n), v(new T[n])
+{
+	for(int i=0; i<n; i++)
+		v[i] = *a++;
+}
+
+template <class T>
+NRVec<T>::NRVec(const NRVec<T> &rhs) : nn(rhs.nn), v(new T[nn])
+{
+	for(int i=0; i<nn; i++)
+		v[i] = rhs[i];
+}
+
+template <class T>
+NRVec<T> & NRVec<T>::operator=(const NRVec<T> &rhs)
+// postcondition: normal assignment via copying has been performed;
+//		if vector and rhs were different sizes, vector
+//		has been resized to match the size of rhs
+{
+	if (this != &rhs)
+	{
+		if (nn != rhs.nn) {
+			if (v != 0) delete [] (v);
+			nn=rhs.nn;
+			v= new T[nn];
+		}
+		for (int i=0; i<nn; i++)
+			v[i]=rhs[i];
+	}
+	return *this;
+}
+
+template <class T>
+NRVec<T> & NRVec<T>::operator=(const T &a)	//assign a to every element
+{
+	for (int i=0; i<nn; i++)
+		v[i]=a;
+	return *this;
+}
+
+template <class T>
+inline T & NRVec<T>::operator[](const int i)	//subscripting
+{
+	return v[i];
+}
+
+template <class T>
+inline const T & NRVec<T>::operator[](const int i) const	//subscripting
+{
+	return v[i];
+}
+
+template <class T>
+inline int NRVec<T>::size() const
+{
+	return nn;
+}
+
+template <class T>
+NRVec<T>::~NRVec()
+{
+	if (v != 0)
+		delete[] (v);
+}
+
+template <class T>
+class NRMat {
+private:
+	int nn;
+	int mm;
+	T **v;
+public:
+	NRMat();
+	NRMat(int n, int m);			// Zero-based array
+	NRMat(const T &a, int n, int m);	//Initialize to constant
+	NRMat(const T *a, int n, int m);	// Initialize to array
+	NRMat(const NRMat &rhs);		// Copy constructor
+	NRMat & operator=(const NRMat &rhs);	//assignment
+	NRMat & operator=(const T &a);		//assign a to every element
+	inline T* operator[](const int i);	//subscripting: pointer to row i
+	inline const T* operator[](const int i) const;
+	inline int nrows() const;
+	inline int ncols() const;
+	~NRMat();
+};
+
+template <class T>
+NRMat<T>::NRMat() : nn(0), mm(0), v(0) {}
+
+template <class T>
+NRMat<T>::NRMat(int n, int m) : nn(n), mm(m), v(new T*[n])
+{
+	v[0] = new T[m*n];
+	for (int i=1; i< n; i++)
+		v[i] = v[i-1] + m;
+}
+
+template <class T>
+NRMat<T>::NRMat(const T &a, int n, int m) : nn(n), mm(m), v(new T*[n])
+{
+	int i,j;
+	v[0] = new T[m*n];
+	for (i=1; i< n; i++)
+		v[i] = v[i-1] + m;
+	for (i=0; i< n; i++)
+		for (j=0; j<m; j++)
+			v[i][j] = a;
+}
+
+template <class T>
+NRMat<T>::NRMat(const T *a, int n, int m) : nn(n), mm(m), v(new T*[n])
+{
+	int i,j;
+	v[0] = new T[m*n];
+	for (i=1; i< n; i++)
+		v[i] = v[i-1] + m;
+	for (i=0; i< n; i++)
+		for (j=0; j<m; j++)
+			v[i][j] = *a++;
+}
+
+template <class T>
+NRMat<T>::NRMat(const NRMat &rhs) : nn(rhs.nn), mm(rhs.mm), v(new T*[nn])
+{
+	int i,j;
+	v[0] = new T[mm*nn];
+	for (i=1; i< nn; i++)
+		v[i] = v[i-1] + mm;
+	for (i=0; i< nn; i++)
+		for (j=0; j<mm; j++)
+			v[i][j] = rhs[i][j];
+}
+
+template <class T>
+NRMat<T> & NRMat<T>::operator=(const NRMat<T> &rhs)
+// postcondition: normal assignment via copying has been performed;
+//		if matrix and rhs were different sizes, matrix
+//		has been resized to match the size of rhs
+{
+	if (this != &rhs) {
+		int i,j;
+		if (nn != rhs.nn || mm != rhs.mm) {
+			if (v != 0) {
+				delete[] (v[0]);
+				delete[] (v);
+			}
+			nn=rhs.nn;
+			mm=rhs.mm;
+			v = new T*[nn];
+			v[0] = new T[mm*nn];
+		}
+		for (i=1; i< nn; i++)
+			v[i] = v[i-1] + mm;
+		for (i=0; i< nn; i++)
+			for (j=0; j<mm; j++)
+				v[i][j] = rhs[i][j];
+	}
+	return *this;
+}
+
+template <class T>
+NRMat<T> & NRMat<T>::operator=(const T &a)	//assign a to every element
+{
+	for (int i=0; i< nn; i++)
+		for (int j=0; j<mm; j++)
+			v[i][j] = a;
+	return *this;
+}
+
+template <class T>
+inline T* NRMat<T>::operator[](const int i)	//subscripting: pointer to row i
+{
+	return v[i];
+}
+
+template <class T>
+inline const T* NRMat<T>::operator[](const int i) const
+{
+	return v[i];
+}
+
+template <class T>
+inline int NRMat<T>::nrows() const
+{
+	return nn;
+}
+
+template <class T>
+inline int NRMat<T>::ncols() const
+{
+	return mm;
+}
+
+template <class T>
+NRMat<T>::~NRMat()
+{
+	if (v != 0) {
+		delete[] (v[0]);
+		delete[] (v);
+	}
+}
+
+template <class T>
+class NRMat3d {
+private:
+	int nn;
+	int mm;
+	int kk;
+	T ***v;
+public:
+	NRMat3d();
+	NRMat3d(int n, int m, int k);
+	inline T** operator[](const int i);	//subscripting: pointer to row i
+	inline const T* const * operator[](const int i) const;
+	inline int dim1() const;
+	inline int dim2() const;
+	inline int dim3() const;
+	~NRMat3d();
+};
+
+template <class T>
+NRMat3d<T>::NRMat3d(): nn(0), mm(0), kk(0), v(0) {}
+
+template <class T>
+NRMat3d<T>::NRMat3d(int n, int m, int k) : nn(n), mm(m), kk(k), v(new T**[n])
+{
+	int i,j;
+	v[0] = new T*[n*m];
+	v[0][0] = new T[n*m*k];
+	for(j=1; j<m; j++)
+		v[0][j] = v[0][j-1] + k;
+	for(i=1; i<n; i++) {
+		v[i] = v[i-1] + m;
+		v[i][0] = v[i-1][0] + m*k;
+		for(j=1; j<m; j++)
+			v[i][j] = v[i][j-1] + k;
+	}
+}
+
+template <class T>
+inline T** NRMat3d<T>::operator[](const int i) //subscripting: pointer to row i
+{
+	return v[i];
+}
+
+template <class T>
+inline const T* const * NRMat3d<T>::operator[](const int i) const
+{
+	return v[i];
+}
+
+template <class T>
+inline int NRMat3d<T>::dim1() const
+{
+	return nn;
+}
+
+template <class T>
+inline int NRMat3d<T>::dim2() const
+{
+	return mm;
+}
+
+template <class T>
+inline int NRMat3d<T>::dim3() const
+{
+	return kk;
+}
+
+template <class T>
+NRMat3d<T>::~NRMat3d()
+{
+	if (v != 0) {
+		delete[] (v[0][0]);
+		delete[] (v[0]);
+		delete[] (v);
+	}
+}
+
+typedef const NRVec<bool> Vec_I_BOOL;
+typedef NRVec<bool> Vec_BOOL, Vec_O_BOOL, Vec_IO_BOOL;
+
+typedef const NRVec<char> Vec_I_CHR;
+typedef NRVec<char> Vec_CHR, Vec_O_CHR, Vec_IO_CHR;
+
+typedef const NRVec<unsigned char> Vec_I_UCHR;
+typedef NRVec<unsigned char> Vec_UCHR, Vec_O_UCHR, Vec_IO_UCHR;
+
+typedef const NRVec<int> Vec_I_INT;
+typedef NRVec<int> Vec_INT, Vec_O_INT, Vec_IO_INT;
+
+typedef const NRVec<unsigned int> Vec_I_UINT;
+typedef NRVec<unsigned int> Vec_UINT, Vec_O_UINT, Vec_IO_UINT;
+
+typedef const NRVec<long> Vec_I_LNG;
+typedef NRVec<long> Vec_LNG, Vec_O_LNG, Vec_IO_LNG;
+
+typedef const NRVec<unsigned long> Vec_I_ULNG;
+typedef NRVec<unsigned long> Vec_ULNG, Vec_O_ULNG, Vec_IO_ULNG;
+
+typedef const NRVec<float> Vec_I_SP;
+typedef NRVec<float> Vec_SP, Vec_O_SP, Vec_IO_SP;
+
+typedef const NRVec<DP> Vec_I_DP;
+typedef NRVec<DP> Vec_DP, Vec_O_DP, Vec_IO_DP;
+
+typedef const NRVec<std::complex<float> > Vec_I_CPLX_SP;
+typedef NRVec<std::complex<float> > Vec_CPLX_SP, Vec_O_CPLX_SP, Vec_IO_CPLX_SP;
+
+typedef const NRVec<std::complex<DP> > Vec_I_CPLX_DP;
+typedef NRVec<std::complex<DP> > Vec_CPLX_DP, Vec_O_CPLX_DP, Vec_IO_CPLX_DP;
+
+// Matrix Types
+
+typedef const NRMat<bool> Mat_I_BOOL;
+typedef NRMat<bool> Mat_BOOL, Mat_O_BOOL, Mat_IO_BOOL;
+
+typedef const NRMat<char> Mat_I_CHR;
+typedef NRMat<char> Mat_CHR, Mat_O_CHR, Mat_IO_CHR;
+
+typedef const NRMat<unsigned char> Mat_I_UCHR;
+typedef NRMat<unsigned char> Mat_UCHR, Mat_O_UCHR, Mat_IO_UCHR;
+
+typedef const NRMat<int> Mat_I_INT;
+typedef NRMat<int> Mat_INT, Mat_O_INT, Mat_IO_INT;
+
+typedef const NRMat<unsigned int> Mat_I_UINT;
+typedef NRMat<unsigned int> Mat_UINT, Mat_O_UINT, Mat_IO_UINT;
+
+typedef const NRMat<long> Mat_I_LNG;
+typedef NRMat<long> Mat_LNG, Mat_O_LNG, Mat_IO_LNG;
+
+typedef const NRMat<unsigned long> Mat_I_ULNG;
+typedef NRMat<unsigned long> Mat_ULNG, Mat_O_ULNG, Mat_IO_ULNG;
+
+typedef const NRMat<float> Mat_I_SP;
+typedef NRMat<float> Mat_SP, Mat_O_SP, Mat_IO_SP;
+
+typedef const NRMat<DP> Mat_I_DP;
+typedef NRMat<DP> Mat_DP, Mat_O_DP, Mat_IO_DP;
+
+typedef const NRMat<std::complex<float> > Mat_I_CPLX_SP;
+typedef NRMat<std::complex<float> > Mat_CPLX_SP, Mat_O_CPLX_SP, Mat_IO_CPLX_SP;
+
+typedef const NRMat<std::complex<DP> > Mat_I_CPLX_DP;
+typedef NRMat<std::complex<DP> > Mat_CPLX_DP, Mat_O_CPLX_DP, Mat_IO_CPLX_DP;
+
+// 3D Matrix Types
+
+typedef const NRMat3d<DP> Mat3D_I_DP;
+typedef NRMat3d<DP> Mat3D_DP, Mat3D_O_DP, Mat3D_IO_DP;
+
+// Miscellaneous Types
+
+typedef NRVec<unsigned long *> Vec_ULNG_p;
+typedef NRVec<NRMat<DP> *> Vec_Mat_DP_p;
+typedef NRVec<std::fstream *> Vec_FSTREAM_p;
+
+
+template<class T>
+inline const T SQR(const T a) {return a*a;}
+
+template<class T>
+inline const T MAX(const T &a, const T &b)
+{return b > a ? (b) : (a);}
+
+inline float MAX(const double &a, const float &b)
+{return b > a ? (b) : float(a);}
+
+inline float MAX(const float &a, const double &b)
+{return b > a ? float(b) : (a);}
+
+template<class T>
+inline const T SIGN(const T &a, const T &b)
+{return b >= 0 ? (a >= 0 ? a : -a) : (a >= 0 ? -a : a);}
+
+inline float SIGN(const float &a, const double &b)
+{return b >= 0 ? (a >= 0 ? a : -a) : (a >= 0 ? -a : a);}
+
+inline float SIGN(const double &a, const float &b)
+{return b >= 0 ? (a >= 0 ? a : -a) : (a >= 0 ? -a : a);}
+
+template<class T>
+inline void SWAP(T &a, T &b)
+{T dum=a; a=b; b=dum;}
+
+
+inline const std::complex<float> operator+(const double &a, const std::complex<float> &b) { return float(a)+b; }
+
+inline const std::complex<float> operator+(const std::complex<float> &a,
+									  const double &b) { return a+float(b); }
+
+inline const std::complex<float> operator-(const double &a,
+									  const std::complex<float> &b) { return float(a)-b; }
+
+inline const std::complex<float> operator-(const std::complex<float> &a,
+									  const double &b) { return a-float(b); }
+
+inline const std::complex<float> operator*(const double &a,
+									  const std::complex<float> &b) { return float(a)*b; }
+
+inline const std::complex<float> operator*(const std::complex<float> &a,
+									  const double &b) { return a*float(b); }
+
+inline const std::complex<float> operator/(const double &a,
+									  const std::complex<float> &b) { return float(a)/b; }
+
+inline const std::complex<float> operator/(const std::complex<float> &a,
+									  const double &b) { return a/float(b); }
+
+class TLMFitter : public TObject{
+   public:
+      TLMFitter(): fIntegrationSteps(1000), fInitChi2Number(3){};
+      ~TLMFitter(){};
+
+   private:
+      int fIntegrationSteps;
+      TH1* fHist;
+      TF1* fFunction;
+      int fInitChi2Number;
+
+      typedef double DP;
+   public:
+      template <class T> class NRVec;
+      template <class T> class NRMat;
+      template <class T> class NRMat3d;
+   public:
+      void Fit(TH1* hist, TF1* function);
+
+   protected:
+	   inline void nrerror(const std::string error_text)
+	   // Numerical Recipes standard error handler
+	   {
+		   //cerr << "Numerical Recipes run-time error..." << endl;
+		   //cerr << error_text << endl;
+		   //cerr << "...now exiting to system..." << endl;
+		   //exit(1);
+	   }
+   
+      void funcs(const DP &x, Vec_IO_DP &a, DP &y, Vec_O_DP &dyda);
+      void mrqmin(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
+            Vec_I_BOOL &ia, Mat_O_DP &covar, Mat_O_DP &alpha, DP &chisq, Vec_I_DP &W,
+            DP &alamda);
+
+      void mrqcof(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
+            Vec_I_BOOL &ia, Mat_O_DP &alpha, Vec_O_DP &beta, DP &chisq, Vec_I_DP &W,
+               DP &chisqexp);
+      void gaussj(Mat_IO_DP &a, Mat_IO_DP &b);
+      void covsrt(Mat_IO_DP &covar, Vec_I_BOOL &ia, const int mfit);
+      int  integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
+			   Vec_IO_DP &a, Vec_DP &dyda, int chisqnumber, const double &bin_width, Vec_DP &yfit, const int &bin);
+
+   public:
+
+   ClassDef(TLMFitter,1);
+};
+
+#endif // TLMFitter_H

--- a/libraries/TGRSIAnalysis/TGRSIFit/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TGRSIFit/LinkDef.h
@@ -1,4 +1,4 @@
-//TGRSIFit.h TGRSIFunctions.h TMultiPeak.h TPeak.h TDecay.h 
+//TGRSIFit.h TGRSIFunctions.h TMultiPeak.h TPeak.h TDecay.h TLMFitter.h
 
 #ifdef __CINT__
 
@@ -21,6 +21,8 @@
 #pragma link C++ class TDecay+;
 #pragma link C++ class TVirtualDecay-;
 #pragma link C++ class std::map<Int_t, std::vector<TSingleDecay*>>+;
+
+#pragma link C++ class TLMFitter+;
 
 #endif
 

--- a/libraries/TGRSIAnalysis/TGRSIFit/TDecay.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TDecay.cxx
@@ -3,6 +3,7 @@
 #include "Math/Factory.h"
 #include "Math/Functor.h"
 #include "GCanvas.h"
+#include "TLMFitter.h"
 
 ///////////////////////////////////////////////////////////////////////
 //
@@ -648,6 +649,10 @@ Double_t TDecay::DecayFit(Double_t *dim, Double_t *par){
 }
 
 TFitResultPtr TDecay::Fit(TH1* fithist, Option_t* opt) {
+   //Use the option "G" to use Geoff's Levenberg-Marquardt algorithm to fit.
+   TString opt1 = opt;
+   opt1.ToUpper();
+      
    ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2","Combination");
    TVirtualFitter::SetPrecision(1.0e-10);
    TVirtualFitter::SetMaxIterations(10000);
@@ -657,11 +662,19 @@ TFitResultPtr TDecay::Fit(TH1* fithist, Option_t* opt) {
    SetParameters();
 
 //   TFitResultPtr fitres = fithist->Fit(fFitFunc,Form("%sWLRS0",opt));
-   TFitResultPtr fitres = fFitFunc->Fit(fithist,Form("%sWLRS",opt));
-   Double_t chi2 = fitres->Chi2();
-   Double_t ndf = fitres->Ndf();
 
-   printf("Chi2/ndf = %lf\n",chi2/ndf);
+   TFitResultPtr fitres;
+   if(opt1.Contains("G")){
+      //Fit using LMFitter..Doesn't do residuals yet
+      TLMFitter fitter;
+      fitter.Fit(fithist,fFitFunc);
+   }
+   else{
+      fitres = fFitFunc->Fit(fithist,Form("%sIWLRS",opt));
+      Double_t chi2 = fitres->Chi2();
+      Double_t ndf = fitres->Ndf();
+      printf("Chi2/ndf = %lf\n",chi2/ndf);
+   }
 
    //Now Tell the decays about the results
    for(size_t i=0; i<fChainList.size(); ++i){

--- a/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
@@ -1,0 +1,473 @@
+#include "TLMFitter.h"
+#include <iomanip>
+#include <iostream>
+
+ClassImp(TLMFitter);
+
+/* DIM is the size of the matrices and DIMM is the last bin to fit */
+
+/* DEFINITIONS */
+/*******************************************************************/
+/* alamda = parameter switches between curve and gradient method   */
+/*          must begin negative to initialize fit routine          */
+/* x[DIM] = x values of the data                                   */
+/* y[DIM] = y values of the data (Number of counts)                */
+/* sig[i] = sigma in the y value                                   */
+/* chisq  = chi-squared definitions defined in mrqcof subroutine   */
+/* sig2i  = 1 over sigma squared (Used in computing the chisq)     */
+/* a[i]   = fit parameters of the fitting function                 */
+/* ia[i]  = set to '1' to free a[i] or '0' for fixed               */
+/* beta[j]= extremum vector                                        */
+/* alpha[k][k] = curvature matrix                                  */
+/* dy     = yfit - ydata                                           */
+/* ma     = number of fit parameters in fit function               */
+/*******************************************************************/
+
+/* Function Subroutine-***Put fitting function here***-------------*/
+void TLMFitter::funcs(const DP &x, Vec_IO_DP &a, DP &y, Vec_O_DP &dyda)
+{
+   for(int i=0; i<a.size();++i){
+      fFunction->SetParameter(i,a[i]);
+   }
+   for(int i=0; i<a.size();++i){
+      dyda[i] = fFunction->GradientPar(i,&x);
+   }
+   y = fFunction->Eval(x);
+}
+/* Main program----------------------------------------------------*/
+
+/*Reads in the binary data and uses subroutines from Num.Recipes   */
+void TLMFitter::Fit(TH1* hist, TF1* func){
+//	char fname1[100], fname2[100], fname3[100], flog[100], fout[100], fruns[100];
+//	char text[100], yfits[100], ydatfile[100], flag, flagtemp,suppress, answer;
+//	double x[DIMM+1], y[DIMM+1], v[DIMM+1], W[DIMM+1], junk;
+//	double ynew, fit[DIMM+1], z[ITER+1], xstart[DIMM+1], ymod;
+//	double yfit[DIMM+1], vsumold[DIMM+1];
+//	double sumnew[DIMM+1], sumold[DIMM+1], vsumnew[DIMM+1];
+//	double bg, thalf1, thalf2, thalf3;
+//	double intens2, intens3;
+//	double BIN, DEAD1;
+//	unsigned long int buffer1[DIM+1], buffer2[DIM+1], sumdatan, sum;
+//	double channel1[DIMM+1], channel2[DIMM+1];
+//	int i, j, k, w, l, u, p, n, q, ndata, run_num, sumdatao, events, chopstep;
+//	int initchisqnumber, chisqnumber, cycles, good, cycbeg, cycend, chopstart, chop_runs, cloop;
+//	int total_runs, chop, chopend, loop, mfit, closed;
+//	char run_number;
+//	double sig[DIMM+1], chisqstart, lamdastart;
+//	FILE *ifp1, *ifp2, *ifp3, *ofp1, *ofp2, *ofpydata, *ofpyfit;
+//	
+//	/* NUMERICAL RECIPES DEFINITIONS (needed for mrqmin subroutine)  */
+   double alamda, chisq, ochisq;
+
+	int ma = func->GetNpar();  /* This is the number of parameters in fit function */
+   int nBins = hist->GetNbinsX();
+//	double *alamda, da, *chisq, a[ma+1], beta[DIMM+1];
+//	double dyda[ma+1];
+	Mat_O_DP alpha(ma,ma), covar(ma,ma);
+//	static double *atry;
+//	int ia[ma+1];
+   Vec_DP x(nBins), y(nBins), sig(nBins), yfit(nBins), W(nBins), v(nBins);
+   Vec_BOOL ia(ma);
+   Vec_O_DP a(ma), dyda(ma);
+
+   fFunction = func;
+   fHist = hist;
+
+   //Sets whether parameters are fixed or free.
+   for(int i=0; i<func->GetNpar();++i){
+      Double_t min,max;
+      a[i] = func->GetParameter(i);
+
+      func->GetParLimits(i,min,max);
+      if(min == max){
+         if(min != 0){
+            //Parameter is fixed
+            ia[i] = false;
+            continue;
+         }
+      }
+      ia[i] = true;
+
+   }
+
+   for(int i=0; i<hist->GetNbinsX();++i){
+      x[i] = hist->GetXaxis()->GetBinCenter(i);
+      y[i] = hist->GetBinContent(i);
+      v[i] = hist->GetBinError(i)*hist->GetBinError(i);
+
+      W[i] = y[i]/v[i];
+   }
+
+	/* Go to integrator to begin obtain yfit with these guesses */
+   double func_range_min, func_range_max;
+   func->GetRange(func_range_min,func_range_max);
+
+   for(int iter=0;iter<1000;++iter){
+      alamda = -1;
+      mrqmin(x,y,sig,a,ia,covar,alpha,chisq,W,alamda);
+      int k = 1;
+      int itst = 0;
+      while(true){
+         std::cout << std::endl << "Iteration #" << std::setw(3) << k;
+         std::cout << std::setw(18) << "chi-squared:" << std::setw(13) << chisq;
+         std::cout << std::setw(11) << "alamda:" << std::setw(10) << alamda << std::endl;
+         fFunction->Print();
+         std::cout << std::endl;
+         ++k;
+         ochisq = chisq;
+         mrqmin(x,y,sig,a,ia,covar,alpha,chisq,W,alamda);
+         std::fabs(ochisq-chisq) < 0.1 ? itst++ : itst =0;
+         if(itst<4) continue;
+         alamda = 0.0;
+         mrqmin(x,y,sig,a,ia,covar,alpha,chisq,W,alamda);
+         std::cout << "Uncertainties:" << std::endl;
+         for(int i=0; i<ma; ++i) std::cout << std::setw(9) << sqrt(covar[i][i]);
+         std::cout << std::endl;
+         break;
+      }
+   }
+/*	for(int q=func_range_min; q<func_range_max; q++)
+	{
+	   chisqnumber = integrator(x,y,sig,W,a,dyda,chisqnumber,bin_width,yfit,q);
+	}*/
+//			
+//			ndata=DIMM-chop;                 /* ndata is # of data points  */
+//			chisqstart = 0.0;
+//			lamdastart = -1.0;
+//			chisq = &chisqstart;
+//			alamda = &lamdastart;
+//			/* Modified mrqmin algorithm */
+//			printf("Now Fitting MCS %c\n",run_number);
+//			printf("Chop: %d to %d\n",chop,DIMM);
+//			mrqmin(x,y,sig,ndata,a,ia,ma,covar,alpha,chisq,funcs,alamda,
+//				   ofp1,BIN,n,u,ofp2,W,chisqnumber,chop,chopend,yfit,flag,ofpyfit,run_number,p,initchisqnumber);
+//			
+//			fclose(ofpyfit);
+//			fclose(ofp1);
+//			fclose(ofp2);
+//			
+//		}/* end of loop over chop files */
+//		
+//	}/* End of loop over all run_numbers */
+//	fclose(ifp3);
+//	printf("END OF RUN \n");
+}
+/*******************************************************************/
+/*                                                                 */
+/* Subroutines below (in order) -                                  */
+/* integrator - integration routine (fit function is an integral)/  */
+/* mrqmin - subroutine, which rejects or accepts fit parameters    */
+/* mrqcof - calculates the chi squared values                      */
+/* covsrt - converts alpha matrix into the error matrix            */
+/* gaussj - row reduces alpha and beta to send to covsrt           */
+/*                                                                 */
+/*******************************************************************/
+
+
+
+
+/*******************************************************************/
+/*  Integrator                                                     */
+/*******************************************************************/
+int TLMFitter::integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
+			   Vec_IO_DP &a, Vec_DP &dyda, int chisqnumber, const double &bin_width, Vec_DP &yfit, const int &bin)
+{
+   //Integrates the function within each bin
+   int ma = a.size();
+//	int i, j, k;
+	double ynew = 0;  
+	double xstart = x[bin]; //This is the start of the bin
+   double ymod;
+   Vec_DP z(fIntegrationSteps), temp(dyda.size());
+	
+	for(int k=0; k<fIntegrationSteps; ++k)
+	{  
+      //Find the y value at different integration stpes along the bin
+		z[k] = xstart + (double)(k)*bin_width/(double)fIntegrationSteps;
+		funcs(z[k],a,ymod,dyda);
+		for(int i=0; i<ma; ++i)
+		{  
+         //Integrates the gradient of the functon within the bin
+			temp[i] += bin_width/(double)fIntegrationSteps*dyda[i];
+		}
+      //integrates the y of the function
+		ynew += bin_width/(double)fIntegrationSteps*ymod;
+	}
+   //Sets the actual variables to the "temporary" variables used for integration
+	for(int i=0; i<ma; ++i)
+	{
+		dyda[i] = temp[i];
+	}
+	yfit[bin] = ynew;
+	
+//	//Change the chisqnumber from what it was defined at the beginning (most likely 3 = Poisson distribution)
+//	//to 2 (= Gaussian distribution with possible bin counts of zero) if yfit < 0.
+	if(yfit[bin] <= 0)
+	{
+		chisqnumber = 2;
+	}
+	else
+	{
+		chisqnumber = fInitChi2Number;
+	}
+	
+	/* Various definitions of sigma used in diff chi squares */
+	if(chisqnumber == 0 || chisqnumber == 3)
+	{
+		sig[bin] = sqrt(yfit[bin]);
+	}
+   if(chisqnumber == 1 || chisqnumber == 2)
+	{
+		sig[bin] = sqrt(y[bin]);
+		if(chisqnumber == 1)
+		{
+			if (y[bin] <= 0.5){sig[bin] = sqrt(yfit[bin]);}
+		}
+		if(chisqnumber == 2)
+		{
+			if (y[bin] <= 0.5){sig[bin] = 1.0;}
+		}
+	}
+	return chisqnumber;
+}
+///*******************************************************************/
+/*  mrqmin                                                         */
+/*******************************************************************/
+
+void TLMFitter::mrqmin(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
+				 Vec_I_BOOL &ia, Mat_O_DP &covar, Mat_O_DP &alpha, DP &chisq, Vec_I_DP &W,
+				 DP &alamda)
+{
+	static int mfit;
+	static DP ochisq;
+	int j,k,l;
+   double chisqexp;
+	
+	int ma=a.size();
+	static Mat_DP *oneda_p;
+	static Vec_DP *atry_p,*beta_p,*da_p;
+	if (alamda < 0.0) {  //Initialization
+		atry_p = new Vec_DP(ma);
+		beta_p = new Vec_DP(ma);
+		da_p = new Vec_DP(ma);
+		mfit=0;
+		for (j=0;j<ma;j++)
+			if (ia[j]) mfit++;
+		oneda_p = new Mat_DP(mfit,1);
+		alamda=0.001;
+		mrqcof(x,y,sig,a,ia,alpha,*beta_p,chisq,W,chisqexp);
+		ochisq=chisq;
+		for (j=0;j<ma;j++) (*atry_p)[j]=a[j];
+	}
+	Mat_DP &oneda=*oneda_p;
+	Vec_DP &atry=*atry_p,&beta=*beta_p,&da=*da_p;
+	Mat_DP temp(mfit,mfit);
+	//After linearized fitting matrix, by augmenting diagonal elements
+   for (j=0;j<mfit;j++) {  
+      for (k=0;k<mfit;k++) covar[j][k]=alpha[j][k];
+		covar[j][j]=alpha[j][j]*(1.0+alamda);
+		for (k=0;k<mfit;k++) temp[j][k]=covar[j][k];
+		oneda[j][0]=beta[j];
+	}
+	gaussj(temp,oneda); //Matrix solution
+	for (j=0;j<mfit;j++) {
+		for (k=0;k<mfit;k++) covar[j][k]=temp[j][k];
+		da[j]=oneda[j][0];
+	}
+	if (alamda == 0.0) { //Once converged, evaluate covariance matrix
+		covsrt(covar,ia,mfit);
+		covsrt(alpha,ia,mfit);  //Spread out alpha to its full size too
+      chisqexp-=mfit;
+      chisq /= chisqexp;
+		delete oneda_p; delete da_p; delete beta_p; delete atry_p;
+		return;
+	}
+	for (j=0,l=0;l<ma;l++){ //Did the trial succeed?
+		if (ia[l]) atry[l]=a[l]+da[j++];
+   }
+	mrqcof(x,y,sig,atry,ia,covar,da,chisq,W,chisqexp);
+
+	if (chisq < ochisq) {   //Success, accept the new solution
+		alamda *= 0.1;
+		ochisq=chisq;
+		for (j=0;j<mfit;j++) {
+			for (k=0;k<mfit;k++) alpha[j][k]=covar[j][k];
+			beta[j]=da[j];
+		}
+		for (l=0;l<ma;l++) a[l]=atry[l];
+	} else {                //Failure, increase alamda and return
+		alamda *= 10.0;
+		chisq=ochisq;
+	}
+}
+
+/*******************************************************************/
+/*  mrqcof                                                         */
+/*******************************************************************/
+
+void TLMFitter::mrqcof(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
+				Vec_I_BOOL &ia, Mat_O_DP &alpha, Vec_O_DP &beta, DP &chisq, Vec_I_DP &W,
+				DP &chisqexp)
+{
+	int i,j,k,l,m,mfit=0;
+	DP wt,sig2i,dy;
+
+   chisqexp = 0.0;
+	
+	int ndata=x.size();
+	int ma=a.size();
+	Vec_DP dyda(ma);
+   Vec_DP yfit(ndata);
+	for (j=0;j<ma;j++)
+		if (ia[j]) mfit++;
+	for (j=0;j<mfit;j++) {     //Initialize (symmetric) alpha, beta.
+		for (k=0;k<=j;k++) alpha[j][k]=0.0;
+		beta[j]=0.0;
+	}
+	chisq=0.0;
+
+	for (i=0;i<ndata;i++) {    //Summation loop over all data.
+      int chisqnumber = integrator(x,y,sig,W,a,dyda,fInitChi2Number,fHist->GetXaxis()->GetBinWidth(1),yfit,i);
+		//funcs(x[i],a,ymod,dyda); Integrator does this instead
+		sig2i=1.0/(sig[i]*sig[i]);
+		dy=y[i]-yfit[i];
+		for (j=0,l=0;l<ma;l++) {
+			if (ia[l]) {
+            //sigs are different for different chisqnumbers
+            //This is done in integrator
+				wt=dyda[l]*sig2i;
+				for (k=0,m=0;m<l+1;m++){
+					if (ia[m]){ 
+                  if(chisqnumber == 0){ //least squares
+                     alpha[j][++k] += wt*dyda[m]*(1.0+dy/yfit[i])*(1.0+dy/yfit[i])*W[i];
+                  }
+                  else{
+                     alpha[j][++k] += wt*dyda[m]*W[i];
+                  }
+               }
+            }
+            if(chisqnumber ==0){ //Least squares
+               beta[j] += dy*wt*(1.0+dy/(2.0*yfit[i]))*W[i];
+            }
+            else{
+               beta[j] += dy*wt*W[i];
+            }
+         }
+         //Now find the correct chi^2 based on the different versions of chisquared
+         if((chisqnumber == 0) || (chisqnumber == 1) || (chisqnumber == 2)){
+            chisq += dy*dy*sig2i*W[i];
+            chisqexp +=1;
+         }
+         if(chisqnumber == 3){
+            if(y[i] <1.0){
+               chisq += 2.0*(yfit[i]-y[i])*W[i];
+            }
+            else{
+               chisq += 2.0*(yfit[i]-y[i]+y[i]*log(y[i]/yfit[i]))*W[i];
+            }
+            
+            //approximation to expectation value of ml chi squared
+			   if(yfit[i] < 4.2){
+				   chisqexp += -2.0*yfit[i]*log(yfit[i])
+				   +pow(yfit[i],2.0)*log(4.0)
+				   -pow(yfit[i],3.0)*log(4.0/3.0)
+				   +(1.0/3.0)*pow(yfit[i],4.0)*log(32.0/27.0)
+				   -(1.0/12.0)*pow(yfit[i],5.0)*log(4096.0/3645.0)
+				   +1442.633448*pow(yfit[i],6.0)/pow(10.0,6.0)
+				   -1782.46047*pow(yfit[i],7.0)/pow(10.0,7.0)
+				   +1588.98494*pow(yfit[i],8.0)/pow(10.0,8.0)
+				   -716.19428*pow(yfit[i],9.0)/pow(10.0,9.0);
+		      }
+		      else
+		      {
+			      chisqexp += 1.0 + 1.0/(6.0*yfit[i])+1.0/(6.0*pow(yfit[i],2.0))
+			      + 19.0/(60.0*pow(yfit[i],3.0))
+			      + 9.0/(10.0*pow(yfit[i],4.0))
+			      - 31.9385/pow(yfit[i],5.0)
+			      + 741.3189/pow(yfit[i],6.0)
+			      - 3928.1260/pow(yfit[i],7.0)
+			      + 6158.3381/pow(yfit[i],8.0);
+		      }
+         }//end of chi2 3
+      }
+   }//end of loop over data
+			
+	for (j=1;j<mfit;j++)       //Fill in the symmetric side.
+		for (k=0;k<j;k++) alpha[k][j]=alpha[j][k];
+}
+
+/*******************************************************************/
+/*  covsrt                                                         */
+/*******************************************************************/
+void TLMFitter::covsrt(Mat_IO_DP &covar, Vec_I_BOOL &ia, const int mfit)
+{
+   //Rearranges the covariance matrix covar in the order of all ma parameters
+	int i,j,k;
+	
+	int ma=ia.size();
+	for (i=mfit;i<ma;i++)
+		for (j=0;j<i+1;j++) covar[i][j]=covar[j][i]=0.0;
+	k=mfit-1;
+	for (j=ma-1;j>=0;j--) {
+		if (ia[j]) {
+			for (i=0;i<ma;i++) SWAP(covar[i][k],covar[i][j]);
+			for (i=0;i<ma;i++) SWAP(covar[k][i],covar[j][i]);
+			k--;
+		}
+	}
+}
+
+
+/*******************************************************************/
+/*  gaussj                                                         */
+/*******************************************************************/
+
+void TLMFitter::gaussj(Mat_IO_DP &a, Mat_IO_DP &b)
+{
+   //Matrix solver
+	int i,icol,irow,j,k,l,ll;
+	DP big,dum,pivinv;
+	
+	int n=a.nrows();
+	int m=b.ncols();
+	Vec_INT indxc(n),indxr(n),ipiv(n);
+	for (j=0;j<n;j++) ipiv[j]=0;
+	for (i=0;i<n;i++) {
+		big=0.0;
+		for (j=0;j<n;j++)
+			if (ipiv[j] != 1)
+				for (k=0;k<n;k++) {
+					if (ipiv[k] == 0) {
+						if (fabs(a[j][k]) >= big) {
+							big=fabs(a[j][k]);
+							irow=j;
+							icol=k;
+						}
+					}
+				}
+		++(ipiv[icol]);
+		if (irow != icol) {
+			for (l=0;l<n;l++) SWAP(a[irow][l],a[icol][l]);
+			for (l=0;l<m;l++) SWAP(b[irow][l],b[icol][l]);
+		}
+		indxr[i]=irow;
+		indxc[i]=icol;
+		if (a[icol][icol] == 0.0) nrerror("gaussj: Singular Matrix");
+		pivinv=1.0/a[icol][icol];
+		a[icol][icol]=1.0;
+		for (l=0;l<n;l++) a[icol][l] *= pivinv;
+		for (l=0;l<m;l++) b[icol][l] *= pivinv;
+		for (ll=0;ll<n;ll++)
+			if (ll != icol) {
+				dum=a[ll][icol];
+				a[ll][icol]=0.0;
+				for (l=0;l<n;l++) a[ll][l] -= a[icol][l]*dum;
+				for (l=0;l<m;l++) b[ll][l] -= b[icol][l]*dum;
+			}
+	}
+	for (l=n-1;l>=0;l--) {
+		if (indxr[l] != indxc[l])
+			for (k=0;k<n;k++)
+				SWAP(a[k][indxr[l]],a[k][indxc[l]]);
+	}
+}

--- a/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
@@ -22,7 +22,7 @@ ClassImp(TLMFitter);
 /*******************************************************************/
 
 /* Function Subroutine-***Put fitting function here***-------------*/
-void TLMFitter::funcs(const DP &x, Vec_IO_DP &a, DP &y, Vec_O_DP &dyda)
+void TLMFitter::funcs(const double &x, Vec_IO_double &a, double &y, Vec_O_double &dyda)
 {
    for(int i=0; i<a.size();++i){
       fFunction->SetParameter(i,a[i]);
@@ -37,9 +37,9 @@ void TLMFitter::Fit(TH1* hist, TF1* func){
    double alamda, chisq, ochisq;
 
 	int ma = func->GetNpar();  /* This is the number of parameters in fit function */
-	Mat_O_DP alpha(ma,ma), covar(ma,ma);
+	Mat_O_double alpha(ma,ma), covar(ma,ma);
    Vec_BOOL ia(ma);
-   Vec_O_DP a(ma), dyda(ma);
+   Vec_O_double a(ma), dyda(ma);
 
    fFunction = func;
    fHist = hist;
@@ -70,7 +70,7 @@ void TLMFitter::Fit(TH1* hist, TF1* func){
    bin_max = hist->FindBin(func_range_max);
 
    nBins = bin_max - bin_min;
-   Vec_DP x(nBins), y(nBins), sig(nBins), yfit(nBins), W(nBins), v(nBins);
+   Vec_double x(nBins), y(nBins), sig(nBins), yfit(nBins), W(nBins), v(nBins);
    
    std::cout << "Setting bin values..." << std::endl;
    std::cout << "Range is " << bin_min << " to " << bin_max << std::endl;
@@ -128,8 +128,8 @@ void TLMFitter::Fit(TH1* hist, TF1* func){
 /*******************************************************************/
 /*  Integrator                                                     */
 /*******************************************************************/
-int TLMFitter::integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
-			   Vec_IO_DP &a, Vec_DP &dyda, int chisqnumber, const double &bin_width, Vec_DP &yfit, const int &bin)
+int TLMFitter::integrator(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_I_double &W,
+			   Vec_IO_double &a, Vec_double &dyda, int chisqnumber, const double &bin_width, Vec_double &yfit, const int &bin)
 {
    //Integrates the function within each bin
    int ma = a.size();
@@ -137,7 +137,7 @@ int TLMFitter::integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
 	double ynew = 0;  
 	double xstart = x[bin]; //This is the start of the bin
    double ymod;
-   Vec_DP z(fIntegrationSteps), temp(dyda.size());
+   Vec_double z(fIntegrationSteps), temp(dyda.size());
 	
 	for(int k=0; k<fIntegrationSteps; ++k)
 	{  
@@ -196,34 +196,34 @@ int TLMFitter::integrator(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_I_DP &W,
 /*  mrqmin                                                         */
 /*******************************************************************/
 
-void TLMFitter::mrqmin(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
-				 Vec_I_BOOL &ia, Mat_O_DP &covar, Mat_O_DP &alpha, DP &chisq, Vec_I_DP &W,
-				 DP &alamda)
+void TLMFitter::mrqmin(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_IO_double &a,
+				 Vec_I_BOOL &ia, Mat_O_double &covar, Mat_O_double &alpha, double &chisq, Vec_I_double &W,
+				 double &alamda)
 {
 	static int mfit;
-	static DP ochisq;
+	static double ochisq;
 	int j,k,l;
    static double chisqexp;
 	
 	int ma=a.size();
-	static Mat_DP *oneda_p;
-	static Vec_DP *atry_p,*beta_p,*da_p;
+	static Mat_double *oneda_p;
+	static Vec_double *atry_p,*beta_p,*da_p;
 	if (alamda < 0.0) {  //Initialization
-		atry_p = new Vec_DP(ma);
-		beta_p = new Vec_DP(ma);
-		da_p = new Vec_DP(ma);
+		atry_p = new Vec_double(ma);
+		beta_p = new Vec_double(ma);
+		da_p = new Vec_double(ma);
 		mfit=0;
 		for (j=0;j<ma;j++)
 			if (ia[j]) mfit++;
-		oneda_p = new Mat_DP(mfit,1);
+		oneda_p = new Mat_double(mfit,1);
 		alamda=0.001;
 		mrqcof(x,y,sig,a,ia,alpha,*beta_p,chisq,W,chisqexp);
 		ochisq=chisq;
 		for (j=0;j<ma;j++) (*atry_p)[j]=a[j];
 	}
-	Mat_DP &oneda=*oneda_p;
-	Vec_DP &atry=*atry_p,&beta=*beta_p,&da=*da_p;
-	Mat_DP temp(mfit,mfit);
+	Mat_double &oneda=*oneda_p;
+	Vec_double &atry=*atry_p,&beta=*beta_p,&da=*da_p;
+	Mat_double temp(mfit,mfit);
 	//After linearized fitting matrix, by augmenting diagonal elements
    for (j=0;j<mfit;j++) {  
       for (k=0;k<mfit;k++) covar[j][k]=alpha[j][k];
@@ -266,19 +266,19 @@ void TLMFitter::mrqmin(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
 /*  mrqcof                                                         */
 /*******************************************************************/
 
-void TLMFitter::mrqcof(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
-				Vec_I_BOOL &ia, Mat_O_DP &alpha, Vec_O_DP &beta, DP &chisq, Vec_I_DP &W,
-				DP &chisqexp)
+void TLMFitter::mrqcof(Vec_I_double &x, Vec_I_double &y, Vec_double &sig, Vec_IO_double &a,
+				Vec_I_BOOL &ia, Mat_O_double &alpha, Vec_O_double &beta, double &chisq, Vec_I_double &W,
+				double &chisqexp)
 {
 	int i=0,j,k,l,m,mfit=0;
-	DP wt,sig2i,dy;
+	double wt,sig2i,dy;
 
    chisqexp = 0.0;
 	
 	int ndata=x.size();
 	int ma=a.size();
-	Vec_DP dyda(ma);
-   Vec_DP yfit(ndata);
+	Vec_double dyda(ma);
+   Vec_double yfit(ndata);
 	for (j=0;j<ma;j++)
 		if (ia[j]) mfit++;
 	for (j=0;j<mfit;j++) {     //Initialize (symmetric) alpha, beta.
@@ -359,7 +359,7 @@ void TLMFitter::mrqcof(Vec_I_DP &x, Vec_I_DP &y, Vec_DP &sig, Vec_IO_DP &a,
 /*******************************************************************/
 /*  covsrt                                                         */
 /*******************************************************************/
-void TLMFitter::covsrt(Mat_IO_DP &covar, Vec_I_BOOL &ia, const int mfit)
+void TLMFitter::covsrt(Mat_IO_double &covar, Vec_I_BOOL &ia, const int mfit)
 {
    //Rearranges the covariance matrix covar in the order of all ma parameters
 	int i,j,k;
@@ -382,11 +382,11 @@ void TLMFitter::covsrt(Mat_IO_DP &covar, Vec_I_BOOL &ia, const int mfit)
 /*  gaussj                                                         */
 /*******************************************************************/
 
-void TLMFitter::gaussj(Mat_IO_DP &a, Mat_IO_DP &b)
+void TLMFitter::gaussj(Mat_IO_double &a, Mat_IO_double &b)
 {
    //Matrix solver
 	int i,icol,irow,j,k,l,ll;
-	DP big,dum,pivinv;
+	double big,dum,pivinv;
 	
 	int n=a.nrows();
 	int m=b.ncols();

--- a/util/TestDecay.C
+++ b/util/TestDecay.C
@@ -12,21 +12,6 @@ TH1F* TestSingleDecay(TSingleDecay *decay,Int_t nPoints=10000){
 
 }
 
-TH1F* TestChainFit(Int_t nPoints=10000){
-   TDecayChain *chain = TestDecayChain();
-   TH1F* decay_curve = (TH1F*)(gROOT->Get("decay_curve"));
-   TH1F* tmp_curve = (TH1F*)(gROOT->Get("tmp_curve"));
-   if(decay_curve) delete decay_curve;
-   if(tmp_curve) delete tmp_curve;
-   decay_curve = new TH1F("decay_curve","",1000,0,100);
-   decay_curve->FillRandom(chain->GetChainFunc()->GetName(),nPoints);
-   decay_curve->Draw();
-
-   //chain->Fit(decay_curve);
-   return (TH1F*)(decay_curve->Clone("tmp_curve"));
-
-}
-
 TDecayChain* TestDecayChain(){
    TDecayChain *chain = new TDecayChain(2);
    chain->GetDecay(0)->SetHalfLife(1);
@@ -45,6 +30,22 @@ TDecayChain* TestDecayChain(){
  //  chain->GetDecay(1)->Draw();
    
    return chain;
+}
+
+
+TH1F* TestChainFit(Int_t nPoints=10000){
+   TDecayChain *chain = TestDecayChain();
+   TH1F* decay_curve = (TH1F*)(gROOT->Get("decay_curve"));
+   TH1F* tmp_curve = (TH1F*)(gROOT->Get("tmp_curve"));
+   if(decay_curve) delete decay_curve;
+   if(tmp_curve) delete tmp_curve;
+   decay_curve = new TH1F("decay_curve","",1000,0,100);
+   decay_curve->FillRandom(chain->GetChainFunc()->GetName(),nPoints);
+   decay_curve->Draw();
+
+   //chain->Fit(decay_curve);
+   return (TH1F*)(decay_curve->Clone("tmp_curve"));
+
 }
 
 void TestDraw(Int_t generation){
@@ -104,12 +105,12 @@ TDecay *TestDecay(){
 
 TDecay *GenDecay(){
    TDecayChain *chain = new TDecayChain(1);
-   TDecayChain *chain2 = new TDecayChain(1);
+//   TDecayChain *chain2 = new TDecayChain(1);
 
    chain->GetDecay(0)->SetHalfLife(5);
    chain->GetDecay(0)->SetDecayId(1);
-   chain2->GetDecay(0)->SetHalfLife(1);
-   chain2->GetDecay(0)->SetDecayId(2);
+//   chain2->GetDecay(0)->SetHalfLife(1);
+//   chain2->GetDecay(0)->SetDecayId(2);
 //   chain->GetDecay(0)->SetDecayRate(log(2)/5);
 //   chain2->GetDecay(0)->SetDecayRate(log(2)/1);
 
@@ -117,7 +118,7 @@ TDecay *GenDecay(){
 //   chain2->GetDecay(0)->SetHalfLife(6);
 
    chain->GetDecay(0)->SetIntensity(100);
-   chain2->GetDecay(0)->SetIntensity(20);
+//   chain2->GetDecay(0)->SetIntensity(20);
 //   chain2->GetDecay(0)->SetIntensity(10);
 
  //  chain2->GetDecay(0)->SetDecayId(12);
@@ -126,9 +127,9 @@ TDecay *GenDecay(){
 
    std::vector<TDecayChain *> list;
    list.push_back(chain);
-   list.push_back(chain2);
+//   list.push_back(chain2);
    TDecay *decay = new TDecay(list);
-   decay->SetHalfLifeLimits(1,4,6);
+//   decay->SetHalfLifeLimits(1,4,6);
 
   // decay->SetHalfLife(12,10);
    decay->SetBackground(10);
@@ -150,9 +151,39 @@ TH1F* TestFullFit(Int_t nPoints=100000){
    decay_curve->FillRandom(decay->GetFitFunc()->GetName(),nPoints);
  //  decay_curve->FillRandom("tmpfit2",nPoints);
    decay_curve->Draw();
-   //decay->Fit(decay_curve);
+   printf("creating fitter\n");
+   decay->SetRange(0,99);
+   decay->Print();
+   decay->GetChain(0)->GetDecay(0)->SetIntensity(700);
+ //  decay->GetChain(1)->GetDecay(0)->SetIntensity(100);
+ //  decay->SetParameters();
+   decay_curve->Draw();
+ //  TLMFitter *fitter = new TLMFitter;
+ //  fitter->Fit(decay_curve,decay->GetFunc());
+  // delete fitter;
+   decay->Fit(decay_curve);
    return (TH1F*)(decay_curve->Clone("tmp_curve"));
   // return decay_curve;
+
+}
+
+TDecay * TestFileDecay(TFile* file){
+   TDecayChain *chain = new TDecayChain(1);
+   chain->GetDecay(0)->SetHalfLife(19.1);
+   chain->GetDecay(0)->SetIntensity(1000000);
+   std::vector<TDecayChain*> vec;
+   vec.push_back(chain);
+   TDecay* decay = new TDecay(vec);
+   decay->SetBackground(50);
+   decay->SetRange(0,499);
+
+   TH1F* decay_curve = (TH1F*)(file->Get("h1"));
+
+//   TLMFitter *fitter = new TLMFitter;
+//   fitter->Fit(decay_curve,decay->GetFunc());
+   decay->Fit(decay_curve,"G");
+   return decay;
+
 
 }
 


### PR DESCRIPTION
- This is a modified Levenberg-Marquardt non-linear least squares fitter. The base is from numerical recipes with a few changes to be able to approximately reproduce Weighted likelihood fits of poisson distributed data.
- TDecay can now be fitted with the fitter with the option "G" included
- ROOT's weighted likelihood and this method seem to agree now when they did not before (Maybe a root 6 fix?)
- This mean it is worthwhile fitting with both methods. ROOT may yell at you about integration if you don't give it reasonable guesses, so it can help to use the other method anyway.
- Might need a bit of cleanup and expansion to be a true class, such as verbosity arguments, precision, etc., but it works (fairly well).
- This was straight from numerical recipes so I apologize for the overboard typedefs... I already removed the line `typedef double DP` because that line needs to be there.... I also appologize for the pseudo c++/fortan hybrid that this code is.
Either way, we now have an internal double check of fitting routines!

I also added to TestDecay.C to show how this works. It's hardcoded to have a histogram name of a file on my laptop, but its meant to be an example anyway.
