### PR TITLE
LaBr addition

### DIFF
--- a/include/TAnalysisTreeBuilder.h
+++ b/include/TAnalysisTreeBuilder.h
@@ -43,6 +43,8 @@
 #include "TSceptar.h"   
 #include "TPaces.h"   
 //#include "TDante.h"     
+#include "TLaBr.h"
+#include "TTAC.h"
 #include "TZeroDegree.h"
 #include "TDescant.h"
 
@@ -226,7 +228,8 @@ class TAnalysisTreeBuilder : public TObject {
       TGriffin*    fGriffin;                                 ///< A pointer to the Griffin Mother Class
       TSceptar*    fSceptar;                                 ///< A pointer to the Sceptar Mother Class
       TPaces*      fPaces;                                   ///< A pointer to the Paces Mother Class
-      //TDante*      fDante;  
+      TLaBr*       fLaBr; 
+      TTAC*        fTAC;
       TZeroDegree* fZeroDegree;                              ///< A pointer to the ZeroDegree mother class
       
       //Aux Detectors

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -82,7 +82,7 @@ class TChannel : public TNamed	{
       mutable int   fSegmentNumber;
 
       mutable int   fCrystalNumber; 
-
+      double        fTimeOffset;
 
       std::vector<Float_t> fENGCoefficients;  //Energy calibration coeffs (low to high order)
       double fENGChi2;                       //Chi2 of the energy calibration
@@ -121,6 +121,7 @@ class TChannel : public TNamed	{
       inline void SetUserInfoNumber(int tempinfo)      { fUserInfoNumber = tempinfo; }
       inline void SetDigitizerType(const char* tmpstr) { fDigitizerType.assign(tmpstr); }
       inline void SetTypeName(std::string tmpstr)      { fTypeName = tmpstr; }
+      inline void SetTimeOffset(double tmpto)          { fTimeOffset = tmpto; }
 
       void SetDetectorNumber(int tempint)   { fDetectorNumber = tempint; }
       void SetSegmentNumber(int tempint)    { fSegmentNumber = tempint; }
@@ -137,6 +138,7 @@ class TChannel : public TNamed	{
       int GetUserInfoNumber()        { return fUserInfoNumber;}
       const char* GetChannelName()  const { return fChannelName.c_str(); }
       const char* GetDigitizerType() { return fDigitizerType.c_str(); }
+      double GetTimeOffset()         { return fTimeOffset; }
       //write the rest of the gettters/setters...
 
       double GetENGChi2()  { return fENGChi2; }

--- a/include/TLaBr.h
+++ b/include/TLaBr.h
@@ -1,0 +1,64 @@
+#ifndef TLABR_H
+#define TLABR_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////
+///
+/// \class TLaBr
+///
+/// The TLaBr class defines the observables and algorithms used
+/// when analyzing LaBr data. It includes detector positions,
+/// etc.
+///
+/////////////////////////////////////////////////////////////
+
+#include <vector>
+#include <cstdio>
+
+#include "TVector3.h"
+
+#include "Globals.h"
+#include "TGRSIDetector.h"
+#include "TLaBrHit.h"
+
+class TLaBr : public TGRSIDetector {
+   public:
+      TLaBr();
+      virtual ~TLaBr();
+      TLaBr(const TLaBr& rhs);
+      
+   public:
+      TGRSIDetectorHit* GetHit(const Int_t& idx =0);
+      void Copy(TObject &rhs) const;
+      TLaBrHit* GetLaBrHit(const int& i);	//!<!
+      Short_t GetMultiplicity() const	       {	return fLaBrHits.size(); }	      //!<!
+      
+      static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; }	//!<!
+      
+      void AddFragment(TFragment*, MNEMONIC*); //!<!
+      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      
+      TLaBr& operator=(const TLaBr&);  //!<!
+      
+   private:
+      std::vector <TLaBrHit> fLaBrHits;                                  //   The set of LaBr hits
+      
+   private:
+      static TVector3 gPosition[9];                                     //!<!  Position of each Paddle
+      
+   public:
+      void Clear(Option_t *opt = "");		//!<!
+      void Print(Option_t *opt = "") const;		//!<!
+      
+   protected:
+      void PushBackHit(TGRSIDetectorHit*);
+      
+      /// \cond CLASSIMP
+      ClassDef(TLaBr,1)  // LaBr Physics structure
+      /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TLaBrHit.h
+++ b/include/TLaBrHit.h
@@ -1,0 +1,58 @@
+#ifndef LABRHIT_H
+#define LABRHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TLaBrHit
+///
+/// This is class that contains the information about a LaBr
+/// hit. This class is used to find energy, time, etc.
+///
+/////////////////////////////////////////////////////////////////
+
+#include <cstdio>
+#include <cmath>
+
+#include "TFragment.h"
+#include "TChannel.h"
+
+#include "TVector3.h"
+
+#include "TGRSIDetectorHit.h"
+
+class TLaBrHit : public TGRSIDetectorHit {
+   public:
+      TLaBrHit();
+      virtual ~TLaBrHit();
+      TLaBrHit(const TLaBrHit&);
+      
+   private:
+      Int_t    fFilter;
+      
+   public:
+      /////////////////////////		/////////////////////////////////////
+      inline void SetFilterPattern(const int &x)   { fFilter   = x; }   //!<!
+      
+      /////////////////////////		/////////////////////////////////////
+      inline Int_t    GetFilterPattern()    const     { return fFilter;   }  //!<!
+      
+      bool   InFilter(Int_t);                                          //!<!
+      
+   public:
+      void Clear(Option_t *opt = "");		                    //!<!
+      void Print(Option_t *opt = "") const;		                    //!<!
+      virtual void Copy(TObject&) const;        //!<!
+      
+   private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!<!
+      
+      /// \cond CLASSIMP
+      ClassDef(TLaBrHit,2) //Stores the information for a LaBrrHit
+      /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -37,7 +37,7 @@ class TTAC : public TGRSIDetector {
       Short_t GetMultiplicity() const	       {	return fTACHits.size(); }	      //!<!
       
       void AddFragment(TFragment*, MNEMONIC*); //!<!
-      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      void BuildHits() {};  //no need to build any hits, everything already done in AddFragment
       
       TTAC& operator=(const TTAC&);  //!<!
       

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -1,0 +1,59 @@
+#ifndef TTAC_H
+#define TTAC_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////
+///
+/// \class TTAC
+///
+/// The TTAC class defines the observables and algorithms used
+/// when analyzing TAC data. It includes detector positions,
+/// etc.
+///
+/////////////////////////////////////////////////////////////
+
+#include <vector>
+#include <cstdio>
+
+#include "TVector3.h"
+
+#include "Globals.h"
+#include "TGRSIDetector.h"
+#include "TTACHit.h"
+
+class TTAC : public TGRSIDetector {
+   public:
+      TTAC();
+      virtual ~TTAC();
+      TTAC(const TTAC& rhs);
+      
+   public:
+      TGRSIDetectorHit* GetHit(const Int_t& idx =0);
+      void Copy(TObject &rhs) const;
+      TTACHit* GetTACHit(const int& i);	//!<!
+      Short_t GetMultiplicity() const	       {	return fTACHits.size(); }	      //!<!
+      
+      void AddFragment(TFragment*, MNEMONIC*); //!<!
+      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      
+      TTAC& operator=(const TTAC&);  //!<!
+      
+   private:
+      std::vector <TTACHit> fTACHits;                                  //   The set of TAC hits
+      
+   public:
+      void Clear(Option_t *opt = "");		//!<!
+      void Print(Option_t *opt = "") const;		//!<!
+      
+   protected:
+      void PushBackHit(TGRSIDetectorHit*);
+      
+      /// \cond CLASSIMP
+      ClassDef(TTAC,1)  // TAC Physics structure
+      /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTACHit.h
+++ b/include/TTACHit.h
@@ -1,0 +1,58 @@
+#ifndef TACHIT_H
+#define TACHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TTACHit
+///
+/// This is class that contains the information about a TAC
+/// hit. This class is used to find energy, time, etc.
+///
+/////////////////////////////////////////////////////////////////
+
+#include <cstdio>
+#include <cmath>
+
+#include "TFragment.h"
+#include "TChannel.h"
+
+#include "TVector3.h"
+
+#include "TGRSIDetectorHit.h"
+
+class TTACHit : public TGRSIDetectorHit {
+   public:
+      TTACHit();
+      virtual ~TTACHit();
+      TTACHit(const TTACHit&);
+      
+   private:
+      Int_t    fFilter;
+      
+   public:
+      /////////////////////////		/////////////////////////////////////
+      inline void SetFilterPattern(const int &x)   { fFilter   = x; }   //!<!
+      
+      /////////////////////////		/////////////////////////////////////
+      inline Int_t    GetFilterPattern()    const     { return fFilter;   }  //!<!
+      
+      bool   InFilter(Int_t);                                          //!<!
+      
+   public:
+      void Clear(Option_t *opt = "");		                    //!<!
+      void Print(Option_t *opt = "") const;		                    //!<!
+      virtual void Copy(TObject&) const;        //!<!
+      
+   private:
+      TVector3 GetChannelPosition(Double_t dist = 0) const; //!<!
+      
+      /// \cond CLASSIMP
+      ClassDef(TTACHit,2) //Stores the information for a TACrHit
+      /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTACHit.h
+++ b/include/TTACHit.h
@@ -51,7 +51,7 @@ class TTACHit : public TGRSIDetectorHit {
       TVector3 GetChannelPosition(Double_t dist = 0) const; //!<!
       
       /// \cond CLASSIMP
-      ClassDef(TTACHit,2) //Stores the information for a TACrHit
+      ClassDef(TTACHit,1) //Stores the information for a TACrHit
       /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
+++ b/libraries/TGRSIAnalysis/TAnalysisTreeBuilder/TAnalysisTreeBuilder.cxx
@@ -170,7 +170,8 @@ TAnalysisTreeBuilder::TAnalysisTreeBuilder() {
   fSceptar = 0;//new TSceptar;
   fPaces   = 0;//new TPaces;
   fDescant = 0;//new TDescant;
-  //fDante->Clear();
+  fLaBr = 0;
+  fTAC = 0;
   fZeroDegree = 0;
 
 }
@@ -552,7 +553,7 @@ void TAnalysisTreeBuilder::SetupAnalysisTree() {
   if(info->Griffin())   { tree->Branch("TGriffin",&fGriffin); }//, basketSize); }
   if(info->Sceptar())   { tree->Branch("TSceptar",&fSceptar); }//, basketSize); }
   if(info->Paces())     { tree->Branch("TPaces",&fPaces); }//, basketSize); } 
-  //if(info->Dante())     { tree->Branch("TDante",&fDante); }//, basketSize); } 
+  if(info->Dante())     { tree->Branch("TLaBr",&fLaBr); tree->Branch("TTAC",&fTAC); }//, basketSize); } 
   if(info->ZeroDegree()){ tree->Branch("TZeroDegree",&fZeroDegree); }//, basketSize); } 
   if(info->Descant())   { tree->Branch("TDescant",&fDescant); }//, basketSize);
 
@@ -576,7 +577,7 @@ void TAnalysisTreeBuilder::ClearActiveAnalysisTreeBranches() {
   if(info->Griffin())   { fGriffin->Clear(); }
   if(info->Sceptar())   { fSceptar->Clear(); }
   if(info->Paces())     { fPaces->Clear(); } 
-  //if(info->Dante())     { fDante->Clear(); } 
+  if(info->Dante())     { fLaBr->Clear(); fTAC->Clear(); } 
   if(info->ZeroDegree()){ fZeroDegree->Clear(); } 
   if(info->Descant())   { fDescant->Clear();}
   //printf("ClearActiveAnalysisTreeBranches done\n");
@@ -600,7 +601,7 @@ void TAnalysisTreeBuilder::ResetActiveAnalysisTreeBranches() {
   if(info->Griffin())   { fGriffin = 0; }
   if(info->Sceptar())   { fSceptar = 0; }
   if(info->Paces())     { fPaces = 0; } 
-  //if(info->Dante())     { fDante = 0; } 
+  if(info->Dante())     { fLaBr = 0; fTAC = 0; } 
   if(info->ZeroDegree()){ fZeroDegree = 0; } 
   if(info->Descant())   { fDescant = 0; }
   //printf("ClearActiveAnalysisTreeBranches done\n");
@@ -677,6 +678,10 @@ void TAnalysisTreeBuilder::FillAnalysisTree(std::map<std::string, TDetector*>* d
       fPaces = static_cast<TPaces*>(det->second);
     } else if(det->first.compare(0,2,"ZD") == 0) {
       fZeroDegree = static_cast<TZeroDegree*>(det->second);
+    } else if(det->first.compare(0,2,"DAN") == 0) {
+      fLaBr = static_cast<TLaBr*>(det->second);
+    } else if(det->first.compare(0,2,"DAT") == 0) {
+      fTAC = static_cast<TTAC*>(det->second);
     } else if(det->first.compare(0,2,"TP") == 0) {
       fTip = static_cast<TTip*>(det->second);
     } 
@@ -819,8 +824,19 @@ void TAnalysisTreeBuilder::ProcessEvent() {
           (*detectors)["DS"] = new TDescant;
         }
         (*detectors)["DS"]->AddFragment(&(event->at(i)), &mnemonic);
-        //} else if(mnemonic.system.compare("DA")==0) {	
-        //	AddFragment(&(event->at(i)), &mnemonic);
+      } else if(mnemonic.system.compare("DA")==0) {
+         if(mnemonic.subsystem.compare("N")==0) {
+            if(detectors->find("DAN") == detectors->end()) {
+               (*detectors)["DAN"] = new TLaBr;
+            }
+            (*detectors)["DAN"]->AddFragment(&(event->at(i)),&mnemonic);
+         } 
+         else {
+            if(detectors->find("DAT") == detectors->end()) {
+               (*detectors)["DAT"] = new TTAC;
+            }
+            (*detectors)["DAT"]->AddFragment(&(event->at(i)),&mnemonic);
+         }
     } else if(mnemonic.system.compare("BA")==0) {
       if(detectors->find("BA") == detectors->end()) {
         (*detectors)["BA"] = new TS3;

--- a/libraries/TGRSIAnalysis/TLaBr/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TLaBr/LinkDef.h
@@ -1,0 +1,19 @@
+//TLaBr.h TLaBrHit.h 
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off nestedclasses;
+
+
+#pragma link C++ class TLaBrHit+;
+#pragma link C++ class std::vector<TSLaBrHit>+;
+#pragma link C++ class TLaBr+;
+
+#endif
+
+
+
+
+

--- a/libraries/TGRSIAnalysis/TLaBr/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TLaBr/LinkDef.h
@@ -8,7 +8,7 @@
 
 
 #pragma link C++ class TLaBrHit+;
-#pragma link C++ class std::vector<TSLaBrHit>+;
+#pragma link C++ class std::vector<TLaBrHit>+;
 #pragma link C++ class TLaBr+;
 
 #endif

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -1,0 +1,107 @@
+#include <iostream>
+#include "TLaBr.h"
+#include <TRandom.h>
+#include <TMath.h>
+
+/// \cond CLASSIMP
+ClassImp(TLaBr)
+/// \endcond
+
+TVector3 TLaBr::gPosition[9] = {
+   //These positions should be updated (they are currently SCEPTAR-ish)
+   TVector3(0,0,1),
+   TVector3(14.3025, 4.6472, 22.8096),
+   TVector3(0, 15.0386, 22.8096),
+   TVector3(-14.3025, 4.6472, 22.8096),
+   TVector3(-8.8395, -12.1665, 22.8096),
+   TVector3(8.8395, -12.1665, 22.8096),
+   TVector3(19.7051, 6.4026, 6.2123),
+   TVector3(0, 20.7192, 6.2123),
+   TVector3(-19.7051, 6.4026, 6.2123),
+};
+
+
+TLaBr::TLaBr() {
+   //Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+}
+
+TLaBr::~TLaBr()	{
+   //Default Destructor
+}
+
+TLaBr::TLaBr(const TLaBr& rhs) : TGRSIDetector() {
+   //Copy Contructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   rhs.Copy(*this);
+}
+
+void TLaBr::Clear(Option_t *opt)	{
+   //Clears all of the hits
+   //The Option "all" clears the base class.
+   if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
+      TGRSIDetector::Clear(opt);
+   }
+   fLaBrHits.clear();
+}
+
+void TLaBr::Copy(TObject &rhs) const {
+   //Copies a TLaBr
+   TGRSIDetector::Copy(rhs);
+   
+   static_cast<TLaBr&>(rhs).fLaBrHits    = fLaBrHits;
+}
+
+TLaBr& TLaBr::operator=(const TLaBr& rhs) {
+   rhs.Copy(*this);
+   return *this;
+}
+
+void TLaBr::Print(Option_t *opt) const	{
+   //Prints out TLaBr Multiplicity, currently does little.
+   printf("%lu fLaBrHits\n",fLaBrHits.size());
+}
+
+void TLaBr::PushBackHit(TGRSIDetectorHit *laHit) {
+   //Adds a Hit to the list of TLaBr Hits
+   fLaBrHits.push_back(*(static_cast<TLaBrHit*>(laHit)));
+}
+
+void TLaBr::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
+   //Builds the LaBr Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
+   //This should be done for both LaBr and it's suppressors.
+   if(frag == NULL || mnemonic == NULL) {
+      return;
+   }
+   
+   for(size_t i = 0; i < frag->Charge.size(); ++i) {
+      TLaBrHit hit;
+      hit.SetAddress(frag->ChannelAddress);
+      hit.SetTimeStamp(frag->GetTimeStamp());
+      hit.SetCfd(frag->GetCfd(i));
+      hit.SetCharge(frag->GetCharge(i));
+      
+      AddHit(&hit);
+   }
+}
+
+TGRSIDetectorHit* TLaBr::GetHit(const Int_t& idx){
+   //Gets the TLaBrHit at index idx.
+   return GetLaBrHit(idx);
+}
+
+TLaBrHit* TLaBr::GetLaBrHit(const int& i) {
+   try{
+      return &fLaBrHits.at(i);
+   }
+   catch (const std::out_of_range& oor){
+      std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw grsi::exit_exception(1);
+   }
+   return NULL;
+}

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBrHit.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBrHit.cxx
@@ -1,0 +1,66 @@
+#include "TLaBrHit.h"
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+#include "Globals.h"
+#include "TLaBr.h"
+
+/// \cond CLASSIMP
+ClassImp(TLaBrHit)
+/// \endcond
+
+TLaBrHit::TLaBrHit()	{
+   //Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+}
+
+TLaBrHit::~TLaBrHit()	{	}
+
+TLaBrHit::TLaBrHit(const TLaBrHit &rhs) : TGRSIDetectorHit() {
+   //Copy Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+   rhs.Copy(*this);
+}
+
+void TLaBrHit::Copy(TObject &rhs) const {
+   //Copies a TLaBrHit
+   TGRSIDetectorHit::Copy(rhs);
+   static_cast<TLaBrHit&>(rhs).fFilter = fFilter;
+}
+
+TVector3 TLaBrHit::GetChannelPosition(double dist) const {
+   //Gets the position of the current TLaBrHit
+   //This should not be called externally, only TGRSIDetector::GetPosition should be
+   return TLaBr::GetPosition(GetDetector());
+}
+
+bool TLaBrHit::InFilter(Int_t wantedfilter) {
+   // check if the desired filter is in wanted filter;
+   // return the answer;
+   //currently does nothing
+   return true;
+}
+
+void TLaBrHit::Clear(Option_t *opt)	{
+   //Clears the LaBrHit
+   fFilter = 0;
+   TGRSIDetectorHit::Clear();
+}
+
+void TLaBrHit::Print(Option_t *opt) const	{
+   //Prints the LaBrHit. Returns:
+   //Detector
+   //Energy
+   //Time
+   printf("LaBr Detector: %i\n",GetDetector());
+   printf("LaBr hit energy: %.2f\n",GetEnergy());
+   printf("LaBr hit time:   %.lf\n",GetTime());
+}

--- a/libraries/TGRSIAnalysis/TTAC/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TTAC/LinkDef.h
@@ -1,0 +1,19 @@
+//TTAC.h TTACHit.h 
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link off nestedclasses;
+
+
+#pragma link C++ class TTACHit+;
+#pragma link C++ class std::vector<TTACHit>+;
+#pragma link C++ class TTAC+;
+
+#endif
+
+
+
+
+

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -1,0 +1,93 @@
+#include <iostream>
+#include "TTAC.h"
+#include <TRandom.h>
+#include <TMath.h>
+
+/// \cond CLASSIMP
+ClassImp(TTAC)
+/// \endcond
+
+TTAC::TTAC() {
+   //Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+}
+
+TTAC::~TTAC()	{
+   //Default Destructor
+}
+
+TTAC::TTAC(const TTAC& rhs) : TGRSIDetector() {
+   //Copy Contructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   rhs.Copy(*this);
+}
+
+void TTAC::Clear(Option_t *opt)	{
+   //Clears all of the hits
+   //The Option "all" clears the base class.
+   if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
+      TGRSIDetector::Clear(opt);
+   }
+   fTACHits.clear();
+}
+
+void TTAC::Copy(TObject &rhs) const {
+   //Copies a TTAC
+   TGRSIDetector::Copy(rhs);
+   
+   static_cast<TTAC&>(rhs).fTACHits    = fTACHits;
+}
+
+TTAC& TTAC::operator=(const TTAC& rhs) {
+   rhs.Copy(*this);
+   return *this;
+}
+
+void TTAC::Print(Option_t *opt) const	{
+   //Prints out TTAC Multiplicity, currently does little.
+   printf("%lu fTACHits\n",fTACHits.size());
+}
+
+void TTAC::PushBackHit(TGRSIDetectorHit *laHit) {
+   //Adds a Hit to the list of TTAC Hits
+   fTACHits.push_back(*(static_cast<TTACHit*>(laHit)));
+}
+
+void TTAC::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
+   //Builds the TAC Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
+   //This should be done for both TAC and it's suppressors.
+   if(frag == NULL || mnemonic == NULL) {
+      return;
+   }
+   
+   for(size_t i = 0; i < frag->Charge.size(); ++i) {
+      TTACHit hit;
+      hit.SetAddress(frag->ChannelAddress);
+      hit.SetTimeStamp(frag->GetTimeStamp());
+      hit.SetCfd(frag->GetCfd(i));
+      hit.SetCharge(frag->GetCharge(i));
+      
+      AddHit(&hit);
+   }
+}
+
+TGRSIDetectorHit* TTAC::GetHit(const Int_t& idx){
+   //Gets the TTACHit at index idx.
+   return GetTACHit(idx);
+}
+
+TTACHit* TTAC::GetTACHit(const int& i) {
+   try{
+      return &fTACHits.at(i);
+   }
+   catch (const std::out_of_range& oor){
+      std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
+      throw grsi::exit_exception(1);
+   }
+   return NULL;
+}

--- a/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
@@ -1,0 +1,65 @@
+#include "TTACHit.h"
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+#include "Globals.h"
+#include "TTAC.h"
+
+/// \cond CLASSIMP
+ClassImp(TTACHit)
+/// \endcond
+
+TTACHit::TTACHit()	{
+   //Default Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+}
+
+TTACHit::~TTACHit()	{	}
+
+TTACHit::TTACHit(const TTACHit &rhs) : TGRSIDetectorHit() {
+   //Copy Constructor
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+   Clear();
+   rhs.Copy(*this);
+}
+
+void TTACHit::Copy(TObject &rhs) const {
+   //Copies a TTACHit
+   TGRSIDetectorHit::Copy(rhs);
+   static_cast<TTACHit&>(rhs).fFilter = fFilter;
+}
+
+TVector3 TTACHit::GetChannelPosition(double dist) const {
+   //There is no position for the TTAC's. This returns a null vector.
+   return TVector3(0., 0., 0.); 
+}
+
+bool TTACHit::InFilter(Int_t wantedfilter) {
+   // check if the desired filter is in wanted filter;
+   // return the answer;
+   //currently does nothing
+   return true;
+}
+
+void TTACHit::Clear(Option_t *opt)	{
+   //Clears the TACHit
+   fFilter = 0;
+   TGRSIDetectorHit::Clear();
+}
+
+void TTACHit::Print(Option_t *opt) const	{
+   //Prints the TACHit. Returns:
+   //Detector
+   //Energy
+   //Time
+   printf("TAC Detector: %i\n",GetDetector());
+   printf("TAC hit energy: %.2f\n",GetEnergy());
+   printf("TAC hit time:   %.lf\n",GetTime());
+}

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -70,6 +70,7 @@ TChannel::TChannel(TChannel* chan) {
   this->SetDetectorNumber(chan->GetDetectorNumber());
 	this->SetSegmentNumber(chan->GetSegmentNumber());
 	this->SetCrystalNumber(chan->GetCrystalNumber());
+   this->SetTimeOffset(chan->GetTimeOffset());
 }
 
 
@@ -165,6 +166,7 @@ void TChannel::OverWriteChannel(TChannel* chan){
   this->SetDetectorNumber(chan->GetDetectorNumber());
 	this->SetSegmentNumber(chan->GetSegmentNumber());
 	this->SetCrystalNumber(chan->GetCrystalNumber());
+   this->SetTimeOffset(chan->GetTimeOffset());
 	return;
 }
 
@@ -182,6 +184,8 @@ void TChannel::AppendChannel(TChannel* chan){
 		this->SetChannelName(chan->GetChannelName());
 	if(strlen(chan->GetDigitizerType())>0)
 		this->SetDigitizerType(chan->GetDigitizerType());
+   if(chan->GetTimeOffset() != 0.0)
+      this->SetTimeOffset(chan->GetTimeOffset());
 
 	if(chan->GetENGCoeff().size()>0)
 		this->SetENGCoefficients(chan->GetENGCoeff());
@@ -257,6 +261,7 @@ void TChannel::Clear(Option_t* opt){
   fDetectorNumber    = -1;
   fSegmentNumber     = -1;
   fCrystalNumber     = -1;
+  fTimeOffset        = 0.0;
 
 	fENGCoefficients.clear();
 	fCFDCoefficients.clear();
@@ -529,6 +534,7 @@ void TChannel::Print(Option_t* opt) const {
 	std::cout <<  "Address:   0x" << std::hex << std::setw(8) << fAddress << std::dec << "\n";
 	std::cout << std::setfill(' ');
 	std::cout <<  "Digitizer: " << fDigitizerType << "\n"; 
+	std::cout <<  "TimeOffset: " << fTimeOffset << "\n"; 
 	std::cout <<  "EngCoeff:  "  ;
 	for(size_t x=0;x<fENGCoefficients.size();x++)
 		std::cout <<  fENGCoefficients.at(x) << "\t";
@@ -565,6 +571,7 @@ std::string TChannel::PrintToString(Option_t* opt) {
 		buffer.append(Form("%f\t",fENGCoefficients.at(x)));
 	buffer.append("\n");
 	buffer.append(Form("Integration: %d\n",fIntegration));
+	buffer.append(Form("TimeOffset: %lf\n",fTimeOffset));
 	buffer.append(Form("ENGChi2:     %f\n",fENGChi2));
 	buffer.append("EffCoeff:  ");
 	for(size_t x=0;x<fEFFCoefficients.size();x++)
@@ -880,6 +887,9 @@ Int_t TChannel::ParseInputData(const char* inputdata,Option_t* opt) {
 					} else if(type.compare("NUMBER")==0) {
 						int tempnum; ss>>tempnum;
 						channel->SetNumber(tempnum);
+					} else if(type.compare("TIMEOFFSET")==0) {
+						int tempoff; ss>>tempoff;
+						channel->SetTimeOffset(tempoff);
 					} else if(type.compare("STREAM")==0) {
 						int tempstream; ss>>tempstream;
 						channel->SetStream(tempstream);

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -129,7 +129,10 @@ long TFragment::GetTimeStamp() const {
    long time = TimeStampHigh;
    time  = time << 28;
    time |= TimeStampLow & 0x0fffffff;
-   return time;
+   TChannel *chan = TChannel::GetChannel(ChannelAddress);
+   if(!chan)
+      return time;
+   return time - chan->GetTimeOffset();;
 }
 
 


### PR DESCRIPTION
- Requires a `make clean` (or removal of TGRSIAnalysis library), need to figure out why
- I have added a TLabr and TTAC class
- ZDS may or may not work. Is not set up with TAC's yet. This should be a discussion point.
- Both are created when Dante is set to true in run info
- I have a time stamp offset that is set in TChannel now, and TFragment can access. This might slow `GetTimeStamp()` down a bit, but I'll worry about it when it becomes a problem.
- The TimeStampOffset is a double. Not sure if we need this precision, but `TFragment::GetTimeStamp()` still returns an int, so I do not see the harm if we want more precision for `TFragment()::GetTime()` down the road.
- There are no positions in the LaBr, someone may have to add these
- There are no positions for TTAC (kind of nonsensical)
- **NONE OF THIS IS TESTED ON LABR DATA** This is Bruno's job
- There may be extra information in these classes that can be removed later
- Will update the wiki later (TChannel) to talk about TimeOffset