### PR TITLE
Fixed default addback window and build window to be in ns

### DIFF
--- a/examples/grsiruninfoexample.info
+++ b/examples/grsiruninfoexample.info
@@ -3,14 +3,14 @@
 /////////////////////////////////////
 
 
-//The event building time, 10ns units. 
-BuildWindow: 200     // 2useconds
+//The event building time, 1 ns units. 
+BuildWindow: 2000     // 2useconds
 
 //Set Moving Window (1) or Static Window (0)/
 MovingWindow: 1
 
-//The Addback event window, 10ns units.
-AddBackWindow: 15.0  // 150.0 nseconds
+//The Addback event window, 1 ns units.
+AddBackWindow: 150.0  // 150.0 nseconds
 
 //The Array position in mm.
 HPGePos:       110.0 // 110.0 mm 

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -174,7 +174,7 @@ class TGRSIRunInfo : public TObject {
       inline void SetMovingWindow(const bool flag)       {fIsMovingWindow = flag; }
       static inline bool IsMovingWindow()                { return Get()->fIsMovingWindow; }
 
-      static inline long int BuildWindow()    { return Get()->fBuildWindow; }
+      static inline long int BuildWindow()    { return Get()->fBuildWindow/10; }
       static inline double   AddBackWindow()  { if(Get()->fAddBackWindow<1) return 15.0; return Get()->fAddBackWindow; }
       static inline long int BufferDuration() { return Get()->fBufferDuration; }
       static inline size_t   BufferSize()     { return Get()->fBufferSize; }

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -200,8 +200,8 @@ TGRSIRunInfo::TGRSIRunInfo() : fRunNumber(0),fSubRunNumber(-1) {
    ///fBufferDuration    = 60000000000;
 
    fHPGeArrayPosition = 110.0;
-   fBuildWindow       = 200;  
-   fAddBackWindow     = 15.0;
+   fBuildWindow       = 2000;  
+   fAddBackWindow     = 150.0;
    fIsMovingWindow    = true;
    fWaveformFitting	 = false;
    fBufferSize        = 1000000;


### PR DESCRIPTION
changed TGRSIRunInfo::BuildWindow() to return the stored value divided by 10 (to be compared to timestamp differences).