### PR TITLE
Removed ROOT 6 ifdefs for IgnoreTObjectStreamer

### DIFF
--- a/include/TFragmentChainLoop.h
+++ b/include/TFragmentChainLoop.h
@@ -63,7 +63,7 @@ class TFragmentChainLoop : public StoppableThread {
 
 		TChain *fInputChain;
 #ifndef __CINT__
-		std::shared_ptr<const TFragment> fFragment;
+		TFragment* fFragment;
 		std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fOutputQueues;
 #endif
 

--- a/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
@@ -9,14 +9,12 @@ ClassImp(TDetector)
 
 TDetector::TDetector() : TObject(){
 	///Default constructor.
-#if MAJOR_ROOT_VERSION < 6
 	Class()->IgnoreTObjectStreamer(kTRUE);
-#endif
 }
 
 TDetector::TDetector(const TDetector& rhs) : TObject() {
 	///Default Copy constructor.
-	//Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 	rhs.Copy(*this);
 }
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -16,12 +16,8 @@ TGRSIDetectorHit::TGRSIDetectorHit(const int& Address) : TObject() {
   ///Default constructor
   Clear();
   fAddress = Address;
-//  if(!fPPG)
- //   fPPG = TPPG::Get();//static_cast<TPPG*>(gDirectory->Get("TPPG")); //There Might be a better way to do this
 
-#if MAJOR_ROOT_VERSION < 6
   Class()->IgnoreTObjectStreamer(kTRUE);
-#endif
 }
 
 TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) : TObject(rhs) {
@@ -31,11 +27,8 @@ TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) :
     rhs.CopyWave(*this);
   }
   ClearTransients();
- // if(!fPPG)
- //   fPPG = TPPG::Get();//static_cast<TPPG*>(gDirectory->Get("TPPG")); //There Might be a better way to do this
-#if MAJOR_ROOT_VERSION < 6
+
   Class()->IgnoreTObjectStreamer(kTRUE);
-#endif
 }
 
 TGRSIDetectorHit::~TGRSIDetectorHit() {

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -12,7 +12,7 @@ ClassImp(TFragment)
 
 Long64_t TFragment::fNumberOfFragments = 0;
 
-TFragment::TFragment() {
+TFragment::TFragment() : TGRSIDetectorHit() {
    // Default Constructor
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);

--- a/libraries/TLoops/TFragmentChainLoop.cxx
+++ b/libraries/TLoops/TFragmentChainLoop.cxx
@@ -31,7 +31,7 @@ TFragmentChainLoop* TFragmentChainLoop::Get(std::string name, TChain *chain) {
 TFragmentChainLoop::TFragmentChainLoop(std::string name, TChain *chain)
   : StoppableThread(name),
     fEntriesTotal(chain->GetEntries()),
-    fInputChain(chain),
+    fInputChain(chain), fFragment(NULL), 
     fSelfStopping(true) {
   SetupChain();
 }


### PR DESCRIPTION
As long as we only do this in the classes directly derived from TObject, this should work in root6 as well. 
Tested this with root 6.06/04 on run 7270_000 and the file size changed from 51 MB to 45 MB.