### PR TITLE
TPulseAnalyzer patching

### DIFF
--- a/include/TPulseAnalyzer.h
+++ b/include/TPulseAnalyzer.h
@@ -206,6 +206,8 @@ class TPulseAnalyzer {
 	 void     get_t90();       
 
 	 double	 get_sin_par(double);
+	 
+	 void GetQuickPara();
 
 	 //bad chi squares for debugging
 	 const static int BADCHISQ_SMOOTH_T0=   -1024-2; //smooth_t0 gives bad result

--- a/include/TS3.h
+++ b/include/TS3.h
@@ -90,7 +90,6 @@ class TS3 : public TGRSIDetector {
 		static Int_t fFrontBackTime;   //!
 		static double fFrontBackEnergy;   //!
 		
-		static TRandom2 s3_rand;// random number gen for TVectors
 
 /// \cond CLASSIMP
 		ClassDef(TS3,4)

--- a/include/TSiLi.h
+++ b/include/TSiLi.h
@@ -91,8 +91,6 @@ class TSiLi: public TGRSIDetector  {
 		static double fInnerDiameter;    //!<!
 		static double fTargetDistance;   //!<!
 		
-		static TRandom2 sili_rand;// random number gen for TVectors
-
 /// \cond CLASSIMP
 		ClassDef(TSiLi,5);
 /// \endcond

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -114,7 +114,6 @@ class TTigress : public TGRSIDetector {
 		static bool fSetSegmentWave;    //!<!
 		static bool fSetBGOWave;        //!<!
 
-		static TRandom2 tigress_rand;
 
 		static double GeBluePosition[17][9][3];  //!<!  detector segment XYZ
 		static double GeGreenPosition[17][9][3]; //!<!

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -24,21 +24,22 @@
 class TTigress : public TGRSIDetector {
 	public:
 		enum ETigressBits {
-			kAddbackSet		= BIT(0),
+			kAddbackSet	= BIT(0),
 			kSuppression	= BIT(1),
-			kBit2				= BIT(2),
-			kBit3				= BIT(3),
-			kBit4				= BIT(4),
-			kBit5				= BIT(5),
-			kBit6				= BIT(6),
-			kBit7				= BIT(7)
+			kBit2		= BIT(2),
+			kBit3		= BIT(3),
+			kBit4		= BIT(4),
+			kBit5		= BIT(5),
+			kBit6		= BIT(6),
+			kBit7		= BIT(7)
 		};
 
 		enum ETigressGlobalBits {
-			kSetBGOWave		= BIT(0),
+			kSetBGOWave	= BIT(0),
 			kSetCoreWave	= BIT(1),
-			kSetSegWave		= BIT(2),
-			kSetBGOHits    = BIT(3)
+			kSetSegWave	= BIT(2),
+			kSetBGOHits	= BIT(3),
+			kForceCrystal	= BIT(4)
 		};
 
 #ifndef __CINT__
@@ -135,9 +136,18 @@ class TTigress : public TGRSIDetector {
 		std::vector<UShort_t> fAddbackFrags;   //!<! Number of crystals involved in creating in the addback hit
 
 	public:
-		static bool SetCoreWave()    { return TestGlobalBit(kSetCoreWave);     }  //!<!
-		static bool SetSegmentWave() { return TestGlobalBit(kSetSegWave);      }  //!<!
-		static bool SetBGOWave()     { return TestGlobalBit(kSetBGOWave);      }  //!<!
+		// Naming convention was off, couldnt find anything that used them in grsisort
+		// Left them as return bool to not break external code
+		static bool SetCoreWave(bool set=true){ SetGlobalBit(kSetCoreWave,set);return set;}  //!<!
+		static bool SetSegmentWave(bool set=true){ SetGlobalBit(kSetSegWave,set);return set;}  //!<!
+		static bool SetBGOWave(bool set=true){ SetGlobalBit(kSetBGOWave,set);return set;}  //!<!
+		static bool SetForceCrystal(bool set=true){ SetGlobalBit(kForceCrystal,set);return set;}  //!<!
+		
+		static bool GetCoreWave()    { return TestGlobalBit(kSetCoreWave);}  //!<!
+		static bool GetSegmentWave() { return TestGlobalBit(kSetSegWave);}  //!<!
+		static bool GetBGOWave()     { return TestGlobalBit(kSetBGOWave);}  //!<!
+		static bool GetForceCrystal(){ return TestGlobalBit(kForceCrystal);}  //!<!
+		
 		static bool BGOSuppression[4][4][5]; //!<!
 
 	public:         

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -79,7 +79,7 @@ class TTigress : public TGRSIDetector {
 #endif
 		void BuildHits();
 
-		void ClearTransients() { fgTigressBits = 0; fTigressBits = 0; for(auto hit : fTigressHits) hit.ClearTransients(); }
+		void ClearTransients() { fTigressBits = 0; for(auto hit : fTigressHits) hit.ClearTransients(); }
 
 		TTigress& operator=(const TTigress&); //!<!
 
@@ -127,7 +127,9 @@ class TTigress : public TGRSIDetector {
 
 		//    void ClearStatus();                      // WARNING: this will change the building behavior!
 		//		void ClearGlobalStatus() { fTigressBits = 0; }
-		static void SetGlobalBit(enum ETigressGlobalBits bit,Bool_t set=true);
+		static void SetGlobalBit(enum ETigressGlobalBits bit,Bool_t set=true){
+			fgTigressBits.SetBit(bit,set);
+		}
 		static Bool_t TestGlobalBit(enum ETigressGlobalBits bit) {
 			return (fgTigressBits.TestBit(bit));
 		}

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -495,7 +495,7 @@ void TPulseAnalyzer::get_baseline_fin(){
 	cWpar->baselinefin=0.;
 	cWpar->baselineStDevfin=0.;
 	int tb=cWpar->t0;//t0 non integer, result always too small before.
-	if(tb>T0RANGE+5)tb-=5;
+	if(tb>T0RANGE+10)tb-=10;
 
 	//error if waveform length cN is shorter than baseline range
 	if(cN>tb&&tb>0){

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -1420,8 +1420,7 @@ TF1  TPulseAnalyzer::Getsilifit(){
 		g.SetParameter(3,cWpar->baselinefin);
 		g.SetParameter(4,cWpar->amplitude);
 		g.SetLineColor(kRed);
-		
-		printf("t0:\t%2.2f, A:\t%2.2f\n",cWpar->t0,cWpar->amplitude);
+
 		return g;
 	}
 	
@@ -1448,6 +1447,7 @@ void  TPulseAnalyzer::Drawsilifit(){
 	DrawWave();
 	if(cWpar){
 		Getsilifit().DrawCopy("same");
+		printf("t0:\t%2.2f, A:\t%2.2f\n",cWpar->t0,cWpar->amplitude);
 	}
 	return;
 }

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -10,19 +10,17 @@
 ClassImp(TS3)
 /// \endcond
 
-int    TS3::fRingNumber;
-int    TS3::fSectorNumber;
+int    TS3::fRingNumber=24;
+int    TS3::fSectorNumber=32;
 
-double TS3::fOffsetPhiCon;
-double TS3::fOffsetPhiSet;
-double TS3::fOuterDiameter;
-double TS3::fInnerDiameter;
-double TS3::fTargetDistance;
+double TS3::fOffsetPhiCon=-0.5*TMath::Pi(); // Offset between connector and sector 0 (viewed from sector side)
+double TS3::fOffsetPhiSet=-22.5*TMath::Pi()/180.; // Phi rotation of connector in setup // -90 for bambino -22.5 for SPICE
+double TS3::fOuterDiameter=70.;
+double TS3::fInnerDiameter=22.;
+double TS3::fTargetDistance=31.;
 
 Int_t TS3::fFrontBackTime;   
 double TS3::fFrontBackEnergy; 
-
-TRandom2 TS3::s3_rand;
 
 TS3::TS3() {
    Clear();	
@@ -294,9 +292,9 @@ TVector3 TS3::GetPosition(int ring, int sector, double offsetphi,double offsetZ,
 	if(smear){
 		double sep=ring_width*0.025;
 		double r1=radius-ring_width*0.5+sep,r2=radius+ring_width*0.5-sep;
-		radius=sqrt(s3_rand.Uniform(r1*r1,r2*r2));
+		radius=sqrt(gRandom->Uniform(r1*r1,r2*r2));
 		double sepphi=sep/radius;
-		phi=s3_rand.Uniform(phi-phi_width*0.5+sepphi,phi+phi_width*0.5-sepphi);	
+		phi=gRandom->Uniform(phi-phi_width*0.5+sepphi,phi+phi_width*0.5-sepphi);	
 	}
 
 	return TVector3(cos(phi)*radius,sin(phi)*radius,offsetZ);
@@ -352,19 +350,11 @@ void TS3::Clear(Option_t *opt) {
 	fS3Hits.clear();
 	fS3RingHits.clear();
 	fS3SectorHits.clear();
-	fRingNumber=24;
-	fSectorNumber=32;
-	fOffsetPhiCon=-0.5*TMath::Pi(); // Offset between connector and sector 0 (viewed from sector side)
-	fOffsetPhiSet=-22.5*TMath::Pi()/180.; // Phi rotation of connector in setup // -90 for bambino -22.5 for SPICE
-	fOuterDiameter=70.;
-	fInnerDiameter=22.;
-	fTargetDistance=31.;
 
 	fFrontBackTime=75;   
 	fFrontBackEnergy=0.9; 
 	SetPixels(false);
 	SetMultiHit(false);
-	s3_rand.SetSeed();
 }
 
 

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -81,8 +81,10 @@ Double_t TS3Hit::GetDefaultPhiOffset() const {
 Double_t TS3Hit::GetDefaultDistance() const {//relative to target (SPICE target not at Z=0)
 	double z=0;
 	if(GetChannel()->GetMnemonic()->System() == TMnemonic::kSiLi){
-		z=32.1;
-		//z=18;//without pedestal
+		std::string str=GetChannel()->GetMnemonic()->ArraySubPositionString();
+		if(str.find("D")<str.size()) z=22.5;
+		else if(str.find("E")<str.size()) z=28.35;
+		else z=42.1;
 	}else{
 		std::string str=GetChannel()->GetMnemonic()->ArraySubPositionString();
 		if(str.find("D")<str.size()) z=20;

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -6,18 +6,19 @@
 ClassImp(TSiLi)
 /// \endcond
 
-int    TSiLi::fRingNumber;
-int    TSiLi::fSectorNumber;
 
-double TSiLi::fOffsetPhi;
-double TSiLi::fOuterDiameter;
-double TSiLi::fInnerDiameter;
-double TSiLi::fTargetDistance;
+//Having these in Clear() caused issues as functions can be called abstract with out initialising a TSiLi
+int    TSiLi::fRingNumber= 10;
+int    TSiLi::fSectorNumber= 12;
+double TSiLi::fOffsetPhi= -165.*TMath::Pi()/180.; // For SPICE. Sectors upstream.
+double TSiLi::fOuterDiameter= 94.;
+double TSiLi::fInnerDiameter= 16.;
+double TSiLi::fTargetDistance= -117.8;
 
-TRandom2 TSiLi::sili_rand;
-double TSiLi::sili_noise_fac;
-double TSiLi::sili_default_decay;
-double TSiLi::sili_default_rise;
+double TSiLi::sili_noise_fac=4;
+double TSiLi::sili_default_decay=4616.18;
+double TSiLi::sili_default_rise=20.90;
+
 
 TSiLi::TSiLi() {
    Clear();	
@@ -42,18 +43,7 @@ TSiLi::TSiLi(const TSiLi& rhs) : TGRSIDetector() {
 void TSiLi::Clear(Option_t *opt)  {
   fSiLiHits.clear();
   fAddbackHits.clear();
-  fSiLiBits.Clear();
-  fRingNumber			= 10;
-  fSectorNumber		= 12;
-  fOffsetPhi			= -165.*TMath::Pi()/180.; // For SPICE, sectors upstream.
-  fOuterDiameter		= 94.;
-  fInnerDiameter		= 16.;
-  fTargetDistance		= -117.8;
-  
-  sili_rand.SetSeed();
-  sili_noise_fac= 4.; 
-  sili_default_decay=4616.18;
-  sili_default_rise=20.90;
+  fSiLiBits.Clear();  
 }
 
 TSiLi& TSiLi::operator=(const TSiLi& rhs) {
@@ -104,9 +94,9 @@ TVector3 TSiLi::GetPosition(int ring, int sector, bool smear)  {
   if(smear){	
 	double sep=ring_width*0.025;
 	double r1=radius-ring_width*0.5+sep,r2=radius+ring_width*0.5-sep;
-	radius=sqrt(sili_rand.Uniform(r1*r1,r2*r2));
+	radius=sqrt(gRandom->Uniform(r1*r1,r2*r2));
 	double sepphi=sep/radius;
-	phi=sili_rand.Uniform(phi-phi_width*0.5+sepphi,phi+phi_width*0.5-sepphi);	
+	phi=gRandom->Uniform(phi-phi_width*0.5+sepphi,phi+phi_width*0.5-sepphi);	
   }
   
   return TVector3(cos(phi)*radius,sin(phi)*radius,dist);

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -20,7 +20,6 @@ bool TTigress::fSetCoreWave = false;
 bool TTigress::fSetSegmentWave = false;
 bool TTigress::fSetBGOWave = false;
 
-TRandom2 TTigress::tigress_rand;
 
 // Default tigress unpacking settings
 TTransientBits<UShort_t> TTigress::fgTigressBits(TTigress::kSetCoreWave | TTigress::kSetBGOHits); 
@@ -95,7 +94,6 @@ void TTigress::Clear(Option_t *opt)  {
   fBgos.clear();
  // fTigressBits.SetBit(TTigress::kAddbackSet,false);
   fTigressBits = 0;
-  tigress_rand.SetSeed();
 }
 
 void TTigress::Print(Option_t *opt)  const {
@@ -407,8 +405,8 @@ TVector3 TTigress::GetPosition(int DetNbr,int CryNbr,int SegNbr, double dist,boo
 		// Not perfect as it takes the perpendicular core vector, not the clover vector, but good enough for my purposes
 		TVector3 a(-yy,xx,0);
 		TVector3 b=det_pos.Cross(a);
-		double x,y,r = sqrt(tigress_rand.Uniform(0,400));
-		tigress_rand.Circle(x,y,r);
+		double x,y,r = sqrt(gRandom->Uniform(0,400));
+		gRandom->Circle(x,y,r);
 		det_pos+=a.Unit()*x+b.Unit()*y;
 	  }
   }

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -24,10 +24,11 @@ bool TTigress::fSetBGOWave = false;
 // Default tigress unpacking settings
 TTransientBits<UShort_t> TTigress::fgTigressBits(TTigress::kSetCoreWave | TTigress::kSetBGOHits); 
 
+//Why arent these TTigress class functions?
 bool DefaultAddback(TTigressHit& one, TTigressHit& two) {
 	
-	//if(one.GetSegmentMultiplicity()==0&&two.GetSegmentMultiplicity()==0){
-	if(one.GetSegmentMultiplicity()==0||two.GetSegmentMultiplicity()==0){//For no-sectors experiment and protection if data loss
+	// Extended options as for efficiency call we have been limited to cores only 
+	if(one.GetSegmentMultiplicity()==0||two.GetSegmentMultiplicity()==0||TTigress::GetForceCrystal()){//For no-sectors experiment and protection if data loss
 		return ((one.GetDetector() == two.GetDetector()) &&
 			  (std::abs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()*10.0));		
 		
@@ -239,20 +240,20 @@ void TTigress::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan
 						return;
 					} else  {
 						hit->CopyFragment(*frag);
-						if(fTigressBits.TestBit(kSetCoreWave))
+						if(TestGlobalBit(kSetCoreWave))
 							frag->CopyWave(*hit);
 						return;
 					}
 				} else {
 					hit->CopyFragment(*frag);
-					if(fTigressBits.TestBit(kSetCoreWave))
+					if(TestGlobalBit(kSetCoreWave))
 						frag->CopyWave(*hit);
 					return;
 				}
 			}
 			}
 			corehit.CopyFragment(*frag);
-			if(fTigressBits.TestBit(kSetCoreWave))
+			if(TestGlobalBit(kSetCoreWave))
 				frag->CopyWave(corehit);
 			fTigressHits.push_back(corehit);
 			return;


### PR DESCRIPTION
Mostly changes to the TPulseAnalyzer and a little bit of tidying up.

I was having trouble with the sort speed of my `GetSiliShape()` which calls our older (stolen from SFU)  `fit_newT0()`, the latter was taking exceedingly long time to process so I've patched around, to partially satisfying results.

For one 1GB Midas file -> AnalysisTree sort time:
With `fit_newT0()`, 1:35
Without `fit_newT0()`, 11:03

It's only this noticeable when I'm sorting SiLi singles data, where the entire file is data that needs waveform fitting.


