### PR TITLE
Changed Queues from 'TFragment' to 'const TFragment'

### DIFF
--- a/histos/MakeGriffinFragmentHistograms.cxx
+++ b/histos/MakeGriffinFragmentHistograms.cxx
@@ -7,7 +7,7 @@
 
 extern "C"
 void MakeFragmentHistograms(TRuntimeObjects& obj) {
-  std::shared_ptr<TFragment> frag = obj.GetFragment();
+  std::shared_ptr<const TFragment> frag = obj.GetFragment();
   TChannel* chan = frag->GetChannel();
 
 

--- a/histos/MakeTigressHistograms.cxx
+++ b/histos/MakeTigressHistograms.cxx
@@ -12,7 +12,7 @@ TCutG *tita = 0;
 
 extern "C"
 void MakeFragmentHistograms(TRuntimeObjects& obj) {
-  std::shared_ptr<TFragment> frag = obj.GetFragment();
+  std::shared_ptr<const TFragment> frag = obj.GetFragment();
   TChannel* chan = frag->GetChannel();
 
   if(!prot) {
@@ -25,7 +25,7 @@ void MakeFragmentHistograms(TRuntimeObjects& obj) {
     current->cd();
     printf("LOADED CUTS!\n"); fflush(stdout);
   }
-  static long first_timestamp = 0;
+  //static long first_timestamp = 0;
   if(frag && chan) {
  /*   if(!first_timestamp) {
       first_timestamp = frag->GetMidasTimeStamp();
@@ -80,7 +80,7 @@ void MakeAnalysisHistograms(TRuntimeObjects& obj) {
   std::shared_ptr<TTigress> tigress = obj.GetDetector<TTigress>();
   std::shared_ptr<TTriFoil> tf = obj.GetDetector<TTriFoil>();
 
-  static long first_ana_timestamp = 0;
+  //static long first_ana_timestamp = 0;
 
   if(tf) {
     for(int x=0; x<tf->NTBeam();x++) {

--- a/include/TCSM.h
+++ b/include/TCSM.h
@@ -42,7 +42,7 @@ class TCSM : public TDetector {
 		static TVector3 GetPosition(int detector, char pos, int horizontalstrip, int verticalstrip, double X=0.00, double Y=0.00, double Z=0.00);
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 		void BuildHits();
 

--- a/include/TCompiledHistograms.h
+++ b/include/TCompiledHistograms.h
@@ -25,7 +25,7 @@ public:
 
   void Load(std::string libname, std::string func_name);
 #ifndef __CINT__
-  void Fill(std::shared_ptr<TFragment> fragment);
+  void Fill(std::shared_ptr<const TFragment> fragment);
   void Fill(std::shared_ptr<TUnpackedEvent> unpacked);
 #endif
   void Reload();

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -51,18 +51,16 @@ public:
   enum EBank { kWFDN=0,kGRF1=1,kGRF2=2,kGRF3=3,kGRF4=4,kFME0=5,kFME1=6,kFME2=7,kFME3=8 };
 
 #ifndef __CINT__
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >&
+  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&
   AddGoodOutputQueue(size_t maxSize = 50000) { 
 	  std::stringstream name; name<<"good_frag_queue_"<<fGoodOutputQueues.size();
-     fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment> > >(name.str(), maxSize));
+     fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >(name.str(), maxSize));
      return fGoodOutputQueues.back(); 
   }
 
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >&
-  BadOutputQueue() { return fBadOutputQueue; }
+  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& BadOutputQueue() { return fBadOutputQueue; }
 
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >&
-  ScalerOutputQueue() { return fScalerOutputQueue; }
+  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerOutputQueue() { return fScalerOutputQueue; }
 #endif
   void ClearQueue();
   size_t ItemsPushed() { if(fGoodOutputQueues.size() > 0) return fGoodOutputQueues.back()->ItemsPushed(); return std::numeric_limits<std::size_t>::max(); }
@@ -70,8 +68,8 @@ public:
 
 private:
 #ifndef __CINT__
-  std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > > fGoodOutputQueues;
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fBadOutputQueue;
+  std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fGoodOutputQueues;
+  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fBadOutputQueue;
   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > > fScalerOutputQueue;
 #endif
 
@@ -91,8 +89,8 @@ private:
 
 public:
 #ifndef __CINT__
-  void Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > >& queue, std::shared_ptr<TFragment> frag);
-  void Push(ThreadsafeQueue<std::shared_ptr<TFragment> >& queue, std::shared_ptr<TFragment> frag);
+  void Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& queue, std::shared_ptr<TFragment> frag);
+  void Push(ThreadsafeQueue<std::shared_ptr<const TFragment> >& queue, std::shared_ptr<TFragment> frag);
 #endif
 
   int TigressDataToFragment(uint32_t *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
@@ -110,8 +108,8 @@ public:
 private:
   //utility
 #ifndef __CINT__
-  void DeleteAll(std::vector<std::shared_ptr<TFragment> >*);
-  void GRIFNormalizeFrags(std::vector<std::shared_ptr<TFragment> > *Frags);
+  void DeleteAll(std::vector<std::shared_ptr<const TFragment> >*);
+  void GRIFNormalizeFrags(std::vector<std::shared_ptr<const TFragment> > *Frags);
 #endif
 
 private:

--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -39,8 +39,8 @@ class TDescant : public TGRSIDetector {
       static TVector3 GetPosition(int DetNbr, double dist=222);	//!<!
       
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
-      TGRSIDetectorHit* CreateHit(std::shared_ptr<TFragment> frag, TChannel *chan) { return new TDescantHit(*frag); }
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
+      TGRSIDetectorHit* CreateHit(std::shared_ptr<const TFragment> frag, TChannel *chan) { return new TDescantHit(*frag); }
 #endif
 
       TDescant& operator=(const TDescant&);  //

--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -21,7 +21,7 @@ class TDescantHit : public TGRSIDetectorHit {
       TDescantHit();
       virtual ~TDescantHit();
       TDescantHit(const TDescantHit&);
-      TDescantHit(TFragment& frag);
+      TDescantHit(const TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/include/TDetBuildingLoop.h
+++ b/include/TDetBuildingLoop.h
@@ -23,7 +23,7 @@ class TDetBuildingLoop : public StoppableThread {
 		virtual ~TDetBuildingLoop();
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment> > > >& InputQueue() { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > >& InputQueue() { return fInputQueue; }
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > >& AddOutputQueue(size_t maxSize = 50000) {
 			std::stringstream name; name<<"event_queue_"<<fOutputQueues.size();
 			fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > >(name.str(), maxSize));
@@ -45,7 +45,7 @@ class TDetBuildingLoop : public StoppableThread {
 		TDetBuildingLoop& operator=(const TDetBuildingLoop& other);
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment> > > > fInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > > fInputQueue;
 		std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > > > fOutputQueues;
 #endif
 

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -45,7 +45,7 @@ class TDetector : public TObject	{
 	public: 
 		virtual void BuildHits()                                        { AbstractMethod("BuildHits()"); } //!<!
 #ifndef __CINT__
-		virtual void AddFragment(std::shared_ptr<TFragment>, TChannel*) { AbstractMethod("AddFragment()"); } //!<!
+		virtual void AddFragment(std::shared_ptr<const TFragment>, TChannel*) { AbstractMethod("AddFragment()"); } //!<!
 #endif
 
 		virtual void Copy(TObject&) const;              //!<!

--- a/include/TEventBuildingLoop.h
+++ b/include/TEventBuildingLoop.h
@@ -22,8 +22,8 @@ class TEventBuildingLoop : public StoppableThread {
 		virtual ~TEventBuildingLoop();
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& InputQueue() { return fInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment> > > >& OutputQueue() { return fOutputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& InputQueue() { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > >& OutputQueue() { return fOutputQueue; }
 #endif
 
 		bool Iteration();
@@ -48,12 +48,12 @@ class TEventBuildingLoop : public StoppableThread {
 		TEventBuildingLoop& operator=(const TEventBuildingLoop& other);
 
 #ifndef __CINT__
-		void CheckBuildCondition(std::shared_ptr<TFragment>);
-		void CheckTimestampCondition(std::shared_ptr<TFragment>);
-		void CheckTriggerIdCondition(std::shared_ptr<TFragment>);
+		void CheckBuildCondition(std::shared_ptr<const TFragment>);
+		void CheckTimestampCondition(std::shared_ptr<const TFragment>);
+		void CheckTriggerIdCondition(std::shared_ptr<const TFragment>);
 
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fInputQueue;
-		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment> > > > fOutputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > > fOutputQueue;
 #endif
 
 		EBuildMode fBuildMode;
@@ -62,10 +62,10 @@ class TEventBuildingLoop : public StoppableThread {
 		bool fPreviousSortingDepthError;
 
 #ifndef __CINT__
-		std::vector<std::shared_ptr<TFragment> > fNextEvent;
+		std::vector<std::shared_ptr<const TFragment> > fNextEvent;
 
-		std::multiset<std::shared_ptr<TFragment>,
-			std::function<bool(std::shared_ptr<TFragment>,std::shared_ptr<TFragment>)> > fOrdered;
+		std::multiset<std::shared_ptr<const TFragment>,
+			std::function<bool(std::shared_ptr<const TFragment>, std::shared_ptr<const TFragment>)> > fOrdered;
 #endif
 
 		ClassDef(TEventBuildingLoop, 0);

--- a/include/TFragHistLoop.h
+++ b/include/TFragHistLoop.h
@@ -16,7 +16,7 @@ class TFragHistLoop : public StoppableThread {
 		~TFragHistLoop();
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& InputQueue() { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& InputQueue() { return fInputQueue; }
 #endif
 
 		void SetOutputFilename(const std::string& name);
@@ -55,7 +55,7 @@ class TFragHistLoop : public StoppableThread {
 		std::string fOutputFilename;
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fInputQueue;
 #endif
 
 		ClassDef(TFragHistLoop,0);

--- a/include/TFragWriteLoop.h
+++ b/include/TFragWriteLoop.h
@@ -18,10 +18,10 @@ class TFragWriteLoop : public StoppableThread {
 		virtual ~TFragWriteLoop();
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& InputQueue() { return fInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& BadInputQueue() { return fBadInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerInputQueue() { return fScalerInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& OutputQueue() { return fOutputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& InputQueue()    { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& BadInputQueue() { return fBadInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerInputQueue()   { return fScalerInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& OutputQueue()   { return fOutputQueue; }
 #endif
 
 		virtual void ClearQueue();
@@ -43,8 +43,8 @@ class TFragWriteLoop : public StoppableThread {
 	private:
 		TFragWriteLoop(std::string name, std::string outputFile);
 #ifndef __CINT__
-		void WriteEvent(std::shared_ptr<TFragment> event);
-		void WriteBadEvent(std::shared_ptr<TFragment> event);
+		void WriteEvent(std::shared_ptr<const TFragment> event);
+		void WriteBadEvent(std::shared_ptr<const TFragment> event);
 		void WriteScaler(std::shared_ptr<TEpicsFrag> scaler);
 #endif
 
@@ -54,15 +54,15 @@ class TFragWriteLoop : public StoppableThread {
 		TTree* fBadEventTree;
 		TTree* fScalerTree;
 
-		TFragment*  fEventAddress;
-		TFragment*  fBadEventAddress;
+		const TFragment*  fEventAddress;
+		const TFragment*  fBadEventAddress;
 		TEpicsFrag* fScalerAddress;
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fInputQueue;
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fBadInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fBadInputQueue;
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > > fScalerInputQueue;
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > fOutputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fOutputQueue;
 #endif
 
 		ClassDef(TFragWriteLoop, 0);

--- a/include/TFragmentChainLoop.h
+++ b/include/TFragmentChainLoop.h
@@ -22,8 +22,8 @@ class TFragmentChainLoop : public StoppableThread {
 		virtual ~TFragmentChainLoop();
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& AddOutputQueue() { 
-			fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment> > >());
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& AddOutputQueue() { 
+			fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >());
 			return fOutputQueues.back(); 
 		}
 #endif
@@ -51,8 +51,8 @@ class TFragmentChainLoop : public StoppableThread {
 
 		TChain *fInputChain;
 #ifndef __CINT__
-		std::shared_ptr<TFragment> fFragment;
-		std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > > fOutputQueues;
+		std::shared_ptr<const TFragment> fFragment;
+		std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fOutputQueues;
 #endif
 
 		bool fSelfStopping;

--- a/include/TFragmentMap.h
+++ b/include/TFragmentMap.h
@@ -26,8 +26,8 @@
 
 class TFragmentMap {
    public:
-      TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > >& goodOutputQueue,
-            std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& badOutputQueue);
+      TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& goodOutputQueue,
+            std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& badOutputQueue);
 
       ~TFragmentMap() {};
 #ifndef __CINT__
@@ -40,8 +40,8 @@ class TFragmentMap {
       void Solve(std::vector<std::shared_ptr<TFragment> >, std::vector<Float_t>, std::vector<Long_t>, int situation = -1);
 
       std::multimap<UInt_t, std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t> > > fMap;
-      std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > >& fGoodOutputQueue;
-      std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& fBadOutputQueue;
+      std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& fGoodOutputQueue;
+      std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& fBadOutputQueue;
 #endif
 };
 /*! @} */

--- a/include/TGRSIDetector.h
+++ b/include/TGRSIDetector.h
@@ -38,7 +38,7 @@ class TGRSIDetector : public TDetector	{
    public: 
       //virtual TGRSIDetectorHit* GetHit(const Int_t idx = 0) { AbstractMethod("GetHit()"); return 0;}
 #ifndef __CINT__
-      virtual void AddFragment(std::shared_ptr<TFragment>, TChannel*) { AbstractMethod("AddFragment()"); } //!<!
+      virtual void AddFragment(std::shared_ptr<const TFragment>, TChannel*) { AbstractMethod("AddFragment()"); } //!<!
 #endif
       virtual void BuildHits() {}
 
@@ -55,7 +55,7 @@ class TGRSIDetector : public TDetector	{
 
    protected:
 #ifndef __CINT__
-      void CopyFragment(std::shared_ptr<TFragment> frag);
+      //void CopyFragment(std::shared_ptr<const TFragment> frag); //not implemented anywhere???
 #endif
    private:
 

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -110,6 +110,7 @@ class TGRSIDetectorHit : public TObject 	{
       void SetCharge(const Int_t& temp_charge)          { fCharge = temp_charge + gRandom->Uniform(); }   //!<!
       virtual void SetCfd(const Int_t& x)               { fCfd    = x; }             //!<!
       void SetWaveform(const std::vector<Short_t>& x)   { fWaveform = x; }           //!<!
+      void AddWaveformSample(const Short_t& x)                 { fWaveform.push_back(x); }  //!<!
       virtual void SetTimeStamp(const Long_t& x)        { fTimeStamp   = x; }        //!<! 
       virtual void AppendTimeStamp(const Long_t& x)     { fTimeStamp   += x; }       //!<! 
 
@@ -122,13 +123,19 @@ class TGRSIDetectorHit : public TObject 	{
       virtual Long_t GetTimeStamp(Option_t* opt="") const;
       Long_t GetRawTimeStamp(Option_t* opt="") const { return fTimeStamp; }
       virtual Double_t GetTime(const UInt_t& correct_flag = kAll, Option_t* opt = "")   const;  ///< Returns a time value to the nearest nanosecond!
-      virtual Int_t   GetCfd()    const      { return fCfd;}                 //!<!
-      virtual UInt_t GetAddress() const      { return fAddress; }            //!<!
-      virtual Int_t  GetCharge()  const      ;                               //!<!
-      virtual Float_t Charge()    const      { return fCharge; }             //!<!
-      virtual Short_t GetKValue() const      { return fKValue; }             //!<!
-      TChannel* GetChannel()      const      { if(!IsChannelSet()) { fChannel = TChannel::GetChannel(fAddress); SetBit(kIsChannelSet, true); } return fChannel; }  //!<!
-      std::vector<Short_t>* GetWaveform()    { return &fWaveform; }          //!<!
+      virtual Int_t   GetCfd()    const               { return fCfd;}                 //!<!
+      virtual UInt_t GetAddress() const               { return fAddress; }            //!<!
+      virtual Int_t  GetCharge()  const;                                              //!<!
+      virtual Float_t Charge()    const               { return fCharge; }             //!<!
+      virtual Short_t GetKValue() const               { return fKValue; }             //!<!
+      const std::vector<Short_t>* GetWaveform() const { return &fWaveform; }          //!<!
+      TChannel* GetChannel()      const               { 
+			if(!IsChannelSet()) { 
+				fChannel = TChannel::GetChannel(fAddress); 
+				SetBit(kIsChannelSet, true); 
+			} 
+			return fChannel; 
+		}  //!<!
 
       //stored in the tchannel (things common to all hits of this address)
       virtual Int_t  GetDetector()  const; //!<!

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -41,7 +41,7 @@ class TGriffin : public TGRSIDetector {
 
     static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
 #ifndef __CINT__
-    void AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan); //!<!
+    void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
 #endif
 
     TGriffin& operator=(const TGriffin&);  //!<!

--- a/include/TLaBr.h
+++ b/include/TLaBr.h
@@ -36,7 +36,7 @@ class TLaBr : public TGRSIDetector {
       TLaBrHit* GetLaBrHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fLaBrHits.size(); }	      //!<!
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
       
       static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; }	//!<!

--- a/include/TPaces.h
+++ b/include/TPaces.h
@@ -28,7 +28,7 @@ class TPaces : public TGRSIDetector {
 		Short_t GetMultiplicity() const { return fPacesHits.size(); }
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment> frag, TChannel *chan);
+      void AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan);
 #endif
 		static TVector3 GetPosition(int DetNbr);		//!<!
 		TPaces& operator=(const TPaces&);  //!<!

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -76,7 +76,7 @@ class TParsingDiagnostics : public TObject {
 	public:
 		//"setter" functions
 #ifndef __CINT__
-		void GoodFragment(std::shared_ptr<TFragment>);
+		void GoodFragment(std::shared_ptr<const TFragment>);
 #endif
 		void GoodFragment(Short_t detType) { fNumberOfGoodFragments[detType]++; }
 		void BadFragment(Short_t detType)  { fNumberOfBadFragments[detType]++; }

--- a/include/TPulseAnalyzer.h
+++ b/include/TPulseAnalyzer.h
@@ -111,12 +111,12 @@ class TPulseAnalyzer {
 	
   public:
     TPulseAnalyzer();
-    TPulseAnalyzer(TFragment &frag,double=0);
-    TPulseAnalyzer(std::vector<Short_t> &wave,double=0,std::string name="");
+    TPulseAnalyzer(const TFragment &frag,double=0);
+    TPulseAnalyzer(const std::vector<Short_t>& wave,double=0,std::string name="");
     virtual ~TPulseAnalyzer();
     
-    void SetData(TFragment &frag,double=0);
-    void SetData(std::vector<Short_t> &wave,double=0);
+    void SetData(const TFragment &frag,double=0);
+    void SetData(const std::vector<Short_t> &wave,double=0);
     void Clear(Option_t *opt = "");
     bool IsSet() { return set; }
     

--- a/include/TRF.h
+++ b/include/TRF.h
@@ -27,7 +27,7 @@ class TRF : public TDetector {
 		time_t   MidasTime() const { return fMidasTime; }
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 		void BuildHits() {} //no need to build any hits, everything already done in AddFragment
 

--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -28,7 +28,7 @@ class TRuntimeObjects : public TNamed {
 public:
   /// Constructor
 #ifndef __CINT__
-  TRuntimeObjects(std::shared_ptr<TFragment> frag,
+  TRuntimeObjects(std::shared_ptr<const TFragment> frag,
                   TList* objects,
                   TList* gates,
                   std::vector<TFile*>& cut_files,
@@ -48,7 +48,7 @@ public:
     return fDetectors->GetDetector<T>();
   }
 
-  std::shared_ptr<TFragment> GetFragment() { return fFrag; }
+  std::shared_ptr<const TFragment> GetFragment() { return fFrag; }
 #endif
 
   TCutG* GetCut(const std::string& name);
@@ -158,7 +158,7 @@ public:
   static TRuntimeObjects *Get(std::string name="default") { if(fRuntimeMap.count(name)) return fRuntimeMap.at(name); return 0; }
 
 #ifndef __CINT__
-  void SetFragment(std::shared_ptr<TFragment> frag) { fFrag = frag; }
+  void SetFragment(std::shared_ptr<const TFragment> frag) { fFrag = frag; }
   void SetDetectors(std::shared_ptr<TUnpackedEvent> det) { fDetectors = det; }
 #endif
 
@@ -169,7 +169,7 @@ private:
   static std::map<std::string,TRuntimeObjects*> fRuntimeMap;
 #ifndef __CINT__
   std::shared_ptr<TUnpackedEvent> fDetectors;
-  std::shared_ptr<TFragment> fFrag;
+  std::shared_ptr<const TFragment> fFrag;
 #endif
   TList* fObjects;
   TList* fGates;

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -31,7 +31,7 @@ class TS3 : public TGRSIDetector {
 		virtual  ~TS3();
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
 		Short_t GetRingMultiplicity() 	const { return fS3RingHits.size()		; }
@@ -65,8 +65,8 @@ class TS3 : public TGRSIDetector {
 		std::vector<TS3Hit> fS3Hits; //!<!
 		std::vector<TS3Hit> fS3RingHits, fS3SectorHits;
 #ifndef __CINT__
-		std::vector<std::shared_ptr<TFragment> > fS3_RingFragment; //! 
-		std::vector<std::shared_ptr<TFragment> > fS3_SectorFragment; //! 
+		std::vector<std::shared_ptr<const TFragment> > fS3_RingFragment; //! 
+		std::vector<std::shared_ptr<const TFragment> > fS3_SectorFragment; //! 
 #endif
 
 		UChar_t fS3Bits;                  // flags for transient members

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -15,7 +15,7 @@
 class TS3Hit : public TGRSIDetectorHit {
 	public:
 		TS3Hit();
-		TS3Hit(TFragment &);
+		TS3Hit(const TFragment &);
 		virtual ~TS3Hit();
 		TS3Hit(const TS3Hit&);
 
@@ -31,23 +31,23 @@ class TS3Hit : public TGRSIDetectorHit {
 		void Print(Option_t* opt="") const;
 		void Clear(Option_t* opt="");
 
-		inline Double_t GetFitTime()			           { return fTimeFit;	   } //!<!
-		inline Double_t GetSignalToNoise()		        { return fSig2Noise;	} //!<!
+		inline Double_t GetFitTime()			         { return fTimeFit;	   } //!<!
+		inline Double_t GetSignalToNoise()		      { return fSig2Noise;	} //!<!
 
-		void SetRingNumber(Short_t rn)     			{ fRing = rn;   }
-		void SetSectorNumber(Short_t sn)   			{ fSector = sn; }
-		void SetIsDownstream(Bool_t dwnstrm) 		{ fIsDownstream = dwnstrm; }
+		void SetRingNumber(Short_t rn)				   { fRing = rn;   }
+		void SetSectorNumber(Short_t sn)   			   { fSector = sn; }
+		void SetIsDownstream(Bool_t dwnstrm) 		   { fIsDownstream = dwnstrm; }
 
-		void SetRingNumber(TFragment &frag)     { fRing = GetMnemonicSegment(frag);   	}
-		void SetSectorNumber(TFragment &frag)   { fSector = GetMnemonicSegment(frag) ; 	}
+		void SetRingNumber(const TFragment &frag)    { fRing = GetMnemonicSegment(frag);   	}
+		void SetSectorNumber(const TFragment &frag)  { fSector = GetMnemonicSegment(frag) ; 	}
 		void SetSectorNumber(int n)   					{ fSector = n ; 												}
 		void SetRingNumber(int n)   						{ fRing 	= n ; 												}
 
-		void SetWavefit(TFragment&);
+		void SetWavefit(const TFragment&);
 		void SetTimeFit(Double_t time)					{ fTimeFit = time;											}
-		void SetSig2Noise(Double_t sig2noise)		{ fSig2Noise = sig2noise;								}
+		void SetSig2Noise(Double_t sig2noise)		   { fSig2Noise = sig2noise;								}
 
-    Short_t GetMnemonicSegment(TFragment &frag);	//could be added to TGRSIDetectorHit base class
+		Short_t GetMnemonicSegment(const TFragment &frag);	//could be added to TGRSIDetectorHit base class
 
 		Double_t GetPhi(double offset=0) {
 			return this->GetPosition(offset).Phi();
@@ -60,6 +60,7 @@ class TS3Hit : public TGRSIDetectorHit {
 			}
 			return this->GetPosition(offset).Angle(*vec);
 		}
+
 		TVector3 GetPosition(Double_t offset, Double_t dist) const; //!
 		TVector3 GetPosition(Double_t offset) const; //!
 		TVector3 GetPosition() const; //!

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -36,7 +36,7 @@ class TSceptar : public TGRSIDetector {
       TSceptarHit* GetSceptarHit(const int& i);	//!<!
       Short_t GetMultiplicity() const	       {	return fSceptarHits.size(); }	      //!<!
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
       static TVector3 GetPosition(int DetNbr) { return gPaddlePosition[DetNbr]; }	//!<!

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -30,7 +30,7 @@ class TSceptarHit : public TGRSIDetectorHit {
       TSceptarHit();
       virtual ~TSceptarHit();
       TSceptarHit(const TSceptarHit&);
-      TSceptarHit(TFragment& frag);
+      TSceptarHit(const TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/include/TSharc.h
+++ b/include/TSharc.h
@@ -44,7 +44,7 @@ class TSharc : public TGRSIDetector  {
     TSharc& operator=(const TSharc& rhs)  { if(this!=&rhs) rhs.Copy(*this); return *this; }//!<!
 
 #ifndef __CINT__
-    void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+    void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
     void BuildHits();
 

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -19,7 +19,7 @@ class TSiLi: public TGRSIDetector  {
 		virtual ~TSiLi();
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
 		TSiLi& operator=(const TSiLi&);  // 

--- a/include/TSiLiHit.h
+++ b/include/TSiLiHit.h
@@ -16,7 +16,7 @@
 class TSiLiHit : public TGRSIDetectorHit {
 	public:
 		TSiLiHit();
-		TSiLiHit(TFragment &);	
+		TSiLiHit(const TFragment &);	
 		virtual ~TSiLiHit();
 		TSiLiHit(const TSiLiHit&);
 		
@@ -30,7 +30,7 @@ class TSiLiHit : public TGRSIDetectorHit {
 		Int_t GetPreamp()      const {  return  ((GetSector()/3)*2)+(((GetSector()%3)+GetRing())%2); }
 		Double_t GetTimeFit()   { return fTimeFit;  }
 
-		void SetWavefit(TFragment&);
+		void SetWavefit(const TFragment&);
 		TVector3 GetPosition(Double_t dist) const; //!  
 		TVector3 GetPosition() const; //!  
 

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -37,7 +37,7 @@ class TTAC : public TGRSIDetector {
       Short_t GetMultiplicity() const	       {	return fTACHits.size(); }	      //!<!
       
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
       
       TTAC& operator=(const TTAC&);  //!<!

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -40,7 +40,7 @@ class TTigress : public TGRSIDetector {
     };
 
 #ifndef __CINT__
-    std::vector<std::vector<std::shared_ptr<TFragment> > > SegmentFragments;
+    std::vector<std::vector<std::shared_ptr<const TFragment> > > SegmentFragments;
 #endif
 
     TTigress();
@@ -71,7 +71,7 @@ class TTigress : public TGRSIDetector {
     UShort_t GetNAddbackFrags(size_t idx) const;
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
     void BuildHits();
 

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -56,7 +56,7 @@ class TTigressHit : public TGRSIDetectorHit {
     //int GetCrystal()   const;           //{  return crystal;      }    //!<!
     //int GetInitialHit() const           {  return fFirstSegment;  }      //!<!
 
-    void SetWavefit(TFragment&);
+    void SetWavefit(const TFragment&);
     void SetWavefit();
     Double_t GetSignalToNoise() const  { return fSig2Noise;  } //!<!
     Double_t GetFitTime()       const  { return fTimeFit;   }  //!<!

--- a/include/TTip.h
+++ b/include/TTip.h
@@ -39,7 +39,7 @@ class TTip : public TGRSIDetector {
 		Short_t GetMultiplicity() const         {  return fTipHits.size();}  //!<!
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 		void Copy(TObject &rhs) const;
 

--- a/include/TTipHit.h
+++ b/include/TTipHit.h
@@ -17,53 +17,53 @@
 #include "TGRSIDetectorHit.h"
 
 class TTipHit : public TGRSIDetectorHit {
-  public:
-    TTipHit();
-	TTipHit(TFragment &);	
-    virtual ~TTipHit();
-    TTipHit(const TTipHit&);
+	public:
+		TTipHit();
+		TTipHit(const TFragment &);	
+		virtual ~TTipHit();
+		TTipHit(const TTipHit&);
 
-  private:
-    Int_t    fFilter;    // 
-    Double_t fPID;       // 
+	private:
+		Int_t    fFilter;    // 
+		Double_t fPID;       // 
 		Int_t		 fChiSq;
 
-    //Double_t fFastAmplitude;
-    //Double_t fSlowAmplitude;
-    //Double_t fGammaAmplitude;
-   
-	bool csi_flag;
+		//Double_t fFastAmplitude;
+		//Double_t fSlowAmplitude;
+		//Double_t fGammaAmplitude;
 
-	 Int_t	 fTipChannel;
+		bool csi_flag;
 
-    Double_t   fTimeFit;
-    Double_t   fSig2Noise;
+		Int_t	 fTipChannel;
 
-  public:
-    /////////////////////////    /////////////////////////////////////
-    inline void SetFilterPattern(const int &x)    { fFilter   = x; }   //!<! 
-    inline void SetPID(Double_t x)                { fPID = x;     }   //!<!
-	 inline void SetTipChannel(const int x)		  { fTipChannel = x; } //!<!
+		Double_t   fTimeFit;
+		Double_t   fSig2Noise;
 
-    inline Int_t    GetFiterPatter()              { return fFilter;     } //!<!
-    inline Double_t GetPID()                      { return fPID;        } //!<!
+	public:
+		/////////////////////////    /////////////////////////////////////
+		inline void SetFilterPattern(const int &x)    { fFilter   = x; }   //!<! 
+		inline void SetPID(Double_t x)                { fPID = x;     }   //!<!
+		inline void SetTipChannel(const int x)		  { fTipChannel = x; } //!<!
+
+		inline Int_t    GetFiterPatter()              { return fFilter;     } //!<!
+		inline Double_t GetPID()                      { return fPID;        } //!<!
 		inline Int_t		GetFitChiSq()									{ return fChiSq;			} //!<!
-	 inline Double_t GetFitTime()			           { return fTimeFit;	   } //!<!
-	 inline Double_t GetSignalToNoise()		        { return fSig2Noise;	} //!<!
-	 inline Int_t	  GetTipChannel()			        { return fTipChannel; } //!<!
+		inline Double_t GetFitTime()			           { return fTimeFit;	   } //!<!
+		inline Double_t GetSignalToNoise()		        { return fSig2Noise;	} //!<!
+		inline Int_t	  GetTipChannel()			        { return fTipChannel; } //!<!
 
-	 inline bool IsCsI()									  { return csi_flag; } //!<!
-	 inline void SetCsI(bool flag="true")	        { csi_flag = flag; } //!<!
-	 inline void SetFitChiSq(int chisq)						{ fChiSq = chisq; }	//!<!
+		inline bool IsCsI()									  { return csi_flag; } //!<!
+		inline void SetCsI(bool flag="true")	        { csi_flag = flag; } //!<!
+		inline void SetFitChiSq(int chisq)						{ fChiSq = chisq; }	//!<!
 
-    bool   InFilter(Int_t);                                         //!<!
+		bool   InFilter(Int_t);                                         //!<!
 
-    //void SetVariables(TFragment &frag) { SetAddress(frag.ChannelAddress);
-	//									 SetCfd(frag.GetCfd());
-    //                                   SetCharge(frag.GetCharge());
-    //                                     SetTimeStamp(frag.GetTimeStamp()); }
+		//void SetVariables(const TFragment &frag) { SetAddress(frag.ChannelAddress);
+		//									 SetCfd(frag.GetCfd());
+		//                                   SetCharge(frag.GetCharge());
+		//                                     SetTimeStamp(frag.GetTimeStamp()); }
 
-	 void SetUpNumbering(TChannel *chan) { 
+		void SetUpNumbering(TChannel *chan) { 
 			TChannel *channel = GetChannel();
 			if(!channel) {
 				Error("SetDetector","No TChannel exists for address %u",GetAddress());
@@ -73,19 +73,19 @@ class TTipHit : public TGRSIDetectorHit {
 			SetTipChannel(10*channel->GetMnemonic()->ArrayPosition() + tmp); 
 			if(channel->GetMnemonic()->SubSystemString().compare(0,1,"W")==0)
 				SetCsI();
-	 }
+		}
 
-    void SetWavefit(TFragment&);
+		void SetWavefit(const TFragment&);
 
-		void SetPID(TFragment&);
+		void SetPID(const TFragment&);
 
-  public:
-    void Clear(Option_t *opt = "");                        //!<!
-    void Print(Option_t *opt = "") const;                  //!<!
-    virtual void Copy(TObject&) const;                     //!<!
+	public:
+		void Clear(Option_t *opt = "");                        //!<!
+		void Print(Option_t *opt = "") const;                  //!<!
+		virtual void Copy(TObject&) const;                     //!<!
 
 /// \cond CLASSIMP
-    ClassDef(TTipHit,1);
+	ClassDef(TTipHit,1);
 /// \endcond
 };
 /*! @} */

--- a/include/TTriFoil.h
+++ b/include/TTriFoil.h
@@ -31,7 +31,7 @@ class TTriFoil :  public TDetector {
     time_t GetTimeStamp() const { return fTimestamp; }
 
 #ifndef __CINT__
-    void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+    void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
     void Clear(Option_t* opt = "");   //!<!

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -23,7 +23,7 @@ public:
 
   std::vector<std::shared_ptr<TDetector> >& GetDetectors() { return fDetectors; }
   void AddDetector(std::shared_ptr<TDetector> det) { fDetectors.push_back(det); }
-  void AddRawData(std::shared_ptr<TFragment> frag);
+  void AddRawData(std::shared_ptr<const TFragment> frag);
 #endif
   void ClearRawData();
 
@@ -35,7 +35,7 @@ private:
   void BuildHits();
 
 #ifndef __CINT__
-  std::vector<std::shared_ptr<TFragment> > fFragments;
+  std::vector<std::shared_ptr<const TFragment> > fFragments;
   std::vector<std::shared_ptr<TDetector> > fDetectors;
 #endif
 };

--- a/include/TUnpackingLoop.h
+++ b/include/TUnpackingLoop.h
@@ -22,10 +22,10 @@ class TUnpackingLoop : public StoppableThread {
 
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<TMidasEvent> >&                  InputQueue()                               { return fInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >&  AddGoodOutputQueue(size_t maxSize = 50000) { return fParser.AddGoodOutputQueue(maxSize); }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >&  BadOutputQueue()                           { return fParser.BadOutputQueue(); }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerOutputQueue()                        { return fParser.ScalerOutputQueue(); }
+		std::shared_ptr<ThreadsafeQueue<TMidasEvent> >&                        InputQueue()                               { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&  AddGoodOutputQueue(size_t maxSize = 50000) { return fParser.AddGoodOutputQueue(maxSize); }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&  BadOutputQueue()                           { return fParser.BadOutputQueue(); }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >&       ScalerOutputQueue()                        { return fParser.ScalerOutputQueue(); }
 #endif
 
 		bool Iteration();

--- a/include/TZeroDegree.h
+++ b/include/TZeroDegree.h
@@ -39,7 +39,7 @@ class TZeroDegree : public TGRSIDetector {
       static TVector3 GetPosition(double dist) { return TVector3(0,0,dist); }	//!<!
       
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<TFragment>, TChannel*); //!<!
+      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
       
       TZeroDegree& operator=(const TZeroDegree&);  //!<!

--- a/include/TZeroDegreeHit.h
+++ b/include/TZeroDegreeHit.h
@@ -29,7 +29,7 @@ class TZeroDegreeHit : public TGRSIDetectorHit {
       TZeroDegreeHit();
       virtual ~TZeroDegreeHit();
       TZeroDegreeHit(const TZeroDegreeHit&);
-      TZeroDegreeHit(TFragment& frag);
+      TZeroDegreeHit(const TFragment& frag);
       
    private:
       Int_t    fFilter;

--- a/libraries/TDataParser/TFragmentMap.cxx
+++ b/libraries/TDataParser/TFragmentMap.cxx
@@ -4,8 +4,8 @@
 
 bool TFragmentMap::fDebug = false;
 
-TFragmentMap::TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > >& good_output_queue,
-      			            std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > >& bad_output_queue)
+TFragmentMap::TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& good_output_queue,
+      			            std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& bad_output_queue)
   : fGoodOutputQueue(good_output_queue), fBadOutputQueue(bad_output_queue) { }
 
 bool TFragmentMap::Add(std::shared_ptr<TFragment> frag, std::vector<Int_t> charge, std::vector<Short_t> integrationLength) {

--- a/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
+++ b/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
@@ -20,7 +20,7 @@ TCSM::TCSM() {
 TCSM::~TCSM() {
 }
 
-void TCSM::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TCSM::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	///This function just stores the fragments and mnemonics in vectors, separated by detector number and type (horizontal/vertical strip or pad).
 	///The hits themselves are built in the BuildHits function because the way we build them depends on the number of hits.
 

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -165,7 +165,7 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
    return NULL;
 }
 
-void TDescant::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TDescant::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the DESCANT Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    ///This is done for both DESCANT and it's suppressors.
    if(frag == NULL || chan == NULL) {

--- a/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
@@ -27,7 +27,7 @@ TDescantHit::TDescantHit(const TDescantHit &rhs) : TGRSIDetectorHit() {
    rhs.Copy(*this);
 }
 
-TDescantHit::TDescantHit(TFragment& frag) : TGRSIDetectorHit(frag) {
+TDescantHit::TDescantHit(const TFragment& frag) : TGRSIDetectorHit(frag) {
 	SetZc(frag.GetZc());
 	SetCcShort(frag.GetCcShort());
 	SetCcLong(frag.GetCcLong());
@@ -150,8 +150,7 @@ void TDescantHit::Print(Option_t *opt) const	{
 bool TDescantHit::AnalyzeWaveform() {
 	bool error = false;
 
-	std::vector<Short_t> *waveform = GetWaveform();
-	if(waveform->empty()) {
+	if(fWaveform.empty()) {
 		return false; //Error!
 	}
 	std::vector<Int_t> baselineCorrections(8, 0);
@@ -164,14 +163,14 @@ bool TDescantHit::AnalyzeWaveform() {
 	int halfSmoothingWindow = 0; //2*halfsmoothingwindow + 1 = number of samples in moving window.
 
 	// baseline algorithm: correct each adc with average of first two samples in that adc
-	for(size_t i = 0; i < 8 && i < waveform->size(); ++i) {
-		baselineCorrections[i] = (*waveform)[i];
+	for(size_t i = 0; i < 8 && i < fWaveform.size(); ++i) {
+		baselineCorrections[i] = fWaveform[i];
 	}
-	for(size_t i = 8; i < 16 && i < waveform->size(); ++i) {
-		baselineCorrections[i-8] = ((baselineCorrections[i-8] + (*waveform)[i]) + ((baselineCorrections[i-8] + (*waveform)[i]) > 0 ? 1 : -1)) >> 1; //Average
+	for(size_t i = 8; i < 16 && i < fWaveform.size(); ++i) {
+		baselineCorrections[i-8] = ((baselineCorrections[i-8] + fWaveform[i]) + ((baselineCorrections[i-8] + fWaveform[i]) > 0 ? 1 : -1)) >> 1; //Average
 	}
-	for(size_t i = 0; i < waveform->size(); ++i) {
-		(*waveform)[i] -= baselineCorrections[i%8];
+	for(size_t i = 0; i < fWaveform.size(); ++i) {
+		fWaveform[i] -= baselineCorrections[i%8];
 	}
 
 	SetCfd(CalculateCfd(attenuation, delay, halfSmoothingWindow, interpolationSteps));
@@ -206,17 +205,16 @@ Int_t TDescantHit::CalculateCfdAndMonitor(double attenuation, unsigned int delay
 	bool armed = false;
 
 	Int_t cfd = 0;
-	std::vector<Short_t> *waveform = GetWaveform();
-	if(waveform->empty()) {
+	if(fWaveform.empty()) {
 		return INT_MAX; //Error!
 	}
 	std::vector<Short_t> smoothedWaveform;
 
-	if(waveform->size() > delay+1) {
+	if(fWaveform.size() > delay+1) {
 		if(halfSmoothingWindow > 0) {
 			smoothedWaveform = TDescantHit::CalculateSmoothedWaveform(halfSmoothingWindow);
 		} else {
-			smoothedWaveform = *waveform;
+			smoothedWaveform = fWaveform;
 		}
 
 		monitor.clear();
@@ -262,17 +260,15 @@ Int_t TDescantHit::CalculateCfdAndMonitor(double attenuation, unsigned int delay
 
 std::vector<Short_t> TDescantHit::CalculateSmoothedWaveform(unsigned int halfSmoothingWindow) {
 
-	std::vector<Short_t> *waveform = GetWaveform();
-
-	if(waveform->empty()) {
+	if(fWaveform.empty()) {
 		return std::vector<Short_t>(); //Error!
 	}
 
-	std::vector<Short_t> smoothedWaveform(std::max((static_cast<size_t>(0)), waveform->size()-2*halfSmoothingWindow), 0);
+	std::vector<Short_t> smoothedWaveform(std::max((static_cast<size_t>(0)), fWaveform.size()-2*halfSmoothingWindow), 0);
 
-	for(size_t i = halfSmoothingWindow; i < waveform->size() - halfSmoothingWindow; ++i) {
+	for(size_t i = halfSmoothingWindow; i < fWaveform.size() - halfSmoothingWindow; ++i) {
 		for(int j = -static_cast<int>(halfSmoothingWindow); j <= static_cast<int>(halfSmoothingWindow); ++j) {
-			smoothedWaveform[i-halfSmoothingWindow] += (*waveform)[i+j];
+			smoothedWaveform[i-halfSmoothingWindow] += fWaveform[i+j];
 		}
 	}
 
@@ -281,8 +277,7 @@ std::vector<Short_t> TDescantHit::CalculateSmoothedWaveform(unsigned int halfSmo
 
 std::vector<Short_t> TDescantHit::CalculateCfdMonitor(double attenuation, unsigned int delay, unsigned int halfSmoothingWindow) {
 
-	std::vector<Short_t> *waveform = GetWaveform();
-	if(waveform->empty()) {
+	if(fWaveform.empty()) {
 		return std::vector<Short_t>(); //Error!
 	}
 	std::vector<Short_t> smoothedWaveform;
@@ -290,12 +285,12 @@ std::vector<Short_t> TDescantHit::CalculateCfdMonitor(double attenuation, unsign
 	if(halfSmoothingWindow > 0) {
 		smoothedWaveform = TDescantHit::CalculateSmoothedWaveform(halfSmoothingWindow);
 	} else {
-		smoothedWaveform = *waveform;
+		smoothedWaveform = fWaveform;
 	}
 
 	std::vector<Short_t> monitor(std::max((static_cast<size_t>(0)), smoothedWaveform.size()-delay), 0);
 
-	for(size_t i = delay; i < waveform->size(); ++i) {
+	for(size_t i = delay; i < fWaveform.size(); ++i) {
 		monitor[i-delay] = attenuation*smoothedWaveform[i]-smoothedWaveform[i-delay];
 	}
 
@@ -304,17 +299,16 @@ std::vector<Short_t> TDescantHit::CalculateCfdMonitor(double attenuation, unsign
 
 std::vector<Int_t> TDescantHit::CalculatePartialSum() {
 
-	std::vector<Short_t> *waveform = GetWaveform();
-	if(waveform->empty()) {
+	if(fWaveform.empty()) {
 		return std::vector<Int_t>(); //Error!
 	}
 
-	std::vector<Int_t> partialSums(waveform->size(), 0);
+	std::vector<Int_t> partialSums(fWaveform.size(), 0);
 
-	if(waveform->size() > 0) {
-		partialSums[0] = waveform->at(0);
-		for(size_t i = 1; i < waveform->size(); ++i) {
-			partialSums[i] = partialSums[i-1] + (*waveform)[i];
+	if(fWaveform.size() > 0) {
+		partialSums[0] = fWaveform.at(0);
+		for(size_t i = 1; i < fWaveform.size(); ++i) {
+			partialSums[i] = partialSums[i-1] + fWaveform[i];
 		}
 	}
 
@@ -335,7 +329,6 @@ Int_t TDescantHit::CalculatePsdAndPartialSums(double fraction, unsigned int inte
 
 	Int_t psd = 0;
 
-	std::vector<Short_t> *waveform = GetWaveform();
 	partialSums = CalculatePartialSum();
 	if(partialSums.empty()) {
 		return -1;
@@ -346,7 +339,7 @@ Int_t TDescantHit::CalculatePsdAndPartialSums(double fraction, unsigned int inte
 	if(partialSums[0] < fraction*totalSum) {
 		for(size_t i = 1; i < partialSums.size(); ++i) {
 			if(partialSums[i] >= fraction*totalSum) {
-				psd = i*interpolationSteps - ((partialSums[i]-fraction*totalSum)*interpolationSteps)/(*waveform)[i];
+				psd = i*interpolationSteps - ((partialSums[i]-fraction*totalSum)*interpolationSteps)/fWaveform[i];
 				break;
 			}
 		}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -200,7 +200,7 @@ TGriffinHit* TGriffin::GetAddbackHit(const int& i) {
    }
 }
 
-void TGriffin::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TGriffin::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
    //This is done for both GRIFFIN and it's suppressors.
    if(frag == NULL || chan == NULL) {

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -84,7 +84,7 @@ TLaBrHit* TLaBr::GetLaBrHit(const int& i) {
    return NULL;
 }
 
-void TLaBr::AddFragment(std::shared_ptr<TFragment> frag, TChannel *chan) {
+void TLaBr::AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan) {
    TLaBrHit laHit(*frag); //Building is controlled in the constructor of the hit
    fLaBrHits.push_back(std::move(laHit)); //use std::move for efficienciy since laHit loses scope here anyway
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -63,7 +63,7 @@ TPaces& TPaces::operator=(const TPaces& rhs) {
 	return *this;
 }
 
-void TPaces::AddFragment(std::shared_ptr<TFragment> frag, TChannel *chan){
+void TPaces::AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan){
    TPacesHit hit(*frag);
    fPacesHits.push_back(std::move(hit));
 }

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -8,12 +8,12 @@ TPulseAnalyzer::TPulseAnalyzer() : wpar(NULL), spar(NULL), shpar(NULL) {
 	Clear();
 }
 
-TPulseAnalyzer::TPulseAnalyzer(TFragment &fragment,double noise_fac) : wpar(NULL), spar(NULL), shpar(NULL) {
+TPulseAnalyzer::TPulseAnalyzer(const TFragment &fragment,double noise_fac) : wpar(NULL), spar(NULL), shpar(NULL) {
 	Clear();
 	SetData(fragment,noise_fac);
 }
 
-TPulseAnalyzer::TPulseAnalyzer(std::vector<Short_t> &wave,double noise_fac,std::string name) : wpar(NULL), spar(NULL), shpar(NULL), fName(name) {
+TPulseAnalyzer::TPulseAnalyzer(const std::vector<Short_t>& wave,double noise_fac,std::string name) : wpar(NULL), spar(NULL), shpar(NULL), fName(name) {
 	Clear();
 	SetData(wave,noise_fac);
 }
@@ -40,7 +40,7 @@ void TPulseAnalyzer::Clear(Option_t *opt) {
 	memset(copy_matrix,0,sizeof(copy_matrix));
 }
 
-void TPulseAnalyzer::SetData(TFragment &fragment,double noise_fac) {
+void TPulseAnalyzer::SetData(const TFragment &fragment,double noise_fac) {
 	SetCsI(false);
 	if(fragment.HasWave()) {
 		if(noise_fac > 0) {
@@ -54,7 +54,7 @@ void TPulseAnalyzer::SetData(TFragment &fragment,double noise_fac) {
 	}
 }
 
-void TPulseAnalyzer::SetData(std::vector<Short_t> &wave,double noise_fac) {
+void TPulseAnalyzer::SetData(const std::vector<Short_t>& wave,double noise_fac) {
 	SetCsI(false);
 	if(wave.size()>0) {
 		if(noise_fac > 0) {

--- a/libraries/TGRSIAnalysis/TRF/TRF.cxx
+++ b/libraries/TGRSIAnalysis/TRF/TRF.cxx
@@ -25,8 +25,8 @@ TRF::TRF(const TRF& rhs) : TDetector() {
 TRF::~TRF() {
 }
 
-void TRF::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
-	TPulseAnalyzer pulse((TFragment&)(*frag));	    
+void TRF::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
+	TPulseAnalyzer pulse(*frag);	    
 	if(pulse.IsSet()){
 		fTime = pulse.fit_rf(fPeriod*0.2);//period taken in half ticks... for reasons
 		fMidasTime = frag->GetMidasTimeStamp();

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -45,7 +45,7 @@ void TS3::Copy(TObject &rhs) const {
   return;                                      
 }  
 
-void TS3::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TS3::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	///This function creates TS3Hits for each fragment and stores them in separate front and back vectors
 	if(frag == NULL || chan == NULL) {
 		return;

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -8,7 +8,7 @@ ClassImp(TS3Hit)
 	TS3Hit::TS3Hit()	{
 		Clear();
 	}
-TS3Hit::TS3Hit(TFragment &frag)	: TGRSIDetectorHit(frag) {}
+TS3Hit::TS3Hit(const TFragment &frag)	: TGRSIDetectorHit(frag) {}
 
 TS3Hit::~TS3Hit()	{}
 
@@ -37,7 +37,7 @@ void TS3Hit::Clear(Option_t *opt)	{
 	fIsDownstream		 = false;
 }
 
-Short_t TS3Hit::GetMnemonicSegment(TFragment &frag){//could be added to TGRSIDetectorHit base class
+Short_t TS3Hit::GetMnemonicSegment(const TFragment &frag){//could be added to TGRSIDetectorHit base class
 	TChannel *channel = TChannel::GetChannel(frag.GetAddress());
 	if(!channel){
 		Error("SetDetector","No TChannel exists for address %u",GetAddress());
@@ -46,7 +46,7 @@ Short_t TS3Hit::GetMnemonicSegment(TFragment &frag){//could be added to TGRSIDet
 	return channel->GetMnemonic()->Segment();
 }
 
-void TS3Hit::SetWavefit(TFragment &frag)   {
+void TS3Hit::SetWavefit(const TFragment &frag)   {
 	TPulseAnalyzer pulse(frag);
 	if(pulse.IsSet()){
 		fTimeFit   = pulse.fit_newT0();

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -79,7 +79,7 @@ TSceptar& TSceptar::operator=(const TSceptar& rhs) {
    return *this;
 }
 
-void TSceptar::AddFragment(std::shared_ptr<TFragment>  frag, TChannel * chan){
+void TSceptar::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan){
    TSceptarHit scHit(*frag);  //Construction of TSceptarHit is handled in the constructor
    fSceptarHits.push_back(std::move(scHit)); //Can't use scHit outside of vector after using std::move
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -84,7 +84,7 @@ TSharc::TSharc(const TSharc& rhs) : TGRSIDetector() {
   rhs.Copy(*this);
 }
 
-void TSharc::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TSharc::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
   if(frag == NULL || chan == NULL) {
     return;
   }

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -51,7 +51,7 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
    return 0;
 }  
 
-void TSiLi::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TSiLi::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
   if(frag == NULL || chan == NULL) {
 	 return;
   }

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
@@ -7,7 +7,7 @@ ClassImp(TSiLiHit)
 
 TSiLiHit::TSiLiHit()  {    Clear(); }
 
-TSiLiHit::TSiLiHit(TFragment &frag)	: TGRSIDetectorHit(frag) {
+TSiLiHit::TSiLiHit(const TFragment &frag)	: TGRSIDetectorHit(frag) {
   
   if(TGRSIRunInfo::IsWaveformFitting())
 	  SetWavefit(frag);
@@ -50,7 +50,7 @@ void TSiLiHit::Clear(Option_t *opt)  {
 	fSig2Noise = -1;
 }
 
-void TSiLiHit::SetWavefit(TFragment &frag)   { 
+void TSiLiHit::SetWavefit(const TFragment &frag)   { 
 	TPulseAnalyzer pulse(frag,4);	    
 	if(pulse.IsSet()){
 		fTimeFit = pulse.fit_newT0();

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -53,7 +53,7 @@ void TTAC::Print(Option_t *opt) const	{
    printf("%lu fTACHits\n",fTACHits.size());
 }
 
-void TTAC::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TTAC::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    TTACHit hit(*frag);
    fTACHits.push_back(std::move(hit));
 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -196,89 +196,82 @@ void TTigress::BuildHits(){
   }
 }
 
-void TTigress::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
-    return;
-  }
-/*  if(GetMidasTimestamp()==-1) {
-    SetMidasTimestamp(frag->GetMidasTimeStamp());
-  }
-*/
-  //printf("%s %s called.\n",__PRETTY_FUNCTION__,channel->GetChannelName());
-  //fflush(stdout);
-  ///frag->Print("all");
+void TTigress::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
+	if(frag == NULL || chan == NULL) {
+		return;
+	}
+	/*  if(GetMidasTimestamp()==-1) {
+		 SetMidasTimestamp(frag->GetMidasTimeStamp());
+		 }
+		 */
+	//printf("%s %s called.\n",__PRETTY_FUNCTION__,channel->GetChannelName());
+	//fflush(stdout);
+	///frag->Print("all");
 
- // if((chan->GetMnemonic()->subsystem.compare(0,1,"G")==0) &&
-  if((chan->GetMnemonic()->SubSystem() == TMnemonic::kG) &&
-     (chan->GetSegmentNumber()==0 || chan->GetSegmentNumber()==9) ) { // it is a core
-    //if(frag->Charge.size() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a good energy and time (cfd or led).
-    //  return;
-    TTigressHit corehit; //(*frag);
-    //loop over existing hits to see if this core was already created by a previously found segment
-    //of course this means if we have a core in "coincidence" with itself we will overwrite the first hit
-    for(size_t i = 0; i < fTigressHits.size(); ++i)	{
-      TTigressHit& hit = GetTigressHit(i);
-      if((hit.GetDetector() == chan->GetDetectorNumber()) &&
-	 (hit.GetCrystal() == chan->GetCrystalNumber())) { //we have a match;
-        //if(hit.Charge() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a good energy and time (cfd or led).
-        //if(chan->GetMnemonic()->outputsensor.compare(0,1,"b")==0) {
-        if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kB) {
-          if(hit.GetName()[9] == 'a') {
-            return;
-          } else  {
-            hit.CopyFragment(*frag);
-            if(TestBit(kSetCoreWave))
-              hit.CopyWave(*frag);
-            return;
-          }
-        } else {
-          hit.CopyFragment(*frag);
-          if(TestBit(kSetCoreWave))
-            hit.CopyWave(*frag);
-          return;
-        }
-      }
-    }
-    corehit.CopyFragment(*frag);
-    if(TestBit(kSetCoreWave))
-      corehit.CopyWave(*frag);
-    fTigressHits.push_back(corehit);
-    return;
-  //} else if(chan->GetMnemonic()->subsystem.compare(0,1,"G")==0) { // its ge but its not a core...
-  } else if(chan->GetMnemonic()->SubSystem() == TMnemonic::kG) { // its ge but its not a core...
-    TGRSIDetectorHit temp(*frag);
-    for(size_t i = 0; i < fTigressHits.size(); ++i)	{
-      TTigressHit& hit = GetTigressHit(i);
-      if((hit.GetDetector() == chan->GetDetectorNumber()) &&
-	 (hit.GetCrystal() == chan->GetCrystalNumber())) { //we have a match;
-        if(TestGlobalBit(kSetSegWave))         
-          temp.CopyWave(*frag);
-        hit.AddSegment(temp);
-        //printf(" I found a core !\t%i\n",hit.GetNSegments()); fflush(stdout);
-        return;
-      }
-    }
-    TTigressHit corehit;
-    corehit.SetAddress( (frag->GetAddress()) );  // fake it till you make it 
-    if(TestGlobalBit(kSetSegWave))         
-      temp.CopyWave(*frag);
-    corehit.AddSegment(temp);
-    fTigressHits.push_back(corehit);
-    //if(fTigressHits.size()>100) {
-    //   printf("size is large!\t%i\n",fTigressHits.size());
-    //   fflush(stdout);
-    //}
-    return;
- // } else if(chan->GetMnemonic()->subsystem.compare(0,1,"S")==0) {
-  } else if(chan->GetMnemonic()->SubSystem() == TMnemonic::kS) {
-    TBgoHit temp(*frag);
-    fBgos.push_back(temp);
-    return;
-  }
-  //if not suprress errors;
-  printf(ALERTTEXT "failed to build!" RESET_COLOR "\n");
-  frag->Print();
-  return;
+	// if((chan->GetMnemonic()->subsystem.compare(0,1,"G")==0) &&
+	if((chan->GetMnemonic()->SubSystem() == TMnemonic::kG) &&
+			(chan->GetSegmentNumber()==0 || chan->GetSegmentNumber()==9) ) { // it is a core
+		//if(frag->Charge.size() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a good energy and time (cfd or led).
+		//  return;
+		TTigressHit corehit; //(*frag);
+		//loop over existing hits to see if this core was already created by a previously found segment
+		//of course this means if we have a core in "coincidence" with itself we will overwrite the first hit
+		for(size_t i = 0; i < fTigressHits.size(); ++i)	{
+			TTigressHit& hit = GetTigressHit(i);
+			if((hit.GetDetector() == chan->GetDetectorNumber()) &&
+				(hit.GetCrystal()  == chan->GetCrystalNumber())) { //we have a match;
+				//if(hit.Charge() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a good energy and time (cfd or led).
+				//if(chan->GetMnemonic()->outputsensor.compare(0,1,"b")==0) 
+				if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kB) {
+					if(hit.GetName()[9] == 'a') {
+						return;
+					} else  {
+						hit.CopyFragment(*frag);
+						if(TestBit(kSetCoreWave)) frag->CopyWave(hit);
+						return;
+					}
+				} else {
+					hit.CopyFragment(*frag);
+					if(TestBit(kSetCoreWave)) frag->CopyWave(hit);
+					return;
+				}
+			}
+		}
+		corehit.CopyFragment(*frag);
+		if(TestBit(kSetCoreWave)) frag->CopyWave(corehit);
+		fTigressHits.push_back(corehit);
+		return;
+	} else if(chan->GetMnemonic()->SubSystem() == TMnemonic::kG) { // its ge but its not a core...
+		TGRSIDetectorHit temp(*frag);
+		for(size_t i = 0; i < fTigressHits.size(); ++i)	{
+			TTigressHit& hit = GetTigressHit(i);
+			if((hit.GetDetector() == chan->GetDetectorNumber()) &&
+				(hit.GetCrystal()  == chan->GetCrystalNumber())) { //we have a match;
+				if(TestGlobalBit(kSetSegWave)) frag->CopyWave(temp);
+				hit.AddSegment(temp);
+				//printf(" I found a core !\t%i\n",hit.GetNSegments()); fflush(stdout);
+				return;
+			}
+		}
+		TTigressHit corehit;
+		corehit.SetAddress( (frag->GetAddress()) );  // fake it till you make it 
+		if(TestGlobalBit(kSetSegWave)) frag->CopyWave(temp);
+		corehit.AddSegment(temp);
+		fTigressHits.push_back(corehit);
+		//if(fTigressHits.size()>100) {
+		//   printf("size is large!\t%i\n",fTigressHits.size());
+		//   fflush(stdout);
+		//}
+		return;
+	} else if(chan->GetMnemonic()->SubSystem() == TMnemonic::kS) {
+		TBgoHit temp(*frag);
+		fBgos.push_back(temp);
+		return;
+	}
+	//if not suprress errors;
+	printf(ALERTTEXT "failed to build!" RESET_COLOR "\n");
+	frag->Print();
+	return;
 }
 
 void TTigress::ResetAddback() {

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -136,7 +136,7 @@ void TTigressHit::SumHit(TTigressHit *hit) {
 //  return chan->GetCrystalNumber();
 //}
 
-void TTigressHit::SetWavefit(TFragment &frag)   { 
+void TTigressHit::SetWavefit(const TFragment &frag)   { 
   TPulseAnalyzer pulse(frag);	    
   if(pulse.IsSet()){
     fTimeFit   = pulse.fit_newT0();

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -39,7 +39,7 @@ TTip& TTip::operator=(const TTip& rhs) {
    return *this;
 }
 
-void TTip::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TTip::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	if(frag == NULL || chan == NULL) {
 		return;
 	}

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -20,7 +20,7 @@ TTipHit::TTipHit() {
    Clear();
 }
 
-TTipHit::TTipHit(TFragment &frag)	: TGRSIDetectorHit(frag) {
+TTipHit::TTipHit(const TFragment &frag) : TGRSIDetectorHit(frag) {
 	//SetVariables(frag);
   if(TGRSIRunInfo::IsWaveformFitting() && !IsCsI())
 		SetWavefit(frag);
@@ -65,7 +65,7 @@ void TTipHit::Print(Option_t *opt) const {
    printf("Tip hit time:   %.f\n",GetTime());
 }
 
-void TTipHit::SetWavefit(TFragment &frag)   { 
+void TTipHit::SetWavefit(const TFragment &frag)   { 
 	TPulseAnalyzer pulse(frag);	    
 	if(pulse.IsSet()){
 		fTimeFit   = pulse.fit_newT0();
@@ -73,7 +73,7 @@ void TTipHit::SetWavefit(TFragment &frag)   {
 	}
 }
 
-void TTipHit::SetPID(TFragment &frag)	{
+void TTipHit::SetPID(const TFragment &frag)	{
 	TPulseAnalyzer pulse(frag);
 	if(pulse.IsSet()){
 		fPID = pulse.CsIPID();

--- a/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
+++ b/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
@@ -34,7 +34,7 @@ TTriFoil::TTriFoil(const TTriFoil& rhs) : TDetector() {
   rhs.Copy(*this);
 }
 
-void TTriFoil::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TTriFoil::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
   if(frag == NULL || chan == NULL) {
     return;
   }

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -59,7 +59,7 @@ void TZeroDegree::Print(Option_t *opt) const	{
    printf("%lu fZeroDegreeHits\n",fZeroDegreeHits.size());
 }
 
-void TZeroDegree::AddFragment(std::shared_ptr<TFragment> frag, TChannel* chan) {
+void TZeroDegree::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the ZDS Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    if(frag == NULL || chan == NULL) {
       return;

--- a/libraries/TGRSIFormat/TParsingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TParsingDiagnostics.cxx
@@ -79,7 +79,7 @@ void TParsingDiagnostics::Print(Option_t* opt) const {
 	}
 }
 
-void TParsingDiagnostics::GoodFragment(std::shared_ptr<TFragment> frag) {
+void TParsingDiagnostics::GoodFragment(std::shared_ptr<const TFragment> frag) {
 	///increment the counter of good fragments for this detector type and check if any trigger ids have been lost
 	fNumberOfGoodFragments[frag->GetDetectorType()]++;
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -556,8 +556,8 @@ void TGRSIint::SetupPipeline() {
 	StoppableThread::StatusWidth(TGRSIOptions::Get()->StatusWidth());
 
    // Different queues that can show up
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > > fragmentQueues;
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment> > > > badQueues;
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fragmentQueues;
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > badQueues;
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > > > scalerQueues;
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > > > analysisQueues;
 
@@ -668,7 +668,7 @@ void TGRSIint::SetupPipeline() {
    // For each leftover queue, terminate if still exists.
    for(auto fragQueue : fragmentQueues) {
       if(fragQueue) {
-         auto loop = TTerminalLoop<TFragment>::Get("9_frag_term_loop");
+         auto loop = TTerminalLoop<const TFragment>::Get("9_frag_term_loop");
          loop->InputQueue() = fragQueue;
       }
    }
@@ -682,7 +682,7 @@ void TGRSIint::SetupPipeline() {
 
    for(auto badQueue : badQueues) {
       if(badQueue) {
-         auto loop = TTerminalLoop<TFragment>::Get("B_bad_frag_term_loop");
+         auto loop = TTerminalLoop<const TFragment>::Get("B_bad_frag_term_loop");
          loop->InputQueue() = badQueue;
       }
    }

--- a/libraries/THistogramming/TCompiledHistograms.cxx
+++ b/libraries/THistogramming/TCompiledHistograms.cxx
@@ -130,7 +130,7 @@ void TCompiledHistograms::swap_lib(TCompiledHistograms& other) {
   std::swap(fCheck_every, other.fCheck_every);
 }
 
-void TCompiledHistograms::Fill(std::shared_ptr<TFragment> frag) {
+void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag) {
   std::lock_guard<std::mutex> lock(fMutex);
   if(time(NULL) > fLast_checked + fCheck_every){
     Reload();

--- a/libraries/THistogramming/TFragHistLoop.cxx
+++ b/libraries/THistogramming/TFragHistLoop.cxx
@@ -20,7 +20,7 @@ TFragHistLoop * TFragHistLoop::Get(std::string name) {
 TFragHistLoop::TFragHistLoop(std::string name)
   : StoppableThread(name),
     fOutputFile(nullptr), fOutputFilename("last.root"),
-    fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment> > >()) {
+    fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()) {
   LoadLibrary(TGRSIOptions::Get()->FragmentHistogramLib());
 }
 
@@ -30,13 +30,13 @@ TFragHistLoop::~TFragHistLoop() {
 
 void TFragHistLoop::ClearQueue() {
   while(fInputQueue->Size()){
-    std::shared_ptr<TFragment> event;
+    std::shared_ptr<const TFragment> event;
     fInputQueue->Pop(event);
   }
 }
 
 bool TFragHistLoop::Iteration() {
-  std::shared_ptr<TFragment> event;
+  std::shared_ptr<const TFragment> event;
   fInputQueue->Pop(event);
 
   if(event) {

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -19,7 +19,7 @@
 
 std::map<std::string,TRuntimeObjects*> TRuntimeObjects::fRuntimeMap;
 
-TRuntimeObjects::TRuntimeObjects(std::shared_ptr<TFragment> frag, TList* objects, TList *gates,
+TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* objects, TList *gates,
                                  std::vector<TFile*>& cut_files,
                                  TDirectory* directory,const char *name)
   : fFrag(frag), //detectors(NULL),

--- a/libraries/TLoops/TDetBuildingLoop.cxx
+++ b/libraries/TLoops/TDetBuildingLoop.cxx
@@ -22,12 +22,12 @@ TDetBuildingLoop *TDetBuildingLoop::Get(std::string name) {
 
 TDetBuildingLoop::TDetBuildingLoop(std::string name)
    : StoppableThread(name),
-   fInputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment> > > >()) { }
+   fInputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > >()) { }
 
 TDetBuildingLoop::~TDetBuildingLoop() { }
 
 bool TDetBuildingLoop::Iteration() {
-   std::vector<std::shared_ptr<TFragment> > frags;
+   std::vector<std::shared_ptr<const TFragment> > frags;
 
 	fInputSize = fInputQueue->Pop(frags);
 	if(fInputSize < 0) fInputSize = 0;
@@ -59,7 +59,7 @@ bool TDetBuildingLoop::Iteration() {
 }
 
 void TDetBuildingLoop::ClearQueue() {
-   std::vector<std::shared_ptr<TFragment> > rawEvent;
+   std::vector<std::shared_ptr<const TFragment> > rawEvent;
    while(fInputQueue->Size()) {
       fInputQueue->Pop(rawEvent);
    }

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -34,8 +34,8 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
   : StoppableThread(name),
     fOutputFile(NULL), fEventTree(NULL), fBadEventTree(NULL), fScalerTree(NULL),
 	 fEventAddress(NULL), fBadEventAddress(NULL), fScalerAddress(NULL),
-    fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment> > >()),
-    fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment> > >()),
+    fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
+    fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fScalerInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >()) {
 
   if(fOutputFilename != "/dev/null"){
@@ -64,7 +64,7 @@ TFragWriteLoop::~TFragWriteLoop() {
 
 void TFragWriteLoop::ClearQueue() {
   while(fInputQueue->Size()){
-    std::shared_ptr<TFragment> event;
+    std::shared_ptr<const TFragment> event;
     fInputQueue->Pop(event);
   }
 }
@@ -76,11 +76,11 @@ std::string TFragWriteLoop::EndStatus() {
 }
 
 bool TFragWriteLoop::Iteration() {
-	std::shared_ptr<TFragment> event;
+	std::shared_ptr<const TFragment> event;
 	fInputSize = fInputQueue->Pop(event,0);
 	if(fInputSize < 0) fInputSize = 0;
 
-	std::shared_ptr<TFragment> badEvent;
+	std::shared_ptr<const TFragment> badEvent;
 	fBadInputQueue->Pop(badEvent,0);
 
 	std::shared_ptr<TEpicsFrag> scaler;
@@ -136,7 +136,7 @@ void TFragWriteLoop::Write() {
 	}
 }
 
-void TFragWriteLoop::WriteEvent(std::shared_ptr<TFragment> event) {
+void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 	if(fEventTree) {
 		fEventAddress = event.get();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
@@ -147,7 +147,7 @@ void TFragWriteLoop::WriteEvent(std::shared_ptr<TFragment> event) {
 	}
 }
 
-void TFragWriteLoop::WriteBadEvent(std::shared_ptr<TFragment> event) {
+void TFragWriteLoop::WriteBadEvent(std::shared_ptr<const TFragment> event) {
 	if(fBadEventTree) {
 		fBadEventAddress = event.get();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);

--- a/libraries/TLoops/TFragmentChainLoop.cxx
+++ b/libraries/TLoops/TFragmentChainLoop.cxx
@@ -41,7 +41,7 @@ TFragmentChainLoop::~TFragmentChainLoop() { }
 void TFragmentChainLoop::ClearQueue() {
    for(auto outQueue : fOutputQueues) {
       while(outQueue->Size()){
-         std::shared_ptr<TFragment> event;
+         std::shared_ptr<const TFragment> event;
          outQueue->Pop(event);
       }
    }

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -27,7 +27,7 @@ void TUnpackedEvent::Build() {
   ClearRawData();
 }
 
-void TUnpackedEvent::AddRawData(std::shared_ptr<TFragment> frag) {
+void TUnpackedEvent::AddRawData(std::shared_ptr<const TFragment> frag) {
   fFragments.push_back(frag);
 }
 

--- a/scripts/DescantMatrices.cxx
+++ b/scripts/DescantMatrices.cxx
@@ -343,7 +343,7 @@ TList *DescantMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEn
 				}
             if(dWaveForm_flag){
 					//Plot the normalized Waveform here.
-					std::vector<Short_t>* waveform = desc->GetDescantHit(one)->GetWaveform();
+					const std::vector<Short_t>* waveform = desc->GetDescantHit(one)->GetWaveform();
 					Short_t maximum = *std::max_element(waveform->begin(), waveform->end());
 					for(size_t i = 0; i < waveform->size(); ++i) {
 						desWaveForm->Fill(i - desc->GetDescantHit(one)->GetCfd()/256., waveform->at(i)/static_cast<double>(maximum));

--- a/util/WalkPlot.cxx
+++ b/util/WalkPlot.cxx
@@ -74,7 +74,7 @@ void ProcessEvent(std::vector<TFragment> *event) {
       if(x==y) continue;
       long timediff      = (event->at(y).GetTimeStamp()-event->at(x).GetTimeStamp());
       Double_t timediff_walk = ((Double_t)(event->at(y).GetTime())-(Double_t)(event->at(x).GetTime()))/10.;
-      int cfddiff  = abs(event->at(x).GetCfd()-event->at(y).GetCfd());
+      //int cfddiff  = abs(event->at(x).GetCfd()-event->at(y).GetCfd());
 
       if((event->at(y).GetDetectorType() == 0) && (event->at(x).GetDetectorType() != 0)){
          timehist_bg->Fill(timediff,event->at(y).GetEnergy());


### PR DESCRIPTION
- this should mitigate the fact that the object a shared_ptr points to
  is not thread-safe (unlike the rest of the shared_ptr)
- this should also avoid future issues if one process (e.g. histogramming)
  sets the transient flags of a fragment before it gets written