### PR TITLE
GRSIProof writes log-file, bug fixes

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -3,6 +3,7 @@
 #include "TChain.h"
 #include "TGRSIProof.h"
 #include "TProofLite.h"
+#include "TProofLog.h"
 #include "TSystemDirectory.h"
 #include "TList.h"
 #include "TChainElement.h"
@@ -11,6 +12,7 @@
 #include "TGRSIOptions.h"
 #include "TChannel.h"
 #include "TGRSIRunInfo.h"
+#include "TObjectWrapper.h"
 
 #include <iostream>
 #include <vector>
@@ -105,6 +107,12 @@ int main(int argc, char **argv) {
    Analyze("FragmentTree",proof);
    Analyze("AnalysisTree",proof);
 
+	TProofLog* pl = TProof::Mgr("proof://__lite__")->GetSessionLogs();
+	if(pl != nullptr) {
+		pl->Save("*", opt->LogFile().c_str());
+	} else {
+		std::cout<<"Failed to get logs!"<<std::endl;
+	}
 }
 
 

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -149,7 +149,7 @@ class TGRSIDetectorHit : public TObject 	{
 
       //The PPG is only stored in events that come out of the GRIFFIN DAQ
       uint16_t GetPPGStatus() const;
-      uint16_t GetCycleTimeStamp() const;
+      Long_t GetCycleTimeStamp() const;
 
       void ClearEnergy()  { fEnergy  = 0.0;  SetHitBit(kIsEnergySet,false); }
       void ClearChannel() { fChannel = NULL; SetHitBit(kIsChannelSet,false); }

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -41,6 +41,8 @@ class TGRSIOptions : public TObject {
 
 		const std::vector<std::string>& OptionFiles() { return fOptionsFile; }
 
+		std::string LogFile() { return fLogFile; }
+
 		int BuildWindow() const { return fBuildWindow; }
 		int AddbackWindow() const { return fAddbackWindow; }
 		bool StaticWindow() const { return fStaticWindow; }

--- a/libraries/GROOT/GValue.cxx
+++ b/libraries/GROOT/GValue.cxx
@@ -201,121 +201,127 @@ int GValue::ReadValFile(const char* filename,Option_t *opt) {
 //  Info  :
 //}
 int GValue::ParseInputData(std::string input, EPriority priority, Option_t *opt) {
-  std::istringstream infile(input);
-  GValue *value = 0;
-  std::string line;
-  int linenumber = 0;
-  int newvalues = 0;
+	std::istringstream infile(input);
+	GValue *value = 0;
+	std::string line;
+	int linenumber = 0;
+	int newvalues = 0;
 
-  bool brace_open = false;
-  std::string name;
+	bool brace_open = false;
+	std::string name;
 
-  while(std::getline(infile,line)) {
-    linenumber++;
-    trim(&line);
-    size_t comment = line.find("//");
-    if(comment != std::string::npos) {
-       line = line.substr(0,comment);
-    }
-    if(line.length()==0)
-      continue;
-    size_t openbrace  = line.find("{");
-    size_t closebrace = line.find("}");
-    size_t colon      = line.find(":");
+	while(std::getline(infile,line)) {
+		linenumber++;
+		trim(&line);
+		size_t comment = line.find("//");
+		if(comment != std::string::npos) {
+			line = line.substr(0,comment);
+		}
+		if(line.length()==0)
+			continue;
+		size_t openbrace  = line.find("{");
+		size_t closebrace = line.find("}");
+		size_t colon      = line.find(":");
 
-    //=============================================//
-    if(openbrace  == std::string::npos &&
-      closebrace == std::string::npos &&
-      colon      == std::string::npos)
-      continue;
-    //=============================================//
-    if(closebrace != std::string::npos) {
-      brace_open = false;
-      if(value) {
-        //Check whether value is in vector. If it isn't add it.
-        GValue *cur_value = FindValue(value->GetName());
-        if(!cur_value) {
-          AddValue(value);
-          newvalues++;
-        } else {
-          value->AppendValue(cur_value);
-          delete value;
-          newvalues++;
-        }
-      }
-      value =0;
-      name.clear();
-    }
-    //=============================================//
-    if(openbrace != std::string::npos) {
-       brace_open = true;
-       name = line.substr(0,openbrace).c_str();
-       trim(&name);
-       value = new GValue(name.c_str());
-    }
-    //=============================================//
-    if(brace_open) {
-      if(colon != std::string::npos) {
-        std::string type = line.substr(0,colon);
-        line = line.substr(colon+1,line.length());
-        trim(&line);
-        std::istringstream ss(line);
-        int j=0;
-        while(type[j]) {
-           char  c = *(type.c_str()+j);
-           c = toupper(c);
-           type[j++] = c;
-        }
-        if(type.compare("NAME")==0) {
-          value->SetName(line.c_str());
-        } else if(type.compare("VALUE")==0) {
-          value->SetValue(std::atof(line.c_str()));
-	  value->fPriority = priority;
-        } else if(type.compare("INFO")==0) {
-          value->SetInfo(line.c_str());
-        }
-      }
-    }
-  }
-  if(!strcmp(opt,"debug"))
-     printf("parsed %i lines,\n",linenumber);
-  return newvalues;
+		//=============================================//
+		if(openbrace  == std::string::npos &&
+				closebrace == std::string::npos &&
+				colon      == std::string::npos)
+			continue;
+		//=============================================//
+		if(openbrace != std::string::npos) {
+			brace_open = true;
+			name = line.substr(0,openbrace).c_str();
+			trim(&name);
+			value = new GValue(name.c_str());
+		}
+		//=============================================//
+		if(brace_open) {
+			if(colon != std::string::npos) {
+				std::string type;
+				if(openbrace == std::string::npos || openbrace > colon) {
+					type = line.substr(0,colon);
+				} else {
+					type = line.substr(openbrace+1,colon - (openbrace+1));
+				}
+				line = line.substr(colon+1,line.length());
+				//trim(&line); //this is not needed? VB
+				trim(&type);
+				//std::istringstream ss(line); //this is not used anywhere? VB
+				int j=0;
+				while(type[j]) {
+					char  c = *(type.c_str()+j);
+					c = toupper(c);
+					type[j++] = c;
+				}
+				if(type.compare("NAME")==0) {
+					value->SetName(line.c_str());
+				} else if(type.compare("VALUE")==0) {
+					value->SetValue(std::atof(line.c_str()));
+					value->fPriority = priority;
+				} else if(type.compare("INFO")==0) {
+					value->SetInfo(line.c_str());
+				}
+			}
+		}
+		//=============================================//
+		if(closebrace != std::string::npos) {
+			brace_open = false;
+			if(value) {
+				//Check whether value is in vector. If it isn't add it.
+				GValue *cur_value = FindValue(value->GetName());
+				if(!cur_value) {
+					AddValue(value);
+					newvalues++;
+				} else {
+					value->AppendValue(cur_value);
+					delete value;
+					newvalues++;
+				}
+			}
+			value =0;
+			name.clear();
+		}
+	}
+	if(!strcmp(opt,"debug"))
+		printf("parsed %i lines,\n",linenumber);
+	return newvalues;
 }
 
 void GValue::trim(std::string * line, const std::string & trimChars) {
-   //Removes the the string "trimCars" from  the string 'line'
-  if(line->length() == 0)
-    return;
-  std::size_t found = line->find_first_not_of(trimChars);
-  if(found != std::string::npos)
-    *line = line->substr(found, line->length());
-  found = line->find_last_not_of(trimChars);
-  if(found != std::string::npos)
-    *line = line->substr(0, found + 1);
-  return;
+	//Removes the the string "trimCars" from  the string 'line'
+	if(line->length() == 0)
+		return;
+	std::size_t found = line->find_first_not_of(trimChars);
+	if(found != std::string::npos)
+		*line = line->substr(found, line->length());
+	found = line->find_last_not_of(trimChars);
+	if(found != std::string::npos)
+		*line = line->substr(0, found + 1);
+	return;
 }
 
 
 void GValue::Streamer(TBuffer &R__b) {
-  this->SetBit(kCanDelete);
-  UInt_t R__s, R__c;
-  if(R__b.IsReading()) {
-     Version_t R__v = R__b.ReadVersion(&R__s,&R__c);
-     TNamed::Streamer(R__b);
-     if(R__v>1) { }
-     {
-       TString R__str;
-       R__str.Streamer(R__b);
-       ParseInputData(R__str.Data(),kRootFile);
-     }
-     R__b.CheckByteCount(R__s,R__c,GValue::IsA());
-  } else {
-     R__c = R__b.WriteVersion(GValue::IsA(),true);
-     TNamed::Streamer(R__b);
-     {
-       TString R__str = GValue::WriteToBuffer();
-       R__str.Streamer(R__b);
-     }
-     R__b.SetByteCount(R__c,true);
-  }
+	this->SetBit(kCanDelete);
+	UInt_t R__s, R__c;
+	if(R__b.IsReading()) {
+		Version_t R__v = R__b.ReadVersion(&R__s,&R__c);
+		TNamed::Streamer(R__b);
+		if(R__v>1) { }
+		{
+			TString R__str;
+			R__str.Streamer(R__b);
+			ParseInputData(R__str.Data(),kRootFile);
+		}
+		R__b.CheckByteCount(R__s,R__c,GValue::IsA());
+	} else {
+		R__c = R__b.WriteVersion(GValue::IsA(),true);
+		TNamed::Streamer(R__b);
+		{
+			TString R__str = GValue::WriteToBuffer();
+			R__str.Streamer(R__b);
+		}
+		R__b.SetByteCount(R__c,true);
+	}
 }

--- a/libraries/GROOT/GValue.cxx
+++ b/libraries/GROOT/GValue.cxx
@@ -1,4 +1,5 @@
 #include "GValue.h"
+#include "TBuffer.h"
 
 #include <iostream>
 #include <vector>

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -270,24 +270,25 @@ uint16_t TGRSIDetectorHit::GetPPGStatus() const {
   if(IsPPGSet())
     return fPPGStatus;
 
-  if(!fPPG)
+  if(!TPPG::Get())
     return TPPG::kJunk;
 
-  fPPGStatus = fPPG->GetStatus(this->GetTime());
-  fCycleTimeStamp = GetTime() - fPPG->GetLastStatusTime(GetTime());
+  fPPGStatus = TPPG::Get()->GetStatus(GetTimeStamp());
+  fCycleTimeStamp = GetTimeStamp() - TPPG::Get()->GetLastStatusTime(GetTimeStamp());
   SetHitBit(kIsPPGSet,true);
   return fPPGStatus;
 }
 
-uint16_t TGRSIDetectorHit::GetCycleTimeStamp() const {
-  if(IsPPGSet())
-    return fCycleTimeStamp;
+Long_t TGRSIDetectorHit::GetCycleTimeStamp() const {
+  if(IsPPGSet()) {
+	  return fCycleTimeStamp;
+  }
 
-  if(!fPPG)
+  if(!TPPG::Get())
     return 0;
 
-  fPPGStatus = fPPG->GetStatus(this->GetTime());
-  fCycleTimeStamp = GetTime() - fPPG->GetLastStatusTime(GetTime());
+  fPPGStatus = TPPG::Get()->GetStatus(GetTimeStamp());
+  fCycleTimeStamp = GetTimeStamp() - TPPG::Get()->GetLastStatusTime(GetTimeStamp());
   SetHitBit(kIsPPGSet,true);
   return fCycleTimeStamp;
 }

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -130,7 +130,7 @@ void TPPG::AddData(TPPGData* pat) {
 ULong64_t TPPG::GetLastStatusTime(ULong64_t time,ppg_pattern pat,bool exact_flag) const {
 	///Gets the last time that a status was given. If the ppg_pattern kJunk is passed, the 
 	///current status at the time "time" is looked for. If exact_flag is false, the bits of "pat" 
-	///are looked for and ignore the rest of the bits in the sotred statuses. If "exact_flag" 
+	///are looked for and the rest of the bits in the sorted statuses ignored. If "exact_flag" 
 	///is true, the entire ppg pattern "pat" must be met.
 	if(MapIsEmpty()) {
 		printf("Empty\n");

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -22,11 +22,14 @@
 // Root > T->Process("TGRSISelector.C+")
 //
 
-#include "TGRSISelector.h"
-#include <TSystem.h>
+#include "TGRSIOptions.h"
 #include "TGRSIRunInfo.h"
-#include <TH2.h>
-#include <TStyle.h>
+#include "TGRSISelector.h"
+#include "GValue.h"
+
+#include "TSystem.h"
+#include "TH2.h"
+#include "TStyle.h"
 /// \cond CLASSIMP
 ClassImp(TGRSISelector)
 /// \endcond
@@ -68,16 +71,16 @@ Bool_t TGRSISelector::Process(Long64_t entry)
    //
    // The return value is currently not used
    
-   static TFile* current_file = nullptr;
-      if(current_file != fChain->GetCurrentFile()){
-         current_file = fChain->GetCurrentFile();
-         std::cout << "Starting to sort: " << current_file << std::endl;
-         TChannel::ReadCalFromFile(current_file);
-         TGRSIRunInfo::Get()->ReadInfoFromFile(current_file);
-      //   TChannel::WriteCalFile();
-      }
+	static TFile* current_file = nullptr;
+	if(current_file != fChain->GetCurrentFile()){
+		current_file = fChain->GetCurrentFile();
+		std::cout << "Starting to sort: " << current_file << std::endl;
+		TChannel::ReadCalFromFile(current_file);
+		TGRSIRunInfo::Get()->ReadInfoFromFile(current_file);
+		//   TChannel::WriteCalFile();
+	}
 
-   fChain->GetEntry(entry);
+	fChain->GetEntry(entry);
    FillHistograms();
 
    return kTRUE;
@@ -101,6 +104,7 @@ void TGRSISelector::Terminate()
    std::cout << runnumber << " " << subrunnumber << std::endl;
    TFile output_file(Form("%s%05d_%03d.root",fOutputPrefix.c_str(),runnumber,subrunnumber),"RECREATE");
    fOutput->Write();
+	TGRSIRunInfo::Get()->Write();
    output_file.Close();
 
 }

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -50,7 +50,7 @@ void TGRSIOptions::Clear(Option_t* opt) {
 
 	fOptionsFile.clear();
 
-	fLogFile = "";
+	fLogFile = "grsisort.log";
 
 	fCloseAfterSort = false;
 	fLogErrors = false;
@@ -127,7 +127,8 @@ void TGRSIOptions::Print(Option_t* opt) const {
 		<<"fStartGui: "<<fStartGui<<std::endl
 		<<"fMakeHistos: "<<fMakeHistos<<std::endl
 		<<"fSortMultiple: "<<fSortMultiple<<std::endl
-		<<"fDebug;: "<<fDebug<<std::endl
+		<<"fDebug: "<<fDebug<<std::endl
+		<<"fLogFile: "<<fLogFile<<std::endl
 		<<std::endl
 		<<"fFragmentWriteQueueSize: "<<fFragmentWriteQueueSize<<std::endl
 		<<"fAnalysisWriteQueueSize: "<<fAnalysisWriteQueueSize<<std::endl
@@ -231,6 +232,8 @@ void TGRSIOptions::Load(int argc, char** argv) {
 		.description("Dump stuff to screen");
 	parser.option("write-diagnostics", &fWriteDiagnostics);
 	parser.option("log-errors",&fLogErrors);
+	parser.option("log-file", &fLogFile)
+		.description("File logs from grsiproof are written to.");
 	parser.option("reading-material",&fReadingMaterial);
 	parser.option("bad-frags write-bad-frags bad-fragments write-bad-fragments",&fWriteBadFrags);
 	parser.option("separate-out-of-order", &fSeparateOutOfOrder)


### PR DESCRIPTION
- GRSIProof now writes log-files, default is grsisort.log, but that can be changed using --log-file. It also writes the run-info to the histogram file.
- Fixed return value of TGRSIDetectorHit::GetCycleTimeStamp.
- TGRSIDetectorHit now uses TPPG::Get instead of an fPPG member.
- Fixed GValue so that it can read values on single lines as well as those that span multiple lines.