### PR TITLE
Various small bug fixes

### DIFF
--- a/include/TAngularCorrelation.h
+++ b/include/TAngularCorrelation.h
@@ -53,7 +53,7 @@ class TAngularCorrelation : public TObject {
 
       // simple setters
       void Set2DSlice(TH2D* hst) { f2DSlice = hst; }
-      void SetIndexCorrelation(TH1D* hst) { fIndexCorrelation = fIndexCorrelation; }
+      void SetIndexCorrelation(TH1D* hst) { } //fIndexCorrelation = fIndexCorrelation; }
       //TODO: move the next function to implementation file and update fIndexCorrelation
       void SetPeak(Int_t index, TPeak* peak) { fPeaks[index] = peak; }
       void Set1DSlice(Int_t index, TH1D* slice) { f1DSlices[index] = slice; }

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -96,8 +96,8 @@ class TGRSIDetectorHit : public TObject 	{
       virtual double GetEnergy(Option_t* opt="");
       virtual UInt_t GetDetector() const;
 		virtual Short_t GetSegment() const;	
-      virtual ULong_t GetTimeStamp(Option_t* opt="")   const     { return fTimeStamp;   }  // Returns a time value to the nearest nanosecond!
-      virtual Double_t GetTime(Option_t* opt = "") const;
+      virtual ULong_t GetTimeStamp(Option_t* opt="")   const     { return fTimeStamp;   }
+      virtual Double_t GetTime(Option_t* opt = "") const;  ///< Returns a time value to the nearest nanosecond!
       virtual Double_t GetTime(Option_t* opt = "");
       virtual UInt_t GetDetector();
 		virtual Short_t GetSegment();
@@ -126,17 +126,19 @@ class TGRSIDetectorHit : public TObject 	{
 		Bool_t IsSegSet() const	 { return (fBitflags & kIsSegSet); }
       void SetFlag(enum Ebitflag,Bool_t set);
 
-   private:
+   protected:
       UInt_t   fAddress;    ///< address of the the channel in the DAQ.
       Float_t  fCharge;     ///< charge collected from the hit
       Int_t    fCfd;        ///< CFD time of the Hit
       ULong_t  fTimeStamp;  ///< Timestamp given to hit
+      std::vector<Short_t> fWaveform;  ///<
+
+	private:
       Double_t fTime;       //!<! Calibrated Time of the hit
       UInt_t   fDetector;   //!<! Detector Number
 		Short_t  fSegment;	 //!<! Segment number
       TVector3 fPosition;   //!<! Position of hit detector.
       Double_t fEnergy;     //!<! Energy of the Hit.
-      std::vector<Short_t> fWaveform;  ///<
       uint16_t fPPGStatus;  //!<! 
       ULong_t  fCycleTimeStamp; //!<!
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -51,10 +51,10 @@ Double_t TGRSIDetectorHit::GetTime(Option_t* opt) const {
 	TChannel* chan = GetChannel();
 	if(!chan) {
 		Error("GetTime","No TChannel exists for address 0x%08x",GetAddress());
-		return dTime;
+		return 10.*dTime;
 	}
 
-	return dTime - chan->GetTZero(GetEnergy());
+	return 10.*(dTime - chan->GetTZero(GetEnergy()));
 }
 
 Double_t TGRSIDetectorHit::GetTime(Option_t* opt) {
@@ -65,10 +65,10 @@ Double_t TGRSIDetectorHit::GetTime(Option_t* opt) {
 	TChannel* chan = GetChannel();
 	if(!chan) {
 		Error("GetTime","No TChannel exists for address 0x%08x",GetAddress());
-		return dTime;
+		return 10.*dTime;
 	}
 
-	SetTime(dTime - chan->GetTZero(GetEnergy()));
+	SetTime(10.*(dTime - chan->GetTZero(GetEnergy())));
 
 	return fTime;
 }

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -325,6 +325,6 @@ Double_t TGRSIFunctions::DeadTimeAffect(Double_t function, Double_t deadtime, Do
 Double_t TGRSIFunctions::LegendrePolynomial(Double_t *x, Double_t *p)
 {
   Double_t val;
-  val = p[0]*(1 + p[1]*ROOT::Math::legendre(2,x[0]) + p[2]*ROOT::Math::legendre(4,x[0]));
+  val = p[0]*(1 + p[1]*::ROOT::Math::legendre(2,x[0]) + p[2]*::ROOT::Math::legendre(4,x[0]));
   return val; 
 }

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -801,7 +801,7 @@ double TPulseAnalyzer::CsIt0(){
 		shpar=new ShapePar;
 		//printf("Calculating exclusion zone\n");
 		GetCsIExclusionZone();
-		int tmpchisq = GetCsIShape();
+		//int tmpchisq = GetCsIShape();
 		//printf("Calculating shape\n");
 
 		SetCsI();
@@ -834,7 +834,7 @@ double TPulseAnalyzer::CsIPID(){
 		shpar->t[3] = 380.0;
 
 		GetCsIExclusionZone();
-		int tmpchisq = GetCsIShape();
+		//int tmpchisq = GetCsIShape();
 	
 		double f = shpar->am[2];
 		double s = shpar->am[3];

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -52,8 +52,6 @@ TFragment::TFragment(const TFragment& rhs, int hit) : TObject() {
   DetectorType = rhs.DetectorType;
   ChannelId = rhs.ChannelId;
 
-  KValue = rhs.KValue;
-
   wavebuffer = rhs.wavebuffer;
 
   if(hit < 0 || hit >= static_cast<int>(Cfd.size())) {
@@ -63,6 +61,7 @@ TFragment::TFragment(const TFragment& rhs, int hit) : TObject() {
 	  ccLong = rhs.ccLong;
 	  Led = rhs.Led;
 	  Charge = rhs.Charge;
+	  KValue = rhs.KValue;
   } else {
 	  Cfd.push_back(rhs.Cfd[hit]);
 	  Zc.push_back(rhs.Zc[hit]);
@@ -70,6 +69,7 @@ TFragment::TFragment(const TFragment& rhs, int hit) : TObject() {
 	  ccLong.push_back(rhs.ccLong[hit]);
 	  Led.push_back(rhs.Led[hit]);
 	  Charge.push_back(rhs.Charge[hit]);
+	  KValue.push_back(rhs.KValue[hit]);
   }
 
   NumberOfHits = Cfd.size();


### PR DESCRIPTION
- removed a few compiler warnings
- KValues were always copied complete in the TFragment copy constructor, even if a single hit was copied, fixed that
- changed non-transient members of TGRSIDetectorHit from private to protected (so that they can be used in derived classes)