### PR TITLE
Moved flags for old fragment and descant data to TGRSIRunInfo.

### DIFF
--- a/include/TGRSIRootIO.h
+++ b/include/TGRSIRootIO.h
@@ -62,8 +62,6 @@ class TGRSIRootIO : public TObject {
 		TScalerData* fDeadtimeScalerData;
 		TScalerData* fRateScalerData;
 
-		static bool fOldFragment;
-		static bool fDescant;
 		Int_t fDescantData[3];
 
    public:
@@ -111,12 +109,6 @@ class TGRSIRootIO : public TObject {
       void FinalizeDiagnostics();
 
       void MakeUserHistsFromFragmentTree();
-
-		void SetOldFragment(bool value) { fOldFragment = value; }
-		bool GetOldFragment() { return fOldFragment; }
-
-		void SetDescant(bool value) { fDescant = value; }
-		bool GetDescant() { return fDescant; }
 
 /// \cond CLASSIMP
    ClassDef(TGRSIRootIO,0)

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -189,6 +189,9 @@ class TGRSIRunInfo : public TObject {
 		static void SetStoreDescantWaveforms(bool flag = true) { fGRSIRunInfo->fStoreDescantWaveforms = flag; }
 		static bool StoreDescantWaveforms()                    { return fGRSIRunInfo->fStoreDescantWaveforms; }
 
+		static void SetOldFragments(bool flag = true) { fGRSIRunInfo->fOldFragments = flag; }
+		static bool OldFragments()                    { return fGRSIRunInfo->fOldFragments; }
+
       Long64_t Merge(TCollection *list);
       void Add(TGRSIRunInfo* runinfo) { fRunStart = 0.; fRunStop = 0.; fRunLength += runinfo->RunLength(); }
 
@@ -271,6 +274,8 @@ class TGRSIRunInfo : public TObject {
 
 		bool     fAnalyzeDescantWaveforms; ///< analyze waveforms of descant detectors (if saved to fragment tree) when building the analysis tree
 		bool     fStoreDescantWaveforms;   ///< store analyzed waveforms of descant detectors when building the analysis tree
+
+		bool     fOldFragments;            ///< use TOldFragment to store data
 
    public:
       void Print(Option_t *opt = "") const;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -251,6 +251,8 @@ void TGRSIRunInfo::Print(Option_t *opt) const {
       printf(DBLUE"\tArray Position = " DRED "%i"    RESET_COLOR "\n",TGRSIRunInfo::HPGeArrayPosition());
       printf(DBLUE"\tWaveform fitting = " DRED "%s"  RESET_COLOR "\n",TGRSIRunInfo::IsWaveformFitting() ? "TRUE" : "FALSE");
       printf(DBLUE"\tDESCANT in ancillary positions = " DRED "%s"  RESET_COLOR "\n",TGRSIRunInfo::DescantAncillary() ? "TRUE" : "FALSE");
+      printf(DBLUE"\tAnalyzing DESCANT waveforms = " DRED "%s"  RESET_COLOR "\n",TGRSIRunInfo::AnalyzeDescantWaveforms() ? "TRUE" : "FALSE");
+      printf(DBLUE"\tStoring analyzed DESCANT waveforms = " DRED "%s"  RESET_COLOR "\n",TGRSIRunInfo::StoreDescantWaveforms() ? "TRUE" : "FALSE");
       printf("\n");
       printf("\t==============================\n");
    }
@@ -284,7 +286,10 @@ void TGRSIRunInfo::Clear(Option_t *opt) {
    fMinorIndex.assign("");  
 
    fNumberOfTrueSystems = 0;
-
+	
+	fAnalyzeDescantWaveforms = false;
+	fStoreDescantWaveforms = false;
+	fOldFragments = false;
 }
 
 
@@ -462,6 +467,10 @@ Bool_t TGRSIRunInfo::ParseInputData(const char *inputdata,Option_t *opt) {
 			Get()->SetAnalyzeDescantWaveforms(true);
 		} else if(type.find("STOREDESCANTWAVEFORM") == 0) {
 			Get()->SetStoreDescantWaveforms(true);
+		} else if(type.find("OLDFRAGMENT") == 0) {
+			Get()->SetOldFragments(true);
+		} else if(type.compare("DESCANT") == 0) {
+			Get()->SetDescant(true);
       }
    }
 
@@ -478,7 +487,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char *inputdata,Option_t *opt) {
 
 
 void TGRSIRunInfo::trim(std::string* line, const std::string & trimChars) {
-	///Removes the the string "trimCars" from  the string 'line'
+	///Removes characters from the string "trimCars" from  the string 'line'
    if(line->length() == 0)
       return;
    std::size_t found = line->find_first_not_of(trimChars);
@@ -493,7 +502,7 @@ void TGRSIRunInfo::trim(std::string* line, const std::string & trimChars) {
 	}
 }
 
-Long64_t TGRSIRunInfo::Merge(TCollection *list){
+Long64_t TGRSIRunInfo::Merge(TCollection *list) {
    //Loop through the TCollection of TGRSISortLists, and add each entry to the original TGRSISort List
    TIter it(list);
    //The TCollection will be filled by something like hadd. Each element in the list will be a TGRSISortList from

--- a/libraries/TGRSIRootIO/TGRSIRootIO.cxx
+++ b/libraries/TGRSIRootIO/TGRSIRootIO.cxx
@@ -13,8 +13,6 @@ ClassImp(TGRSIRootIO)
 /// \endcond
 
 TGRSIRootIO* TGRSIRootIO::fTGRSIRootIO = 0;
-bool TGRSIRootIO::fOldFragment = false;
-bool TGRSIRootIO::fDescant = false;
 
 TGRSIRootIO* TGRSIRootIO::Get() {
 	if(!fTGRSIRootIO)
@@ -48,12 +46,12 @@ void TGRSIRootIO::SetUpFragmentTree() {
 	fTimesFillCalled = 0;
 	fFragmentTree = new TTree("FragmentTree","FragmentTree");
 	fBufferFrag = NULL;
-	if(fOldFragment) {
+	if(TGRSIRunInfo::Get()->OldFragments()) {
      fFragmentTree->Bronch("TFragment","TOldFragment",&fBufferFrag,128000,99);
 	} else {
 	  fFragmentTree->Bronch("TFragment","TNewFragment",&fBufferFrag,128000,99);
 	}
-	if(fDescant) {
+	if(TGRSIRunInfo::Get()->Descant()) {
 	  fFragmentTree->Branch("DescantData", &fDescantData, "Zc/I:CcShort/I:ccLong/I", 128000);
 	}
 	//fFragmentTree->BranchRef();
@@ -69,7 +67,7 @@ void TGRSIRootIO::SetUpBadFragmentTree() {
 	fTimesBadFillCalled = 0;
 	fBadFragmentTree = new TTree("BadFragmentTree","BadFragmentTree");
 	fBadBufferFrag = 0;
-	if(fOldFragment) {
+	if(TGRSIRunInfo::Get()->OldFragments()) {
  	  fBadFragmentTree->Bronch("TFragment","TOldFragment",&fBadBufferFrag,128000,99);
 	} else {
 	  fBadFragmentTree->Bronch("TFragment","TNewFragment",&fBadBufferFrag,128000,99);
@@ -151,12 +149,12 @@ void TGRSIRootIO::FillFragmentTree(TFragment* frag) {
 	// if(!fFragmentTree)
 	//    return;
 	//the (double) casting is necessary so that the copy constructor of the "real" class is being used, not the virtual one of TFragment
-	if(fOldFragment) {
+	if(TGRSIRunInfo::Get()->OldFragments()) {
       *static_cast<TOldFragment*>(fBufferFrag) = *static_cast<TOldFragment*>(frag);
    } else {
       *static_cast<TNewFragment*>(fBufferFrag) = *static_cast<TNewFragment*>(frag);
    }
-	if(fDescant) {
+	if(TGRSIRunInfo::Get()->Descant()) {
 	  fDescantData[0] = frag->GetZc();
 	  fDescantData[1] = frag->GetCcShort();
 	  fDescantData[2] = frag->GetCcLong();

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -359,9 +359,9 @@ void TGRSIint::GetOptions(int *argc, char **argv) {
 			} else if(temp.compare("ignore-scaler") == 0 || temp.compare("ignore_scaler") == 0) { 
 				TGRSIOptions::SetIgnoreScaler(true);          
 			} else if(temp.compare("old-fragment") == 0 || temp.compare("old_fragment") == 0) {
-				TGRSIRootIO::Get()->SetOldFragment(true);
+				TGRSIRunInfo::Get()->SetOldFragments(true);
 			} else if(temp.compare("descant") == 0) {
-				TGRSIRootIO::Get()->SetDescant(true);
+				TGRSIRunInfo::Get()->SetDescant(true);
 			} else {
 				printf(DBLUE  "    option: " DYELLOW "%s " DBLUE "passed but not understood." RESET_COLOR "\n",temp.c_str());
 			}


### PR DESCRIPTION
These flags can now be set either in a run-info file, or via command-line. The descant data flag is now the same as the already existing descant flag in TGRSIRunInfo.