### PR TITLE
PUHit and NPileUps now return shorts instead of char

### DIFF
--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -57,8 +57,8 @@ class TGriffinHit : public TGRSIDetectorHit {
       UInt_t SetCrystal(UInt_t crynum);
       Bool_t IsCrystalSet() const {return IsSubDetSet();}
 
-      UChar_t NPileUps() const; 
-      UChar_t PUHit() const;    
+      UShort_t NPileUps() const; 
+      UShort_t PUHit() const;    
       void SetNPileUps(UChar_t npileups);
       void SetPUHit(UChar_t puhit);
       

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -155,12 +155,12 @@ void TGriffinHit::SetGriffinFlag(enum EGriffinHitBits flag,Bool_t set){
       fGriffinHitBits &= (~flag);
 }
 
-UChar_t TGriffinHit::NPileUps() const {
-   return ((fGriffinHitBits & kTotalPU1) + (fGriffinHitBits & kTotalPU2));
+UShort_t TGriffinHit::NPileUps() const {
+   return static_cast<UShort_t>(((fGriffinHitBits & kTotalPU1) + (fGriffinHitBits & kTotalPU2)));
 }
 
-UChar_t TGriffinHit::PUHit() const { 
-   return ((fGriffinHitBits & kPUHit1) + (fGriffinHitBits & kPUHit2)) >> 2; 
+UShort_t TGriffinHit::PUHit() const { 
+   return static_cast<UShort_t>(((fGriffinHitBits & kPUHit1) + (fGriffinHitBits & kPUHit2)) >> 2); 
 } 
 
 void TGriffinHit::SetNPileUps(UChar_t npileups) {


### PR DESCRIPTION
- This was done in case you wanted to print to screen. There is really no reason to force the return to be a char, even though we want to store it in a single byte.