### PR TITLE
Better unpacking status, grsiproof only starts limited amount of workers

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -109,8 +109,16 @@ int main(int argc, char **argv) {
       std::cout << DRED << "Can't Proof a Midas file..." << RESET_COLOR << std::endl;
 
    //The first thing we do is get the PROOF Lite instance to run
-   TGRSIProof *proof = TGRSIProof::Open("");
-   proof->SetParallel(opt->GetMaxWorkers());
+	TGRSIProof* proof = nullptr;
+	if(opt->GetMaxWorkers() >= 0) {
+		std::cout<<"Opening proof with '"<<Form("workers=%d",opt->GetMaxWorkers())<<"'"<<std::endl;
+		proof = TGRSIProof::Open(Form("workers=%d",opt->GetMaxWorkers()));
+	} else if(opt->SelectorOnly()) {
+		std::cout<<"Opening proof with one worker (selector-only)"<<std::endl;
+		proof = TGRSIProof::Open("workers=1");
+	} else {
+		proof = TGRSIProof::Open("");
+	}
    if(!proof){
       std::cout << "Can't connect to proof" << std::endl;
       return 0;

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -67,6 +67,10 @@ public:
   void SetFinished();
   std::string OutputQueueStatus();
 
+	void SetStatusVariables(std::atomic_size_t* itemsPopped, std::atomic_long* inputSize) {
+		fItemsPopped = itemsPopped;
+		fInputSize = inputSize;
+	}
 private:
 #ifndef __CINT__
   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fGoodOutputQueues;
@@ -87,6 +91,9 @@ private:
   bool fFragmentHasWaveform;
 
   TFragmentMap fFragmentMap;
+
+  std::atomic_size_t* fItemsPopped;
+  std::atomic_long* fInputSize;
 
 public:
 #ifndef __CINT__

--- a/include/TUnpackingLoop.h
+++ b/include/TUnpackingLoop.h
@@ -26,6 +26,11 @@
 
 class TUnpackingLoop : public StoppableThread {
 	public:
+		enum EDataType {
+			kMidas,
+			kLst
+		};
+
 		static TUnpackingLoop *Get(std::string name="");
 		virtual ~TUnpackingLoop();
 
@@ -58,6 +63,9 @@ class TUnpackingLoop : public StoppableThread {
 		TDataParser fParser;
 		long fFragsReadFromRaw;
 		long fGoodFragsRead;
+
+		bool fEvaluateDataType;
+		UInt_t fDataType;
 
 		TUnpackingLoop(std::string name);
 		TUnpackingLoop(const TUnpackingLoop& other);

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -24,7 +24,7 @@ TDataParser::TDataParser()
     fMaxTriggerId(1024*1024*16),
     fLastMidasId(0), fLastTriggerId(0), fLastNetworkPacket(0),
     fFragmentHasWaveform(false),
-    fFragmentMap(fGoodOutputQueues, fBadOutputQueue) {
+    fFragmentMap(fGoodOutputQueues, fBadOutputQueue), fItemsPopped(NULL), fInputSize(NULL) {
   gChannel = new TChannel;
 }
 
@@ -1217,12 +1217,26 @@ int TDataParser::FippsToFragment(std::vector<char> data) {
 	int eventsRead = 0;
 	std::shared_ptr<TFragment> eventFrag = std::make_shared<TFragment>();
 	Long64_t tmpTimestamp;
+	if(fItemsPopped != NULL && fInputSize != NULL) {
+		*fItemsPopped = 0;
+		*fInputSize = data.size()/16;
+	}
+
 	for(size_t i = 0; i+3 < data.size()/4; i += 4) {
+		if(fItemsPopped != NULL && fInputSize != NULL) {
+			++(*fItemsPopped);
+			--(*fInputSize);
+		}
 		eventFrag->SetAddress(ptr[i]>>16);
 		tmpTimestamp = ptr[i]&0xffff;
 		tmpTimestamp = tmpTimestamp << 30;
 		tmpTimestamp |= ptr[i+1]&0x3fffffff;
 		eventFrag->SetTimeStamp(tmpTimestamp);
+		if((ptr[i+2] & 0x7fff) == 0) {
+			if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(99);
+         Push(*fBadOutputQueue,eventFrag);
+			continue;
+		}
 		eventFrag->SetCharge(ptr[i+2] & 0x7fff);
 		if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(eventFrag);
 		Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));


### PR DESCRIPTION
grsiproof only starts the number of threads needed
- if a number of workers has been selected, the argument is directly passed to TProof::Open
- else the normal TProof::Open("") is used, unless --selector-only is being used, in which case 1 worker is used (maybe this should be changed to 0?)


Updated unpacking queue status for lst files 
In the case of lst files, only one event is being read, leading to the situation that the status always showed the unpacking to work on 1/1 events. I've changed this to be the actual number of fragments created out of the number of fragments calculated from the size of the raw event.