### PR TITLE
Changed pileup calculations in Addback

### DIFF
--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -145,6 +145,19 @@ void TGriffinHit::Add(const TGriffinHit *hit)	{
    this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
    //this has to be done at the very end, otherwise this->GetEnergy() might not work
    this->SetCharge(0);
+   //Add all of the pileups.This should be changed when the max number of pileups changes
+   if((this->NPileUps() + hit->NPileUps()) < 4){
+      this->SetNPileUps(this->NPileUps() + hit->NPileUps());
+   }  
+   else{
+      this->SetNPileUps(3);
+   }
+   if((this->PUHit() + hit->PUHit()) < 4){
+      this->SetPUHit(this->PUHit() + hit->PUHit());
+   }  
+   else{
+      this->SetPUHit(3);
+   }
 }
 
 void TGriffinHit::SetGriffinFlag(enum EGriffinHitBits flag,Bool_t set){


### PR DESCRIPTION
Not sure if this is correct, but I add up all pileups from the fragments that make up a piled up hit.