### PR TITLE
Uncommented PID line in TPulseAnalyzer added chisq condition

### DIFF
--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -821,11 +821,15 @@ double TPulseAnalyzer::CsIt0(){
 		shpar=new ShapePar;
 		//printf("Calculating exclusion zone\n");
 		GetCsIExclusionZone();
-		//int tmpchisq = GetCsIShape();
+		int tmpchisq = GetCsIShape();
 		//printf("Calculating shape\n");
 
-		SetCsI();
-		return shpar->t[0];
+		if(tmpchisq > 0){	
+			SetCsI();
+			return shpar->t[0];
+		}
+		else
+			return -1.;
 	}
 	return -1.0;
 }
@@ -854,15 +858,23 @@ double TPulseAnalyzer::CsIPID(){
 		shpar->t[3] = 380.0;
 
 		GetCsIExclusionZone();
-		//int tmpchisq = GetCsIShape();
-	
-		double f = shpar->am[2];
-		double s = shpar->am[3];
-		double r = s/f*100;
+		int tmpchisq = GetCsIShape();
 
-		SetCsI();
+		double f;
+		double s;
+		double r;
+
+		if(tmpchisq>0){
+			f = shpar->am[2];
+			s = shpar->am[3];
+			r = s/f*100;
+
+			SetCsI();
 		
-		return r;
+			return r;
+		}
+		else
+			return -1.;
 	}
 	return -1.0;
 


### PR DESCRIPTION
Uncommented the line which called the CsIPID function. Originally commented out because it resulted in an unused variable warning, so I added a (minimal) chi-squared condition so the resulting variable is actually used.