### PR TITLE
Fixed setting time and a few flags

### DIFF
--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -160,7 +160,7 @@ void TDescant::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	for(size_t i = 0; i < frag->Charge.size(); ++i) {
 	  TDescantHit hit;
 	  hit.SetAddress(frag->ChannelAddress);
-	  hit.SetTime(frag->GetTimeStamp());
+	  hit.SetTimeStamp(frag->GetTimeStamp());
 	  hit.SetCfd(frag->GetCfd(i));
 	  hit.SetCharge(frag->GetCharge(i));
 	  hit.SetZc(frag->GetZc(i));

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -89,7 +89,7 @@ void TGriffin::Copy(TObject &rhs) const {
   static_cast<TGriffin&>(rhs).fAddbackFrags      = fAddbackFrags;
   static_cast<TGriffin&>(rhs).fSetCoreWave       = fSetCoreWave;
   static_cast<TGriffin&>(rhs).fCycleStart        = fCycleStart;
-  static_cast<TGriffin&>(rhs).fGriffinBits       = fGriffinBits;
+  static_cast<TGriffin&>(rhs).fGriffinBits       = 0;
 }                                       
 
 TGriffin::~TGriffin()	{
@@ -216,7 +216,7 @@ void TGriffin::AddFragment(TFragment* frag, MNEMONIC *mnemonic)	{
 		for(size_t i = 0; i < frag->Charge.size(); ++i) {
 			TGriffinHit corehit;
 			corehit.SetAddress(frag->ChannelAddress);
-			corehit.SetTime(frag->GetTimeStamp());
+			corehit.SetTimeStamp(frag->GetTimeStamp());
 			corehit.SetCfd(frag->GetCfd(i));
 			corehit.SetCharge(frag->GetCharge(i));
 			//check if this is a fragment where we already pulled the pile-up hits apart

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -27,7 +27,7 @@ TGriffinHit::~TGriffinHit()  {	}
 void TGriffinHit::Copy(TObject &rhs) const {
   TGRSIDetectorHit::Copy(rhs);
   static_cast<TGriffinHit&>(rhs).fFilter                = fFilter;
-  static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = 0;
+  static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = fGriffinHitBits;
   static_cast<TGriffinHit&>(rhs).fCrystal               = fCrystal;
   static_cast<TGriffinHit&>(rhs).fPPG                   = fPPG;
   static_cast<TGriffinHit&>(rhs).fBremSuppressed_flag   = fBremSuppressed_flag; // Bremsstrahlung Suppression flag.

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -93,7 +93,7 @@ void TPaces::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	for(size_t i = 0; i < frag->Charge.size(); ++i) {
 	  TPacesHit hit;
 	  hit.SetAddress(frag->ChannelAddress);
-	  hit.SetTime(frag->GetTimeStamp());
+	  hit.SetTimeStamp(frag->GetTimeStamp());
 	  hit.SetCfd(frag->GetCfd(i));
 	  hit.SetCharge(frag->GetCharge(i));
 	  

--- a/libraries/TGRSIAnalysis/TRF/TRF.cxx
+++ b/libraries/TGRSIAnalysis/TRF/TRF.cxx
@@ -29,8 +29,8 @@ void TRF::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	TPulseAnalyzer pulse((TFragment&)(*frag));	    
 	if(pulse.IsSet()){
 		fTime = pulse.fit_rf(fPeriod*0.2);//period taken in half ticks... for reasons
-		fTimeStamp = frag->MidasTimeStamp;
-		fMidasTime = frag->GetTimeStamp();		
+		fMidasTime = frag->MidasTimeStamp;
+		fTimeStamp = frag->GetTimeStamp();		
 	}
 }
 

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -111,7 +111,7 @@ void TSceptar::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	for(size_t i = 0; i < frag->Charge.size(); ++i) {
 		TSceptarHit hit;
 		hit.SetAddress(frag->ChannelAddress);
-		hit.SetTime(frag->GetTimeStamp());
+		hit.SetTimeStamp(frag->GetTimeStamp());
 		hit.SetCfd(frag->GetCfd(i));
 		hit.SetCharge(frag->GetCharge(i));
 	  

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -47,7 +47,7 @@ void TTigress::Copy(TObject& rhs) const {
   static_cast<TTigress&>(rhs).fTigressHits    = fTigressHits;
   static_cast<TTigress&>(rhs).fAddbackHits    = fAddbackHits;
   static_cast<TTigress&>(rhs).fAddbackFrags   = fAddbackFrags;
-  static_cast<TTigress&>(rhs).fTigressBits    = fTigressBits;
+  static_cast<TTigress&>(rhs).fTigressBits    = 0;
   static_cast<TTigress&>(rhs).fSetSegmentHits = fSetSegmentHits;	
   static_cast<TTigress&>(rhs).fSetBGOHits     = fSetBGOHits;	
   static_cast<TTigress&>(rhs).fSetCoreWave    = fSetCoreWave;	


### PR DESCRIPTION
- For future reference, no one should touch SetTime, SetEnergy, SetDetector etc (transient members) unless absolutely necessary
- For future reference, bits that are used to set transient members should be set to 0 in the Copy function to force root to write the flags as 0 to disk.