### PR TITLE
Added Low- and High-gain GRIFFIN hits to TGriffin

### DIFF
--- a/.grsirc
+++ b/.grsirc
@@ -1,4 +1,4 @@
-Unix.*.Root.MacroPath: .:$(GRSISYS)/util:$(ROOTSYS)/macros:$(GRSISYS)/scripts:$(GRSISYS)/examples:$(GRSISYS)/myAnalysis
+Unix.*.Root.MacroPath: .:$(GRSISYS)/util:$(ROOTSYS)/macros:$(GRSISYS)/scripts:$(GRSISYS)/examples:$(GRSISYS)/myAnalysis:$(GRSISYS)/GRSIProof
 Unix.*.Root.DynamicPath:  .:~/rootlibs:$(ROOTSYS)/lib:$(GRSISYS)/lib:$(GRSISYS)/GRSIProof
 Unix.*.Root.IncludePath:  .:~/rootlibs:$(ROOTSYS)/include:$(GRSISYS)/include:$(GRSISYS)/GRSIProof
 

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -65,6 +65,7 @@ int main(int argc, char **argv) {
 
    //Add the path were we store headers for GRSIProof macros to see
    const char* pPath = getenv("GRSISYS");
+   gROOT->SetMacroPath(Form("%s/GRSIProof",pPath));
    gInterpreter->AddIncludePath(Form("%s/include",pPath));
    //The first thing we want to do is see if we can compile the macros that are passed to us
    if(!opt->MacroInputFiles().size()){
@@ -89,6 +90,7 @@ int main(int argc, char **argv) {
 
    //The first thing we do is get the PROOF Lite instance to run
    TGRSIProof *proof = TGRSIProof::Open("");
+   proof->SetParallel(opt->GetMaxWorkers());
    if(!proof){
       std::cout << "Can't connect to proof" << std::endl;
       return 0;

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -97,6 +97,9 @@ class TGRSIOptions : public TObject {
 		unsigned int StatusInterval() const { return fStatusInterval; }
 		bool LongFileDescription() const { return fLongFileDescription; }
 
+      //Proof only
+      int GetMaxWorkers() const { return fMaxWorkers; }
+
 	private:
 		TGRSIOptions(int argc, char** argv);
 
@@ -173,6 +176,9 @@ class TGRSIOptions : public TObject {
 		size_t fStatusWidth;
 		unsigned int fStatusInterval;
 		bool fLongFileDescription;
+
+      //Proof only
+      int fMaxWorkers;
 
 		ClassDef(TGRSIOptions,1);
 };

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstdio>
 #include <functional>
+//#include <tuple>
 
 #include "TBits.h"
 #include "TVector3.h"
@@ -20,14 +21,18 @@
 class TGriffin : public TGRSIDetector {
 	public:
 		enum EGriffinBits {
-			kIsAddbackSet	= 1<<0,
-			kIsCrossTalkSet   = 1<<1,
-			kBit2		= 1<<2,
-			kBit3		= 1<<3,
+			kIsLowGainAddbackSet			= 1<<0,
+			kIsHighGainAddbackSet		= 1<<1,
+			kIsLowGainCrossTalkSet   	= 1<<2,
+			kIsHighGainCrossTalkSet   	= 1<<3,
 			kBit4		= 1<<4,
 			kBit5		= 1<<5,
 			kBit6		= 1<<6,
 			kBit7		= 1<<7
+		};
+		enum EGainBits {
+			kLowGain,
+			kHighGain
 		};
 
 		TGriffin();
@@ -35,16 +40,21 @@ class TGriffin : public TGRSIDetector {
 		virtual ~TGriffin();
 
 	public:
-		TGriffinHit* GetGriffinHit(const int& i); //!<!
+		TGriffinHit* GetGriffinLowGainHit(const int& i); //!<!
+		TGriffinHit* GetGriffinHighGainHit(const int& i); //!<!
+		TGriffinHit* GetGriffinHit(const Int_t &i) { return GetGriffinHit(i,GetDefaultGainType()); } //!<!
 		TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
-		Short_t GetMultiplicity() const {return fGriffinHits.size();}
+		Short_t GetLowGainMultiplicity() const {return fGriffinLowGainHits.size();}
+		Short_t GetHighGainMultiplicity() const {return fGriffinHighGainHits.size();}
+		Int_t GetMultiplicity() const { return GetMultiplicity(GetDefaultGainType()); }
 
 		static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);    //!<!
 #ifndef __CINT__
 		void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
 #endif
-
-		void ClearTransients() { fGriffinBits = 0; for(auto hit : fGriffinHits) hit.ClearTransients(); }
+      //TODO: Make a better ClearTransients function with all vectors included
+		void ClearTransients() { fGriffinBits = 0; for(auto hit : fGriffinLowGainHits) hit.ClearTransients(); for(auto hit: fGriffinHighGainHits) hit.ClearTransients(); }
+		void ResetFlags() const;
 
 		TGriffin& operator=(const TGriffin&);  //!<!
 
@@ -53,14 +63,26 @@ class TGriffin : public TGRSIDetector {
 		std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
 #endif
 
-		Int_t GetAddbackMultiplicity();
-		TGriffinHit* GetAddbackHit(const int& i);
+		Int_t GetAddbackLowGainMultiplicity();
+		Int_t GetAddbackHighGainMultiplicity();
+		Int_t GetAddbackMultiplicity() { return GetAddbackMultiplicity(GetDefaultGainType()); }
+		TGriffinHit* GetAddbackLowGainHit(const int& i);
+		TGriffinHit* GetAddbackHighGainHit(const int& i);
+		TGriffinHit* GetAddbackHit(const int& i) { return GetAddbackHit(i,GetDefaultGainType()); }
+		bool IsAddbackSet(const Int_t &gain_type) const;
+		void ResetLowGainAddback();         //!<!
+		void ResetHighGainAddback();         //!<!
+		void ResetAddback() { ResetAddback(GetDefaultGainType()); }         //!<!
+		UShort_t GetNHighGainAddbackFrags(const size_t &idx);
+		UShort_t GetNLowGainAddbackFrags(const size_t &idx);
+		UShort_t GetNAddbackFrags(const size_t &idx) { return GetNAddbackFrags(idx,GetDefaultGainType()); }
 
 	private:
 #if !defined (__CINT__) && !defined (__CLING__)
 		static std::function<bool(TGriffinHit&, TGriffinHit&)> fAddbackCriterion;
 #endif
-		std::vector <TGriffinHit> fGriffinHits; //  The set of crystal hits
+		std::vector <TGriffinHit> fGriffinLowGainHits; //  The set of crystal hits
+		std::vector <TGriffinHit> fGriffinHighGainHits; //  The set of crystal hits
 
 		//static bool fSetBGOHits;                //!<!  Flag that determines if BGOHits are being measured       
 
@@ -68,21 +90,29 @@ class TGriffin : public TGRSIDetector {
 		//static bool fSetBGOWave;                //!<!  Flag for BGO Waveforms ON/OFF
 
 		long fCycleStart;                //!<!  The start of the cycle
-		UChar_t fGriffinBits;            // Transient member flags
+		mutable UChar_t fGriffinBits;            // Transient member flags
 
-		std::vector<TGriffinHit> fAddbackHits; //!<! Used to create addback hits on the fly
-		std::vector<UShort_t> fAddbackFrags; //!<! Number of crystals involved in creating in the addback hit
+		mutable std::vector<TGriffinHit> fAddbackLowGainHits; //!<! Used to create addback hits on the fly
+		mutable std::vector<TGriffinHit> fAddbackHighGainHits; //!<! Used to create addback hits on the fly
+		mutable std::vector<UShort_t> fAddbackLowGainFrags; //!<! Number of crystals involved in creating in the addback hit
+		mutable std::vector<UShort_t> fAddbackHighGainFrags; //!<! Number of crystals involved in creating in the addback hit
+
+		static Int_t fDefaultGainType;
 
 	public:
 		static bool SetCoreWave()        { return fSetCoreWave;  }  //!<!
 		//static bool SetBGOHits()       { return fSetBGOHits;   }  //!<!
 		//static bool SetBGOWave()      { return fSetBGOWave;   } //!<!
+		static void SetDefaultGainType(const Int_t &gain_type); 
+		static Int_t GetDefaultGainType() { return fDefaultGainType; }
 
 	private:
 		static TVector3 gCloverPosition[17];               //!<! Position of each HPGe Clover
-		void ClearStatus() { fGriffinBits = 0; } //!<!
-		void SetBitNumber(enum EGriffinBits bit,Bool_t set);
+		void ClearStatus() const { fGriffinBits = 0; } //!<!
+		void SetBitNumber(enum EGriffinBits bit,Bool_t set) const;
 		Bool_t TestBitNumber(enum EGriffinBits bit) const {return (bit & fGriffinBits);}
+
+     // const std::tuple<std::vector<TGriffinHit> *, std::vector<TGriffinHit> *, std::vector<UShort_t>*> fLowGainTuple = std::make_tuple(&fGriffinLowGainHits,&fAddbackLowGainHits,&fAddbackLowGainFrags);
 
 		//Cross-Talk stuff
 	public:
@@ -90,19 +120,32 @@ class TGriffin : public TGRSIDetector {
 		static const Double_t gWeakCT[2]; //!<!
 		static const Double_t gCrossTalkPar[2][4][4]; //!<! 
 		static Double_t CTCorrectedEnergy(const TGriffinHit* const energy_to_correct, const TGriffinHit* const other_energy, Bool_t time_constraint = true);
-		Bool_t IsCrossTalkSet() const;
-		void FixCrossTalk();
+		Bool_t IsCrossTalkSet(const Int_t &gain_type) const;
+		void FixLowGainCrossTalk();
+		void FixHighGainCrossTalk();
+
+	private:
+		//This is where the general untouchable functions live.
+		std::vector<TGriffinHit> 	*GetHitVector(const Int_t &gain_type); //!<!
+		std::vector<TGriffinHit> 	*GetAddbackVector(const Int_t &gain_type); //!<!
+		std::vector<UShort_t> 		*GetAddbackFragVector(const Int_t &gain_type); //!<!
+		TGriffinHit* GetGriffinHit(const Int_t &i,const Int_t &gain_type); //!<!
+		Int_t GetMultiplicity(const Int_t &gain_type) const;
+		TGriffinHit* GetAddbackHit(const int& i, const Int_t &gain_type);
+		Int_t GetAddbackMultiplicity(const Int_t &gain_type);
+		void SetAddback(const Int_t &gain_type,bool flag = true) const;
+		void ResetAddback(const Int_t &gain_type);         //!<!
+		UShort_t GetNAddbackFrags(const size_t &idx, const Int_t &gain_type);
+		void FixCrossTalk(const Int_t &gain_type);
+		void SetCrossTalk(const Int_t &gain_type, bool flag = true) const;
 
 	public:
 		virtual void Copy(TObject&) const;                //!<!
 		virtual void Clear(Option_t* opt = "all");         //!<!
 		virtual void Print(Option_t* opt = "") const;      //!<!
-		void ResetFlags();
-		void ResetAddback();         //!<!
-		UShort_t GetNAddbackFrags(size_t idx) const;
 
 /// \cond CLASSIMP
-	ClassDef(TGriffin,4)  // Griffin Physics structure
+	ClassDef(TGriffin,5)  // Griffin Physics structure
 /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -1,6 +1,8 @@
 #include "TGriffin.h"
 
+#include <sstream>
 #include <iostream>
+#include <iomanip>
 
 #include "TRandom.h"
 #include "TMath.h"
@@ -21,16 +23,17 @@
 
 /// \cond CLASSIMP
 ClassImp(TGriffin)
-  /// \endcond
+	/// \endcond
 
-bool DefaultAddback(TGriffinHit& one, TGriffinHit& two) {
-  return ((one.GetDetector() == two.GetDetector()) &&
-	  (std::fabs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()));
-}
+	bool DefaultAddback(TGriffinHit& one, TGriffinHit& two) {
+		return ((one.GetDetector() == two.GetDetector()) &&
+		(std::fabs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()));
+	}
 
 std::function<bool(TGriffinHit&, TGriffinHit&)> TGriffin::fAddbackCriterion = DefaultAddback;
 
 bool TGriffin::fSetCoreWave = false;
+Int_t TGriffin::fDefaultGainType = kLowGain;
 
 //This seems unnecessary, and why 17?;//  they are static members, and need
 //  to be defined outside the header
@@ -42,301 +45,450 @@ bool TGriffin::fSetCoreWave = false;
 //Initiallizes the HPGe Clover positions as per the wiki <https://www.triumf.info/wiki/tigwiki/index.php/HPGe_Coordinate_Table>
 //                                                                             theta                                 phi                                 theta                                phi                                 theta
 TVector3 TGriffin::gCloverPosition[17] = { 
-  TVector3(TMath::Sin(TMath::DegToRad()*(0.0))*TMath::Cos(TMath::DegToRad()*(0.0)), TMath::Sin(TMath::DegToRad()*(0.0))*TMath::Sin(TMath::DegToRad()*(0.0)), TMath::Cos(TMath::DegToRad()*(0.0))),
-  //Downstream lampshade
-  TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
-  //Corona
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(22.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(22.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(112.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(112.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(202.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(202.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(292.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(292.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
-  //Upstream lampshade
-  TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
-  TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(135.0)))
+	TVector3(TMath::Sin(TMath::DegToRad()*(0.0))*TMath::Cos(TMath::DegToRad()*(0.0)), TMath::Sin(TMath::DegToRad()*(0.0))*TMath::Sin(TMath::DegToRad()*(0.0)), TMath::Cos(TMath::DegToRad()*(0.0))),
+	//Downstream lampshade
+	TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(45.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(45.0))),
+	//Corona
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(22.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(22.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(112.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(112.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(202.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(202.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(292.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(292.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(90.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(90.0))),
+	//Upstream lampshade
+	TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(67.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(67.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(157.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(157.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(247.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(247.5)), TMath::Cos(TMath::DegToRad()*(135.0))),
+	TVector3(TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Cos(TMath::DegToRad()*(337.5)), TMath::Sin(TMath::DegToRad()*(135.0))*TMath::Sin(TMath::DegToRad()*(337.5)), TMath::Cos(TMath::DegToRad()*(135.0)))
 };
 
 //Cross Talk stuff
 const Double_t TGriffin::gStrongCT[2] = { -0.02674, -0.000977 }; //This is for the 0-1 and 2-3 combination
 const Double_t TGriffin::gWeakCT[2]   = { 0.005663, - 0.00028014};
 const Double_t TGriffin::gCrossTalkPar[2][4][4] = {
-   { {0.0, gStrongCT[0], gWeakCT[0], gWeakCT[0]}, {gStrongCT[0], 0.0, gWeakCT[0], gWeakCT[0]}, {gWeakCT[0], gWeakCT[0], 0.0, gStrongCT[0]}, {gWeakCT[0], gWeakCT[0], gStrongCT[0], 0.0}},
-   { {0.0, gStrongCT[1], gWeakCT[1], gWeakCT[1]}, {gStrongCT[1], 0.0, gWeakCT[1], gWeakCT[1]}, {gWeakCT[1], gWeakCT[1], 0.0, gStrongCT[1]}, {gWeakCT[1], gWeakCT[1], gStrongCT[1], 0.0}}};
+	{ {0.0, gStrongCT[0], gWeakCT[0], gWeakCT[0]}, {gStrongCT[0], 0.0, gWeakCT[0], gWeakCT[0]}, {gWeakCT[0], gWeakCT[0], 0.0, gStrongCT[0]}, {gWeakCT[0], gWeakCT[0], gStrongCT[0], 0.0}},
+	{ {0.0, gStrongCT[1], gWeakCT[1], gWeakCT[1]}, {gStrongCT[1], 0.0, gWeakCT[1], gWeakCT[1]}, {gWeakCT[1], gWeakCT[1], 0.0, gStrongCT[1]}, {gWeakCT[1], gWeakCT[1], gStrongCT[1], 0.0}}};
 
 TGriffin::TGriffin() : TGRSIDetector() {
-  //Default ctor. Ignores TObjectStreamer in ROOT < 6
+	//Default ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
-  Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-  Clear();
+	Clear();
 }
 
 TGriffin::TGriffin(const TGriffin& rhs) : TGRSIDetector() {
-  //Copy ctor. Ignores TObjectStreamer in ROOT < 6
+	//Copy ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
-  Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-  rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TGriffin::Copy(TObject &rhs) const {
-  //Copy function.
-  TGRSIDetector::Copy(rhs);
+	//Copy function.
+	TGRSIDetector::Copy(rhs);
 
-  static_cast<TGriffin&>(rhs).fGriffinHits       = fGriffinHits;
-  static_cast<TGriffin&>(rhs).fAddbackHits       = fAddbackHits;
-  static_cast<TGriffin&>(rhs).fAddbackFrags      = fAddbackFrags;
-  static_cast<TGriffin&>(rhs).fSetCoreWave       = fSetCoreWave;
-  static_cast<TGriffin&>(rhs).fCycleStart        = fCycleStart;
-  static_cast<TGriffin&>(rhs).fGriffinBits       = 0;
+	static_cast<TGriffin&>(rhs).fGriffinLowGainHits        = fGriffinLowGainHits;
+	static_cast<TGriffin&>(rhs).fGriffinHighGainHits       = fGriffinHighGainHits;
+	static_cast<TGriffin&>(rhs).fAddbackLowGainHits        = fAddbackLowGainHits;
+	static_cast<TGriffin&>(rhs).fAddbackHighGainHits       = fAddbackHighGainHits;
+	static_cast<TGriffin&>(rhs).fAddbackLowGainFrags       = fAddbackLowGainFrags;
+	static_cast<TGriffin&>(rhs).fAddbackHighGainFrags      = fAddbackHighGainFrags;
+	static_cast<TGriffin&>(rhs).fSetCoreWave               = fSetCoreWave;
+	static_cast<TGriffin&>(rhs).fCycleStart                = fCycleStart;
+	static_cast<TGriffin&>(rhs).fGriffinBits               = 0;
 
 }                                       
 
 TGriffin::~TGriffin()	{
-  //Default Destructor
+	//Default Destructor
 }
 
 void TGriffin::Clear(Option_t *opt)	{
-  //Clears the mother, and all of the hits
-  //  if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
-  ClearStatus();
-  //  }
-  TGRSIDetector::Clear(opt);
-  fGriffinHits.clear();
-  fAddbackHits.clear();
-  fAddbackFrags.clear();
-  fCycleStart = 0;
-  //fGriffinBits.Class()->IgnoreTObjectStreamer(kTRUE);
+	//Clears the mother, and all of the hits
+	//  if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
+	ClearStatus();
+	//  }
+	TGRSIDetector::Clear(opt);
+	fGriffinLowGainHits.clear();
+	fGriffinHighGainHits.clear();
+	fAddbackLowGainHits.clear();
+	fAddbackHighGainHits.clear();
+	fAddbackLowGainFrags.clear();
+	fAddbackHighGainFrags.clear();
+	fCycleStart = 0;
+	//fGriffinBits.Class()->IgnoreTObjectStreamer(kTRUE);
 }
 
 
 void TGriffin::Print(Option_t *opt) const {
-  //Prints out TGriffin members, currently does nothing.
-  printf("%lu fGriffinHits\n",fGriffinHits.size());
-  printf("%ld cycle start\n",fCycleStart);
-  return;
+	std::cout << "Griffin Contains: " << std::endl;
+	std::cout << std::setw(6) << GetLowGainMultiplicity() << " Low gain hits"  << std::endl;
+	std::cout << std::setw(6) << GetHighGainMultiplicity() << " High gain hits"  << std::endl;
+
+	if(IsAddbackSet(kLowGain)) 
+		std::cout << std::setw(6) << fAddbackLowGainHits.size() << " Low gain addback hits" << std::endl; 
+	else
+		std::cout << std::setw(6) << " " << " Low Gain Addback not set" << std::endl;
+
+	if(IsAddbackSet(kHighGain))  
+		std::cout << std::setw(6) << fAddbackHighGainHits.size() << " High gain addback hits" << std::endl;  
+	else
+		std::cout << std::setw(6) << " " << " High Gain Addback not set" << std::endl;
+
+	std::cout << std::setw(6) << " " << " Cross-talk Set?  Low gain: " << IsCrossTalkSet(kLowGain) << "   High gain: " << IsCrossTalkSet(kHighGain) << std::endl;
+	std::cout << std::setw(6) << fCycleStart  << " cycle start" << std::endl;
 }
 
 TGriffin& TGriffin::operator=(const TGriffin& rhs) {
-  rhs.Copy(*this);
-  return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
+void TGriffin::SetDefaultGainType(const Int_t &gain_type) { 
+	if((gain_type == kLowGain) || (gain_type == kHighGain)){
+		 fDefaultGainType = gain_type;
+	} else {
+		std::cout << gain_type << " is not a known gain type. Please use kLowGain or kHighGain" << std::endl;
+	}
+}
+
+Int_t TGriffin::GetMultiplicity(const Int_t &gain_type) const{
+	switch(gain_type){
+		case kLowGain:
+			return fGriffinLowGainHits.size();
+		case kHighGain:
+			return fGriffinHighGainHits.size();
+	};
+	return 0;
+}
+
+std::vector<TGriffinHit> *TGriffin::GetHitVector(const Int_t &gain_type) {
+	switch(gain_type){
+		case kLowGain:
+			return &fGriffinLowGainHits;
+		case kHighGain:
+			return &fGriffinHighGainHits;
+	};
+	return nullptr;
+}
+
+std::vector<TGriffinHit> *TGriffin::GetAddbackVector(const Int_t &gain_type) {
+	switch(gain_type){
+		case kLowGain:
+			return &fAddbackLowGainHits;
+		case kHighGain:
+			return &fAddbackHighGainHits;
+	};
+	return nullptr;
+}
+
+std::vector<UShort_t> *TGriffin::GetAddbackFragVector(const Int_t &gain_type) {
+	switch(gain_type){
+		case kLowGain:
+			return &fAddbackLowGainFrags;
+		case kHighGain:
+			return &fAddbackHighGainFrags;
+	};
+	return nullptr;
+}
+
+bool TGriffin::IsAddbackSet(const Int_t &gain_type) const{
+	switch(gain_type){
+		case kLowGain:
+			return TestBitNumber(kIsLowGainAddbackSet);
+		case kHighGain:
+			return TestBitNumber(kIsHighGainAddbackSet);
+	};
+	return false;
+}
+
+bool TGriffin::IsCrossTalkSet(const Int_t &gain_type) const{
+	switch(gain_type){
+		case kLowGain:
+			return TestBitNumber(kIsLowGainCrossTalkSet);
+		case kHighGain:
+			return TestBitNumber(kIsHighGainCrossTalkSet);
+	};
+	return false;
+}
+
+void TGriffin::SetAddback(const Int_t &gain_type,const Bool_t flag) const{
+	switch(gain_type){
+		case kLowGain:
+			return SetBitNumber(kIsLowGainAddbackSet,flag);
+		case kHighGain:
+			return SetBitNumber(kIsHighGainAddbackSet,flag);
+	};
+}
+
+void TGriffin::SetCrossTalk(const Int_t &gain_type, const Bool_t flag) const{
+	switch(gain_type){
+		case kLowGain:
+			return SetBitNumber(kIsLowGainCrossTalkSet,flag);
+		case kHighGain:
+			return SetBitNumber(kIsHighGainCrossTalkSet,flag);
+	};
+}
 
 TGRSIDetectorHit* TGriffin::GetHit(const Int_t& idx) {
-  return GetGriffinHit(idx);
+	return GetGriffinHit(idx);
 }
 
-TGriffinHit* TGriffin::GetGriffinHit(const int& i) {
-  try {
-    if(!IsCrossTalkSet()){
-      FixCrossTalk();
-    }
-    return &(fGriffinHits.at(i));
-  } catch (const std::out_of_range& oor) {
-    std::cerr << ClassName() << " Hits are out of range: " << oor.what() << std::endl;
-    if(!gInterpreter)
-      throw grsi::exit_exception(1);
-  }
-  return NULL;
+TGriffinHit* TGriffin::GetGriffinLowGainHit(const int& i) {
+	return GetGriffinHit(i,kLowGain);
 }
 
-Int_t TGriffin::GetAddbackMultiplicity() {
-   // Automatically builds the addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero) and return the number of addback hits.
-   if(!IsCrossTalkSet()){
-      //Calculate Cross Talk on each hit
-      FixCrossTalk();
-   }
-   if(fGriffinHits.size() == 0) {
-      return 0;
-   }
-   //if the addback has been reset, clear the addback hits
-   if((fGriffinBits & kIsAddbackSet) == 0x0) {
-      fAddbackHits.clear();
-   }
-   if(fAddbackHits.size() == 0) {
-      // use the first griffin hit as starting point for the addback hits
-      fAddbackHits.push_back(fGriffinHits[0]);
-      fAddbackFrags.push_back(1);
-
-      // loop over remaining griffin hits
-      size_t i, j;
-      for(i = 1; i < fGriffinHits.size(); ++i) {
-         // check for each existing addback hit if this griffin hit should be added
-         for(j = 0; j < fAddbackHits.size(); ++j) {
-            if(fAddbackCriterion(fAddbackHits[j], fGriffinHits[i])) {
-               fAddbackHits[j].Add(&(fGriffinHits[i]));
-               fAddbackFrags[j]++;
-               break;
-            }
-         }
-         if(j == fAddbackHits.size()) {
-            fAddbackHits.push_back(fGriffinHits[i]);
-            fAddbackFrags.push_back(1);
-         }
-      }
-      SetBitNumber(kIsAddbackSet, true);
-   }
-
-
-   return fAddbackHits.size();
+TGriffinHit* TGriffin::GetGriffinHighGainHit(const int& i) {
+	return GetGriffinHit(i,kHighGain);
 }
 
-TGriffinHit* TGriffin::GetAddbackHit(const int& i) {
-   if(i < GetAddbackMultiplicity()) {
-      return &fAddbackHits.at(i);
-   } else {
-      std::cerr << "Addback hits are out of range" << std::endl;
-      throw grsi::exit_exception(1);
-      return NULL;
-   }
+TGriffinHit* TGriffin::GetGriffinHit(const int& i, const Int_t &gain_type) {
+	try {
+		if(!IsCrossTalkSet(gain_type)){
+			FixCrossTalk(gain_type);
+		}
+		return &(GetHitVector(gain_type)->at(i));
+	} catch (const std::out_of_range& oor) {
+		std::cerr << ClassName() << " Hits are out of range: " << oor.what() << std::endl;
+		if(!gInterpreter)
+			throw grsi::exit_exception(1);
+	}
+	return NULL;
+}
+
+Int_t TGriffin::GetAddbackLowGainMultiplicity() {
+	return GetAddbackMultiplicity(kLowGain);
+}
+
+Int_t TGriffin::GetAddbackHighGainMultiplicity() {
+	return GetAddbackMultiplicity(kHighGain);
+}
+
+Int_t TGriffin::GetAddbackMultiplicity(const Int_t &gain_type)  {
+	// Automatically builds the addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero) and return the number of addback hits.
+	if(!IsCrossTalkSet(gain_type)){
+		//Calculate Cross Talk on each hit
+		FixCrossTalk(gain_type);
+	} 
+	auto hit_vec = GetHitVector(gain_type);
+	auto ab_vec = GetAddbackVector(gain_type);
+	auto frag_vec = GetAddbackFragVector(gain_type);
+	if(hit_vec->size() == 0) {
+		return 0;
+	}
+	//if the addback has been reset, clear the addback hits
+	if(!IsAddbackSet(gain_type)) {
+		ab_vec->clear();
+	}
+	if(ab_vec->size() == 0) {
+		// use the first griffin hit as starting point for the addback hits
+		ab_vec->push_back(hit_vec->at(0));
+		frag_vec->push_back(1);
+
+		// loop over remaining griffin hits
+		size_t i, j;
+		for(i = 1; i < hit_vec->size(); ++i) {
+			// check for each existing addback hit if this griffin hit should be added
+			for(j = 0; j < ab_vec->size(); ++j) {
+				if(fAddbackCriterion(ab_vec->at(j), hit_vec->at(i))) {
+					ab_vec->at(j).Add(&(hit_vec->at(i)));
+					frag_vec->at(j)++;
+					break;
+				}
+			}
+			if(j == ab_vec->size()) {
+				ab_vec->push_back(hit_vec->at(i));
+				frag_vec->push_back(1);
+			}
+		}
+		SetAddback(gain_type,true);
+	}
+
+
+	return ab_vec->size();
+}
+
+
+TGriffinHit* TGriffin::GetAddbackLowGainHit(const int& i) {
+	return GetAddbackHit(i,kLowGain);
+}
+
+TGriffinHit* TGriffin::GetAddbackHighGainHit(const int& i) {
+	return GetAddbackHit(i,kHighGain);
+}
+
+TGriffinHit* TGriffin::GetAddbackHit(const int& i, const Int_t &gain_type) {
+	if(i < GetAddbackMultiplicity(gain_type)) {
+		return &GetAddbackVector(gain_type)->at(i);
+	} else {
+		std::cerr << "Addback hits are out of range" << std::endl;
+		throw grsi::exit_exception(1);
+		return NULL;
+	}
 }
 
 void TGriffin::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-   //Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
-   //This is done for both GRIFFIN and it's suppressors.
-   if(frag == NULL || chan == NULL) {
-      return;
-   }
-   //TODO: Fix kA to kB
-   if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kA) { return; }  //make this smarter.
+	//Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
+	//This is done for both GRIFFIN and it's suppressors.
+	if(frag == NULL || chan == NULL) {
+		return;
+	}
+	if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kA) {  }  
 
-   switch(chan->GetMnemonic()->SubSystem()){
-      case TMnemonic::kG :
-         TGriffinHit geHit(*frag);
-         fGriffinHits.push_back(std::move(geHit));
-         break;
-         //     case TMnemonic::kS :
-         //do supressor stuff
-         //      break;
-   };
-   //  if(chan->GetMnemonic()->SubSystem() == TMnemonic::kG ) {
-   //set griffin
-   //    if(chan->GetMnemonic()->outputsensor[0] == 'B') { return; }  //make this smarter.
+	switch(chan->GetMnemonic()->SubSystem()){
+		case TMnemonic::kG :
+			TGriffinHit geHit(*frag);
+			switch(chan->GetMnemonic()->OutputSensor()){
+				case TMnemonic::kA :
+					GetHitVector(kLowGain)->push_back(std::move(geHit));
+					break;
+				case TMnemonic::kB :
+					GetHitVector(kHighGain)->push_back(std::move(geHit));
+					break;
+			};
+			//     case TMnemonic::kS :
+			//do supressor stuff in the future
+			//      break;
+	};
 }
 
 TVector3 TGriffin::GetPosition(int DetNbr,int CryNbr, double dist ) {
-   //Gets the position vector for a crystal specified by CryNbr within Clover DetNbr at a distance of dist mm away.
-   //This is calculated to the most likely interaction point within the crystal.
-   if(DetNbr>16)
-      return TVector3(0,0,1);
+	//Gets the position vector for a crystal specified by CryNbr within Clover DetNbr at a distance of dist mm away.
+	//This is calculated to the most likely interaction point within the crystal.
+	if(DetNbr>16)
+		return TVector3(0,0,1);
 
-   TVector3 temp_pos(gCloverPosition[DetNbr]);
+	TVector3 temp_pos(gCloverPosition[DetNbr]);
 
-   //Interaction points may eventually be set externally. May make these members of each crystal, or pass from waveforms.
-   Double_t cp = 26.0; //Crystal Center Point  mm.
-   Double_t id = 45.0;//45.0;  //Crystal interaction depth mm.
-   //Set Theta's of the center of each DETECTOR face
-   ////Define one Detector position
-   TVector3 shift;
-   switch(CryNbr) {
-      case 0:
-         shift.SetXYZ(-cp,cp,id);
-         break;
-      case 1:
-         shift.SetXYZ(cp,cp,id);
-         break;
-      case 2:
-         shift.SetXYZ(cp,-cp,id);
-         break;
-      case 3:
-         shift.SetXYZ(-cp,-cp,id);
-         break;
-      default:
-         shift.SetXYZ(0,0,1);
-         break;
-   };
-   shift.RotateY(temp_pos.Theta());
-   shift.RotateZ(temp_pos.Phi());
+	//Interaction points may eventually be set externally. May make these members of each crystal, or pass from waveforms.
+	Double_t cp = 26.0; //Crystal Center Point  mm.
+	Double_t id = 45.0;//45.0;  //Crystal interaction depth mm.
+	//Set Theta's of the center of each DETECTOR face
+	////Define one Detector position
+	TVector3 shift;
+	switch(CryNbr) {
+		case 0:
+			shift.SetXYZ(-cp,cp,id);
+			break;
+		case 1:
+			shift.SetXYZ(cp,cp,id);
+			break;
+		case 2:
+			shift.SetXYZ(cp,-cp,id);
+			break;
+		case 3:
+			shift.SetXYZ(-cp,-cp,id);
+			break;
+		default:
+			shift.SetXYZ(0,0,1);
+			break;
+	};
+	shift.RotateY(temp_pos.Theta());
+	shift.RotateZ(temp_pos.Phi());
 
-   temp_pos.SetMag(dist);
+	temp_pos.SetMag(dist);
 
-   return (temp_pos + shift);
+	return (temp_pos + shift);
 
 }
 
-void TGriffin::ResetFlags(){
-   fGriffinBits = 0;
+void TGriffin::ResetFlags() const{
+	fGriffinBits = 0;
 }
 
 
-void TGriffin::ResetAddback() {
-   //Used to clear the addback hits. When playing back a tree, this must
-   //be called before building the new addback hits, otherwise, a copy of
-   //the old addback hits will be stored instead.
-   //This should have changed now, we're using the stored griffin bits to reset the addback
-   //unset the addback bit in fGriffinBits
-   SetBitNumber(kIsAddbackSet, false);
-   SetBitNumber(kIsCrossTalkSet,false);
-   fAddbackHits.clear();
-   fAddbackFrags.clear();
+void TGriffin::ResetLowGainAddback() {
+	ResetAddback(kLowGain);
 }
 
-UShort_t TGriffin::GetNAddbackFrags(size_t idx) const{
-   //Get the number of addback "fragments" contributing to the total addback hit
-   //with index idx.
-   if(idx < fAddbackFrags.size())
-      return fAddbackFrags.at(idx);   
-   else
-      return 0;
+void TGriffin::ResetHighGainAddback() {
+	ResetAddback(kLowGain);
 }
 
-void TGriffin::SetBitNumber(enum EGriffinBits bit,Bool_t set){
-   //Used to set the flags that are stored in TGriffin.
-   if(set)
-      fGriffinBits |= bit;
-   else
-      fGriffinBits &= (~bit);
+void TGriffin::ResetAddback(const Int_t &gain_type) {
+	SetAddback(gain_type, false);
+	SetCrossTalk(gain_type,false);
+	GetAddbackVector(gain_type)->clear();
+	GetAddbackFragVector(gain_type)->clear();
+}
+
+UShort_t TGriffin::GetNLowGainAddbackFrags(const size_t &idx) {
+	return GetNAddbackFrags(idx,kLowGain);
+}
+
+UShort_t TGriffin::GetNHighGainAddbackFrags(const size_t &idx) {
+	return GetNAddbackFrags(idx,kHighGain);
+}
+
+UShort_t TGriffin::GetNAddbackFrags(const size_t &idx, const Int_t &gain_type) {
+	//Get the number of addback "fragments" contributing to the total addback hit
+	//with index idx.
+	if(idx < GetAddbackFragVector(gain_type)->size())
+		return GetAddbackFragVector(gain_type)->at(idx);   
+	else
+		return 0;
+}
+
+void TGriffin::SetBitNumber(enum EGriffinBits bit,Bool_t set) const{
+	//Used to set the flags that are stored in TGriffin.
+	if(set)
+		fGriffinBits |= bit;
+	else
+		fGriffinBits &= (~bit);
 }
 
 Double_t TGriffin::CTCorrectedEnergy(const TGriffinHit* const hit_to_correct, const TGriffinHit* const other_hit, Bool_t time_constraint){
-   if(!hit_to_correct || !other_hit){
-      printf("One of the hits is invalid in TGriffin::CTCorrectedEnergy\n");
-      return 0;
-   }
+	if(!hit_to_correct || !other_hit){
+		printf("One of the hits is invalid in TGriffin::CTCorrectedEnergy\n");
+		return 0;
+	}
 
-   if(time_constraint){
-      //Figure out if this passes the selected window
-      if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIRunInfo::AddBackWindow()) //placeholder
-         return hit_to_correct->GetEnergy();
-   }
+	if(time_constraint){
+		//Figure out if this passes the selected window
+		if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIRunInfo::AddBackWindow()) //placeholder
+			return hit_to_correct->GetEnergy();
+	}
 
-   if(hit_to_correct->GetDetector() != other_hit->GetDetector() ){
-      return hit_to_correct->GetEnergy();
-   }
-   return hit_to_correct->GetEnergy() - (gCrossTalkPar[0][hit_to_correct->GetCrystal()][other_hit->GetCrystal()] + gCrossTalkPar[1][hit_to_correct->GetCrystal()][other_hit->GetCrystal()]*other_hit->GetNoCTEnergy());
+	if(hit_to_correct->GetDetector() != other_hit->GetDetector() ){
+		return hit_to_correct->GetEnergy();
+	}
+	return hit_to_correct->GetEnergy() - (gCrossTalkPar[0][hit_to_correct->GetCrystal()][other_hit->GetCrystal()] + gCrossTalkPar[1][hit_to_correct->GetCrystal()][other_hit->GetCrystal()]*other_hit->GetNoCTEnergy());
 
 }
 
-Bool_t TGriffin::IsCrossTalkSet() const{
-   return (fGriffinBits & kIsCrossTalkSet);
+void TGriffin::FixLowGainCrossTalk() {
+	FixCrossTalk(kLowGain);
 }
 
-void TGriffin::FixCrossTalk() {
-   if(fGriffinHits.size() < 2) {
-      SetBitNumber(kIsCrossTalkSet,true);
-      return;
-   }
-   for(size_t i=0; i<fGriffinHits.size(); ++i)
-      fGriffinHits[i].ClearEnergy();
+void TGriffin::FixHighGainCrossTalk() {
+	FixCrossTalk(kHighGain);	
+}
 
-   if(TGRSIRunInfo::Get()->IsCorrectingCrossTalk()){
-      size_t i, j;
-      for(i = 0; i < fGriffinHits.size(); ++i) {
-         for(j = i+1; j < fGriffinHits.size(); ++j) {
-            fGriffinHits[i].SetEnergy(TGriffin::CTCorrectedEnergy(&(fGriffinHits[i]),&(fGriffinHits[j])));
-            fGriffinHits[j].SetEnergy(TGriffin::CTCorrectedEnergy(&(fGriffinHits[j]),&(fGriffinHits[i])));
-         }
-      }
-   }
-   SetBitNumber(kIsCrossTalkSet,true);
 
+void TGriffin::FixCrossTalk(const Int_t& gain_type) {
+	auto hit_vec = GetHitVector(gain_type);
+	if(hit_vec->size() < 2) {
+		SetCrossTalk(gain_type,true);
+		return;
+	}
+	for(size_t i=0; i<hit_vec->size(); ++i)
+		hit_vec->at(i).ClearEnergy();
+
+	if(TGRSIRunInfo::Get()->IsCorrectingCrossTalk()){
+		size_t i, j;
+		for(i = 0; i < hit_vec->size(); ++i) {
+			for(j = i+1; j < hit_vec->size(); ++j) {
+				hit_vec->at(i).SetEnergy(TGriffin::CTCorrectedEnergy(&(hit_vec->at(i)),&(hit_vec->at(j))));
+				hit_vec->at(j).SetEnergy(TGriffin::CTCorrectedEnergy(&(hit_vec->at(j)),&(hit_vec->at(i))));
+			}
+		}
+	}
+	SetCrossTalk(gain_type,true);
 }

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -141,6 +141,10 @@ void TGriffinHit::Add(const TGriffinHit *hit)	{
    else{
       this->SetPUHit(3);
    }
+   //KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
+   if(this->GetKValue() > hit->GetKValue()){
+      this->SetKValue(hit->GetKValue());
+   }
 }
 
 void TGriffinHit::SetGriffinFlag(enum EGriffinHitBits flag,Bool_t set){

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -291,6 +291,12 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	//   .description("Show version information");
 
 
+   //Proof only parser options
+	parser.option("max-workers", &fMaxWorkers)
+	      .description("Max number of nodes to use when running a grsiproof session")
+			.default_value(-1);
+
+
 	// look for any arguments ending with .info, pass to parser.
 	for(int i=0; i<argc; i++){
 		std::string filename = argv[i];


### PR DESCRIPTION
- There are now calls to functions such as `GetLowGainMultiplicity()`
- All of the old functions still exist ie `GetMultiplicity()`
- The old functions call the default gain type which defaults to `kLowGain` but can be changes with `TGriffin::SetDefaultGainType(kHighGain)` or kLowGain.
- If you try to set it to a type that doesn't exist, you get a warning and nothing changes.
- The vector members written to the tree are now called `fGriffinHighGainHits, fGriffinLowGainHits, fAddbackHighGainHits, fAddbackLowGainHits` so use those appropriately when accessing them directly.
- This breaks griffin analysis trees and the tag index will be incremented appropriately during the next tag. 
- The flag accessors should be written in such a way to allow the fGriffinBits to be moved into TObject.
- The number of workers upgrade that I claimed in the last release is actually in here.