### PR TITLE
Removed check that trailer of PPG repeats the "new" status

### DIFF
--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -749,14 +749,14 @@ int TDataParser::GriffinDataToPPGEvent(uint32_t* data, int size, int bank, unsig
 				SetPPGHighTimeStamp(value,ppgEvent);
 				break;
 			case 0xe0000000:
-				if((value & 0xFFFF) == (ppgEvent->GetNewPPG())){
+				//if((value & 0xFFFF) == (ppgEvent->GetNewPPG())){
 					TGRSIRootIO::Get()->FillPPG(ppgEvent);
 					TGRSIRootIO::Get()->GetDiagnostics()->GoodFragment(-2); //use detector type -2 for PPG
 					return x;
-				} else  {
-					TGRSIRootIO::Get()->GetDiagnostics()->BadFragment(-2); //use detector type -2 for PPG
-					return -x;
-				}
+				//} else  {
+				//	TGRSIRootIO::Get()->GetDiagnostics()->BadFragment(-2); //use detector type -2 for PPG
+				//	return -x;
+				//}
 				break;
 		};
 	}


### PR DESCRIPTION
the new meaning is NewPPG = requested PPG, OldPPG = read back PPG, trailer = old PPG value (not stored in TPPGData right now)