### PR TITLE
Making sure transients are zero when writing

### DIFF
--- a/include/TCSM.h
+++ b/include/TCSM.h
@@ -46,6 +46,8 @@ class TCSM : public TDetector {
 #endif
 		void BuildHits();
 
+		void ClearTransients() { for(auto hit : fCsmHits) hit.ClearTransients(); }
+
 	private: 
 		std::map<int16_t, std::vector<std::vector<std::vector<std::pair<TFragment, TMnemonic> > > > > fFragments; //!<!
 		std::vector<TCSMHit> fCsmHits;

--- a/include/TDescant.h
+++ b/include/TDescant.h
@@ -43,6 +43,8 @@ class TDescant : public TGRSIDetector {
       TGRSIDetectorHit* CreateHit(std::shared_ptr<const TFragment> frag, TChannel *chan) { return new TDescantHit(*frag); }
 #endif
 
+		void ClearTransients() { for(auto hit : fDescantHits) hit.ClearTransients(); }
+
       TDescant& operator=(const TDescant&);  //
       
    private:

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -50,6 +50,7 @@ class TDetector : public TObject	{
 
 		virtual void Copy(TObject&) const;              //!<!
 		virtual void Clear(Option_t* opt = "");         //!<!
+      virtual void ClearTransients() {}               //!<!
 		virtual void Print(Option_t* opt = "") const;   //!<!
 
 /// \cond CLASSIMP

--- a/include/TFragWriteLoop.h
+++ b/include/TFragWriteLoop.h
@@ -54,8 +54,8 @@ class TFragWriteLoop : public StoppableThread {
 		TTree* fBadEventTree;
 		TTree* fScalerTree;
 
-		const TFragment*  fEventAddress;
-		const TFragment*  fBadEventAddress;
+		TFragment*  fEventAddress;
+		TFragment*  fBadEventAddress;
 		TEpicsFrag* fScalerAddress;
 
 #ifndef __CINT__

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -94,6 +94,7 @@ class TGRSIOptions : public TObject {
 
 		size_t ColumnWidth() const { return fColumnWidth; }
 		size_t StatusWidth() const { return fStatusWidth; }
+		unsigned int StatusInterval() const { return fStatusInterval; }
 		bool LongFileDescription() const { return fLongFileDescription; }
 
 	private:
@@ -170,6 +171,7 @@ class TGRSIOptions : public TObject {
 
 		size_t fColumnWidth;
 		size_t fStatusWidth;
+		unsigned int fStatusInterval;
 		bool fLongFileDescription;
 
 		ClassDef(TGRSIOptions,1);

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -18,90 +18,92 @@
 #include "TGRSIRunInfo.h"
 
 class TGriffin : public TGRSIDetector {
-  public:
-    enum EGriffinBits {
-      kIsAddbackSet	= 1<<0,
-      kIsCrossTalkSet   = 1<<1,
-      kBit2		= 1<<2,
-      kBit3		= 1<<3,
-      kBit4		= 1<<4,
-      kBit5		= 1<<5,
-      kBit6		= 1<<6,
-      kBit7		= 1<<7
-    };
+	public:
+		enum EGriffinBits {
+			kIsAddbackSet	= 1<<0,
+			kIsCrossTalkSet   = 1<<1,
+			kBit2		= 1<<2,
+			kBit3		= 1<<3,
+			kBit4		= 1<<4,
+			kBit5		= 1<<5,
+			kBit6		= 1<<6,
+			kBit7		= 1<<7
+		};
 
-    TGriffin();
-    TGriffin(const TGriffin&);
-    virtual ~TGriffin();
+		TGriffin();
+		TGriffin(const TGriffin&);
+		virtual ~TGriffin();
 
-  public:
-    TGriffinHit* GetGriffinHit(const int& i); //!<!
-    TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
-    Short_t GetMultiplicity() const {return fGriffinHits.size();}
+	public:
+		TGriffinHit* GetGriffinHit(const int& i); //!<!
+		TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
+		Short_t GetMultiplicity() const {return fGriffinHits.size();}
 
-    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
+		static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
 #ifndef __CINT__
-    void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
+		void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
 #endif
 
-    TGriffin& operator=(const TGriffin&);  //!<!
+		void ClearTransients() { fGriffinBits = 0; for(auto hit : fGriffinHits) hit.ClearTransients(); }
+
+		TGriffin& operator=(const TGriffin&);  //!<!
 
 #if !defined (__CINT__) && !defined (__CLING__)
-    void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { fAddbackCriterion = criterion; }
-    std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
+		void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion) { fAddbackCriterion = criterion; }
+		std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
 #endif
 
-    Int_t GetAddbackMultiplicity();
-    TGriffinHit* GetAddbackHit(const int& i);
+		Int_t GetAddbackMultiplicity();
+		TGriffinHit* GetAddbackHit(const int& i);
 
-  private:
+	private:
 #if !defined (__CINT__) && !defined (__CLING__)
-    static std::function<bool(TGriffinHit&, TGriffinHit&)> fAddbackCriterion;
+		static std::function<bool(TGriffinHit&, TGriffinHit&)> fAddbackCriterion;
 #endif
-    std::vector <TGriffinHit> fGriffinHits; //  The set of crystal hits
+		std::vector <TGriffinHit> fGriffinHits; //  The set of crystal hits
 
-    //static bool fSetBGOHits;                //!<!  Flag that determines if BGOHits are being measured       
+		//static bool fSetBGOHits;                //!<!  Flag that determines if BGOHits are being measured       
 
-    static bool fSetCoreWave;             //!<!  Flag for Waveforms ON/OFF
-    //static bool fSetBGOWave;                //!<!  Flag for BGO Waveforms ON/OFF
+		static bool fSetCoreWave;             //!<!  Flag for Waveforms ON/OFF
+		//static bool fSetBGOWave;                //!<!  Flag for BGO Waveforms ON/OFF
 
-    long fCycleStart;                //!<!  The start of the cycle
-    UChar_t fGriffinBits;            // Transient member flags
+		long fCycleStart;                //!<!  The start of the cycle
+		UChar_t fGriffinBits;            // Transient member flags
 
-    std::vector<TGriffinHit> fAddbackHits; //!<! Used to create addback hits on the fly
-    std::vector<UShort_t> fAddbackFrags; //!<! Number of crystals involved in creating in the addback hit
+		std::vector<TGriffinHit> fAddbackHits; //!<! Used to create addback hits on the fly
+		std::vector<UShort_t> fAddbackFrags; //!<! Number of crystals involved in creating in the addback hit
 
-  public:
-    static bool SetCoreWave()        { return fSetCoreWave;  }  //!<!
-    //static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!
-    //static bool SetBGOWave()      { return fSetBGOWave;   } //!<!
+	public:
+		static bool SetCoreWave()        { return fSetCoreWave;  }  //!<!
+		//static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!
+		//static bool SetBGOWave()      { return fSetBGOWave;   } //!<!
 
-  private:
-    static TVector3 gCloverPosition[17];               //!<! Position of each HPGe Clover
-    void ClearStatus() { fGriffinBits = 0; } //!<!
-    void SetBitNumber(enum EGriffinBits bit,Bool_t set);
-    Bool_t TestBitNumber(enum EGriffinBits bit) const {return (bit & fGriffinBits);}
+	private:
+		static TVector3 gCloverPosition[17];               //!<! Position of each HPGe Clover
+		void ClearStatus() { fGriffinBits = 0; } //!<!
+		void SetBitNumber(enum EGriffinBits bit,Bool_t set);
+		Bool_t TestBitNumber(enum EGriffinBits bit) const {return (bit & fGriffinBits);}
 
-      //Cross-Talk stuff
-   public:
-      static const Double_t gStrongCT[2];   //!<!
-      static const Double_t gWeakCT[2]; //!<!
-      static const Double_t gCrossTalkPar[2][4][4]; //!<! 
-      static Double_t CTCorrectedEnergy(const TGriffinHit* const energy_to_correct, const TGriffinHit* const other_energy, Bool_t time_constraint = true);
-      Bool_t IsCrossTalkSet() const;
-      void FixCrossTalk();
+		//Cross-Talk stuff
+	public:
+		static const Double_t gStrongCT[2];   //!<!
+		static const Double_t gWeakCT[2]; //!<!
+		static const Double_t gCrossTalkPar[2][4][4]; //!<! 
+		static Double_t CTCorrectedEnergy(const TGriffinHit* const energy_to_correct, const TGriffinHit* const other_energy, Bool_t time_constraint = true);
+		Bool_t IsCrossTalkSet() const;
+		void FixCrossTalk();
 
-  public:
-    virtual void Copy(TObject&) const;                //!<!
-    virtual void Clear(Option_t* opt = "all");         //!<!
-    virtual void Print(Option_t* opt = "") const;      //!<!
-    void ResetFlags();
-    void ResetAddback();         //!<!
-    UShort_t GetNAddbackFrags(size_t idx) const;
+	public:
+		virtual void Copy(TObject&) const;                //!<!
+		virtual void Clear(Option_t* opt = "all");         //!<!
+		virtual void Print(Option_t* opt = "") const;      //!<!
+		void ResetFlags();
+		void ResetAddback();         //!<!
+		UShort_t GetNAddbackFrags(size_t idx) const;
 
-    /// \cond CLASSIMP
-    ClassDef(TGriffin,4)  // Griffin Physics structure
-      /// \endcond
+/// \cond CLASSIMP
+	ClassDef(TGriffin,4)  // Griffin Physics structure
+/// \endcond
 };
 /*! @} */
 #endif

--- a/include/TLaBr.h
+++ b/include/TLaBr.h
@@ -41,6 +41,8 @@ class TLaBr : public TGRSIDetector {
       
       static TVector3 GetPosition(int DetNbr) { return gPosition[DetNbr]; }	//!<!
       
+		void ClearTransients() { for(auto hit : fLaBrHits) hit.ClearTransients(); }
+
       TLaBr& operator=(const TLaBr&);  //!<!
       
    private:

--- a/include/TPaces.h
+++ b/include/TPaces.h
@@ -31,6 +31,9 @@ class TPaces : public TGRSIDetector {
       void AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan);
 #endif
 		static TVector3 GetPosition(int DetNbr);		//!<!
+
+		void ClearTransients() { for(auto hit : fPacesHits) hit.ClearTransients(); }
+
 		TPaces& operator=(const TPaces&);  //!<!
 
 	private: 

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -56,6 +56,8 @@ class TS3 : public TGRSIDetector {
 
 		void SetTargetDistance(double dist)	{ fTargetDistance = dist; }
 
+		void ClearTransients() { fS3Bits = 0; for(auto hit : fS3Hits) hit.ClearTransients(); for(auto hit : fS3RingHits) hit.ClearTransients(); for(auto hit : fS3SectorHits) hit.ClearTransients(); }
+
 		void Copy(TObject&) const;
 		TS3& operator=(const TS3&);  // 
       virtual void Clear(Option_t *opt = "all");		     //!<!

--- a/include/TSceptar.h
+++ b/include/TSceptar.h
@@ -41,6 +41,8 @@ class TSceptar : public TGRSIDetector {
 
       static TVector3 GetPosition(int DetNbr) { return gPaddlePosition[DetNbr]; }	//!<!
 
+		void ClearTransients() { for(auto hit : fSceptarHits) hit.ClearTransients(); }
+
       TSceptar& operator=(const TSceptar&);  //!<!
       
    private:

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -22,6 +22,8 @@ class TSiLi: public TGRSIDetector  {
       void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
+		void ClearTransients() { for(auto hit : fSiLiHits) hit.ClearTransients(); }
+
 		TSiLi& operator=(const TSiLi&);  // 
 
 		void Copy(TObject&) const;

--- a/include/TTAC.h
+++ b/include/TTAC.h
@@ -40,6 +40,8 @@ class TTAC : public TGRSIDetector {
       void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
       
+		void ClearTransients() { for(auto hit : fTACHits) hit.ClearTransients(); }
+
       TTAC& operator=(const TTAC&);  //!<!
       
    private:

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -21,125 +21,127 @@
 #include "TBgoHit.h"
 
 class TTigress : public TGRSIDetector {
-  public:
-    enum ETigressBits {
-      kAddbackSet	= TGRSIDetectorHit::kDetHitBit0,
-      kSuppression	= TGRSIDetectorHit::kDetHitBit1,
-      kBit3		= TGRSIDetectorHit::kDetHitBit2,
-      kBit4		= TGRSIDetectorHit::kDetHitBit3,
-      kBit5		= TGRSIDetectorHit::kDetHitBit4,
-      kBit6		= TGRSIDetectorHit::kDetHitBit5,
-      kBit7		= TGRSIDetectorHit::kDetHitBit6
-    };
+	public:
+		enum ETigressBits {
+			kAddbackSet	= TGRSIDetectorHit::kDetHitBit0,
+			kSuppression	= TGRSIDetectorHit::kDetHitBit1,
+			kBit3		= TGRSIDetectorHit::kDetHitBit2,
+			kBit4		= TGRSIDetectorHit::kDetHitBit3,
+			kBit5		= TGRSIDetectorHit::kDetHitBit4,
+			kBit6		= TGRSIDetectorHit::kDetHitBit5,
+			kBit7		= TGRSIDetectorHit::kDetHitBit6
+		};
 
-    enum ETigressGlobalBits {
-      kSetBGOWave	= BIT(0),
-      kSetCoreWave	= BIT(1),
-      kSetSegWave	= BIT(2),
-      kSetBGOHits       = BIT(3)
-    };
-
-#ifndef __CINT__
-    std::vector<std::vector<std::shared_ptr<const TFragment> > > SegmentFragments;
-#endif
-
-    TTigress();
-    TTigress(const TTigress&);
-    virtual ~TTigress();
-
-    const TTigressHit &GetTigressHit(int i) const { return fTigressHits.at(i);  }  //!<!
-          TTigressHit &GetTigressHit(int i)       { return fTigressHits.at(i);  }  //!<!
-    const TGRSIDetectorHit &GetHit(int i)   const { return GetTigressHit(i);    }  //!<!
-    size_t GetMultiplicity()                const { return fTigressHits.size(); }  //!<!
-    static TVector3 GetPosition(int DetNbr ,int CryNbr, int SegNbr, double distance = 110.);    //!<!
-    static TVector3 GetPosition(const TTigressHit&,double distance = 110.);    //!<!
-
-    
-    std::vector<TBgoHit> fBgos;
-    void AddBGO(TBgoHit& bgo) { fBgos.push_back(bgo);	}	   //!<!
-    int GetBGOMultiplicity() const      { return fBgos.size();     }   //!<!
-    int GetNBGOs() const      { return fBgos.size();     }   //!<!
-    TBgoHit GetBGO( int &i)	   const { return fBgos.at(i);	     }   //!<!
-    TBgoHit& GetBGO( int &i)	         { return fBgos.at(i);	     }   //!<!
-
-    // Delete tigress hit from vector (for whatever reason)
-    //void DeleteTigressHit(const int& i) { fTigressHits.erase(fTigressHits.begin()+i); } 
-
-    Int_t GetAddbackMultiplicity();
-    TTigressHit* GetAddbackHit(const int&);
-    void ResetAddback();         //!<!
-    UShort_t GetNAddbackFrags(size_t idx) const;
+		enum ETigressGlobalBits {
+			kSetBGOWave	= BIT(0),
+			kSetCoreWave	= BIT(1),
+			kSetSegWave	= BIT(2),
+			kSetBGOHits       = BIT(3)
+		};
 
 #ifndef __CINT__
-      void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
+		std::vector<std::vector<std::shared_ptr<const TFragment> > > SegmentFragments;
 #endif
-    void BuildHits();
 
-    TTigress& operator=(const TTigress&); //!<!
+		TTigress();
+		TTigress(const TTigress&);
+		virtual ~TTigress();
+
+		const TTigressHit &GetTigressHit(int i) const { return fTigressHits.at(i);  }  //!<!
+		TTigressHit &GetTigressHit(int i)       { return fTigressHits.at(i);  }  //!<!
+		const TGRSIDetectorHit &GetHit(int i)   const { return GetTigressHit(i);    }  //!<!
+		size_t GetMultiplicity()                const { return fTigressHits.size(); }  //!<!
+		static TVector3 GetPosition(int DetNbr ,int CryNbr, int SegNbr, double distance = 110.);    //!<!
+		static TVector3 GetPosition(const TTigressHit&,double distance = 110.);    //!<!
+
+
+		std::vector<TBgoHit> fBgos;
+		void AddBGO(TBgoHit& bgo) { fBgos.push_back(bgo);	}	   //!<!
+		int GetBGOMultiplicity() const      { return fBgos.size();     }   //!<!
+		int GetNBGOs() const      { return fBgos.size();     }   //!<!
+		TBgoHit GetBGO( int &i)	   const { return fBgos.at(i);	     }   //!<!
+		TBgoHit& GetBGO( int &i)	         { return fBgos.at(i);	     }   //!<!
+
+		// Delete tigress hit from vector (for whatever reason)
+		//void DeleteTigressHit(const int& i) { fTigressHits.erase(fTigressHits.begin()+i); } 
+
+		Int_t GetAddbackMultiplicity();
+		TTigressHit* GetAddbackHit(const int&);
+		void ResetAddback();         //!<!
+		UShort_t GetNAddbackFrags(size_t idx) const;
+
+#ifndef __CINT__
+		void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
+#endif
+		void BuildHits();
+
+		void ClearTransients() { fgTigressBits = 0; for(auto hit : fTigressHits) hit.ClearTransients(); }
+
+		TTigress& operator=(const TTigress&); //!<!
 
 #if !defined (__CINT__) && !defined (__CLING__)
-    void SetAddbackCriterion(std::function<bool(TTigressHit&, TTigressHit&)> criterion) {
-      fAddbackCriterion = criterion;
-    }
+		void SetAddbackCriterion(std::function<bool(TTigressHit&, TTigressHit&)> criterion) {
+			fAddbackCriterion = criterion;
+		}
 
-    std::function<bool(TTigressHit&, TTigressHit&)> GetAddbackCriterion() const {
-      return fAddbackCriterion;
-    }
-    void SetSuppressionCriterion(std::function<bool(TTigressHit&, TBgoHit&)> criterion) {
-      fSuppressionCriterion = criterion;
-    }
-    std::function<bool(TTigressHit&, TBgoHit&)> GetSuppressionCriterion() const {
-      return fSuppressionCriterion;
-    }
+		std::function<bool(TTigressHit&, TTigressHit&)> GetAddbackCriterion() const {
+			return fAddbackCriterion;
+		}
+		void SetSuppressionCriterion(std::function<bool(TTigressHit&, TBgoHit&)> criterion) {
+			fSuppressionCriterion = criterion;
+		}
+		std::function<bool(TTigressHit&, TBgoHit&)> GetSuppressionCriterion() const {
+			return fSuppressionCriterion;
+		}
 #endif
 
-  private: 
+	private: 
 #if !defined (__CINT__) && !defined (__CLING__)
-    static std::function<bool(TTigressHit&, TTigressHit&)> fAddbackCriterion;
-    static std::function<bool(TTigressHit&, TBgoHit&)> fSuppressionCriterion;
+		static std::function<bool(TTigressHit&, TTigressHit&)> fAddbackCriterion;
+		static std::function<bool(TTigressHit&, TBgoHit&)> fSuppressionCriterion;
 #endif
-    static unsigned short fgTigressBits; //!
-    std::vector<TTigressHit> fTigressHits;
+		static unsigned short fgTigressBits; //!
+		std::vector<TTigressHit> fTigressHits;
 
-    static bool fSetSegmentHits;    //!<!
-    static bool fSetBGOHits;        //!<!
+		static bool fSetSegmentHits;    //!<!
+		static bool fSetBGOHits;        //!<!
 
-    static bool fSetCoreWave;       //!<!
-    static bool fSetSegmentWave;    //!<!
-    static bool fSetBGOWave;        //!<!
+		static bool fSetCoreWave;       //!<!
+		static bool fSetSegmentWave;    //!<!
+		static bool fSetBGOWave;        //!<!
 
-    static double GeBluePosition[17][9][3];  //!<!  detector segment XYZ
-    static double GeGreenPosition[17][9][3]; //!<!
-    static double GeRedPosition[17][9][3];   //!<!
-    static double GeWhitePosition[17][9][3]; //!<!
-    static double GeBluePositionBack[17][9][3];  //!<!  detector segment XYZ
-    static double GeGreenPositionBack[17][9][3]; //!<!
-    static double GeRedPositionBack[17][9][3];   //!<!
-    static double GeWhitePositionBack[17][9][3]; //!<!
+		static double GeBluePosition[17][9][3];  //!<!  detector segment XYZ
+		static double GeGreenPosition[17][9][3]; //!<!
+		static double GeRedPosition[17][9][3];   //!<!
+		static double GeWhitePosition[17][9][3]; //!<!
+		static double GeBluePositionBack[17][9][3];  //!<!  detector segment XYZ
+		static double GeGreenPositionBack[17][9][3]; //!<!
+		static double GeRedPositionBack[17][9][3];   //!<!
+		static double GeWhitePositionBack[17][9][3]; //!<!
 
-	  //    void ClearStatus();                      // WARNING: this will change the building behavior!
-    //		void ClearGlobalStatus() { fTigressBits = 0; }
-    static void SetGlobalBit(enum ETigressGlobalBits bit,Bool_t set=true);
-    static Bool_t TestGlobalBit(enum ETigressGlobalBits bit) {
-      return (bit & fgTigressBits);
-    }
+		//    void ClearStatus();                      // WARNING: this will change the building behavior!
+		//		void ClearGlobalStatus() { fTigressBits = 0; }
+		static void SetGlobalBit(enum ETigressGlobalBits bit,Bool_t set=true);
+		static Bool_t TestGlobalBit(enum ETigressGlobalBits bit) {
+			return (bit & fgTigressBits);
+		}
 
-    std::vector<TTigressHit> fAddbackHits; //!<! Used to create addback hits on the fly
-    std::vector<UShort_t> fAddbackFrags;   //!<! Number of crystals involved in creating in the addback hit
+		std::vector<TTigressHit> fAddbackHits; //!<! Used to create addback hits on the fly
+		std::vector<UShort_t> fAddbackFrags;   //!<! Number of crystals involved in creating in the addback hit
 
-  public:
-    static bool SetCoreWave()    { return TestGlobalBit(kSetCoreWave);     }  //!<!
-    static bool SetSegmentWave() { return TestGlobalBit(kSetSegWave);      }  //!<!
-    static bool SetBGOWave()     { return TestGlobalBit(kSetBGOWave);      }  //!<!
-    static bool BGOSuppression[4][4][5]; //!<!
+	public:
+		static bool SetCoreWave()    { return TestGlobalBit(kSetCoreWave);     }  //!<!
+		static bool SetSegmentWave() { return TestGlobalBit(kSetSegWave);      }  //!<!
+		static bool SetBGOWave()     { return TestGlobalBit(kSetBGOWave);      }  //!<!
+		static bool BGOSuppression[4][4][5]; //!<!
 
-  public:         
-    virtual void Clear(Option_t *opt = "");     //!<!
-    virtual void Print(Option_t *opt = "") const; //!<!
-    virtual void Copy(TObject&) const;           //!<!
+	public:         
+		virtual void Clear(Option_t *opt = "");     //!<!
+		virtual void Print(Option_t *opt = "") const; //!<!
+		virtual void Copy(TObject&) const;           //!<!
 
 /// \cond CLASSIMP
-    ClassDef(TTigress,7)  // Tigress Physics structure
+		ClassDef(TTigress,7)  // Tigress Physics structure
 /// \endcond
 };
 /*! @} */

--- a/include/TTip.h
+++ b/include/TTip.h
@@ -43,6 +43,8 @@ class TTip : public TGRSIDetector {
 #endif
 		void Copy(TObject &rhs) const;
 
+		void ClearTransients() { for(auto hit : fTipHits) hit.ClearTransients(); }
+
 		TTip& operator=(const TTip&);  //!<!
 
 		void Clear(Option_t* opt = "");

--- a/include/TTriFoil.h
+++ b/include/TTriFoil.h
@@ -13,39 +13,39 @@
 #include "TFragment.h"
 
 class TTriFoil :  public TDetector {
-  public:
-    TTriFoil();
-    virtual ~TTriFoil();
-    TTriFoil(const TTriFoil& rhs);
+	public:
+		TTriFoil();
+		virtual ~TTriFoil();
+		TTriFoil(const TTriFoil& rhs);
 
-    std::vector<Short_t> GetWave() { return fTfWave; }
-    bool Beam() const { return fBeam; }
-    int NTBeam() const { return fTBeam.size(); }
-    //int TBeam() const { return TBeam(0); }
-    int TBeam(unsigned int n=0) const { 	if(n<fTBeam.size()) 
-					return fTBeam.at(n);
-				else
-					return -1; }
+		std::vector<Short_t> GetWave() { return fTfWave; }
+		bool Beam() const { return fBeam; }
+		int NTBeam() const { return fTBeam.size(); }
+		//int TBeam() const { return TBeam(0); }
+		int TBeam(unsigned int n=0) const { 	if(n<fTBeam.size()) 
+			return fTBeam.at(n);
+			else
+				return -1; }
 
-    bool HasWave() const { return !fTfWave.empty(); }
-    time_t GetTimeStamp() const { return fTimestamp; }
+		bool HasWave() const { return !fTfWave.empty(); }
+		time_t GetTimeStamp() const { return fTimestamp; }
 
 #ifndef __CINT__
-    void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
+		void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
 
-    void Clear(Option_t* opt = "");   //!<!
-    void Print(Option_t* opt = "") const;   //!<!
-    void Copy(TObject &rhs) const;
+		void Clear(Option_t* opt = "");   //!<!
+		void Print(Option_t* opt = "") const;   //!<!
+		void Copy(TObject &rhs) const;
 
-  private:
-    std::vector<Short_t> fTfWave;
-    Long_t fTimestamp;
-    bool fBeam;
-    std::vector<int> fTBeam;
+	private:
+		std::vector<Short_t> fTfWave;
+		Long_t fTimestamp;
+		bool fBeam;
+		std::vector<int> fTBeam;
 
 /// \cond CLASSIMP
-    ClassDef(TTriFoil,2)
+		ClassDef(TTriFoil,2)
 /// \endcond
 };
 /*! @} */

--- a/include/TZeroDegree.h
+++ b/include/TZeroDegree.h
@@ -42,6 +42,8 @@ class TZeroDegree : public TGRSIDetector {
       void AddFragment(std::shared_ptr<const TFragment>, TChannel*); //!<!
 #endif
       
+		void ClearTransients() { for(auto hit : fZeroDegreeHits) hit.ClearTransients(); }
+
       TZeroDegree& operator=(const TZeroDegree&);  //!<!
       
    private:

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -24,7 +24,7 @@ TGRSIDetectorHit::TGRSIDetectorHit(const int& Address) : TObject() {
 #endif
 }
 
-TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) : TObject() {
+TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) : TObject(rhs) {
   ///Default Copy constructor
   rhs.Copy(*this);
   if(copywave) {

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -92,6 +92,7 @@ void TGRSIOptions::Clear(Option_t* opt) {
 
 	fColumnWidth = 20;
 	fStatusWidth = 80;
+	fStatusInterval = 10;
   fLongFileDescription = false;
 }
 
@@ -139,6 +140,7 @@ void TGRSIOptions::Print(Option_t* opt) const {
 			  <<std::endl
 			  <<"fColumnWidth: "<<fColumnWidth<<std::endl
 			  <<"fStatusWidth: "<<fStatusWidth<<std::endl
+			  <<"fStatusInterval: "<<fStatusInterval<<std::endl
 			  <<"fLongFileDescription: "<<fLongFileDescription<<std::endl;
 }
 
@@ -272,6 +274,9 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	parser.option("status-width", &fStatusWidth)
 	      .description("number of characters to be used for status output")
 			.default_value(80);
+	parser.option("status-interval", &fStatusInterval)
+	      .description("seconds between each detailed status output (each a new line)")
+			.default_value(10);
 
 	// parser.option("long-file-description", &fLongFileDescription)
 	//   .description("Show full path to file in status messages")

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -174,7 +174,7 @@ void TGRSIint::LoopUntilDone() {
 		fAllowedToTerminate = true;
 
 		++iter;
-		if(iter%10 == 0) {
+		if(iter%TGRSIOptions::Get()->StatusInterval() == 0) {
 			std::cout<<"\r"<<StoppableThread::AllThreadStatus()<<std::endl;
 		}
 		std::cout<<"\r"<<StoppableThread::AllThreadProgress()<<std::flush;

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -149,18 +149,20 @@ void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event) {
 		//   which suggests that a new object would be constructed only when setting the address,
 		//   not when filling the TTree.
 		for(auto& elem : fDetMap){
-			*elem.second = fDefaultDets[elem.first];
+			//*elem.second = fDefaultDets[elem.first];
+			(*elem.second)->Clear();
 		}
 
 		// Load current events
 		for(auto det : event.GetDetectors()) {
 			TClass* cls = det->IsA();
 			try{
-				*fDetMap.at(cls) = det.get();
+				**fDetMap.at(cls) = *(det.get());
 			} catch (std::out_of_range& e) {
 				AddBranch(cls);
-				*fDetMap.at(cls) = det.get();
+				**fDetMap.at(cls) = *(det.get());
 			}
+			(*fDetMap.at(cls))->ClearTransients();
 			//if(cls == TDescant::Class()) {
 			//	for(int i = 0; i < static_cast<TDescant*>(det)->GetMultiplicity(); ++i) {
 			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == NULL ? " has no debug data": " has debug data")<<std::endl;

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -33,7 +33,7 @@ TFragWriteLoop* TFragWriteLoop::Get(std::string name, std::string fOutputFilenam
 TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
   : StoppableThread(name),
     fOutputFile(NULL), fEventTree(NULL), fBadEventTree(NULL), fScalerTree(NULL),
-	 fEventAddress(NULL), fBadEventAddress(NULL), fScalerAddress(NULL),
+	 //fEventAddress(NULL), fBadEventAddress(NULL), fScalerAddress(NULL),
     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fScalerInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >()) {
@@ -45,12 +45,15 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
     fOutputFile = new TFile(fOutputFilename.c_str(),"RECREATE");
 
     fEventTree = new TTree("FragmentTree","FragmentTree");
+	 fEventAddress = new TFragment;
     fEventTree->Branch("TFragment", &fEventAddress);
 
     fBadEventTree = new TTree("BadFragmentTree","BadFragmentTree");
+	 fBadEventAddress = new TFragment;
     fBadEventTree->Branch("TFragment", &fBadEventAddress);
 
     fScalerTree = new TTree("EpicsTree","EpicsTree");
+	 fScalerAddress = NULL;
     fScalerTree->Branch("TEpicsFrag", &fScalerAddress);
 
     TThread::UnLock();
@@ -138,10 +141,11 @@ void TFragWriteLoop::Write() {
 
 void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 	if(fEventTree) {
-		fEventAddress = event.get();
+		*fEventAddress = *(event.get());
+		fEventAddress->ClearTransients();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fEventTree->Fill();
-		fEventAddress = NULL;
+		//fEventAddress = NULL;
 	} else {
 		std::cout<<__PRETTY_FUNCTION__<<": no fragment tree!"<<std::endl;
 	}
@@ -149,10 +153,10 @@ void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 
 void TFragWriteLoop::WriteBadEvent(std::shared_ptr<const TFragment> event) {
 	if(fBadEventTree) {
-		fBadEventAddress = event.get();
+		*fBadEventAddress = *(event.get());
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fBadEventTree->Fill();
-		fBadEventAddress = NULL;
+		//fBadEventAddress = NULL;
 	}
 }
 


### PR DESCRIPTION
- we are now copying the fragments/events before writing them, so that we can call ClearTransients on the copy w/o having another thread setting the bit-flags again
- to this effect all detectors that have a collection of hits (i.e. all expect TTriFoil) have now a custom ClearTransients function