### PR TITLE
small griffin addback bug

### DIFF
--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -165,6 +165,7 @@ class TGRSIDetectorHit : public TObject 	{
       Bool_t IsTimeSet()    const { return (fBitflags.TestBit(kIsTimeSet)); }
       Bool_t IsPPGSet()     const { return (fBitflags.TestBit(kIsPPGSet)); }
 
+   public:
       void SetHitBit(enum EBitFlag,Bool_t set=true) const; //const here is dirty
       bool TestHitBit(enum EBitFlag flag) const { return fBitflags.TestBit(flag); }
 
@@ -184,7 +185,7 @@ class TGRSIDetectorHit : public TObject 	{
       mutable Double_t fEnergy;     //!<! Energy of the Hit.
       mutable uint16_t fPPGStatus;  //!<! 
       mutable ULong_t  fCycleTimeStamp; //!<!
-		mutable TChannel* fChannel; //!<!
+      mutable TChannel* fChannel; //!<!
 
    protected:
       static TPPG* fPPG;

--- a/include/TTigressHit.h
+++ b/include/TTigressHit.h
@@ -38,11 +38,8 @@ class TTigressHit : public TGRSIDetectorHit {
     Float_t fTimeFit;
     Float_t fSig2Noise;
 
-/*     //need to do sudo tracking to build addback. */
-/*     TVector3 fLastHit;                //!<! */
-/* #if !defined (__CINT__) && !defined (__CLING__) */
-/*     std::tuple<int,int,int> fLastPos; //!<! */
-/* #endif */
+    //need to do sudo tracking to build addback. do not remove.  pcb. */
+    //TVector3 fLastHit;                //!   <! */
 
   public:
     void SetHit() {}
@@ -88,7 +85,7 @@ class TTigressHit : public TGRSIDetectorHit {
 
     const TGRSIDetectorHit& GetSegmentHit(int i) const { return fSegments.at(i);  }  //!<!
     /* const TGRSIDetectorHit& GetBGO(int i)     const { return fBgos.at(i);      }  //!<! */
-    const TGRSIDetectorHit& GetCore()         const { return *this;            }  //!<!
+    const TGRSIDetectorHit& GetCore()            const { return *this;            }  //!<!
     
     const std::vector<TGRSIDetectorHit>& GetSegmentVec() const { return fSegments; }
     /* const std::vector<TGRSIDetectorHit>& GetBGOVec()     const { return fBgos; } */

--- a/include/TTransientBits.h
+++ b/include/TTransientBits.h
@@ -21,25 +21,25 @@
 
 template<typename T>
 class TTransientBits {
-	public:
-		TTransientBits() : fBits(0) { }
-		TTransientBits(const T& tmp) : fBits(tmp) { }
-		~TTransientBits() { } 
+  public:
+    TTransientBits() : fBits(0) { }
+    TTransientBits(const T& tmp) : fBits(tmp) { }
+    ~TTransientBits() { } 
 
-		void SetBit(Int_t f, Bool_t flag) { flag ? SetBit(f) : ClearBit(f); } 
-		void SetBit(Int_t f) { fBits |= f; }
-		void ClearBit(Int_t f) { fBits &= ~f; } 
-		Bool_t TestBit(Int_t f) const { return fBits & f; }
-		T      TestBits(Int_t f) const { return static_cast<T>(fBits & f); }
+    void SetBit(Int_t f, Bool_t flag) { flag ? SetBit(f) : ClearBit(f); } 
+    void SetBit(Int_t f) { fBits |= f; }
+    void ClearBit(Int_t f) { fBits &= ~f; } 
+    Bool_t TestBit(Int_t f) const { return fBits & f; }
+    T      TestBits(Int_t f) const { return static_cast<T>(fBits & f); }
 
-		TTransientBits & operator=(const T & rhs) { fBits = rhs; return *this; }
+    TTransientBits & operator=(const T & rhs) { fBits = rhs; return *this; }
 
-		void Clear(){ fBits = 0; }
-		void Print() const { std::cout << fBits << std::endl; }
+    void Clear(){ fBits = 0; }
+    void Print() const { std::cout << fBits << std::endl; }
 
-		T fBits;
-		
-	//	ClassDefT(TTransientBits<T>,0);
+    T fBits;
+
+    //	ClassDefT(TTransientBits<T>,0);
 };
 
 /*! @} */

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -54,7 +54,6 @@ Double_t TGRSIDetectorHit::GetTime(const UInt_t& correction_flag,Option_t* opt) 
     Error("GetTime","No TChannel exists for address 0x%08x",GetAddress());
     return SetTime(10.*(static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
   }
-
 	switch(chan->GetDigitizerType()) {
 		Double_t dTime;
 		case TMnemonic::kGRF16:

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -298,7 +298,9 @@ Int_t TGriffin::GetAddbackMultiplicity(const Int_t &gain_type)  {
 			// check for each existing addback hit if this griffin hit should be added
 			for(j = 0; j < ab_vec->size(); ++j) {
 				if(fAddbackCriterion(ab_vec->at(j), hit_vec->at(i))) {
-					ab_vec->at(j).Add(&(hit_vec->at(i)));
+					ab_vec->at(j).Add(&(hit_vec->at(i)));    // copy constructor does not copy the bit field, so we set it.
+					ab_vec->at(j).SetHitBit(TGRSIDetectorHit::kIsEnergySet);  // this must be set for summed hits.
+					ab_vec->at(j).SetHitBit(TGRSIDetectorHit::kIsTimeSet);    // this must be set for summed hits. pcb.
 					frag_vec->at(j)++;
 					break;
 				}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -83,34 +83,36 @@ bool TGriffinHit::CompareEnergy(const TGriffinHit *lhs, const TGriffinHit *rhs)	
 }
 
 void TGriffinHit::Add(const TGriffinHit *hit)	{
-	// add another griffin hit to this one (for addback), 
-	// using the time and position information of the one with the higher energy
-	if(!CompareEnergy(this,hit)) {
-		this->SetCfd(hit->GetCfd());
-		this->SetTime(hit->GetTime());
-		//this->SetPosition(hit->GetPosition());
-		this->SetAddress(hit->GetAddress());
-	}
-	this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
-   //this has to be done at the very end, otherwise this->GetEnergy() might not work
-   this->SetCharge(0);
-   //Add all of the pileups.This should be changed when the max number of pileups changes
-   if((this->NPileUps() + hit->NPileUps()) < 4){
-      this->SetNPileUps(this->NPileUps() + hit->NPileUps());
-   }  
-   else{
-      this->SetNPileUps(3);
-   }
-   if((this->PUHit() + hit->PUHit()) < 4){
-      this->SetPUHit(this->PUHit() + hit->PUHit());
-   }  
-   else{
-      this->SetPUHit(3);
-   }
-   //KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
-   if(this->GetKValue() > hit->GetKValue()){
-      this->SetKValue(hit->GetKValue());
-   }
+  // add another griffin hit to this one (for addback), 
+  // using the time and position information of the one with the higher energy
+  if(!CompareEnergy(this,hit)) {
+    this->SetCfd(hit->GetCfd());
+    this->SetTime(hit->GetTime());
+    //this->SetPosition(hit->GetPosition());
+    this->SetAddress(hit->GetAddress());
+  } else {
+    this->SetTime(this->GetTime());
+  }
+  this->SetEnergy(this->GetEnergy() + hit->GetEnergy());
+  //this has to be done at the very end, otherwise this->GetEnergy() might not work
+  this->SetCharge(0);
+  //Add all of the pileups.This should be changed when the max number of pileups changes
+  if((this->NPileUps() + hit->NPileUps()) < 4){
+     this->SetNPileUps(this->NPileUps() + hit->NPileUps());
+  }  
+  else{
+     this->SetNPileUps(3);
+  }
+  if((this->PUHit() + hit->PUHit()) < 4){
+     this->SetPUHit(this->PUHit() + hit->PUHit());
+  }  
+  else{
+     this->SetPUHit(3);
+  }
+  //KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
+  if(this->GetKValue() > hit->GetKValue()){
+     this->SetKValue(hit->GetKValue());
+  }
 }
 
 void TGriffinHit::SetGriffinFlag(enum EGriffinHitBits flag,Bool_t set){

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -22,6 +22,12 @@ TTransientBits<UShort_t> TTigress::fgTigressBits(TTigress::kSetCoreWave | TTigre
 bool DefaultAddback(TTigressHit& one, TTigressHit& two) {
 	
 	// Extended options as for efficiency call we have been limited to cores only 
+  //
+  // the below code (in the if statement)  should be changed. There is no 
+  // real reason the we should add diagonal xtals in a detector and not 
+  // adjcent xtal in the array. If one is worried about the suppressor status 
+  // of the array, the position could also be checked.  pcb.
+  //
 	if(one.GetSegmentMultiplicity()==0||two.GetSegmentMultiplicity()==0||TTigress::GetForceCrystal()){//For no-sectors experiment and protection if data loss
 		return ((one.GetDetector() == two.GetDetector()) &&
 			  (std::abs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()*10.0));		
@@ -132,15 +138,13 @@ Int_t TTigress::GetAddbackMultiplicity() {
     
   // use the first tigress hit as starting point for the addback hits
   fAddbackHits.push_back(fTigressHits[0]);
-  //I can see nothing in the current TTigressHit class or SumHit method that requires this line
-  //fAddbackHits.back().SumHit(&(fAddbackHits.back()));//this sets the last position
   fAddbackFrags.push_back(1);
 
   // loop over remaining tigress hits
   size_t i, j;
-  for(i = 1; i < fTigressHits.size(); ++i) {
+  for(i = 1; i < fTigressHits.size(); i++) {
     // check for each existing addback hit if this tigress hit should be added
-    for(j = 0; j < fAddbackHits.size(); ++j) {
+    for(j = 0; j < fAddbackHits.size(); j++) {
       if(fAddbackCriterion(fAddbackHits[j], fTigressHits[i])) {
         fAddbackHits[j].SumHit(&(fTigressHits[i]));
         fAddbackFrags[j]++;
@@ -149,7 +153,7 @@ Int_t TTigress::GetAddbackMultiplicity() {
     }
     if(j == fAddbackHits.size()) {
       fAddbackHits.push_back(fTigressHits[i]);
-      fAddbackHits.back().SumHit(&(fAddbackHits.back()));//this sets the last position
+      fAddbackHits.back().SumHit(&(fAddbackHits.back()));
       fAddbackFrags.push_back(1);
     }
   }


### PR DESCRIPTION
The addback hits where being copied into the addback vector using the copy constructor.  By default this sets the transient bits to zero.  However for a summed addback hit, both the kIsTimeSet and kIsEnergySet flags and coorisponding values must be set.  This pull request fixes this problem for griffin, haven't looked into tigresss yet...