### PR TITLE
Changed S3 hit construction - pixels not built during analysis stage (similar to addback)

### DIFF
--- a/include/TS3.h
+++ b/include/TS3.h
@@ -21,7 +21,8 @@ class TS3 : public TGRSIDetector {
 		virtual void BuildHits();
 
 		Int_t GetPixelMultiplicity();
-		void	SetFrontBackEnergy(double de)	{ fFrontBackEnergy = de; SetPixels(false); }
+		void	SetFrontBackEnergy(double de)	{ fFrontBackEnergy = de; SetPixels(false); } // Set fractional allowed energy difference
+		void	SetFrontBackTime(int time)		{ fFrontBackTime = time; SetPixels(false); } // Set absolute allow time difference
 
 		TGRSIDetectorHit* GetHit(const int& idx =0);
 		TS3Hit* GetS3Hit(const int& i);  

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -28,8 +28,8 @@ class TS3 : public TGRSIDetector {
 		Short_t GetMultiplicity() const { return fS3Hits.size(); }
 		void PushBackHit(TGRSIDetectorHit* deshit);
 
-		bool MultiHit()										{ return fMultHit;	 }
-		void SetMultiHit(bool flag=true)	{ fMultHit = flag;	 }
+		bool MultiHit()										{ return fMultHit;	 } // Get allow shared hits
+		void SetMultiHit(bool flag=true)	{ fMultHit = flag; SetPixels(false);	 } // Set allow shared hits
 
 		bool PixelsSet()									{ return fPixelsSet; }
 		void SetPixels(bool flag=true) 		{ fPixelsSet = flag; }

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -20,10 +20,20 @@ class TS3 : public TGRSIDetector {
 		virtual void AddFragment(TFragment*, MNEMONIC*);
 		virtual void BuildHits();
 
+		Int_t GetPixelMultiplicity();
+		void	SetFrontBackEnergy(double de)	{ fFrontBackEnergy = de; SetPixels(false); }
+
 		TGRSIDetectorHit* GetHit(const int& idx =0);
 		TS3Hit* GetS3Hit(const int& i);  
 		Short_t GetMultiplicity() const { return fS3Hits.size(); }
 		void PushBackHit(TGRSIDetectorHit* deshit);
+
+		bool MultiHit()										{ return fMultHit;	 }
+		void SetMultiHit(bool flag=true)	{ fMultHit = flag;	 }
+
+		bool PixelsSet()									{ return fPixelsSet; }
+		void SetPixels(bool flag=true) 		{ fPixelsSet = flag; }
+		void BuildPixels();
 
 		static TVector3 GetPosition(int ring, int sector, bool downstream, double offset);
 
@@ -35,10 +45,14 @@ class TS3 : public TGRSIDetector {
       virtual void Print(Option_t *opt = "") const;		  //!<!
 		
 	private:
-		std::vector<TS3Hit> fS3Hits;
+		std::vector<TS3Hit> fS3Hits; //!<!
+		std::vector<TS3Hit> fS3RingHits, fS3SectorHits;
 		std::vector<TFragment*> fS3_RingFragment; //! 
 		std::vector<TFragment*> fS3_SectorFragment; //! 
 
+		bool fPixelsSet;
+		bool fMultHit;
+	
 		///for geometery
 		static int fRingNumber;          //!<!
 		static int fSectorNumber;        //!<!

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -13,6 +13,19 @@
 
 class TS3 : public TGRSIDetector {
 	public:
+
+		enum ES3Bits {
+			kPixelsSet 		= BIT(0),
+			kMultHit      = BIT(1),
+			kBit2         = BIT(2),
+			kBit3         = BIT(3),
+			kBit4         = BIT(4),
+			kBit5  				= BIT(5),
+			kBit6   			= BIT(6),
+			kBit7   			= BIT(7)
+		};
+
+
 		TS3();
 		TS3(const TS3&);
 		virtual  ~TS3();
@@ -29,11 +42,11 @@ class TS3 : public TGRSIDetector {
 		Short_t GetMultiplicity() const { return fS3Hits.size(); }
 		void PushBackHit(TGRSIDetectorHit* deshit);
 
-		bool MultiHit()										{ return fMultHit;	 } // Get allow shared hits
-		void SetMultiHit(bool flag=true)	{ fMultHit = flag; SetPixels(false);	 } // Set allow shared hits
+		bool MultiHit()										{ return TestBitNumber(kMultHit);	 } // Get allow shared hits
+		void SetMultiHit(bool flag=true)	{ SetBitNumber(kMultHit, flag); SetPixels(false);	 } // Set allow shared hits
 
-		bool PixelsSet()									{ return fPixelsSet; }
-		void SetPixels(bool flag=true) 		{ fPixelsSet = flag; }
+		bool PixelsSet()									{ return TestBitNumber(kPixelsSet); }
+		void SetPixels(bool flag=true) 		{ SetBitNumber(kPixelsSet, flag); }
 		void BuildPixels();
 
 		static TVector3 GetPosition(int ring, int sector, bool downstream, double offset);
@@ -51,8 +64,13 @@ class TS3 : public TGRSIDetector {
 		std::vector<TFragment*> fS3_RingFragment; //! 
 		std::vector<TFragment*> fS3_SectorFragment; //! 
 
-		bool fPixelsSet;
-		bool fMultHit;
+		//bool fPixelsSet;
+		//bool fMultHit;
+
+		UChar_t fS3Bits;                  // flags for transient members
+		void ClearStatus() { fS3Bits = 0; }
+		void SetBitNumber(enum ES3Bits bit,Bool_t set=true);
+		Bool_t TestBitNumber(enum ES3Bits bit) const {return (bit & fS3Bits);}
 	
 		///for geometery
 		static int fRingNumber;          //!<!

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -9,6 +9,7 @@
 #include "TFragment.h"
 #include "TChannel.h"
 #include "TMath.h"
+#include "TPulseAnalyzer.h"
 #include "TGRSIDetectorHit.h" 
 
 class TS3Hit : public TGRSIDetectorHit {
@@ -22,33 +23,52 @@ class TS3Hit : public TGRSIDetectorHit {
     Short_t  GetRing()  const  { return fRing;   }
     Short_t  GetSector() const { return fSector; }
 		Bool_t	 GetIsDownstream() const { return fIsDownstream; }
+		Double_t GetSectorE()									 	const { return fSectorE; 	}
+
+    Double_t   fTimeFit;
+    Double_t   fSig2Noise;
 
   public:
     void Copy(TObject&) const;        //!
     void Print(Option_t* opt="") const;
     void Clear(Option_t* opt="");
 
-    void SetVariables(TFragment &frag) {  fLed    = frag.GetLed(); }
-    void SetRingNumber(Short_t rn)     { fRing = rn;   }
-    void SetSectorNumber(Short_t sn)   { fSector = sn; }
-		void SetIsDownstream(Bool_t dwnstrm) 	{ fIsDownstream = dwnstrm; }
+		inline Double_t GetFitTime()			           { return fTimeFit;	   } //!<!
+		inline Double_t GetSignalToNoise()		        { return fSig2Noise;	} //!<!
+
+    void SetVariables(TFragment &frag) 			{ fLed    = frag.GetLed(); }
+    void SetRingNumber(Short_t rn)     			{ fRing = rn;   }
+    void SetSectorNumber(Short_t sn)   			{ fSector = sn; }
+		void SetIsDownstream(Bool_t dwnstrm) 		{ fIsDownstream = dwnstrm; }
+		void SetSectorE(Double_t E)							{ fSectorE = E; }
     
-    void SetRingNumber(TFragment &frag)     { fRing = GetMnemonicSegment(frag);   }
-    void SetSectorNumber(TFragment &frag)   { fSector =GetMnemonicSegment(frag) ; }
+    void SetRingNumber(TFragment &frag)     { fRing = GetMnemonicSegment(frag);   	}
+    void SetSectorNumber(TFragment &frag)   { fSector = GetMnemonicSegment(frag) ; 	}
+    void SetSectorNumber(int n)   					{ fSector = n ; 												}
+    void SetRingNumber(int n)   						{ fRing 	= n ; 												}
     
+    void SetWavefit(TFragment&);
+		void SetTimeFit(Double_t time)					{ fTimeFit = time;											}
+		void SetSig2Noise(Double_t sig2noise)		{ fSig2Noise = sig2noise;								}
+
     Short_t GetMnemonicSegment(TFragment &frag);//could be added to TGRSIDetectorHit base class
-	 
+	
+		Double_t GetPhi(double offset=0) {
+			return this->GetChannelPosition(offset).Phi();
+		}
+
 		Double_t GetTheta(double offset=0, TVector3 *vec=0) {
 			if(vec==0) {
 				vec = new TVector3();
 				vec->SetXYZ(0,0,1);
 			}
-			return TMath::Pi() - TMath::Cos(this->GetChannelPosition(offset).Angle(*vec));
+			return this->GetChannelPosition(offset).Angle(*vec);
 		}
+    TVector3 GetChannelPosition(Double_t offset = 0, Double_t dist = 0) const; //!
 
   private:
-     TVector3 GetChannelPosition(Double_t offset = 0, Double_t dist = 0) const; //!
 
+		Double_t fSectorE;
       
     Bool_t 	 fIsDownstream; // Downstream check
     Double_t fLed;

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -23,7 +23,6 @@ class TS3Hit : public TGRSIDetectorHit {
     Short_t  GetRing()  const  { return fRing;   }
     Short_t  GetSector() const { return fSector; }
 		Bool_t	 GetIsDownstream() const { return fIsDownstream; }
-		Double_t GetSectorE()									 	const { return fSectorE; 	}
 
     Double_t   fTimeFit;
     Double_t   fSig2Noise;
@@ -40,7 +39,6 @@ class TS3Hit : public TGRSIDetectorHit {
     void SetRingNumber(Short_t rn)     			{ fRing = rn;   }
     void SetSectorNumber(Short_t sn)   			{ fSector = sn; }
 		void SetIsDownstream(Bool_t dwnstrm) 		{ fIsDownstream = dwnstrm; }
-		void SetSectorE(Double_t E)							{ fSectorE = E; }
     
     void SetRingNumber(TFragment &frag)     { fRing = GetMnemonicSegment(frag);   	}
     void SetSectorNumber(TFragment &frag)   { fSector = GetMnemonicSegment(frag) ; 	}
@@ -68,8 +66,6 @@ class TS3Hit : public TGRSIDetectorHit {
 
   private:
 
-		Double_t fSectorE;
-      
     Bool_t 	 fIsDownstream; // Downstream check
     Double_t fLed;
     Short_t  fRing;   //front

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -101,7 +101,7 @@ void TS3::BuildPixels(){
 
 	if(fS3RingHits.size()==0 || fS3SectorHits.size()==0)
 		return;
-  //if the pixels have been reset, clear the addback hits
+  //if the pixels have been reset, clear the pixel hits
   if(!PixelsSet())
     fS3Hits.clear();
   if(fS3Hits.size() == 0) {

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -101,7 +101,7 @@ void TS3::BuildPixels(){
 
 	if(fS3RingHits.size()==0 || fS3SectorHits.size()==0)
 		return;
-  //if the addback has been reset, clear the addback hits
+  //if the pixels have been reset, clear the addback hits
   if(!PixelsSet())
     fS3Hits.clear();
   if(fS3Hits.size() == 0) {
@@ -342,7 +342,7 @@ void TS3::Clear(Option_t *opt) {
   fTargetDistance=31.;
   
   fFrontBackTime=75;   
-  fFrontBackEnergy=0.1; 
+  fFrontBackEnergy=0.9; 
 	fPixelsSet = false;
 	fMultHit = false;
 }

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -40,7 +40,6 @@ void TS3::Copy(TObject &rhs) const {
   TGRSIDetector::Copy(rhs);
   static_cast<TS3&>(rhs).fS3RingHits    	= fS3RingHits;
   static_cast<TS3&>(rhs).fS3SectorHits    = fS3SectorHits;
-	static_cast<TS3&>(rhs).fPixelsSet				= fPixelsSet;
   return;                                      
 }  
 
@@ -84,6 +83,13 @@ void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	}	
 }
 
+void TS3::SetBitNumber(enum ES3Bits bit,Bool_t set){
+  //Used to set the flags that are stored in TTigress.
+  if(set)
+    fS3Bits |= bit;
+  else
+    fS3Bits &= (~bit);
+}
 
 void TS3::BuildHits()  {
 }
@@ -108,7 +114,7 @@ void TS3::BuildPixels(){
 	if(fS3RingHits.size()==0 || fS3SectorHits.size()==0)
 		return;
   //if the pixels have been reset, clear the pixel hits
-  if(!PixelsSet())
+  if((fS3Bits & kPixelsSet) == 0x0)
     fS3Hits.clear();
   if(fS3Hits.size() == 0) {
 		
@@ -153,7 +159,7 @@ void TS3::BuildPixels(){
 			}
 		}
 	
-		if(MultiHit()){
+		if((fS3Bits & kMultHit) == 0x1){
 		
 			int ringcount = 0;
 			int sectorcount = 0;
@@ -273,9 +279,8 @@ void TS3::BuildPixels(){
 			}
 
 		}
-		
 
-		SetPixels();
+		SetBitNumber(kPixelsSet, true);
 	}
 
 }
@@ -340,8 +345,8 @@ void TS3::Clear(Option_t *opt) {
   
   fFrontBackTime=75;   
   fFrontBackEnergy=0.9; 
-	fPixelsSet = false;
-	fMultHit = false;
+	SetPixels(false);
+	SetMultiHit(false);
 }
 
 

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -45,7 +45,7 @@ void TS3::Copy(TObject &rhs) const {
 }  
 
 void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
-	///This function just stores the fragments in vectors, separated by detector type (front/back strip).
+	///This function creates TS3Hits for each fragment and stores them in separate front and back vectors
 	if(frag == NULL || mnemonic == NULL) {
 		return;
 	}
@@ -89,6 +89,8 @@ void TS3::BuildHits()  {
 }
 
 Int_t TS3::GetPixelMultiplicity(){
+	// Creates a vector of TS3Hits based on front/back coincidences
+	// Returns the size of the resultant vector
 
 	BuildPixels();
 	
@@ -97,6 +99,10 @@ Int_t TS3::GetPixelMultiplicity(){
 }
 
 void TS3::BuildPixels(){
+	// Constructs the front/back coincidences to create pixels based on energy and time differences
+	// Energy and time differences can be changed using the SetFrontBackEnergy and SetFrontBackTime functions
+	// Shared rings and sectors can be constructed, by default they are not. 
+	// To enable shared hits, use SetMultiHit function
 
 
 	if(fS3RingHits.size()==0 || fS3SectorHits.size()==0)

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -142,15 +142,6 @@ void TS3::BuildPixels(){
 
 						UsedRing[i]=true;
 						UsedSector[j]=true;
-					
-						//Now we have "used" these parts of hits the are removed
-						//This is a relatively cheap operation because fragment vectors are pointers.
-						//fS3_SectorFragment.erase(fS3_SectorFragment.begin() + j);
-						//EneS.erase(EneS.begin() + j);
-						//fS3_RingFragment.erase(fS3_RingFragment.begin() + i);
-						//EneR.erase(EneR.begin() + i);
-						//j=fS3_SectorFragment.size();
-						//i--;
 					}
 				}
 			}
@@ -189,7 +180,7 @@ void TS3::BuildPixels(){
 									(EneS[j]+EneS[k])*fFrontBackEnergy<EneR[i]){  //if time is good check energy
 
 									//Now we have accepted a good event, build it
-									TS3Hit dethit = fS3SectorHits[j]; // Ring defines all data sector just gives position
+									TS3Hit dethit = fS3SectorHits[j]; // Sector now defines all data ring just gives position
 									dethit.SetRingNumber(fS3RingHits[i].GetRing());
 									if(TGRSIRunInfo::IsWaveformFitting()){
 										dethit.SetTimeFit(fS3SectorHits[j].GetFitTime());
@@ -198,7 +189,7 @@ void TS3::BuildPixels(){
 									fS3Hits.push_back(dethit);
 
 									//Now we have accepted a good event, build it
-									TS3Hit dethitB = fS3SectorHits[k]; // Ring defines all data sector just gives position
+									TS3Hit dethitB = fS3SectorHits[k]; // Sector now defines all data ring just gives position
 									dethitB.SetRingNumber(fS3RingHits[i].GetRing());
 									if(TGRSIRunInfo::IsWaveformFitting()){
 										dethitB.SetTimeFit(fS3SectorHits[k].GetFitTime());

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -25,7 +25,6 @@ void TS3Hit::Copy(TObject &rhs) const {
 	 static_cast<TS3Hit&>(rhs).fRing = fRing;
 	 static_cast<TS3Hit&>(rhs).fSector = fSector;
 	 static_cast<TS3Hit&>(rhs).fIsDownstream = fIsDownstream;
-	 static_cast<TS3Hit&>(rhs).fSectorE = fSectorE;
    return;
 }
 
@@ -34,7 +33,6 @@ void TS3Hit::Clear(Option_t *opt)	{
    fLed            = -1;
    fRing           = -1;
    fSector         = -1;
-	 fSectorE				 = -1;
 	 fIsDownstream		 = false;
 }
 

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -25,15 +25,16 @@ void TS3Hit::Copy(TObject &rhs) const {
 	 static_cast<TS3Hit&>(rhs).fRing = fRing;
 	 static_cast<TS3Hit&>(rhs).fSector = fSector;
 	 static_cast<TS3Hit&>(rhs).fIsDownstream = fIsDownstream;
+	 static_cast<TS3Hit&>(rhs).fSectorE = fSectorE;
    return;
 }
-
 
 void TS3Hit::Clear(Option_t *opt)	{
    TGRSIDetectorHit::Clear(opt);
    fLed            = -1;
    fRing           = -1;
    fSector         = -1;
+	 fSectorE				 = -1;
 	 fIsDownstream		 = false;
 }
 
@@ -49,6 +50,13 @@ Short_t TS3Hit::GetMnemonicSegment(TFragment &frag){//could be added to TGRSIDet
 	return mnemonic.segment;
 }
 
+void TS3Hit::SetWavefit(TFragment &frag)   { 
+	TPulseAnalyzer pulse(frag);	    
+	if(pulse.IsSet()){
+		fTimeFit   = pulse.fit_newT0();
+		fSig2Noise = pulse.get_sig2noise();
+	}
+}
 
 TVector3 TS3Hit::GetChannelPosition(double offset, double dist) const {
 	return TS3::GetPosition(GetRing(),GetSector(),this->GetIsDownstream(),offset);


### PR DESCRIPTION
In order to give the user a bit more flexibility in their S3 front-back coincidence conditions, we've changed the style of S3 hit construction.

Now, during the analysis tree building stage, we just create RingHits and SectorHits and don't attempt to correlate them. 

Pixels are then constructed by the user, in an analogous method to how we deal with addback in TIGRESS and GRIFFIN. 

This means that users can easily vary their front-back energy/time conditions, should they feel the need, and also means that they actually have access to both the rings and sector energies (previously they only had ring energies). 

Obviously this is less efficient in terms of the file sizes, but I think the benefits outweigh the costs.

New setters:
SetFrontBackEnergy() sets the fractional energy difference "allowed" between coincident hits
SetFrontBackTime() sets the absolute time difference "allowed" between coincident hits
SetMultiHit() sets whether you're going to allow shared hits
SetPixels() sets flag to determine whether we want to remake our pixel hits

New getters:
GetPixelMultiplicity() calls the BuildPixels() function and returns the size of the resultant vector

Other:
BuildPixels() is where all the magic happens

I also made the GetChannelPosition() function public, so we can actually do stuff with the vector it creates.