### PR TITLE
Use TChannel to build events

### DIFF
--- a/include/TAnalysisTreeBuilder.h
+++ b/include/TAnalysisTreeBuilder.h
@@ -16,12 +16,17 @@
 #include <chrono>
 #endif
 
+#include <map>
+#include <iostream>
+#include <utility>
+
 #include "TObject.h"
 #include "TFile.h"
 #include "TMemFile.h"
 #include "TTree.h"
 #include "TChain.h"
 #include "TList.h"
+#include "TClass.h"
 
 #include "Globals.h"
 
@@ -109,8 +114,8 @@ class TEventQueue : public TObject {
 class TWriteQueue {
    public:
       static TWriteQueue* Get();
-      static void Add(std::map<std::string, TDetector*>* event); 
-      static std::map<std::string, TDetector*>* PopEntry();
+      static void Add(std::map<TClass*, TDetector*>* event); 
+      static std::map<TClass*, TDetector*>* PopEntry();
       static int Size();
       virtual ~TWriteQueue() { }
 
@@ -119,11 +124,11 @@ class TWriteQueue {
       static TWriteQueue* fPtrToQue;
 
       
-      void AddInstance(std::map<std::string, TDetector*>* event); 
-      std::map<std::string, TDetector*>* PopEntryInstance();
+      void AddInstance(std::map<TClass*, TDetector*>* event); 
+      std::map<TClass*, TDetector*>* PopEntryInstance();
       int SizeInstance();
       
-      std::queue<std::map<std::string, TDetector*>*> fWriteQueue;
+      std::queue<std::map<TClass*, TDetector*>*> fWriteQueue;
 #if !defined (__CINT__) && !defined (__CLING__)
       std::mutex m_write;
 #endif
@@ -162,9 +167,9 @@ class TAnalysisTreeBuilder : public TObject {
       void SetupOutFile();
       void SetupAnalysisTree();
 
-      void FillWriteQueue(std::map<std::string, TDetector*>*);
+      void FillWriteQueue(std::map<TClass*, TDetector*>*);
 
-      void FillAnalysisTree(std::map<std::string, TDetector*>*);
+      void FillAnalysisTree(std::map<TClass*, TDetector*>*);
       void WriteAnalysisTree();
       void CloseAnalysisFile();
 
@@ -172,7 +177,7 @@ class TAnalysisTreeBuilder : public TObject {
 
       void ClearActiveAnalysisTreeBranches();
       void ResetActiveAnalysisTreeBranches();
-		void BuildActiveAnalysisTreeBranches(std::map<std::string, TDetector*>*);
+		void BuildActiveAnalysisTreeBranches(std::map<TClass*, TDetector*>*);
 
       void Print(Option_t *opt ="") const;
 

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -39,6 +39,7 @@
 #include "TRandom.h"
 #include "TList.h"
 #include "TTree.h"
+#include "TClass.h"
 
 #include "TFragment.h"
 #include "Globals.h"
@@ -68,21 +69,22 @@ class TChannel : public TNamed	{
       static TChannel* GetDefaultChannel();
 
    private:
-      unsigned int	fAddress;                                 //The address of the digitizer
-      int		        fIntegration;                             //The charge integration setting
-      std::string   fChannelName;                             //The name of the channel (MNEMONIC)
-      std::string   fTypeName;
-      std::string   fDigitizerType;
-      int 	        fNumber;
-      int		        fStream;
-      int           fUserInfoNumber;
-      bool          fUseCalFileInt;
+      unsigned int	   fAddress;                                 //The address of the digitizer
+      int		         fIntegration;                             //The charge integration setting
+      std::string       fChannelName;                             //The name of the channel (MNEMONIC)
+      std::string       fTypeName;
+      std::string       fDigitizerType;
+      int 	            fNumber;
+      int		         fStream;
+      int               fUserInfoNumber;
+      bool              fUseCalFileInt;
 
-      mutable int   fDetectorNumber;
-      mutable int   fSegmentNumber;
+      mutable int       fDetectorNumber;
+      mutable int       fSegmentNumber;
 
-      mutable int   fCrystalNumber; 
-      double        fTimeOffset;
+      mutable int       fCrystalNumber; 
+      double            fTimeOffset;
+      mutable TClass*   fClassType;          //!<! TGRSIDetector Type that this channel represents
 
       std::vector<Float_t> fENGCoefficients;  //Energy calibration coeffs (low to high order)
       double fENGChi2;                       //Chi2 of the energy calibration
@@ -94,6 +96,8 @@ class TChannel : public TNamed	{
       double fTIMEChi2;                      //Chi2 of the Time calibration
       std::vector<double> fEFFCoefficients;  //Efficiency calibration coeffs (low to high order)
       double fEFFChi2;                       //Chi2 of Efficiency calibration
+
+      void SetClassType(TClass* classType)               { fClassType = classType; }
 
       static std::map<unsigned int,TChannel*>* fChannelMap; //A map to all of the channels based on address
       static std::map<int,TChannel*>* fChannelNumberMap;    //A map of TChannels based on channel number
@@ -130,6 +134,7 @@ class TChannel : public TNamed	{
       int GetDetectorNumber() const; 
       int GetSegmentNumber()  const;  
       int GetCrystalNumber()  const;  
+      TClass* GetClassType() const;
 
       int	GetNumber()		          { return fNumber;  }
       unsigned int	GetAddress()    { return fAddress; }

--- a/include/TGRSIDetector.h
+++ b/include/TGRSIDetector.h
@@ -37,7 +37,7 @@ class TGRSIDetector : public TDetector	{
 
 	public: 
 		//virtual TGRSIDetectorHit* GetHit(const Int_t idx = 0) { AbstractMethod("GetHit()"); return 0;}
-		virtual void AddFragment(TFragment*, MNEMONIC*)         { AbstractMethod("AddFragment()"); } //!<! = 0; //!
+		virtual void AddFragment(TFragment*,MNEMONIC*)         { AbstractMethod("AddFragment()"); } //!<! = 0; //!
 		virtual void BuildHits() {}
 
 		virtual void Copy(TObject&) const;              //!<!

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -220,7 +220,7 @@ void TGriffin::AddFragment(TFragment* frag, MNEMONIC *mnemonic)	{
 		return;
 	}
 
-   if(mnemonic->subsystem[0] == 'G') {
+  // if(mnemonic->subsystem[0] == 'G') {
 		//set griffin
 		if(mnemonic->outputsensor[0] == 'B') { return; }  //make this smarter.
 		
@@ -234,7 +234,6 @@ void TGriffin::AddFragment(TFragment* frag, MNEMONIC *mnemonic)	{
 		//	CoreNbr=2;
 		//else if(mnemonic->arraysubposition[0] == 'W')
 		//	CoreNbr=3;
-   
 		for(size_t i = 0; i < frag->Charge.size(); ++i) {
 			TGriffinHit corehit;
 			corehit.SetAddress(frag->ChannelAddress);
@@ -258,9 +257,9 @@ void TGriffin::AddFragment(TFragment* frag, MNEMONIC *mnemonic)	{
 			
 			AddHit(&corehit);
 		}
-	} else if(mnemonic->subsystem[0] == 'S') {
+	//} else if(mnemonic->subsystem[0] == 'S') {
 		//set BGO
-   }
+  // }
 }
 
 TVector3 TGriffin::GetPosition(int DetNbr,int CryNbr, double dist ) {

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -589,11 +589,11 @@ std::string TChannel::PrintToString(Option_t* opt) {
 	std::string buffer;
 	buffer.append("\n");
 	buffer.append(fChannelName); buffer.append("\t{\n");  //,channelname.c_str();
-   std::cout << "Type:      ";
+   buffer.append("Type:      ");
    if(GetClassType())
-      std::cout << GetClassType()->GetName()<<std::endl;
+      buffer.append(Form("%s\n",GetClassType()->GetName()));
    else
-      std::cout << "None" << std::endl;
+      buffer.append("None\n");
 	buffer.append("Name:      "); buffer.append(fChannelName); buffer.append("\n");
 	buffer.append(Form("Number:    %d\n",fNumber));
 	buffer.append(Form("Address:   0x%08x\n",fAddress));


### PR DESCRIPTION
Removed mnemonic parsing fro event building. There are still a couple of mnemonic statements in the event building. These will be cleaned out at some point. The performance gain doesn't seem to be huge on our computer at Guelph, but it is being used to sort other data right now, so it is hard to tell. The main change here is that mnemonics only get parsed once per channel, and set in the TChannel.