### PR TITLE
Add flexible BGO suppression to TTigress

### DIFF
--- a/include/TBgoHit.h
+++ b/include/TBgoHit.h
@@ -1,0 +1,48 @@
+#ifndef TBGOHIT_H
+#define TBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined (__CINT__) && !defined (__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TGRSIDetectorHit.h"
+
+class TBgoHit : public TGRSIDetectorHit {
+  public:
+    TBgoHit();
+    TBgoHit(const TBgoHit&);
+    TBgoHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
+    virtual ~TBgoHit();
+
+
+  public:
+
+	/////////////////////////		/////////////////////////////////////
+	int GetCrystal() const;	
+  private:
+
+  public:
+	virtual void Clear(Option_t *opt = "");		                      //!<!
+	virtual void Copy(TObject&) const;                             //!<!
+	virtual void Print(Option_t *opt = "") const;       		                //!<!
+
+/// \cond CLASSIMP
+	ClassDef(TBgoHit,1)
+/// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -18,12 +18,13 @@
 
 #include "TGRSIDetector.h" 
 #include "TTigressHit.h"
+#include "TBgoHit.h"
 
 class TTigress : public TGRSIDetector {
 	public:
 		enum ETigressBits {
 			kIsAddbackSet = BIT(0),
-			kBit1         = BIT(1),
+			kSuppression  = BIT(1),
 			kBit2         = BIT(2),
 			kBit3         = BIT(3),
 			kBit4         = BIT(4),
@@ -31,6 +32,13 @@ class TTigress : public TGRSIDetector {
 			kSetSegWave   = BIT(6),
 			kSetBGOWave   = BIT(7)
 		};
+
+    std::vector<TBgoHit> fBgos;
+		void AddBGO(TBgoHit& bgo) 		    { fBgos.push_back(bgo);	}	   //!<!
+		int GetBGOMultiplicity()			    const      { return fBgos.size();     }   //!<!
+		int GetNBGOs()			              const      { return fBgos.size();     }   //!<!
+		TBgoHit GetBGO( int &i)	   const { return fBgos.at(i);	     }   //!<!
+		TBgoHit& GetBGO( int &i)	         { return fBgos.at(i);	     }   //!<!
 
 		std::vector<std::vector<TFragment*> > SegmentFragments;
 
@@ -50,6 +58,7 @@ class TTigress : public TGRSIDetector {
 		Int_t GetAddbackMultiplicity();
 		TTigressHit* GetAddbackHit(const int&);
 		void ResetAddback();		     //!<!
+		void SetDoSuppression(bool flag = true);
 		UShort_t GetNAddbackFrags(size_t idx) const;
 
 		void AddFragment(TFragment*, MNEMONIC*); //!<!
@@ -60,11 +69,16 @@ class TTigress : public TGRSIDetector {
 #if !defined (__CINT__) && !defined (__CLING__)
 		void SetAddbackCriterion(std::function<bool(TTigressHit&, TTigressHit&)> criterion) { fAddbackCriterion = criterion; }
 		std::function<bool(TTigressHit&, TTigressHit&)> GetAddbackCriterion() const         { return fAddbackCriterion; }
+
+		void SetSuppressionCriterion(std::function<bool(TTigressHit&, TBgoHit&)> criterion) { fSuppressionCriterion = criterion; }
+		std::function<bool(TTigressHit&, TBgoHit&)> GetSuppressionCriterion() const     { return fSuppressionCriterion; }
 #endif
 
 	private: 
 #if !defined (__CINT__) && !defined (__CLING__)
 		static std::function<bool(TTigressHit&, TTigressHit&)> fAddbackCriterion;
+
+		static std::function<bool(TTigressHit&, TBgoHit&)> fSuppressionCriterion;
 #endif
 		std::vector<TTigressHit> fTigressHits;
 
@@ -100,6 +114,7 @@ class TTigress : public TGRSIDetector {
 		static bool SetCoreWave()    { return fSetCoreWave;	    }	//!<!
 		static bool SetSegmentWave() { return fSetSegmentWave;  }	//!<!
 		static bool SetBGOWave()	 { return fSetBGOWave;		}     //!<!
+		static bool BGOSuppression[4][4][5]; //!<!
 
 	public:         
 		virtual void Clear(Option_t *opt = "");		 //!<!

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -34,7 +34,6 @@ class TTigressHit : public TGRSIDetectorHit {
 	 Float_t  fFirstSegmentCharge; //!<!
 
     std::vector<TGRSIDetectorHit> fSegments;
-    std::vector<TGRSIDetectorHit> fBgos;
 
     Double_t fTimeFit;
     Double_t fSig2Noise;
@@ -50,7 +49,6 @@ class TTigressHit : public TGRSIDetectorHit {
 	/////////////////////////		/////////////////////////////////////
 	void SetCore(TGRSIDetectorHit& core)		  { Copy(core);	} 					//!<!
 	void AddSegment(TGRSIDetectorHit& seg) 	  { fSegments.push_back(seg);	}	//!<!
-	void AddBGO(TGRSIDetectorHit& bgo) 		    { fBgos.push_back(bgo);	}	   //!<!
 
   //int SetCrystal(char color);
   //int SetCrystal(int crynum);
@@ -86,15 +84,11 @@ class TTigressHit : public TGRSIDetectorHit {
 
 	int GetSegmentMultiplicity()		  const      { return fSegments.size(); }	//!<!
 	int GetNSegments()		            const      { return fSegments.size(); }	//!<!
-	int GetBGOMultiplicity()			    const      { return fBgos.size();     }   //!<!
-	int GetNBGOs()			              const      { return fBgos.size();     }   //!<!
 	using TGRSIDetectorHit::GetSegment;
 	TGRSIDetectorHit& GetSegment(int &i)       { return fSegments.at(i);  }   //!<!
-	TGRSIDetectorHit& GetBGO( int &i)	         { return fBgos.at(i);	     }   //!<!
 	TGRSIDetectorHit& GetCore()                { return *this;	           }   //!<!
 	
   TGRSIDetectorHit GetSegment(int &i) const { return fSegments.at(i);  }   //!<!
-	TGRSIDetectorHit GetBGO( int &i)	   const { return fBgos.at(i);	     }   //!<!
 	TGRSIDetectorHit GetCore()          const { return *this;	           }   //!<!
 
 	void CheckFirstHit(int charge,int segment);								               //!<!

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -50,7 +50,7 @@ void TS3::AddFragment(TFragment* frag, MNEMONIC* mnemonic) {
 	}
 
 	bool IsDownstream = false;		
-	if(mnemonic->collectedcharge.compare(0,1,"P")==0) { //front  (ring)	
+	if(mnemonic->collectedcharge.compare(0,1,"N")==0) { // ring	
 			TS3Hit dethit(*frag);
 			dethit.SetVariables(*frag);	
 			dethit.SetRingNumber(*frag);

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -25,6 +25,8 @@ void TS3Hit::Copy(TObject &rhs) const {
 	 static_cast<TS3Hit&>(rhs).fRing = fRing;
 	 static_cast<TS3Hit&>(rhs).fSector = fSector;
 	 static_cast<TS3Hit&>(rhs).fIsDownstream = fIsDownstream;
+   static_cast<TS3Hit&>(rhs).fTimeFit		   = fTimeFit;
+   static_cast<TS3Hit&>(rhs).fSig2Noise		= fSig2Noise;
    return;
 }
 

--- a/libraries/TGRSIAnalysis/TTigress/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TTigress/LinkDef.h
@@ -9,6 +9,7 @@
 //#pragma link C++ class std::vector<Short_t>+;
 
 #pragma link C++ class TTigressHit+;
+#pragma link C++ class TBgoHit+;
 //#pragma link C++ class std::vector<TTigressHit>+;
 #pragma link C++ class TTigress+;
 

--- a/libraries/TGRSIAnalysis/TTigress/TBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TBgoHit.cxx
@@ -1,0 +1,47 @@
+#include "TBgoHit.h"
+
+#include "TClass.h"
+
+#include "TTigress.h"
+
+/// \cond CLASSIMP
+ClassImp(TBgoHit)
+/// \endcond
+
+TBgoHit::TBgoHit() {	
+  Clear();
+}
+
+TBgoHit::~TBgoHit() {	}
+
+TBgoHit::TBgoHit(const TBgoHit& rhs) : TGRSIDetectorHit() {	
+  rhs.Copy(*this);
+}
+
+void TBgoHit::Clear(Option_t *opt) {
+  TGRSIDetectorHit::Clear(opt);
+}
+
+void TBgoHit::Copy(TObject &rhs) const {
+  TGRSIDetectorHit::Copy(rhs);
+}
+
+
+void TBgoHit::Print(Option_t *opt) const	{
+  TString sopt(opt);
+  printf("==== BgoHit @ 0x%p\n ====",(void*)this);
+  printf("\t%s\n",GetName());
+  printf("\tCharge: %.2f\n",GetCharge());
+  printf("\tTime:   %.2f\n",GetTime());
+  std::cout <<"\tTime:   "<< GetTimeStamp() <<"\n";
+  printf("============================\n");
+}
+
+
+
+int TBgoHit::GetCrystal() const {
+  TChannel *chan = GetChannel();
+  if(!chan)
+    return -1;
+  return chan->GetCrystalNumber();
+}

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -27,7 +27,6 @@ void TTigressHit::Clear(Option_t *opt) {
   fTimeFit = 0;
 
   fSegments.clear();
-  fBgos.clear();
 
   fLastHit.SetXYZ(0,0,0);
 }
@@ -36,7 +35,6 @@ void TTigressHit::Copy(TObject &rhs) const {
   TGRSIDetectorHit::Copy(rhs);
   static_cast<TTigressHit&>(rhs).fTimeFit              = fTimeFit;
   static_cast<TTigressHit&>(rhs).fSegments             = fSegments;
-  static_cast<TTigressHit&>(rhs).fBgos                 = fBgos;
   static_cast<TTigressHit&>(rhs).fCrystal              = fCrystal;
   static_cast<TTigressHit&>(rhs).fFirstSegment         = fFirstSegment;
   static_cast<TTigressHit&>(rhs).fFirstSegmentCharge   = fFirstSegmentCharge;


### PR DESCRIPTION
I've (re-)added reasonably flexible BGO suppression to the TTigress class. This required the recreation of the TBgoHits and their storage within TTigress (rather than TTigressHits) to allow for suppression from BGOs belonging to neighbouring detectors. 

Suppression is now done on the fly during GetAddbackMultiplicity(), and is evaluated much in the same way as addback. I've also included a fairly basic suppression as a default. I've tested it with data and it does a good job without oversuppressing good events (I see no loss of events for a 1564-keV gamma-ray in the data I tested).

Suppression is considered on by default, but can be toggled using the SetDoSuppression function, which also resets the addback.

Additionally I fixed a bug in TS3 where the fitted times weren't being copied over.