### PR TITLE
Fixed bug in data parser

### DIFF
--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -459,12 +459,12 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, int bank, unsig
 					//   EventFrag->AcceptedChannelId = 0;
 					//}
 
-					TFragmentQueue::GetQueue("GOOD")->Add(EventFrag);
 					if(fRecordDiag) TGRSIRootIO::Get()->GetDiagnostics()->GoodFragment(EventFrag);
+					TFragmentQueue::GetQueue("GOOD")->Add(EventFrag);
 					return x;
 				} else  {
-					TFragmentQueue::GetQueue("BAD")->Add(EventFrag);
 					if(fRecordDiag) TGRSIRootIO::Get()->GetDiagnostics()->BadFragment(EventFrag->DetectorType);
+					TFragmentQueue::GetQueue("BAD")->Add(EventFrag);
 					return -x;
 				}
 				break;


### PR DESCRIPTION
Fixed bug in data parser, fragment has to be passed first to the diagnostics, then be put in the queue. Otherwise the separate thread emptying the queue might delete the fragment before diagnostics is done with it.