### PR TITLE
Small fixes for compiler warnings and class version

### DIFF
--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -73,6 +73,7 @@ class TDescantHit : public TGRSIDetectorHit {
 
    public:
       void Copy(TObject&) const;        //!<!
+      void Copy(TObject&, bool) const;        //!<!
       void Clear(Option_t *opt = "");		                    //!<!
       void Print(Option_t *opt = "") const;		                    //!<!
       

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -195,7 +195,7 @@ class TGRSIDetectorHit : public TObject 	{
       static TVector3 fBeamDirection; //!
 
       /// \cond CLASSIMP
-      ClassDef(TGRSIDetectorHit,9) //Stores the information for a detector hit
+      ClassDef(TGRSIDetectorHit,10) //Stores the information for a detector hit
       /// \endcond
 };
 /*! @} */

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -84,6 +84,7 @@ class TGriffinHit : public TGRSIDetectorHit {
     virtual void Clear(Option_t *opt = "");		 //!<!
     virtual void Print(Option_t *opt = "") const; //!<!
     virtual void Copy(TObject&) const;        //!<!
+    virtual void Copy(TObject&, bool) const;        //!<!
 
     TVector3 GetPosition(double dist) const; //!<!
     TVector3 GetPosition() const;

--- a/include/TSceptarHit.h
+++ b/include/TSceptarHit.h
@@ -57,6 +57,7 @@ class TSceptarHit : public TGRSIDetectorHit {
       void Clear(Option_t *opt = "");		                    //!<!
       void Print(Option_t *opt = "") const;		                    //!<!
       virtual void Copy(TObject&) const;        //!<!
+      virtual void Copy(TObject&, bool) const;        //!<!
       
    private:
       Double_t GetDefaultDistance() const { return 0.0; }

--- a/include/TZeroDegreeHit.h
+++ b/include/TZeroDegreeHit.h
@@ -63,6 +63,7 @@ class TZeroDegreeHit : public TGRSIDetectorHit {
       void Clear(Option_t *opt = "");		                    //!<!
       void Print(Option_t *opt = "") const;		                    //!<!
       virtual void Copy(TObject&) const;        //!<!
+      virtual void Copy(TObject&, bool) const;        //!<!
       
       //Position Not written for ZeroDegree Yet
       

--- a/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
@@ -93,6 +93,11 @@ void TDescantHit::Copy(TObject &rhs) const {
    static_cast<TDescantHit&>(rhs).fPartialSum = fPartialSum;
 }
 
+void TDescantHit::Copy(TObject& obj, bool waveform) const {
+	Copy(obj);
+	if(waveform) CopyWave(obj);
+}
+
 TVector3 TDescantHit::GetPosition(Double_t dist) const {
    ///TGRSIDetectorHit::GetPosition
    return TDescant::GetPosition(GetDetector(),dist);

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -30,19 +30,24 @@ TGriffinHit::TGriffinHit(const TFragment &frag) : TGRSIDetectorHit(frag) {
 TGriffinHit::~TGriffinHit()  {	}
 
 void TGriffinHit::Copy(TObject &rhs) const {
-  TGRSIDetectorHit::Copy(rhs);
-  static_cast<TGriffinHit&>(rhs).fFilter                = fFilter;
-  static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = 0; //We should copy over a 0 and let the hit recalculate, this is safest
-  static_cast<TGriffinHit&>(rhs).fCrystal               = fCrystal;
-  static_cast<TGriffinHit&>(rhs).fPPG                   = fPPG;
-  static_cast<TGriffinHit&>(rhs).fBremSuppressed_flag   = fBremSuppressed_flag; // Bremsstrahlung Suppression flag.
-  return;                                      
+	TGRSIDetectorHit::Copy(rhs);
+	static_cast<TGriffinHit&>(rhs).fFilter                = fFilter;
+	static_cast<TGriffinHit&>(rhs).fGriffinHitBits        = 0; //We should copy over a 0 and let the hit recalculate, this is safest
+	static_cast<TGriffinHit&>(rhs).fCrystal               = fCrystal;
+	static_cast<TGriffinHit&>(rhs).fPPG                   = fPPG;
+	static_cast<TGriffinHit&>(rhs).fBremSuppressed_flag   = fBremSuppressed_flag; // Bremsstrahlung Suppression flag.
+	return;                                      
 }                                       
 
+void TGriffinHit::Copy(TObject& obj, bool waveform) const {
+	Copy(obj);
+	if(waveform) CopyWave(obj);
+}
+
 bool TGriffinHit::InFilter(Int_t wantedfilter) {
- // check if the desired filter is in wanted filter;
- // return the answer;
- return true;
+	// check if the desired filter is in wanted filter;
+	// return the answer;
+	return true;
 }
 
 void TGriffinHit::Clear(Option_t *opt)	{
@@ -78,15 +83,15 @@ bool TGriffinHit::CompareEnergy(const TGriffinHit *lhs, const TGriffinHit *rhs)	
 }
 
 void TGriffinHit::Add(const TGriffinHit *hit)	{
-   // add another griffin hit to this one (for addback), 
-   // using the time and position information of the one with the higher energy
-   if(!CompareEnergy(this,hit)) {
-      this->SetCfd(hit->GetCfd());
-      this->SetTime(hit->GetTime());
-      //this->SetPosition(hit->GetPosition());
-      this->SetAddress(hit->GetAddress());
-   }
-   this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
+	// add another griffin hit to this one (for addback), 
+	// using the time and position information of the one with the higher energy
+	if(!CompareEnergy(this,hit)) {
+		this->SetCfd(hit->GetCfd());
+		this->SetTime(hit->GetTime());
+		//this->SetPosition(hit->GetPosition());
+		this->SetAddress(hit->GetAddress());
+	}
+	this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
    //this has to be done at the very end, otherwise this->GetEnergy() might not work
    this->SetCharge(0);
    //Add all of the pileups.This should be changed when the max number of pileups changes

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -119,7 +119,7 @@ UShort_t TGriffinHit::NPileUps() const {
 
 UShort_t TGriffinHit::PUHit() const { 
 	//The pluralized test bits returns the actual value of the fBits masked. Not just a bool.
-   return static_cast<UShort_t>(fGriffinHitBits.TestBits(kPUHit1) + fGriffinHitBits.TestBits(kPUHit2) >> kPUHitOffset); 
+   return static_cast<UShort_t>(fGriffinHitBits.TestBits(kPUHit1) + (fGriffinHitBits.TestBits(kPUHit2) >> kPUHitOffset)); 
 } 
 
 void TGriffinHit::SetNPileUps(UChar_t npileups) {

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
@@ -81,6 +81,11 @@ void TSceptarHit::Copy(TObject &rhs) const {
    static_cast<TSceptarHit&>(rhs).fFilter = fFilter;
 }
 
+void TSceptarHit::Copy(TObject& obj, bool waveform) const {
+	Copy(obj);
+	if(waveform) CopyWave(obj);
+}
+
 TVector3 TSceptarHit::GetPosition(Double_t dist) const {
    //Gets the position of the current TSceptarHit
    return TSceptar::GetPosition(GetDetector());

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
@@ -56,6 +56,11 @@ void TZeroDegreeHit::Copy(TObject &rhs) const {
    static_cast<TZeroDegreeHit&>(rhs).fPartialSum = fPartialSum;
 }
 
+void TZeroDegreeHit::Copy(TObject &obj, bool waveform) const {
+	Copy(obj);
+	if(waveform) CopyWave(obj);
+}
+
 bool TZeroDegreeHit::InFilter(Int_t wantedfilter) {
 	/// check if the desired filter is in wanted filter;
    /// return the answer;

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -282,7 +282,7 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	      .description("number of characters to be used for status output")
 			.default_value(80);
 	parser.option("status-interval", &fStatusInterval)
-	      .description("seconds between each detailed status output (each a new line)")
+	      .description("seconds between each detailed status output (each a new line), non-positive numbers mean no detailed status")
 			.default_value(10);
 
 	// parser.option("long-file-description", &fLongFileDescription)

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -174,7 +174,7 @@ void TGRSIint::LoopUntilDone() {
 		fAllowedToTerminate = true;
 
 		++iter;
-		if(iter%TGRSIOptions::Get()->StatusInterval() == 0) {
+		if(TGRSIOptions::Get()->StatusInterval() > 0 && iter%TGRSIOptions::Get()->StatusInterval() == 0) {
 			std::cout<<"\r"<<StoppableThread::AllThreadStatus()<<std::endl;
 		}
 		std::cout<<"\r"<<StoppableThread::AllThreadProgress()<<std::flush;


### PR DESCRIPTION
- Fixed compiler warnings in TGriffinHit
- Fixed (cint) compiler warnings in TGriffinHit, TSceptarHit, TZeroDegreeHit, and TDescantHit. This (adding a Copy(TObject&, bool) function) probably has to be done for all the other detectors as well.
- Incremented class version of TGRSIDetectorHit (due to updated fBitflags). Without out this the wrong streamer gets forwarded from an old fragment-tree to a new analysis-tree when re-sorting from fragment-tree.

- Added option to suppress the detailed status messages, leaves a single line of updating progress bars.