### PR TITLE
GVersion.h creation fix for CentOS

### DIFF
--- a/util/gen_version.sh
+++ b/util/gen_version.sh
@@ -18,12 +18,12 @@ fi
       
 include_file="$script_dir"/../include/GVersion.h
 
-release_commit=$(git describe --abbrev=0 --match="v*")
+release_commit=$(git describe --abbrev=0 --match="v*" --tags)
 release_num=$(echo "$release_commit" | sed -e 's/v//')
 release_time=$(git show -s --format=%ai "$release_commit" | tail -n 1)
 release_name=$(git rev-parse "$release_commit" | xargs git cat-file -p | tail -n1)
 
-git_commit=$(git describe)
+git_commit=$(git describe --tags)
 git_branch=$(git branch | sed -n '/\* /s///p')
 git_commit_time=$(git show -s --format=%ai "$git_commit" | tail -n 1)
 


### PR DESCRIPTION
I was having a problem with compilation arising from the GVersion.h creation on the current master on belodon (CentOS7):

"fatal: No annotated tags can describe 'a4125b4fd59d275ab047ee7c2a75c9b5589ef6aa'.
However, there were unannotated tags: try --tags.
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
usage: git cat-file (-t|-s|-e|-p|<type>|--textconv) <object>
   or: git cat-file (--batch|--batch-check) < <list_of_objects>

<type> can be one of: blob, tree, commit, tag
    -t                    show object type
    -s                    show object size
    -e                    exit with zero when there's no error
    -p                    pretty-print object's content
    --textconv            for blob objects, run textconv on object's content
    --batch               show info and content of objects fed from the standard input
    --batch-check         show info about objects fed from the standard input

fatal: No annotated tags can describe 'a4125b4fd59d275ab047ee7c2a75c9b5589ef6aa'.
However, there were unannotated tags: try --tags.
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]' "

It seems that it doesn't like the `git describe' command without the `--tags' option. Once I include this option, it compiles just fine.

This was only for CentOS (I didn't have the same problem compiling on SL6 on midtig02). 