### PR TITLE
Added option to write out-of-order fragments to separate tree in analysis file

### DIFF
--- a/include/TAnalysisWriteLoop.h
+++ b/include/TAnalysisWriteLoop.h
@@ -30,6 +30,7 @@ class TAnalysisWriteLoop : public StoppableThread {
 
 #ifndef __CINT__
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > >& InputQueue() { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& OutOfOrderQueue() { return fOutOfOrderQueue; }
 #endif
 
 		virtual void ClearQueue();
@@ -54,10 +55,13 @@ class TAnalysisWriteLoop : public StoppableThread {
 		TFile* fOutputFile;
 		TTree* fEventTree;
 
+		TTree* fOutOfOrderTree;
+		TFragment* fOutOfOrderFrag;
 #ifndef __CINT__
 		std::map<TClass*, TDetector**> fDetMap;
 		std::map<TClass*, TDetector*> fDefaultDets;
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent> > > fInputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fOutOfOrderQueue;
 #endif
 
 		ClassDef(TAnalysisWriteLoop, 0);

--- a/include/TEventBuildingLoop.h
+++ b/include/TEventBuildingLoop.h
@@ -37,6 +37,7 @@ class TEventBuildingLoop : public StoppableThread {
 #ifndef __CINT__
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& InputQueue() { return fInputQueue; }
 		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > >& OutputQueue() { return fOutputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& OutOfOrderQueue() { return fOutOfOrderQueue; }
 #endif
 
 		bool Iteration();
@@ -62,12 +63,13 @@ class TEventBuildingLoop : public StoppableThread {
 		TEventBuildingLoop& operator=(const TEventBuildingLoop& other);
 
 #ifndef __CINT__
-		void CheckBuildCondition(std::shared_ptr<const TFragment>);
-		void CheckTimestampCondition(std::shared_ptr<const TFragment>);
-		void CheckTriggerIdCondition(std::shared_ptr<const TFragment>);
+		bool CheckBuildCondition(std::shared_ptr<const TFragment>);
+		bool CheckTimestampCondition(std::shared_ptr<const TFragment>);
+		bool CheckTriggerIdCondition(std::shared_ptr<const TFragment>);
 
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fInputQueue;
 		std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment> > > > fOutputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fOutOfOrderQueue;
 #endif
 
 		EBuildMode fBuildMode;

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -27,19 +27,19 @@ class TGRSIOptions : public TObject {
 		const std::vector<std::string>& WinInputFiles()   { return fInputWinFiles;   }
 		const std::vector<std::string>& MacroInputFiles() { return fMacroFiles;      }
 
-		const std::string& OutputFragmentFile() { return output_fragment_file; }
-		const std::string& OutputAnalysisFile() { return output_analysis_file; }
+		const std::string& OutputFragmentFile() { return fOutputFragmentFile; }
+		const std::string& OutputAnalysisFile() { return fOutputAnalysisFile; }
 
 
-		const std::string& OutputFilteredFile()        { return output_filtered_file; }
-		const std::string& OutputFragmentHistogramFile(){ return output_fragment_histogram_file; }
-		const std::string& OutputAnalysisHistogramFile(){ return output_analysis_histogram_file; }
-		std::string InputRing() { return input_ring; }
-		std::string FragmentHistogramLib() { return fragment_histogram_lib; }
-		std::string AnalysisHistogramLib() { return analysis_histogram_lib; }
-		std::string CompiledFilterFile() { return compiled_filter_file; }
+		const std::string& OutputFilteredFile()        { return fOutputFilteredFile; }
+		const std::string& OutputFragmentHistogramFile(){ return fOutputFragmentHistogramFile; }
+		const std::string& OutputAnalysisHistogramFile(){ return fOutputAnalysisHistogramFile; }
+		std::string InputRing() { return fInputRing; }
+		std::string FragmentHistogramLib() { return fFragmentHistogramLib; }
+		std::string AnalysisHistogramLib() { return fAnalysisHistogramLib; }
+		std::string CompiledFilterFile() { return fCompiledFilterFile; }
 
-		const std::vector<std::string>& OptionFiles() { return options_file; }
+		const std::vector<std::string>& OptionFiles() { return fOptionsFile; }
 
 		int BuildWindow() const { return fBuildWindow; }
 		int AddbackWindow() const { return fAddbackWindow; }
@@ -96,8 +96,8 @@ class TGRSIOptions : public TObject {
 		unsigned int StatusInterval() const { return fStatusInterval; }
 		bool LongFileDescription() const { return fLongFileDescription; }
 
-      //Proof only
-      int GetMaxWorkers() const { return fMaxWorkers; }
+		//Proof only
+		int GetMaxWorkers() const { return fMaxWorkers; }
 		bool SelectorOnly() const { return fSelectorOnly; } 
 
 	private:
@@ -115,21 +115,21 @@ class TGRSIOptions : public TObject {
 		std::vector<std::string> fInputCutsFiles;
 		std::vector<std::string> fInputValFiles;
 		std::vector<std::string> fInputWinFiles;
-		std::string input_ring;
+		std::string fInputRing;
 
-		std::string output_fragment_file;
-		std::string output_analysis_file;
-		std::string output_filtered_file;
-		std::string output_fragment_histogram_file;
-		std::string output_analysis_histogram_file;
+		std::string fOutputFragmentFile;
+		std::string fOutputAnalysisFile;
+		std::string fOutputFilteredFile;
+		std::string fOutputFragmentHistogramFile;
+		std::string fOutputAnalysisHistogramFile;
 
-		std::string fragment_histogram_lib;
-		std::string analysis_histogram_lib;
-		std::string compiled_filter_file;
+		std::string fFragmentHistogramLib;
+		std::string fAnalysisHistogramLib;
+		std::string fCompiledFilterFile;
 
-		std::vector<std::string> options_file;
+		std::vector<std::string> fOptionsFile;
 
-		std::string log_file;
+		std::string fLogFile;
 
 		bool fCloseAfterSort;
 		bool fLogErrors;
@@ -176,8 +176,8 @@ class TGRSIOptions : public TObject {
 		unsigned int fStatusInterval;
 		bool fLongFileDescription;
 
-      //Proof only
-      int fMaxWorkers;
+		//Proof only
+		int fMaxWorkers;
 		bool fSelectorOnly;
 
 		ClassDef(TGRSIOptions,1);

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -44,6 +44,7 @@ class TGRSIOptions : public TObject {
 		int BuildWindow() const { return fBuildWindow; }
 		int AddbackWindow() const { return fAddbackWindow; }
 		bool StaticWindow() const { return fStaticWindow; }
+		bool SeparateOutOfOrder() const { return fSeparateOutOfOrder; }
 		bool RecordDialog() const { return fRecordDialog; }
 		bool StartGui() const { return fStartGui; }
 
@@ -168,6 +169,7 @@ class TGRSIOptions : public TObject {
 		int fBuildWindow;
 		int fAddbackWindow;
 		bool fStaticWindow;
+		bool fSeparateOutOfOrder;
 
 		bool fShouldExit;
 

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -94,7 +94,7 @@ class TGriffinHit : public TGRSIDetectorHit {
     Double_t GetDefaultDistance() const { return 110.; }
 
     /// \cond CLASSIMP
-    ClassDef(TGriffinHit,6); //Information about a GRIFFIN Hit
+    ClassDef(TGriffinHit,7); //Information about a GRIFFIN Hit
     /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -86,6 +86,7 @@ void TGRSIOptions::Clear(Option_t* opt) {
 	fBuildWindow = 200;
 	fAddbackWindow = 300;
 	fStaticWindow = false;
+	fSeparateOutOfOrder = false;
 
 	fShouldExit = false;
 
@@ -137,6 +138,7 @@ void TGRSIOptions::Print(Option_t* opt) const {
 		<<"fBuildWindow: "<<fBuildWindow<<std::endl
 		<<"fAddbackWindow: "<<fAddbackWindow<<std::endl
 		<<"fStaticWindow: "<<fStaticWindow<<std::endl
+		<<"fSeparateOutOfOrder: "<<fSeparateOutOfOrder<<std::endl
 		<<std::endl
 		<<"fShouldExit: "<<fShouldExit<<std::endl
 		<<std::endl
@@ -155,6 +157,7 @@ void TGRSIOptions::PrintSortingOptions() const {
 		<<DBLUE<<"fBuildWindow:   "<<DCYAN<<fBuildWindow<<std::endl
 		<<DBLUE<<"fAddbackWindow: "<<DCYAN<<fAddbackWindow<<std::endl
 		<<DBLUE<<"fStaticWindow:  "<<DCYAN<<fStaticWindow<<std::endl
+		<<DBLUE<<"fSeparateOutOfOrder:  "<<DCYAN<<fSeparateOutOfOrder<<std::endl
 		<<RESET_COLOR<<std::endl;
 }
 
@@ -230,6 +233,9 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	parser.option("log-errors",&fLogErrors);
 	parser.option("reading-material",&fReadingMaterial);
 	parser.option("bad-frags write-bad-frags bad-fragments write-bad-fragments",&fWriteBadFrags);
+	parser.option("separate-out-of-order", &fSeparateOutOfOrder)
+		.description("Write out-of-order fragments to a separate tree at the sorting stage")
+		.default_value(false);
 	parser.option("ignore-odb", &fIgnoreFileOdb);
 	parser.option("ignore-epics", &fIgnoreEpics);
 	parser.option("ignore-scaler", &fIgnoreScaler);

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -13,155 +13,155 @@
 #include "GRootCommands.h"
 
 TGRSIOptions* TGRSIOptions::Get(int argc, char** argv){
-  static TGRSIOptions* item = NULL;
-  if(!item) {
-    item = new TGRSIOptions(argc, argv);
-  }
-  return item;
+	static TGRSIOptions* item = NULL;
+	if(!item) {
+		item = new TGRSIOptions(argc, argv);
+	}
+	return item;
 }
 
 TGRSIOptions::TGRSIOptions(int argc, char** argv)
-  : fShouldExit(false) {
-  Load(argc, argv);
-}
+	: fShouldExit(false) {
+		Load(argc, argv);
+	}
 
 void TGRSIOptions::Clear(Option_t* opt) {
-  fInputMidasFiles.clear();
-  fInputRootFiles.clear();
-  fInputCalFiles.clear();
-  fInputOdbFiles.clear();
-  fExternalRunInfo.clear();
-  fMacroFiles.clear();
+	fInputMidasFiles.clear();
+	fInputRootFiles.clear();
+	fInputCalFiles.clear();
+	fInputOdbFiles.clear();
+	fExternalRunInfo.clear();
+	fMacroFiles.clear();
 
-  fInputCutsFiles.clear();
-  fInputValFiles.clear();
-  fInputWinFiles.clear();
-  input_ring = "";
+	fInputCutsFiles.clear();
+	fInputValFiles.clear();
+	fInputWinFiles.clear();
+	fInputRing = "";
 
-  output_fragment_file = "";
-  output_analysis_file = "";
-  output_filtered_file = "";
-  output_fragment_histogram_file = "";
-  output_analysis_histogram_file = "";
+	fOutputFragmentFile = "";
+	fOutputAnalysisFile = "";
+	fOutputFilteredFile = "";
+	fOutputFragmentHistogramFile = "";
+	fOutputAnalysisHistogramFile = "";
 
-  fragment_histogram_lib = "";
-  analysis_histogram_lib = "";
-  compiled_filter_file = "";
+	fFragmentHistogramLib = "";
+	fAnalysisHistogramLib = "";
+	fCompiledFilterFile = "";
 
-  options_file.clear();
+	fOptionsFile.clear();
 
-  log_file = "";
+	fLogFile = "";
 
-  fCloseAfterSort = false;
-  fLogErrors = false;
-  fUseMidFileOdb = false;
+	fCloseAfterSort = false;
+	fLogErrors = false;
+	fUseMidFileOdb = false;
 
-  fMakeAnalysisTree = false;
-  fProgressDialog = false;
-  fReadingMaterial = false;
-  fIgnoreFileOdb = false;
+	fMakeAnalysisTree = false;
+	fProgressDialog = false;
+	fReadingMaterial = false;
+	fIgnoreFileOdb = false;
 
-  fIgnoreScaler = false;
-  fIgnoreEpics = false;
-  fWriteBadFrags = false;
-  fWriteDiagnostics = false;
+	fIgnoreScaler = false;
+	fIgnoreEpics = false;
+	fWriteBadFrags = false;
+	fWriteDiagnostics = false;
 
-  fShowedVersion = false;
-  fHelp = false;
-  fShowLogo = false;
-  fSortRaw = true;
-  fSortRoot = false;
-  fExtractWaves = false;
-  fIsOnline = false;
-  fStartGui = false;
-  fMakeHistos = false;
-  fSortMultiple = false;
-  fDebug = false;
+	fShowedVersion = false;
+	fHelp = false;
+	fShowLogo = false;
+	fSortRaw = true;
+	fSortRoot = false;
+	fExtractWaves = false;
+	fIsOnline = false;
+	fStartGui = false;
+	fMakeHistos = false;
+	fSortMultiple = false;
+	fDebug = false;
 
-  fFragmentWriteQueueSize = 10000000;
-  fAnalysisWriteQueueSize = 1000000;
+	fFragmentWriteQueueSize = 10000000;
+	fAnalysisWriteQueueSize = 1000000;
 
-  fTimeSortInput = false;
+	fTimeSortInput = false;
 
-  fBuildWindow = 200;
-  fAddbackWindow = 300;
-  fStaticWindow = false;
+	fBuildWindow = 200;
+	fAddbackWindow = 300;
+	fStaticWindow = false;
 
-  fShouldExit = false;
+	fShouldExit = false;
 
 	fColumnWidth = 20;
 	fStatusWidth = 80;
 	fStatusInterval = 10;
-  fLongFileDescription = false;
+	fLongFileDescription = false;
 
-  //Proof only
-  fMaxWorkers = -1;
-  fSelectorOnly = false;
+	//Proof only
+	fMaxWorkers = -1;
+	fSelectorOnly = false;
 }
 
 void TGRSIOptions::Print(Option_t* opt) const { 
-  std::cout<<"fCloseAfterSort: "<<fCloseAfterSort<<std::endl
-			  <<"fLogErrors: "<<fLogErrors<<std::endl
-			  <<"fUseMidFileOdb: "<<fUseMidFileOdb<<std::endl
-			  <<"fSuppressErrors: "<<fSuppressErrors<<std::endl
-			  <<std::endl
-			  <<"fMakeAnalysisTree: "<<fMakeAnalysisTree<<std::endl
-			  <<"fProgressDialog: "<<fProgressDialog<<std::endl
-			  <<"fReadingMaterial;: "<<fReadingMaterial<<std::endl
-			  <<"fIgnoreFileOdb: "<<fIgnoreFileOdb<<std::endl
-			  <<"fRecordDialog: "<<fRecordDialog<<std::endl
-			  <<std::endl
-			  <<"fIgnoreScaler: "<<fIgnoreScaler<<std::endl
-			  <<"fIgnoreEpics: "<<fIgnoreEpics<<std::endl
-			  <<"fWriteBadFrags: "<<fWriteBadFrags<<std::endl
-			  <<"fWriteDiagnostics: "<<fWriteDiagnostics<<std::endl
-			  <<std::endl
-			  <<"fShowedVersion: "<<fShowedVersion<<std::endl
-			  <<"fHelp: "<<fHelp<<std::endl
-			  <<"fShowLogo: "<<fShowLogo<<std::endl
-			  <<"fSortRaw: "<<fSortRaw<<std::endl
-			  <<"fSortRoot: "<<fSortRoot<<std::endl
-			  <<"fExtractWaves;: "<<fExtractWaves<<std::endl
-			  <<"fIsOnline: "<<fIsOnline<<std::endl
-			  <<"fStartGui: "<<fStartGui<<std::endl
-			  <<"fMakeHistos: "<<fMakeHistos<<std::endl
-			  <<"fSortMultiple: "<<fSortMultiple<<std::endl
-			  <<"fDebug;: "<<fDebug<<std::endl
-			  <<std::endl
-			  <<"fFragmentWriteQueueSize: "<<fFragmentWriteQueueSize<<std::endl
-			  <<"fAnalysisWriteQueueSize: "<<fAnalysisWriteQueueSize<<std::endl
-			  <<std::endl
-			  <<"fTimeSortInput: "<<fTimeSortInput<<std::endl
-			  <<"fSortDepth: "<<fSortDepth<<std::endl
-			  <<std::endl
-			  <<"fBuildWindow: "<<fBuildWindow<<std::endl
-			  <<"fAddbackWindow: "<<fAddbackWindow<<std::endl
-			  <<"fStaticWindow: "<<fStaticWindow<<std::endl
-			  <<std::endl
-			  <<"fShouldExit: "<<fShouldExit<<std::endl
-			  <<std::endl
-			  <<"fColumnWidth: "<<fColumnWidth<<std::endl
-			  <<"fStatusWidth: "<<fStatusWidth<<std::endl
-			  <<"fStatusInterval: "<<fStatusInterval<<std::endl
-			  <<"fLongFileDescription: "<<fLongFileDescription<<std::endl
+	std::cout<<"fCloseAfterSort: "<<fCloseAfterSort<<std::endl
+		<<"fLogErrors: "<<fLogErrors<<std::endl
+		<<"fUseMidFileOdb: "<<fUseMidFileOdb<<std::endl
+		<<"fSuppressErrors: "<<fSuppressErrors<<std::endl
+		<<std::endl
+		<<"fMakeAnalysisTree: "<<fMakeAnalysisTree<<std::endl
+		<<"fProgressDialog: "<<fProgressDialog<<std::endl
+		<<"fReadingMaterial;: "<<fReadingMaterial<<std::endl
+		<<"fIgnoreFileOdb: "<<fIgnoreFileOdb<<std::endl
+		<<"fRecordDialog: "<<fRecordDialog<<std::endl
+		<<std::endl
+		<<"fIgnoreScaler: "<<fIgnoreScaler<<std::endl
+		<<"fIgnoreEpics: "<<fIgnoreEpics<<std::endl
+		<<"fWriteBadFrags: "<<fWriteBadFrags<<std::endl
+		<<"fWriteDiagnostics: "<<fWriteDiagnostics<<std::endl
+		<<std::endl
+		<<"fShowedVersion: "<<fShowedVersion<<std::endl
+		<<"fHelp: "<<fHelp<<std::endl
+		<<"fShowLogo: "<<fShowLogo<<std::endl
+		<<"fSortRaw: "<<fSortRaw<<std::endl
+		<<"fSortRoot: "<<fSortRoot<<std::endl
+		<<"fExtractWaves;: "<<fExtractWaves<<std::endl
+		<<"fIsOnline: "<<fIsOnline<<std::endl
+		<<"fStartGui: "<<fStartGui<<std::endl
+		<<"fMakeHistos: "<<fMakeHistos<<std::endl
+		<<"fSortMultiple: "<<fSortMultiple<<std::endl
+		<<"fDebug;: "<<fDebug<<std::endl
+		<<std::endl
+		<<"fFragmentWriteQueueSize: "<<fFragmentWriteQueueSize<<std::endl
+		<<"fAnalysisWriteQueueSize: "<<fAnalysisWriteQueueSize<<std::endl
+		<<std::endl
+		<<"fTimeSortInput: "<<fTimeSortInput<<std::endl
+		<<"fSortDepth: "<<fSortDepth<<std::endl
+		<<std::endl
+		<<"fBuildWindow: "<<fBuildWindow<<std::endl
+		<<"fAddbackWindow: "<<fAddbackWindow<<std::endl
+		<<"fStaticWindow: "<<fStaticWindow<<std::endl
+		<<std::endl
+		<<"fShouldExit: "<<fShouldExit<<std::endl
+		<<std::endl
+		<<"fColumnWidth: "<<fColumnWidth<<std::endl
+		<<"fStatusWidth: "<<fStatusWidth<<std::endl
+		<<"fStatusInterval: "<<fStatusInterval<<std::endl
+		<<"fLongFileDescription: "<<fLongFileDescription<<std::endl
 
-				<<"fMaxWorkers: "<< fMaxWorkers << std::endl
-				<<"fSelectorOnly "<<fSelectorOnly << std::endl;
+		<<"fMaxWorkers: "<< fMaxWorkers << std::endl
+		<<"fSelectorOnly "<<fSelectorOnly << std::endl;
 }
 
 void TGRSIOptions::PrintSortingOptions() const {
 	std::cout<<DBLUE<<"fTimeSortInput: "<<DCYAN<<fTimeSortInput<<std::endl
-	         <<DBLUE<<"fSortDepth:     "<<DCYAN<<fSortDepth<<std::endl
-				<<DBLUE<<"fBuildWindow:   "<<DCYAN<<fBuildWindow<<std::endl
-		      <<DBLUE<<"fAddbackWindow: "<<DCYAN<<fAddbackWindow<<std::endl
-		      <<DBLUE<<"fStaticWindow:  "<<DCYAN<<fStaticWindow<<std::endl
-		      <<RESET_COLOR<<std::endl;
+		<<DBLUE<<"fSortDepth:     "<<DCYAN<<fSortDepth<<std::endl
+		<<DBLUE<<"fBuildWindow:   "<<DCYAN<<fBuildWindow<<std::endl
+		<<DBLUE<<"fAddbackWindow: "<<DCYAN<<fAddbackWindow<<std::endl
+		<<DBLUE<<"fStaticWindow:  "<<DCYAN<<fStaticWindow<<std::endl
+		<<RESET_COLOR<<std::endl;
 }
 
 void TGRSIOptions::Load(int argc, char** argv) {
 	Clear();
-	fragment_histogram_lib = gEnv->GetValue("GRSI.FragmentHistLib","");
-	analysis_histogram_lib = gEnv->GetValue("GRSI.AnalysisHistLib","");
+	fFragmentHistogramLib = gEnv->GetValue("GRSI.FragmentHistLib","");
+	fAnalysisHistogramLib = gEnv->GetValue("GRSI.AnalysisHistLib","");
 
 	// Load default TChannels, if specified.
 	{
@@ -188,13 +188,13 @@ void TGRSIOptions::Load(int argc, char** argv) {
 
 	parser.default_option(&input_files)
 		.description("Input file(s)");
-	parser.option("output-fragment-tree", &output_fragment_file)
+	parser.option("output-fragment-tree", &fOutputFragmentFile)
 		.description("Filename of output fragment tree");
-	parser.option("output-analysis-tree", &output_analysis_file)
+	parser.option("output-analysis-tree", &fOutputAnalysisFile)
 		.description("Filename of output analysis tree");
-	parser.option("output-fragment-hists", &output_fragment_histogram_file)
+	parser.option("output-fragment-hists", &fOutputFragmentHistogramFile)
 		.description("Filename of output fragment hists");
-	parser.option("output-analysis-hists", &output_analysis_histogram_file)
+	parser.option("output-analysis-hists", &fOutputAnalysisHistogramFile)
 		.description("Filename of output analysis hists");
 
 
@@ -236,19 +236,19 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	parser.option("suppress-error suppress-errors suppress_error suppress_errors", &fSuppressErrors);
 
 	parser.option("fragment-size", &fFragmentWriteQueueSize)
-	      .description("size of fragment write queue")
-			.default_value(10000000);
+		.description("size of fragment write queue")
+		.default_value(10000000);
 	parser.option("analysis-size", &fAnalysisWriteQueueSize)
-	      .description("size of analysis write queue")
-			.default_value(1000000);
-	
+		.description("size of analysis write queue")
+		.default_value(1000000);
+
 	// parser.option("o output", &output_file)
 	//   .description("Root output file");
-	// parser.option("f filter-output",&output_filtered_file)
+	// parser.option("f filter-output",&fOutputFilteredFile)
 	//   .description("Output file for raw filtered data");
-	// parser.option("hist-output",&output_histogram_file)
+	// parser.option("hist-output",&fOutputHistogramFile)
 	//   .description("Output file for histograms");
-	// parser.option("r ring",&input_ring)
+	// parser.option("r ring",&fInputRing)
 	//   .description("Input ring source (host/ringname).  Requires --format to be specified.");
 	//   .default_value(false);
 	// parser.option("n no-sort", &fSortRaw)
@@ -273,14 +273,14 @@ void TGRSIOptions::Load(int argc, char** argv) {
 		.description("use static window for event building")
 		.default_value(false);
 	parser.option("column-width", &fColumnWidth)
-	      .description("width of one column of status")
-			.default_value(20);
+		.description("width of one column of status")
+		.default_value(20);
 	parser.option("status-width", &fStatusWidth)
-	      .description("number of characters to be used for status output")
-			.default_value(80);
+		.description("number of characters to be used for status output")
+		.default_value(80);
 	parser.option("status-interval", &fStatusInterval)
-	      .description("seconds between each detailed status output (each a new line), non-positive numbers mean no detailed status")
-			.default_value(10);
+		.description("seconds between each detailed status output (each a new line), non-positive numbers mean no detailed status")
+		.default_value(10);
 
 	// parser.option("long-file-description", &fLongFileDescription)
 	//   .description("Show full path to file in status messages")
@@ -295,13 +295,13 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	//   .description("Show version information");
 
 
-   //Proof only parser options
+	//Proof only parser options
 	parser.option("max-workers", &fMaxWorkers)
-	      .description("Max number of nodes to use when running a grsiproof session")
-			.default_value(-1);
+		.description("Max number of nodes to use when running a grsiproof session")
+		.default_value(-1);
 
 	parser.option("selector-only", &fSelectorOnly)
-	      .description("Turns off PROOF to run a selector on the main thread");
+		.description("Turns off PROOF to run a selector on the main thread");
 
 	// look for any arguments ending with .info, pass to parser.
 	for(int i=0; i<argc; i++){
@@ -339,12 +339,12 @@ void TGRSIOptions::Load(int argc, char** argv) {
 		fShouldExit = true;
 	}
 
-	if(output_fragment_histogram_file.length()>0 &&
-			output_fragment_histogram_file != "none") {
+	if(fOutputFragmentHistogramFile.length()>0 &&
+			fOutputFragmentHistogramFile != "none") {
 		fMakeHistos = true;
 	}
-	if(output_analysis_histogram_file.length()>0 &&
-			output_analysis_histogram_file != "none") {
+	if(fOutputAnalysisHistogramFile.length()>0 &&
+			fOutputAnalysisHistogramFile != "none") {
 		fMakeHistos = true;
 	}
 
@@ -424,11 +424,11 @@ bool TGRSIOptions::FileAutoDetect(const std::string& filename) {
 																  bool used = false;
 																  DynamicLibrary lib(filename);
 																  if(lib.GetSymbol("MakeFragmentHistograms")) {
-																	  fragment_histogram_lib = filename;
+																	  fFragmentHistogramLib = filename;
 																	  used = true;
 																  }
 																  if(lib.GetSymbol("MakeAnalysisHistograms")) {
-																	  analysis_histogram_lib = filename;
+																	  fAnalysisHistogramLib = filename;
 																	  used = true;
 																  }
 																  if(!used) {

--- a/libraries/TLoops/StoppableThread.cxx
+++ b/libraries/TLoops/StoppableThread.cxx
@@ -114,7 +114,7 @@ std::string StoppableThread::Progress() {
 }
 
 void StoppableThread::SendStop() {
-	for(auto& elem : fThreadMap){
+	for(auto& elem : fThreadMap) {
 		TDataLoop* data_loop = dynamic_cast<TDataLoop*>(elem.second);
 		TFragmentChainLoop* chain_loop = dynamic_cast<TFragmentChainLoop*>(elem.second);
 		if(data_loop || chain_loop) {

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -149,7 +149,7 @@ void TFragWriteLoop::Write() {
 
 void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 	if(fEventTree) {
-		*fEventAddress = *(event.get());
+		*fEventAddress = *event;
 		fEventAddress->ClearTransients();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fEventTree->Fill();


### PR DESCRIPTION
Using the option --separate-out-of-order creates a TTree OutOfOrder in the analysis file. Any fragments that appear out of order (be it timestamp or trigger ID), are not put into an event, but directly send to the OutOfOrder tree.