### PR TITLE
AddFragment refactor

### DIFF
--- a/include/Globals.h
+++ b/include/Globals.h
@@ -257,6 +257,7 @@ struct MNEMONIC {
   int ArraySubPosition() const { return fArraySubPosition; }
   int CollectedCharge() const { return fCollectedCharge; }
   int OutputSensor() const { return fOutputSensor; } 
+  int ArrayPosition() const {return arrayposition; }
 	
   void Print() const{
       printf("======MNEMONIC ======\n");

--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -38,8 +38,7 @@ class TDescant : public TGRSIDetector {
       
       static TVector3 GetPosition(int DetNbr, double dist=222);	//!<!
       
-   //   void AddFragment(TFragment*, TChannel*);           //!<!
-      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      void AddFragment(TFragment*, TChannel*);           //!<!
       TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel *chan) { return new TDescantHit(*frag); }
 
       TDescant& operator=(const TDescant&);  //
@@ -61,8 +60,6 @@ class TDescant : public TGRSIDetector {
       void Copy(TObject&) const;                                              //!<!
       void Clear(Option_t* opt = "");                                         //!<!
       void Print(Option_t* opt = "") const;                                   //!<!
-      
-      void PushBackHit(TGRSIDetectorHit* deshit);
       
       /// \cond CLASSIMP
       ClassDef(TDescant,1)  // Descant Physics structure

--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -38,9 +38,10 @@ class TDescant : public TGRSIDetector {
       
       static TVector3 GetPosition(int DetNbr, double dist=222);	//!<!
       
-      void AddFragment(TFragment*, TChannel*);           //!<!
+   //   void AddFragment(TFragment*, TChannel*);           //!<!
       void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-      
+      TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel *chan) { return new TDescantHit(*frag); }
+
       TDescant& operator=(const TDescant&);  //
       
    private:

--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -21,7 +21,7 @@ class TDescantHit : public TGRSIDetectorHit {
       TDescantHit();
       virtual ~TDescantHit();
       TDescantHit(const TDescantHit&);
-      TDescantHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
+      TDescantHit(TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -21,6 +21,7 @@ class TDescantHit : public TGRSIDetectorHit {
       TDescantHit();
       virtual ~TDescantHit();
       TDescantHit(const TDescantHit&);
+      TDescantHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
       
    private:
       Int_t    fFilter;

--- a/include/TGRSIDetector.h
+++ b/include/TGRSIDetector.h
@@ -37,8 +37,9 @@ class TGRSIDetector : public TDetector	{
 
   public: 
     //virtual TGRSIDetectorHit* GetHit(const Int_t idx = 0) { AbstractMethod("GetHit()"); return 0;}
-    virtual void AddFragment(TFragment*, TChannel*)         { AbstractMethod("AddFragment()"); } //!<! = 0; //!
+    virtual void AddFragment(TFragment*, TChannel*); //!<! = 0; //!
     virtual void BuildHits() {}
+    virtual TGRSIDetectorHit* CreateHit(TFragment* frag,TChannel* chan = 0) { return 0; }
 
     virtual void Copy(TObject&) const;              //!<!
     virtual void Clear(Option_t *opt = "");         //!<!
@@ -54,7 +55,7 @@ class TGRSIDetector : public TDetector	{
 
   protected:
     virtual void PushBackHit(TGRSIDetectorHit* hit) = 0;
-    
+    void CopyFragment(TFragment *frag);
   private:
     
     //Long_t fMidasTimestamp;

--- a/include/TGRSIDetector.h
+++ b/include/TGRSIDetector.h
@@ -37,15 +37,13 @@ class TGRSIDetector : public TDetector	{
 
   public: 
     //virtual TGRSIDetectorHit* GetHit(const Int_t idx = 0) { AbstractMethod("GetHit()"); return 0;}
-    virtual void AddFragment(TFragment*, TChannel*); //!<! = 0; //!
+    virtual void AddFragment(TFragment*, TChannel*) = 0; //!<! = 0; //!
     virtual void BuildHits() {}
-    virtual TGRSIDetectorHit* CreateHit(TFragment* frag,TChannel* chan = 0) { return 0; }
 
     virtual void Copy(TObject&) const;              //!<!
     virtual void Clear(Option_t *opt = "");         //!<!
     virtual void Print(Option_t *opt = "") const;   //!<!
 
-    void AddHit(TGRSIDetectorHit *hit,Option_t *opt ="");
     //      virtual void AddHit(TGRSIDetectorHit* hit, Option_t *opt ="") {}        //!<!
 
     //  void Init();
@@ -54,7 +52,6 @@ class TGRSIDetector : public TDetector	{
     //virtual Long_t GetMidasTimestamp() const { return fMidasTimestamp; }
 
   protected:
-    virtual void PushBackHit(TGRSIDetectorHit* hit) = 0;
     void CopyFragment(TFragment *frag);
   private:
     

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -111,6 +111,7 @@ class TGRSIDetectorHit : public TObject 	{
       virtual TVector3 GetPosition()    const { return TVector3(0.,0.,0.); } //!<!
       virtual double GetEnergy(Option_t* opt="")     const;
       virtual Long_t GetTimeStamp(Option_t* opt="") const;
+      Long_t GetRawTimeStamp(Option_t* opt="") const { return fTimeStamp; }
       virtual Double_t GetTime(Option_t* opt = "")   const;  ///< Returns a time value to the nearest nanosecond!
       virtual Int_t   GetCfd()    const      { return fCfd;}                 //!<!
       virtual UInt_t GetAddress() const      { return fAddress; }            //!<!

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -152,6 +152,7 @@ private:
   int fSortDepth;
 
   int fBuildWindow;
+  int fAddbackWindow;
 
   bool fShouldExit;
 

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -40,8 +40,9 @@ class TGriffin : public TGRSIDetector {
     Short_t GetMultiplicity() const {return fGriffinHits.size();}
 
     static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
-    void AddFragment(TFragment* frag, TChannel* chan); //!<!
+    //void AddFragment(TFragment* frag, TChannel* chan); //!<!
     void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+    TGRSIDetectorHit * CreateHit(TFragment* frag,TChannel*chan = 0) { return new TGriffinHit(*frag); }
 
     TGriffin& operator=(const TGriffin&);  //!<!
 

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -40,9 +40,7 @@ class TGriffin : public TGRSIDetector {
     Short_t GetMultiplicity() const {return fGriffinHits.size();}
 
     static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
-    //void AddFragment(TFragment* frag, TChannel* chan); //!<!
-    void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-    TGRSIDetectorHit * CreateHit(TFragment* frag,TChannel*chan = 0) { return new TGriffinHit(*frag); }
+    void AddFragment(TFragment* frag, TChannel* chan); //!<!
 
     TGriffin& operator=(const TGriffin&);  //!<!
 
@@ -98,9 +96,6 @@ class TGriffin : public TGRSIDetector {
     void ResetFlags();
     void ResetAddback();         //!<!
     UShort_t GetNAddbackFrags(size_t idx) const;
-
-  protected:
-    void PushBackHit(TGRSIDetectorHit* ghit);
 
     /// \cond CLASSIMP
     ClassDef(TGriffin,4)  // Griffin Physics structure

--- a/include/TLaBr.h
+++ b/include/TLaBr.h
@@ -35,12 +35,9 @@ class TLaBr : public TGRSIDetector {
       void Copy(TObject &rhs) const;
       TLaBrHit* GetLaBrHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fLaBrHits.size(); }	      //!<!
+      void AddFragment(TFragment *frag, TChannel *chan);
       
       static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; }	//!<!
-      
-     // void AddFragment(TFragment*, TChannel*); //!<!
-      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-      TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel* chan) { return new TLaBrHit(*frag); }
       
       TLaBr& operator=(const TLaBr&);  //!<!
       
@@ -53,9 +50,6 @@ class TLaBr : public TGRSIDetector {
    public:
       void Clear(Option_t *opt = "");		//!<!
       void Print(Option_t *opt = "") const;		//!<!
-      
-   protected:
-      void PushBackHit(TGRSIDetectorHit*);
       
       /// \cond CLASSIMP
       ClassDef(TLaBr,1)  // LaBr Physics structure

--- a/include/TLaBr.h
+++ b/include/TLaBr.h
@@ -38,8 +38,9 @@ class TLaBr : public TGRSIDetector {
       
       static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; }	//!<!
       
-      void AddFragment(TFragment*, TChannel*); //!<!
+     // void AddFragment(TFragment*, TChannel*); //!<!
       void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel* chan) { return new TLaBrHit(*frag); }
       
       TLaBr& operator=(const TLaBr&);  //!<!
       

--- a/include/TLaBrHit.h
+++ b/include/TLaBrHit.h
@@ -29,6 +29,7 @@ class TLaBrHit : public TGRSIDetectorHit {
       TLaBrHit();
       virtual ~TLaBrHit();
       TLaBrHit(const TLaBrHit&);
+      TLaBrHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
       
    private:
       Int_t    fFilter;

--- a/include/TPaces.h
+++ b/include/TPaces.h
@@ -27,12 +27,9 @@ class TPaces : public TGRSIDetector {
 		TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
 		Short_t GetMultiplicity() const { return fPacesHits.size(); }
 
+      void AddFragment(TFragment *frag, TChannel *chan);
 		static TVector3 GetPosition(int DetNbr);		//!<!
-		void AddFragment(TFragment*, TChannel*); //!<!
-		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-
-		TPaces& operator=(const TPaces&);  //!<! 
-
+		TPaces& operator=(const TPaces&);  //!<!
 
 	private: 
 		std::vector<TPacesHit> fPacesHits; //  The set of crystal hits
@@ -45,9 +42,6 @@ class TPaces : public TGRSIDetector {
 		virtual void Copy(TObject&) const;                //!<!
 		virtual void Clear(Option_t* opt = "all");		     //!<!
 		virtual void Print(Option_t* opt = "") const;		  //!<!
-
-	protected:
-		void PushBackHit(TGRSIDetectorHit* phit);
 
 /// \cond CLASSIMP
 		ClassDef(TPaces,4)  // Paces Physics structure

--- a/include/TPacesHit.h
+++ b/include/TPacesHit.h
@@ -19,6 +19,7 @@ class TPacesHit : public TGRSIDetectorHit {
 	public:
 		TPacesHit();
 		TPacesHit(const TPacesHit&);
+      TPacesHit(const TFragment& frag) : TGRSIDetectorHit(frag) {} 
 		virtual ~TPacesHit();
 
 	private:

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -31,7 +31,6 @@ class TS3 : public TGRSIDetector {
 		virtual  ~TS3();
 
 		virtual void AddFragment(TFragment*, TChannel*);
-		virtual void BuildHits();
 
 		Short_t GetRingMultiplicity() 	const { return fS3RingHits.size()		; }
 		Short_t GetSectorMultiplicity() const { return fS3SectorHits.size()	; }
@@ -43,7 +42,6 @@ class TS3 : public TGRSIDetector {
 		TGRSIDetectorHit* GetHit(const int& idx =0);
 		TS3Hit* GetS3Hit(const int& i);  
 		Short_t GetMultiplicity() const { return fS3Hits.size(); }
-		void PushBackHit(TGRSIDetectorHit* deshit);
 
 		bool MultiHit()										{ return TestBitNumber(kMultHit);	 } // Get allow shared hits
 		void SetMultiHit(bool flag=true)	{ SetBitNumber(kMultHit, flag); SetPixels(false);	 } // Set allow shared hits

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -38,9 +38,10 @@ class TSceptar : public TGRSIDetector {
       
       static TVector3 GetPosition(int DetNbr) { return gPaddlePosition[DetNbr]; }	//!<!
       
-      void AddFragment(TFragment*, TChannel*); //!<!
+    //  void AddFragment(TFragment*, TChannel*); //!<!
       void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-      
+      TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel* chan = 0) { return new TSceptarHit(*frag); }
+
       TSceptar& operator=(const TSceptar&);  //!<!
       
    private:

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -35,12 +35,9 @@ class TSceptar : public TGRSIDetector {
       void Copy(TObject &rhs) const;
       TSceptarHit* GetSceptarHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fSceptarHits.size(); }	      //!<!
-      
+      void AddFragment(TFragment* frag, TChannel *chan);
+
       static TVector3 GetPosition(int DetNbr) { return gPaddlePosition[DetNbr]; }	//!<!
-      
-    //  void AddFragment(TFragment*, TChannel*); //!<!
-      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-      TGRSIDetectorHit * CreateHit(TFragment* frag, TChannel* chan = 0) { return new TSceptarHit(*frag); }
 
       TSceptar& operator=(const TSceptar&);  //!<!
       
@@ -58,9 +55,6 @@ class TSceptar : public TGRSIDetector {
    public:
       void Clear(Option_t *opt = "");		//!<!
       void Print(Option_t *opt = "") const;		//!<!
-      
-   protected:
-      void PushBackHit(TGRSIDetectorHit*);
       
       /// \cond CLASSIMP
       ClassDef(TSceptar,2)  // Sceptar Physics structure

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -30,7 +30,7 @@ class TSceptarHit : public TGRSIDetectorHit {
       TSceptarHit();
       virtual ~TSceptarHit();
       TSceptarHit(const TSceptarHit&);
-      TSceptarHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
+      TSceptarHit(TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -30,6 +30,7 @@ class TSceptarHit : public TGRSIDetectorHit {
       TSceptarHit();
       virtual ~TSceptarHit();
       TSceptarHit(const TSceptarHit&);
+      TSceptarHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
       
    private:
       Int_t    fFilter;

--- a/include/TSharc.h
+++ b/include/TSharc.h
@@ -47,9 +47,6 @@ class TSharc : public TGRSIDetector  {
     void BuildHits();   //no need to build any hits, everything already done in AddFragment;  
     //we still need to build hits as one hit is composed of multiple fragments.  pcb.
 
-  protected:
-    void PushBackHit(TGRSIDetectorHit* sharcHit) { fSharcHits.push_back(*(static_cast<TSharcHit*>(sharcHit))); };
-
   private:
     std::vector <TSharcHit> fSharcHits;
     int  CombineHits(TSharcHit*,TSharcHit*,int,int);        //!<!

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -10,6 +10,7 @@
 
 #include "TGRSIDetector.h"
 #include "TSiLiHit.h"
+#include "TGRSIRunInfo.h"
 
 class TSiLi: public TGRSIDetector  {
 	public:
@@ -18,14 +19,12 @@ class TSiLi: public TGRSIDetector  {
 		virtual ~TSiLi();
 
 		void AddFragment(TFragment*, TChannel*);
-		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
 
 		TSiLi& operator=(const TSiLi&);  // 
 
 		void Copy(TObject&) const;
 		void Clear(Option_t *opt="");   
 		void Print(Option_t *opt="") const;
-		void PushBackHit(TGRSIDetectorHit* deshit);
 
 		Short_t GetMultiplicity() const { return fSiLiHits.size(); }
 		TGRSIDetectorHit* GetHit(const Int_t& idx =0);

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -36,8 +36,9 @@ class TTAC : public TGRSIDetector {
       TTACHit* GetTACHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fTACHits.size(); }	      //!<!
       
-      void AddFragment(TFragment*, TChannel*); //!<!
+     // void AddFragment(TFragment*, TChannel*); //!<!
       void BuildHits() {};  //no need to build any hits, everything already done in AddFragment
+      TGRSIDetectorHit * CreateHit(TFragment* frag,TChannel* chan = 0) { return new TTACHit(*frag); } 
       
       TTAC& operator=(const TTAC&);  //!<!
       

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -36,9 +36,7 @@ class TTAC : public TGRSIDetector {
       TTACHit* GetTACHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fTACHits.size(); }	      //!<!
       
-     // void AddFragment(TFragment*, TChannel*); //!<!
-      void BuildHits() {};  //no need to build any hits, everything already done in AddFragment
-      TGRSIDetectorHit * CreateHit(TFragment* frag,TChannel* chan = 0) { return new TTACHit(*frag); } 
+      void AddFragment(TFragment*, TChannel*); //!<!
       
       TTAC& operator=(const TTAC&);  //!<!
       
@@ -48,9 +46,6 @@ class TTAC : public TGRSIDetector {
    public:
       void Clear(Option_t *opt = "");		//!<!
       void Print(Option_t *opt = "") const;		//!<!
-      
-   protected:
-      void PushBackHit(TGRSIDetectorHit*);
       
       /// \cond CLASSIMP
       ClassDef(TTAC,1)  // TAC Physics structure

--- a/include/TTACHit.h
+++ b/include/TTACHit.h
@@ -29,7 +29,8 @@ class TTACHit : public TGRSIDetectorHit {
       TTACHit();
       virtual ~TTACHit();
       TTACHit(const TTACHit&);
-      
+      TTACHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
+
    private:
       Int_t    fFilter;
       

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -134,9 +134,6 @@ class TTigress : public TGRSIDetector {
     virtual void Print(Option_t *opt = "") const; //!<!
     virtual void Copy(TObject&) const;           //!<!
 
-  protected:
-    void PushBackHit(TGRSIDetectorHit* ghit);
-
 /// \cond CLASSIMP
     ClassDef(TTigress,7)  // Tigress Physics structure
 /// \endcond

--- a/include/TTip.h
+++ b/include/TTip.h
@@ -39,16 +39,12 @@ class TTip : public TGRSIDetector {
 		Short_t GetMultiplicity() const         {  return fTipHits.size();}  //!<!
 
 		void AddFragment(TFragment*, TChannel*); //!<!
-		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
 		void Copy(TObject &rhs) const;
 
 		TTip& operator=(const TTip&);  //!<!
 
 		void Clear(Option_t* opt = "");
 		void Print(Option_t* opt = "") const;
-
-	protected:
-		void PushBackHit(TGRSIDetectorHit* tiphit);
 
 	private:
 		std::vector <TTipHit> fTipHits;                                  //   The set of detector hits

--- a/include/TTriFoil.h
+++ b/include/TTriFoil.h
@@ -31,7 +31,6 @@ class TTriFoil :  public TDetector {
     time_t GetTimeStamp() const { return fTimestamp; }
 
     void AddFragment(TFragment*, TChannel*); //!<!
-    void BuildHits() {} //no need to build any hits, everything already done in AddFragment
 
     void Clear(Option_t* opt = "");   //!<!
     void Print(Option_t* opt = "") const;   //!<!

--- a/include/TZeroDegree.h
+++ b/include/TZeroDegree.h
@@ -38,9 +38,7 @@ class TZeroDegree : public TGRSIDetector {
       
       static TVector3 GetPosition(double dist) { return TVector3(0,0,dist); }	//!<!
       
-    //  void AddFragment(TFragment*, TChannel*); //!<!
-      void BuildHits() {} //no need to build any hits, everything already done in AddFragment
-      TGRSIDetectorHit * CreateHit(TFragment *frag, TChannel *chan =0 ) { return new TZeroDegreeHit(*frag); }
+      void AddFragment(TFragment*, TChannel*); //!<!
       
       TZeroDegree& operator=(const TZeroDegree&);  //!<!
       
@@ -55,9 +53,6 @@ class TZeroDegree : public TGRSIDetector {
    public:
       void Clear(Option_t *opt = "");		//!<!
       void Print(Option_t *opt = "") const;		//!<!
-      
-   protected:
-      void PushBackHit(TGRSIDetectorHit*);
       
       /// \cond CLASSIMP
       ClassDef(TZeroDegree,2)  // ZeroDegree Physics structure

--- a/include/TZeroDegree.h
+++ b/include/TZeroDegree.h
@@ -38,8 +38,9 @@ class TZeroDegree : public TGRSIDetector {
       
       static TVector3 GetPosition(double dist) { return TVector3(0,0,dist); }	//!<!
       
-      void AddFragment(TFragment*, TChannel*); //!<!
+    //  void AddFragment(TFragment*, TChannel*); //!<!
       void BuildHits() {} //no need to build any hits, everything already done in AddFragment
+      TGRSIDetectorHit * CreateHit(TFragment *frag, TChannel *chan =0 ) { return new TZeroDegreeHit(*frag); }
       
       TZeroDegree& operator=(const TZeroDegree&);  //!<!
       

--- a/include/TZeroDegreeHit.h
+++ b/include/TZeroDegreeHit.h
@@ -29,7 +29,7 @@ class TZeroDegreeHit : public TGRSIDetectorHit {
       TZeroDegreeHit();
       virtual ~TZeroDegreeHit();
       TZeroDegreeHit(const TZeroDegreeHit&);
-      TZeroDegreeHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
+      TZeroDegreeHit(TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/include/TZeroDegreeHit.h
+++ b/include/TZeroDegreeHit.h
@@ -29,6 +29,7 @@ class TZeroDegreeHit : public TGRSIDetectorHit {
       TZeroDegreeHit();
       virtual ~TZeroDegreeHit();
       TZeroDegreeHit(const TZeroDegreeHit&);
+      TZeroDegreeHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
       
    private:
       Int_t    fFilter;

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -165,72 +165,16 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
    return NULL;
 }
 
-void TDescant::PushBackHit(TGRSIDetectorHit *desHit) {
-//TODO: FIX THIS FOR WAVEFORMS 
-   fDescantHits.push_back(*static_cast<TDescantHit*>(desHit));
-}
-
-/*void TDescant::AddFragment(TFragment* frag, TChannel* chan) {
+void TDescant::AddFragment(TFragment* frag, TChannel* chan) {
    ///Builds the DESCANT Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    ///This is done for both DESCANT and it's suppressors.
    if(frag == NULL || chan == NULL) {
       return;
    }
    
-	TDescantHit hit;
-	hit.SetAddress(frag->GetAddress());
-	hit.SetTimeStamp(frag->GetTimeStamp());
-	hit.SetCfd(frag->GetCfd());
-	hit.SetCharge(frag->GetCharge());
-	hit.SetZc(frag->GetZc());
-	hit.SetCcShort(frag->GetCcShort());
-	hit.SetCcLong(frag->GetCcLong());
-      
-	//if(TDescant::SetWave()) {
-	if(TGRSIOptions::Get()->ExtractWaves()) {
-		if(frag->GetWaveform()->size() == 0) {
-			//printf("Warning, TDescant::SetWave() set, but data waveform size is zero!\n");
-		}
-		if(0) {
-			std::vector<Short_t> x;
-			//Need to reorder waveform data for S1507 data from December 2014
-			//All pairs of samples are swapped.
-			//The first two samples are also delayed by 8.
-			//We choose to throw out the first 2 samples (junk) and the last 6 samples (convience)
-			x = *(frag->GetWaveform());
-			size_t length = x.size() - (x.size()%8);
-			Short_t temp;
-            
-			if(length > 8) {
-				for(size_t i = 0; i < length-8; i+=8) {
-					x[i] = x[i+9];
-					x[i+1] = x[i+8];
-					temp = x[i+2];
-					x[i+2] = x[i+3];
-					x[i+3] = temp;
-					temp = x[i+4];
-					x[i+4] = x[i+5];
-					x[i+5] = temp;
-					temp = x[i+6];
-					x[i+6] = x[i+7];
-					x[i+7] = temp;
-				}
-				x.resize(length-8);
-			}
-			hit.SetWaveform(x);
-		} else {
-			frag->CopyWave(hit);
-		}
-		if(hit.GetWaveform()->size() > 0) {
-			//printf("Analyzing waveform, current cfd = %d, psd = %d\n",hit.GetCfd(),hit.GetPsd());
-			hit.AnalyzeWaveform();
-			//          bool analyzed = hit.AnalyzeWaveform();
-			//          printf("%s analyzed waveform, cfd = %d, psd = %d\n",analyzed ? "successfully":"unsuccessfully",hit.GetCfd(),hit.GetPsd());
-		}
-	}
-      
-	AddHit(&hit);
-}*/
+	TDescantHit hit(*frag);
+   fDescantHits.push_back(std::move(hit));    
+}
 
 TVector3 TDescant::GetPosition(int DetNbr, double dist) {
    //Gets the position vector for detector DetNbr

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -166,10 +166,11 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
 }
 
 void TDescant::PushBackHit(TGRSIDetectorHit *desHit) {
+//TODO: FIX THIS FOR WAVEFORMS 
    fDescantHits.push_back(*static_cast<TDescantHit*>(desHit));
 }
 
-void TDescant::AddFragment(TFragment* frag, TChannel* chan) {
+/*void TDescant::AddFragment(TFragment* frag, TChannel* chan) {
    ///Builds the DESCANT Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    ///This is done for both DESCANT and it's suppressors.
    if(frag == NULL || chan == NULL) {
@@ -229,7 +230,7 @@ void TDescant::AddFragment(TFragment* frag, TChannel* chan) {
 	}
       
 	AddHit(&hit);
-}
+}*/
 
 TVector3 TDescant::GetPosition(int DetNbr, double dist) {
    //Gets the position vector for detector DetNbr

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
@@ -47,7 +47,6 @@ void TGRSIDetector::Copy(TObject &rhs) const {
   //if(!rhs.InheritsFrom("TGRSIDetector"))
   //   return;
   TObject::Copy(rhs);
-  
 }
 
 
@@ -61,5 +60,9 @@ void TGRSIDetector::Clear(Option_t *opt) {
   //fMidasTimestamp = -1;
 }
 
+void TGRSIDetector::AddFragment(TFragment *frag, TChannel* chan){
+   TGRSIDetectorHit *hit = CreateHit(frag); //Creates a hit of the detector type.
+   PushBackHit(hit); //Calls the detector dependent push_back function. These are defined in the derived classes.
+}
 
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
@@ -36,13 +36,6 @@ TGRSIDetector::~TGRSIDetector() {
 //Default Destructor.
 }
 
-
-void TGRSIDetector::AddHit(TGRSIDetectorHit *hit,Option_t *opt) {
-   // hit->SetParent(this); 
-  PushBackHit(hit);
-  return;
-}
-
 void TGRSIDetector::Copy(TObject &rhs) const {
   //if(!rhs.InheritsFrom("TGRSIDetector"))
   //   return;
@@ -59,10 +52,4 @@ void TGRSIDetector::Clear(Option_t *opt) {
 // Default clear statement for TGRSIDetector. 
   //fMidasTimestamp = -1;
 }
-
-void TGRSIDetector::AddFragment(TFragment *frag, TChannel* chan){
-   TGRSIDetectorHit *hit = CreateHit(frag); //Creates a hit of the detector type.
-   PushBackHit(hit); //Calls the detector dependent push_back function. These are defined in the derived classes.
-}
-
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -259,12 +259,11 @@ bool TGRSIDetectorHit::CompareEnergy(TGRSIDetectorHit* lhs, TGRSIDetectorHit* rh
 }
 
 Long_t TGRSIDetectorHit::GetTimeStamp(Option_t* opt) const  { 
- /*  TChannel* tmpChan = GetChannel();
+   TChannel* tmpChan = GetChannel();
    if(!tmpChan){
-      return fTimeStamp - tmpChan->GetTimeOffset();   
+      return fTimeStamp;   
    }
-*/
-   return fTimeStamp;   
+   return fTimeStamp - tmpChan->GetTimeOffset();   
 }
 
 uint16_t TGRSIDetectorHit::GetPPGStatus() const {

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -130,7 +130,30 @@ TGriffin& TGriffin::operator=(const TGriffin& rhs) {
 }
 
 void TGriffin::PushBackHit(TGRSIDetectorHit *ghit){
-  fGriffinHits.push_back(*static_cast<TGriffinHit*>(ghit));
+  //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
+  //This is done for both GRIFFIN and it's suppressors.
+
+   //TODO: Maybe overload the the pushback function to push back into the appropriate vector
+ //  if(ghit->Class() == TGriffinHit::Class()){
+      //std::cout << ghit->Class() << " "  << TGriffinHit::Class() << std::endl; throw grsi::exit_exception(1);
+      fGriffinHits.push_back(*static_cast<TGriffinHit*>(ghit));
+  // }
+   /* if(chan->GetMnemonic()->outputsensor[0] == 'B') { return; }  //make this smarter.
+
+    TGriffinHit corehit(*frag);
+    //corehit.SetAddress(frag->GetAddress());
+    //corehit.SetTimeStamp(frag->GetTimeStamp());
+    //corehit.SetCfd(frag->GetCfd());
+    //corehit.SetCharge(frag->GetCharge());
+    //check if this is a fragment where we already pulled the pile-up hits apart
+    //if((frag->Charge.size() == 1) && (frag->NumberOfHits >= 0) && (frag->HitIndex >= 0)) {
+    //corehit.SetNPileUps(frag->NumberOfHits);//We subtract 1 in order to start counter from 0
+    //corehit.SetPUHit(frag->HitIndex);
+    AddHit(&corehit);
+    //}
+  } else if(chan->GetMnemonic()->subsystem[0] == 'S') {
+    //set BGO
+  }*/
 }
 
 
@@ -204,7 +227,7 @@ TGriffinHit* TGriffin::GetAddbackHit(const int& i) {
   }
 }
 
-void TGriffin::AddFragment(TFragment* frag, TChannel* chan) {
+/*void TGriffin::AddFragment(TFragment* frag, TChannel* chan) {
   //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
   //This is done for both GRIFFIN and it's suppressors.
   if(frag == NULL || chan == NULL) {
@@ -229,7 +252,7 @@ void TGriffin::AddFragment(TFragment* frag, TChannel* chan) {
   } else if(chan->GetMnemonic()->subsystem[0] == 'S') {
     //set BGO
   }
-}
+}*/
 
 TVector3 TGriffin::GetPosition(int DetNbr,int CryNbr, double dist ) {
   //Gets the position vector for a crystal specified by CryNbr within Clover DetNbr at a distance of dist mm away.

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -129,38 +129,10 @@ TGriffin& TGriffin::operator=(const TGriffin& rhs) {
   return *this;
 }
 
-void TGriffin::PushBackHit(TGRSIDetectorHit *ghit){
-  //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
-  //This is done for both GRIFFIN and it's suppressors.
-
-   //TODO: Maybe overload the the pushback function to push back into the appropriate vector
- //  if(ghit->Class() == TGriffinHit::Class()){
-      //std::cout << ghit->Class() << " "  << TGriffinHit::Class() << std::endl; throw grsi::exit_exception(1);
-      fGriffinHits.push_back(*static_cast<TGriffinHit*>(ghit));
-  // }
-   /* if(chan->GetMnemonic()->outputsensor[0] == 'B') { return; }  //make this smarter.
-
-    TGriffinHit corehit(*frag);
-    //corehit.SetAddress(frag->GetAddress());
-    //corehit.SetTimeStamp(frag->GetTimeStamp());
-    //corehit.SetCfd(frag->GetCfd());
-    //corehit.SetCharge(frag->GetCharge());
-    //check if this is a fragment where we already pulled the pile-up hits apart
-    //if((frag->Charge.size() == 1) && (frag->NumberOfHits >= 0) && (frag->HitIndex >= 0)) {
-    //corehit.SetNPileUps(frag->NumberOfHits);//We subtract 1 in order to start counter from 0
-    //corehit.SetPUHit(frag->HitIndex);
-    AddHit(&corehit);
-    //}
-  } else if(chan->GetMnemonic()->subsystem[0] == 'S') {
-    //set BGO
-  }*/
-}
-
 
 TGRSIDetectorHit* TGriffin::GetHit(const Int_t& idx) {
   return GetGriffinHit(idx);
 }
-
 
 TGriffinHit* TGriffin::GetGriffinHit(const int& i) {
   try {
@@ -227,32 +199,26 @@ TGriffinHit* TGriffin::GetAddbackHit(const int& i) {
   }
 }
 
-/*void TGriffin::AddFragment(TFragment* frag, TChannel* chan) {
+void TGriffin::AddFragment(TFragment* frag, TChannel* chan) {
   //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
   //This is done for both GRIFFIN and it's suppressors.
   if(frag == NULL || chan == NULL) {
     return;
   }
 
-  if(chan->GetMnemonic()->subsystem[0] == 'G') {
+  switch(chan->GetMnemonic()->SubSystem()){
+      case MNEMONIC::kG :
+         TGriffinHit geHit(*frag);
+         fGriffinHits.push_back(std::move(geHit));
+         break;
+ //     case MNEMONIC::kS :
+      //do supressor stuff
+   //      break;
+  };
+//  if(chan->GetMnemonic()->SubSystem() == MNEMONIC::kG ) {
     //set griffin
-    if(chan->GetMnemonic()->outputsensor[0] == 'B') { return; }  //make this smarter.
-
-    TGriffinHit corehit(*frag);
-    //corehit.SetAddress(frag->GetAddress());
-    //corehit.SetTimeStamp(frag->GetTimeStamp());
-    //corehit.SetCfd(frag->GetCfd());
-    //corehit.SetCharge(frag->GetCharge());
-    //check if this is a fragment where we already pulled the pile-up hits apart
-    //if((frag->Charge.size() == 1) && (frag->NumberOfHits >= 0) && (frag->HitIndex >= 0)) {
-    //corehit.SetNPileUps(frag->NumberOfHits);//We subtract 1 in order to start counter from 0
-    //corehit.SetPUHit(frag->HitIndex);
-    AddHit(&corehit);
-    //}
-  } else if(chan->GetMnemonic()->subsystem[0] == 'S') {
-    //set BGO
-  }
-}*/
+//    if(chan->GetMnemonic()->outputsensor[0] == 'B') { return; }  //make this smarter.
+}
 
 TVector3 TGriffin::GetPosition(int DetNbr,int CryNbr, double dist ) {
   //Gets the position vector for a crystal specified by CryNbr within Clover DetNbr at a distance of dist mm away.

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -27,8 +27,6 @@ TGriffinHit::TGriffinHit(const TFragment &frag) : TGRSIDetectorHit(frag) {
   SetNPileUps(frag.GetNumberOfPileups());
 }
 
-
-
 TGriffinHit::~TGriffinHit()  {	}
 
 void TGriffinHit::Copy(TObject &rhs) const {

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -67,29 +67,6 @@ void TLaBr::Print(Option_t *opt) const	{
    printf("%lu fLaBrHits\n",fLaBrHits.size());
 }
 
-void TLaBr::PushBackHit(TGRSIDetectorHit *laHit) {
-   //Adds a Hit to the list of TLaBr Hits
-   fLaBrHits.push_back(*(static_cast<TLaBrHit*>(laHit)));
-}
-
-/*void TLaBr::AddFragment(TFragment* frag, TChannel* chan) {
-   //Builds the LaBr Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
-   //This should be done for both LaBr and it's suppressors.
-   if(frag == NULL || chan == NULL) {
-      return;
-   }
-   
-   //   for(size_t i = 0; i < frag->Charge.size(); ++i) {
-   TLaBrHit hit;
-   hit.SetAddress(frag->GetAddress());
-   hit.SetTimeStamp(frag->GetTimeStamp());
-   hit.SetCfd(frag->GetCfd());
-   hit.SetCharge(frag->Charge());
-	hit.SetKValue(frag->GetKValue());
-      
-   AddHit(&hit);
-      //   }
-}*/
 
 TGRSIDetectorHit* TLaBr::GetHit(const Int_t& idx){
    //Gets the TLaBrHit at index idx.
@@ -105,4 +82,9 @@ TLaBrHit* TLaBr::GetLaBrHit(const int& i) {
       throw grsi::exit_exception(1);
    }
    return NULL;
+}
+
+void TLaBr::AddFragment(TFragment *frag, TChannel *chan) {
+   TLaBrHit laHit(*frag); //Building is controlled in the constructor of the hit
+   fLaBrHits.push_back(std::move(laHit)); //use std::move for efficienciy since laHit loses scope here anyway
 }

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -72,7 +72,7 @@ void TLaBr::PushBackHit(TGRSIDetectorHit *laHit) {
    fLaBrHits.push_back(*(static_cast<TLaBrHit*>(laHit)));
 }
 
-void TLaBr::AddFragment(TFragment* frag, TChannel* chan) {
+/*void TLaBr::AddFragment(TFragment* frag, TChannel* chan) {
    //Builds the LaBr Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    //This should be done for both LaBr and it's suppressors.
    if(frag == NULL || chan == NULL) {
@@ -89,7 +89,7 @@ void TLaBr::AddFragment(TFragment* frag, TChannel* chan) {
       
    AddHit(&hit);
       //   }
-}
+}*/
 
 TGRSIDetectorHit* TLaBr::GetHit(const Int_t& idx){
    //Gets the TLaBrHit at index idx.

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -63,8 +63,9 @@ TPaces& TPaces::operator=(const TPaces& rhs) {
 	return *this;
 }
 
-void TPaces::PushBackHit(TGRSIDetectorHit *pHit){
-   fPacesHits.push_back(*(static_cast<TPacesHit*>(pHit)));
+void TPaces::AddFragment(TFragment* frag, TChannel *chan){
+   TPacesHit hit(*frag);
+   fPacesHits.push_back(std::move(hit));
 }
 
 TGRSIDetectorHit* TPaces::GetHit(const Int_t& idx) {
@@ -79,24 +80,6 @@ TPacesHit* TPaces::GetPacesHit(const int& i) {
       throw grsi::exit_exception(1);
    }
    return NULL;
-}
-
-void TPaces::AddFragment(TFragment* frag, TChannel* chan) {
-  //Builds the PACES Hits directly from the TFragment. Basically, loops through the data for an event and sets observables. 
-  //This is done for both PACES and it's suppressors.
-	if(frag == NULL || chan == NULL) {
-		return;
-	}
-
-	//for(size_t i = 0; i < frag->Charge.size(); ++i) {
-	  TPacesHit hit;
-	  hit.SetAddress(frag->GetAddress());
-	  hit.SetTimeStamp(frag->GetTimeStamp());
-	  hit.SetCfd(frag->GetCfd());
-	  hit.SetCharge(frag->GetCharge());
-	  
-	  AddHit(&hit);
-	//}
 }
 
 TVector3 TPaces::GetPosition(int DetNbr) {

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -49,9 +49,44 @@ void TS3::AddFragment(TFragment* frag, TChannel* chan) {
 		return;
 	}
 
-	bool IsDownstream = false;		
+   TS3Hit dethit(*frag);
+
+	bool IsDownstream = false;	
+   //preferably channel would be pushed to the ctor as well and all of this would be done in the ctor
+   if(chan->GetMnemonic()->CollectedCharge() == MNEMONIC::kN){
+		dethit.SetRingNumber(*frag);
+		dethit.SetSectorNumber(0);
+		if(chan->GetMnemonic()->ArrayPosition() == 0 || chan->GetMnemonic()->ArrayPosition() == 2)
+			IsDownstream = true;
+		else if(chan->GetMnemonic()->ArrayPosition() == 1)
+			IsDownstream = false;
+		else
+			IsDownstream = true; // In case of incorrect value, we assume downstream
+		
+      dethit.SetIsDownstream(IsDownstream);
+		if(TGRSIRunInfo::IsWaveformFitting())	// Only fit waveforms for rings
+			dethit.SetWavefit(*frag);
+
+		fS3RingHits.push_back(std::move(dethit));
+   }
+   else {
+		dethit.SetRingNumber(0);
+		dethit.SetSectorNumber(*frag);
+		if(chan->GetMnemonic()->ArrayPosition() == 0 || chan->GetMnemonic()->ArrayPosition() == 2)
+			IsDownstream = true;
+		else if(chan->GetMnemonic()->ArrayPosition() == 1)
+			IsDownstream = false;
+		else
+			IsDownstream = true; // In case of incorrect value, we assume downstream
+		
+      dethit.SetIsDownstream(IsDownstream);
+		if(TGRSIRunInfo::IsWaveformFitting())	// Only fit waveforms for rings
+			dethit.SetWavefit(*frag);
+		
+      fS3SectorHits.push_back(std::move(dethit));
+	}	
+/*
 	if(chan->GetMnemonic()->collectedcharge.compare(0,1,"N")==0) { // ring	
-			TS3Hit dethit(*frag);
 			dethit.SetRingNumber(*frag);
 			dethit.SetSectorNumber(0);
 			if(chan->GetMnemonic()->arrayposition == 0 || chan->GetMnemonic()->arrayposition == 2)
@@ -65,7 +100,6 @@ void TS3::AddFragment(TFragment* frag, TChannel* chan) {
 				dethit.SetWavefit(*frag);
 			fS3RingHits.push_back(dethit);
 	} else {
-			TS3Hit dethit(*frag);
 			dethit.SetRingNumber(0);
 			dethit.SetSectorNumber(*frag);
 			if(chan->GetMnemonic()->arrayposition == 0 || chan->GetMnemonic()->arrayposition == 2)
@@ -78,7 +112,7 @@ void TS3::AddFragment(TFragment* frag, TChannel* chan) {
 			if(TGRSIRunInfo::IsWaveformFitting())	// Only fit waveforms for rings
 				dethit.SetWavefit(*frag);
 			fS3SectorHits.push_back(dethit);
-	}	
+	}	*/
 }
 
 void TS3::SetBitNumber(enum ES3Bits bit,Bool_t set){
@@ -87,9 +121,6 @@ void TS3::SetBitNumber(enum ES3Bits bit,Bool_t set){
     fS3Bits |= bit;
   else
     fS3Bits &= (~bit);
-}
-
-void TS3::BuildHits()  {
 }
 
 Int_t TS3::GetPixelMultiplicity(){
@@ -317,11 +348,11 @@ TS3Hit *TS3::GetS3Hit(const int& i) {
   }
 }  
 
-void TS3::PushBackHit(TGRSIDetectorHit *deshit) {
+/*void TS3::PushBackHit(TGRSIDetectorHit *deshit) {
   fS3Hits.push_back(*((TS3Hit*)deshit));
   return;
 }
-
+*/
 
 void TS3::Print(Option_t *opt) const {
    printf("%s\tnot yet written.\n",__PRETTY_FUNCTION__);

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -79,76 +79,15 @@ TSceptar& TSceptar::operator=(const TSceptar& rhs) {
    return *this;
 }
 
+void TSceptar::AddFragment(TFragment * frag, TChannel * chan){
+   TSceptarHit scHit(*frag);  //Construction of TSceptarHit is handled in the constructor
+   fSceptarHits.push_back(std::move(scHit)); //Can't use scHit outside of vector after using std::move
+}
+
 void TSceptar::Print(Option_t *opt) const	{
    //Prints out TSceptar Multiplicity, currently does little.
    printf("%lu fSceptarHits\n",fSceptarHits.size());
 }
-
-void TSceptar::PushBackHit(TGRSIDetectorHit *scHit) {
-   //Adds a Hit to the list of TSceptar Hits
-   
-   fSceptarHits.push_back(*(static_cast<TSceptarHit*>(scHit)));
-}
-/*
-void TSceptar::AddFragment(TFragment* frag, TChannel* chan) {
-   //Builds the SCEPTAR Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
-   //This is done for both SCEPTAR and it's suppressors.
-   if(frag == NULL || chan == NULL) {
-      return;
-   }
-   
-   //for(size_t i = 0; i < frag->Charge.size(); ++i) {
-      TSceptarHit hit;
-      hit.SetAddress(frag->GetAddress());
-      hit.SetTimeStamp(frag->GetTimeStamp());
-      hit.SetCfd(frag->GetCfd());
-      hit.SetCharge(frag->GetCharge());
-      
-      if(TSceptar::SetWave()){
-         if(frag->GetWaveform()->size() == 0) {
-            printf("Warning, TSceptar::SetWave() set, but data waveform size is zero!\n");
-         }
-         if(0) {
-            std::vector<Short_t> x;
-            //Need to reorder waveform data for S1507 data from December 2014
-            //All pairs of samples are swapped.
-            //The first two samples are also delayed by 8.
-            //We choose to throw out the first 2 samples (junk) and the last 6 samples (convience)
-            x = *(frag->GetWaveform());
-            size_t length = x.size() - (x.size()%8);
-            Short_t temp;
-            
-            if(length > 8) {
-               for(size_t i = 0; i < length-8; i+=8) {
-                  x[i] = x[i+9];
-                  x[i+1] = x[i+8];
-                  temp = x[i+2];
-                  x[i+2] = x[i+3];
-                  x[i+3] = temp;
-                  temp = x[i+4];
-                  x[i+4] = x[i+5];
-                  x[i+5] = temp;
-                  temp = x[i+6];
-                  x[i+6] = x[i+7];
-                  x[i+7] = temp;
-               }
-               x.resize(length-8);
-            }
-            hit.SetWaveform(x);
-         }
-         else {
-            hit.CopyWave(*frag);
-         }
-         if(hit.GetWaveform()->size() > 0) {
-            //            printf("Analyzing waveform, current cfd = %d\n",dethit.GetCfd());
-            hit.AnalyzeWaveform();
-            //            printf("%s analyzed waveform, cfd = %d\n",analyzed ? "successfully":"unsuccessfully",dethit.GetCfd());
-         }
-      }
-      
-      AddHit(&hit);
-   //}
-}*/
 
 TGRSIDetectorHit* TSceptar::GetHit(const Int_t& idx){
    //Gets the TSceptarHit at index idx.

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -86,9 +86,10 @@ void TSceptar::Print(Option_t *opt) const	{
 
 void TSceptar::PushBackHit(TGRSIDetectorHit *scHit) {
    //Adds a Hit to the list of TSceptar Hits
+   
    fSceptarHits.push_back(*(static_cast<TSceptarHit*>(scHit)));
 }
-
+/*
 void TSceptar::AddFragment(TFragment* frag, TChannel* chan) {
    //Builds the SCEPTAR Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    //This is done for both SCEPTAR and it's suppressors.
@@ -147,7 +148,7 @@ void TSceptar::AddFragment(TFragment* frag, TChannel* chan) {
       
       AddHit(&hit);
    //}
-}
+}*/
 
 TGRSIDetectorHit* TSceptar::GetHit(const Int_t& idx){
    //Gets the TSceptarHit at index idx.

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
@@ -31,6 +31,50 @@ TSceptarHit::TSceptarHit(const TSceptarHit &rhs) : TGRSIDetectorHit() {
    rhs.Copy(*this);
 }
 
+TSceptarHit::TSceptarHit(TFragment& frag) : TGRSIDetectorHit(frag){
+      if(TSceptar::SetWave()){
+         if(frag.GetWaveform()->size() == 0) {
+            printf("Warning, TSceptar::SetWave() set, but data waveform size is zero!\n");
+         }
+         if(0) {
+            std::vector<Short_t> x;
+            //Need to reorder waveform data for S1507 data from December 2014
+            //All pairs of samples are swapped.
+            //The first two samples are also delayed by 8.
+            //We choose to throw out the first 2 samples (junk) and the last 6 samples (convience)
+            x = *(frag.GetWaveform());
+            size_t length = x.size() - (x.size()%8);
+            Short_t temp;
+            
+            if(length > 8) {
+               for(size_t i = 0; i < length-8; i+=8) {
+                  x[i] = x[i+9];
+                  x[i+1] = x[i+8];
+                  temp = x[i+2];
+                  x[i+2] = x[i+3];
+                  x[i+3] = temp;
+                  temp = x[i+4];
+                  x[i+4] = x[i+5];
+                  x[i+5] = temp;
+                  temp = x[i+6];
+                  x[i+6] = x[i+7];
+                  x[i+7] = temp;
+               }
+               x.resize(length-8);
+            }
+            this->SetWaveform(x);
+         }
+         else {
+            this->CopyWave(frag);
+         }
+         if(this->GetWaveform()->size() > 0) {
+            //            printf("Analyzing waveform, current cfd = %d\n",dethit.GetCfd());
+            this->AnalyzeWaveform();
+            //            printf("%s analyzed waveform, cfd = %d\n",analyzed ? "successfully":"unsuccessfully",dethit.GetCfd());
+         }
+      }
+}
+
 void TSceptarHit::Copy(TObject &rhs) const {
    //Copies a TSceptarHit
    TGRSIDetectorHit::Copy(rhs);

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -91,20 +91,23 @@ void TSharc::AddFragment(TFragment* frag, TChannel* chan) {
     SetMidasTimestamp(frag->GetMidasTimeStamp());
   }
 */
-  if(chan->GetMnemonic()->arraysubposition.compare(0,1,"D") == 0) {
-    if(chan->GetMnemonic()->collectedcharge.compare(0,1,"P") == 0) {
-      
+  switch(chan->GetMnemonic()->ArraySubPosition()){
+      case MNEMONIC::kD :
+         if(chan->GetMnemonic()->CollectedCharge() == MNEMONIC::kP){
+            fFrontFragments.push_back(*frag);
+         }
+         else {
+            fBackFragments.push_back(*frag);
+         }
+         break;
+      case MNEMONIC::kE :
+         fPadFragments.push_back(*frag);
+         break;
+  };
+
       // if(frag->GetDetector()==11 && frag->GetSegment()==16)
       //   return;
       //printf("FRONT:  %s\n",frag->GetName());
-      fFrontFragments.push_back(*frag);
-    } else {
-      //printf("BACK:  %s\n",frag->GetName());
-      fBackFragments.push_back(*frag);
-    }
-  } else if(chan->GetMnemonic()->arraysubposition.compare(0,1,"E") == 0) {
-    fPadFragments.push_back(*frag);
-  }
 }
 
 
@@ -134,7 +137,7 @@ void TSharc::BuildHits() {
       TSharcHit hit;
       hit.SetFront(*front);
       hit.SetBack(*back);
-      fSharcHits.push_back(hit);
+      fSharcHits.push_back(hit);//TODO: consider using std::move here
       front = fFrontFragments.erase(front);
       back  = fBackFragments.erase(back);
     } else {

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -51,22 +51,13 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
    return 0;
 }  
 
-void TSiLi::PushBackHit(TGRSIDetectorHit *deshit) {
-  fSiLiHits.push_back(*((TSiLiHit*)deshit));
-  return;
-}
-
 void TSiLi::AddFragment(TFragment* frag, TChannel* chan) {
   if(frag == NULL || chan == NULL) {
 	 return;
   }
 
-  TSiLiHit hit(*frag);
-  
-  if(TGRSIRunInfo::IsWaveformFitting())
-	  hit.SetWavefit(*frag);
-    
-  fSiLiHits.push_back(hit);
+  TSiLiHit hit(*frag);//Waveform fitting happens in ctor now
+  fSiLiHits.push_back(std::move(hit));
 }
 
 TVector3 TSiLi::GetPosition(int seg)  {

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
@@ -8,6 +8,10 @@ ClassImp(TSiLiHit)
 TSiLiHit::TSiLiHit()  {    Clear(); }
 
 TSiLiHit::TSiLiHit(TFragment &frag)	: TGRSIDetectorHit(frag) {
+  
+  if(TGRSIRunInfo::IsWaveformFitting())
+	  SetWavefit(frag);
+    
 }
 
 TSiLiHit::~TSiLiHit()  {  }

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -53,10 +53,11 @@ void TTAC::Print(Option_t *opt) const	{
    printf("%lu fTACHits\n",fTACHits.size());
 }
 
-void TTAC::PushBackHit(TGRSIDetectorHit *laHit) {
-   //Adds a Hit to the list of TTAC Hit
-   fTACHits.push_back(*(static_cast<TTACHit*>(laHit)));
+void TTAC::AddFragment(TFragment* frag, TChannel* chan) {
+   TTACHit hit(*frag);
+   fTACHits.push_back(std::move(hit));
 }
+
 /*
 void TTAC::AddFragment(TFragment* frag, TChannel* chan) {
    //Builds the TAC Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -54,10 +54,10 @@ void TTAC::Print(Option_t *opt) const	{
 }
 
 void TTAC::PushBackHit(TGRSIDetectorHit *laHit) {
-   //Adds a Hit to the list of TTAC Hits
+   //Adds a Hit to the list of TTAC Hit
    fTACHits.push_back(*(static_cast<TTACHit*>(laHit)));
 }
-
+/*
 void TTAC::AddFragment(TFragment* frag, TChannel* chan) {
    //Builds the TAC Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    //This should be done for both TAC and it's suppressors.
@@ -75,7 +75,7 @@ void TTAC::AddFragment(TFragment* frag, TChannel* chan) {
    AddHit(&hit);
       //   }
 }
-
+*/
 TGRSIDetectorHit* TTAC::GetHit(const Int_t& idx){
    //Gets the TTACHit at index idx.
    return GetTACHit(idx);

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -97,10 +97,6 @@ TTigress& TTigress::operator=(const TTigress& rhs) {
   return *this;
 }
 
-void TTigress::PushBackHit(TGRSIDetectorHit *ghit){
-  fTigressHits.push_back(*static_cast<TTigressHit*>(ghit));
-}
-
 //TTigressHit &TTigress::GetTigressHit(int i) {
   /*
   try {

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -45,14 +45,8 @@ void TTip::AddFragment(TFragment* frag, TChannel* chan) {
 	}
 
   TTipHit dethit(*frag);
-  dethit.SetUpNumbering(chan);
-
-  if(TGRSIRunInfo::IsWaveformFitting() && !dethit.IsCsI())
-		dethit.SetWavefit(*frag);
-  else if(TGRSIRunInfo::IsWaveformFitting() && dethit.IsCsI()) 	   
-		dethit.SetPID(*frag);
-
-  fTipHits.push_back(dethit);
+  dethit.SetUpNumbering(chan); //Think about moving this to ctor
+  fTipHits.push_back(std::move(dethit)); //Once we are done with it we can move the memory
 }
 
 void TTip::Print(Option_t *opt) const {
@@ -74,7 +68,3 @@ TTipHit* TTip::GetTipHit(const int& i) {
    return 0;
 }
 
-void TTip::PushBackHit(TGRSIDetectorHit *tiphit) {
-  fTipHits.push_back(*(static_cast<TTipHit*>(tiphit)));
-  return;
-}

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -1,5 +1,6 @@
 #include "TTip.h"
 #include "TTipHit.h"
+#include "TGRSIRunInfo.h"
 
 ////////////////////////////////////////////////////////////
 //                    
@@ -21,6 +22,10 @@ TTipHit::TTipHit() {
 
 TTipHit::TTipHit(TFragment &frag)	: TGRSIDetectorHit(frag) {
 	//SetVariables(frag);
+  if(TGRSIRunInfo::IsWaveformFitting() && !IsCsI())
+		SetWavefit(frag);
+  else if(TGRSIRunInfo::IsWaveformFitting() && IsCsI()) 	   
+		SetPID(frag);
 }
 
 TTipHit::~TTipHit() { }

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -59,37 +59,15 @@ void TZeroDegree::Print(Option_t *opt) const	{
    printf("%lu fZeroDegreeHits\n",fZeroDegreeHits.size());
 }
 
-void TZeroDegree::PushBackHit(TGRSIDetectorHit *scHit) {
-   ///Adds a Hit to the list of TZeroDegree Hits
-   fZeroDegreeHits.push_back(*(static_cast<TZeroDegreeHit*>(scHit)));
-}
-
-/*void TZeroDegree::AddFragment(TFragment* frag, TChannel* chan) {
+void TZeroDegree::AddFragment(TFragment* frag, TChannel* chan) {
    ///Builds the ZDS Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    if(frag == NULL || chan == NULL) {
       return;
    }
    
-	TZeroDegreeHit hit;
-	hit.SetAddress(frag->GetAddress());
-	hit.SetTimeStamp(frag->GetTimeStamp());
-	hit.SetCfd(frag->GetCfd());
-	hit.SetCharge(frag->GetCharge());
-      
-	//if(TZeroDegree::SetWave()){
-	if(TGRSIOptions::Get()->ExtractWaves()) {
-		if(frag->GetWaveform()->size() == 0) {
-			printf("Warning, TZeroDegree::SetWave() set, but data waveform size is zero!\n");
-		} else {
-			frag->CopyWave(hit);
-		}
-		if(hit.GetWaveform()->size() > 0) {
-			hit.AnalyzeWaveform();
-		}
-	}
-      
-	AddHit(&hit);
-}*/
+	TZeroDegreeHit hit(*frag);
+   fZeroDegreeHits.push_back(std::move(hit));
+}
 
 TGRSIDetectorHit* TZeroDegree::GetHit(const Int_t& idx){
    //Gets the TZeroDegreeHit at index idx.

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -64,7 +64,7 @@ void TZeroDegree::PushBackHit(TGRSIDetectorHit *scHit) {
    fZeroDegreeHits.push_back(*(static_cast<TZeroDegreeHit*>(scHit)));
 }
 
-void TZeroDegree::AddFragment(TFragment* frag, TChannel* chan) {
+/*void TZeroDegree::AddFragment(TFragment* frag, TChannel* chan) {
    ///Builds the ZDS Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    if(frag == NULL || chan == NULL) {
       return;
@@ -89,7 +89,7 @@ void TZeroDegree::AddFragment(TFragment* frag, TChannel* chan) {
 	}
       
 	AddHit(&hit);
-}
+}*/
 
 TGRSIDetectorHit* TZeroDegree::GetHit(const Int_t& idx){
    //Gets the TZeroDegreeHit at index idx.

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
@@ -23,6 +23,19 @@ TZeroDegreeHit::TZeroDegreeHit()	{
 
 TZeroDegreeHit::~TZeroDegreeHit()	{	}
 
+TZeroDegreeHit::TZeroDegreeHit(TFragment &frag) : TGRSIDetectorHit(frag) {
+	if(TGRSIOptions::Get()->ExtractWaves()) {
+		if(frag.GetWaveform()->size() == 0) {
+			printf("Warning, TZeroDegree::SetWave() set, but data waveform size is zero!\n");
+		} else {
+			frag.CopyWave(*this);
+		}
+		if(GetWaveform()->size() > 0) {
+			AnalyzeWaveform();
+		}
+	}
+}
+
 TZeroDegreeHit::TZeroDegreeHit(const TZeroDegreeHit &rhs) : TGRSIDetectorHit() {
    //Copy Constructor
 #if MAJOR_ROOT_VERSION < 6

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -226,6 +226,10 @@ void TGRSIOptions::Load(int argc, char** argv) {
   // parser.option("time-sort-depth",&fTimeSortDepth)
   //   .description("Number of events to hold when time sorting")
   //   .default_value(100000);
+  parser.option("addback-window", &fAddbackWindow)
+     .description("Addback window, time in ns")
+     .default_value(300);
+     
   parser.option("build-window", &fBuildWindow)
      .description("Build window, timestamp units")
      .default_value(200);


### PR DESCRIPTION
- Made all TGRSIDetectors use a ctor with fragment argument. 
- I didn't touch Tigress because I didn't want to mess it up. 
- I also removed PushBackHit functions, BuildHits when unnecessary. 
- When moving the temporary hit into the hit vector I have also used std::move as it is more efficient in this scenario. 
- TimeStamp offsets work now.
- Would like the hit constructors to do the bulk of the work and let the derived TGRSIDetectors be more simple at the AddFragment point. This would allow base TGRSIDetector to more of the heavy lifting, and make these detectors easier to maintain.