### PR TITLE
Updates to GRSIProof, added GetCorrectedTime

### DIFF
--- a/GRSIProof/ExampleEventSelector.C
+++ b/GRSIProof/ExampleEventSelector.C
@@ -2,8 +2,6 @@
 // The class definition in ExampleEventSelector.h has been generated automatically
 #include "ExampleEventSelector.h"
 
-#include "TH1.h"
-
 void ExampleEventSelector::CreateHistograms() {
    fH1["gE"] = new TH1D("gE","#gamma Singles",12000,0,3000);
    fH1["gE_b"] = new TH1D("gE_b","#gamma Singles in rough #beta coincidence",12000,0,3000);

--- a/GRSIProof/ExampleEventSelector.h
+++ b/GRSIProof/ExampleEventSelector.h
@@ -28,10 +28,6 @@ class ExampleEventSelector : public TGRSISelector {
    TGriffin * fGrif;
    TSceptar * fScep;
 
-   std::map<const char*, TH1*> fH1;
-	std::map<const char*, TH2*> fH2;
-	std::map<const char*, THnSparseF*> fHSparse;
-
    ExampleEventSelector(TTree * /*tree*/ =0) : TGRSISelector(), fGrif(0), fScep(0) {
       SetOutputPrefix("ExampleEvent");
    }
@@ -40,7 +36,6 @@ class ExampleEventSelector : public TGRSISelector {
    void CreateHistograms();
    void FillHistograms();
    void InitializeBranches(TTree *tree);
-
 
    ClassDef(ExampleEventSelector,2);
 };

--- a/GRSIProof/ExampleFragmentSelector.C
+++ b/GRSIProof/ExampleFragmentSelector.C
@@ -2,24 +2,23 @@
 // The class definition in ExampleFragmentSelector.h has been generated automatically
 #include "ExampleFragmentSelector.h"
 
-#include "TH2.h"
+void ExampleFragmentSelector::CreateHistograms() {
+   fH2["hp_charge"] = new TH2D("hp_charge","#gamma Charge vs. Channel", 128, 0., 128., 12000, 0., 12000.);
+   fH2["hp_energy"] = new TH2D("hp_energy","#gamma Energy vs. Channel", 128, 0., 128., 16000, 0., 8000.);
 
-//need to define these histograms either globally or as members of the class
-TH2F* hp_charge;
-TH2F* hp_energy;
-
-void ExampleFragmentSelector::CreateHistograms()
-{
-   hp_charge = new TH2F("hp_charge","Channel vs Charge",128,0,128,24000,0,12000);
-   hp_energy = new TH2F("hp_energy","Channel vs Energy",128,0,128,16000,0,8000);
-   GetOutputList()->AddAll(gDirectory->GetList());
+	for(auto it : fH1) {
+		GetOutputList()->Add(it.second);
+	}
+	for(auto it : fH2) {
+		GetOutputList()->Add(it.second);
+	}
+	for(auto it : fHSparse) {
+		GetOutputList()->Add(it.second);
+	}
 }
 
-void ExampleFragmentSelector::FillHistograms()
-{
-	if(fFragment->GetKValue() == 700){
-   	hp_charge->Fill(fFragment->GetChannelNumber(),fFragment->Charge()/700.);
-   	hp_energy->Fill(fFragment->GetChannelNumber(),fFragment->GetEnergy());
-	}
+void ExampleFragmentSelector::FillHistograms() {
+	fH2["hp_charge"]->Fill(fFragment->GetChannelNumber(),fFragment->GetCharge());
+	fH2["hp_energy"]->Fill(fFragment->GetChannelNumber(),fFragment->GetEnergy());
 }
 

--- a/GRSIProof/ExampleFragmentSelector.h
+++ b/GRSIProof/ExampleFragmentSelector.h
@@ -31,7 +31,6 @@ class ExampleFragmentSelector : public TGRSISelector {
    void FillHistograms();
    void InitializeBranches(TTree *tree);
 
-
    ClassDef(ExampleFragmentSelector,2);
 };
 

--- a/include/ArgParser.h
+++ b/include/ArgParser.h
@@ -28,7 +28,7 @@ public:
   virtual bool matches(const std::string& flag) const = 0;
   virtual void parse_item(const std::vector<std::string>& arguments) = 0;
   virtual int num_arguments() const = 0;
-  virtual std::string printable(int description_column = -1, int* chars_before_desc=NULL) const = 0;
+  virtual std::string printable(int description_column = -1, int* chars_before_desc=nullptr) const = 0;
   virtual bool is_required() const = 0;
   bool is_present() const {return present_;}
   virtual std::string flag_name() const = 0;
@@ -116,7 +116,7 @@ public:
 
   virtual ArgParseConfig& default_value(T value) = 0;
 
-  virtual std::string printable(int description_column = -1, int* chars_before_desc=NULL) const {
+  virtual std::string printable(int description_column = -1, int* chars_before_desc=nullptr) const {
     std::stringstream ss;
 
     ss << "  ";

--- a/include/GH1D.h
+++ b/include/GH1D.h
@@ -10,15 +10,15 @@ class TF1;
 
 class GH1D : public TH1D {
 public:
-  GH1D() : TH1D(), parent(NULL), projection_axis(-1) { }
+  GH1D() : TH1D(), parent(nullptr), projection_axis(-1) { }
   GH1D(const TVectorD& v)
-    : TH1D(v), parent(NULL), projection_axis(-1) { }
+    : TH1D(v), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, const Float_t* xbins)
-    : TH1D(name, title, nbinsx, xbins), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xbins), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, const Double_t* xbins)
-    : TH1D(name, title, nbinsx, xbins), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xbins), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup)
-    : TH1D(name, title, nbinsx, xlow, xup), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xlow, xup), parent(nullptr), projection_axis(-1) { }
 
   GH1D(const TF1& function,Int_t nbinsx,Double_t xlow,Double_t xup);
 

--- a/include/GH2Base.h
+++ b/include/GH2Base.h
@@ -84,7 +84,7 @@ public:
   class iterator {
   public:
   iterator(GH2Base* mat, bool at_end = false)
-    : fMat(mat), fFirst(mat->GetNext(NULL)), fCurr(at_end ? NULL : fFirst) { }
+    : fMat(mat), fFirst(mat->GetNext(nullptr)), fCurr(at_end ? nullptr : fFirst) { }
 
     GH1D& operator*() const {
       return *fCurr;

--- a/include/GSnapshot.h
+++ b/include/GSnapshot.h
@@ -11,10 +11,10 @@ class GSnapshot {
  public:
   static GSnapshot& Get();
 
-  GSnapshot(const char* snapshot_dir = NULL);
+  GSnapshot(const char* snapshot_dir = nullptr);
   ~GSnapshot() { }
 
-  void Snapshot(TCanvas *canvas=NULL);
+  void Snapshot(TCanvas* canvas = nullptr);
 
  private:
   std::string fSnapshotDir;

--- a/include/TDescantHit.h
+++ b/include/TDescantHit.h
@@ -54,7 +54,8 @@ class TDescantHit : public TGRSIDetectorHit {
 
       Int_t GetCfd() const;
 		Int_t GetRemainder() const;
-      Double_t GetTime(const UInt_t& correction_flag = ETimeFlag::kAll,Option_t* opt = "") const;  ///< Returns a time value to the nearest nanosecond!
+      Double_t GetTime(const UInt_t& correction_flag = ETimeFlag::kAll,Option_t* opt = "") const;  ///< Returns a time value using the CFD with 1/256 ns intrinsic binning
+		Double_t GetCorrectedTime() const; ///< Returns a time value using the CFD with 1/256 ns intrinsic binning, corrected using GValue
 
       Int_t CalculateCfd(double attenuation, unsigned int delay, int halfsmoothingwindow, unsigned int interpolation_steps); //!<!
       Int_t CalculateCfdAndMonitor(double attenuation, unsigned int delay, int halfsmoothingwindow, unsigned int interpolation_steps, std::vector<Short_t> &monitor); //!<!

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -152,7 +152,7 @@ class TGRSIDetectorHit : public TObject 	{
       Long64_t GetCycleTimeStamp() const;
 
       void ClearEnergy()  { fEnergy  = 0.0;  SetHitBit(kIsEnergySet,false); }
-      void ClearChannel() { fChannel = NULL; SetHitBit(kIsChannelSet,false); }
+      void ClearChannel() { fChannel = nullptr; SetHitBit(kIsChannelSet,false); }
 
       static TVector3 *GetBeamDirection() { return &fBeamDirection; }
 

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -9,7 +9,7 @@
 
 class TGRSIOptions : public TObject {
 	public:
-		static TGRSIOptions* Get(int argc = 0, char** argv = NULL);
+		static TGRSIOptions* Get(int argc = 0, char** argv = nullptr);
 
 		void Clear(Option_t* opt = "");
 		void Load(int argc, char** argv);

--- a/include/TGRSIProof.h
+++ b/include/TGRSIProof.h
@@ -61,7 +61,6 @@ class TGRSIProof : public TProof	{
       this->Exec(Form("gInterpreter->AddIncludePath(\"%s/include\")",pPath));
       std::cout << "Loading Libraries" << std::endl;
       this->Exec(Form("gSystem->Load(\"%s/lib/libGRSI.so\");",pPath));
-
    }
 
    /// \cond CLASSIMP

--- a/include/TGRSISelector.h
+++ b/include/TGRSISelector.h
@@ -8,10 +8,13 @@
 #ifndef TGRSISelector_h
 #define TGRSISelector_h
 
-#include <TROOT.h>
-#include <TChain.h>
-#include <TFile.h>
-#include <TSelector.h>
+#include "TROOT.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TSelector.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "THnSparse.h"
 
 #include <string>
 
@@ -46,6 +49,10 @@ public :
    void SetOutputPrefix(const char* prefix) { fOutputPrefix = prefix; }
 
  private:
+	std::map<std::string, TH1*> fH1;
+	std::map<std::string, TH2*> fH2;
+	std::map<std::string, THnSparseF*> fHSparse;
+
    std::string fOutputPrefix;
 
    ClassDef(TGRSISelector,2);

--- a/include/TKinematics.h
+++ b/include/TKinematics.h
@@ -23,7 +23,7 @@
 
 class TKinematics : public TNamed {
 public:
-  TKinematics(double beame, const char* projectile, const char* target,const char* ejectile = NULL, const char* recoil = NULL, const char* name = "");
+  TKinematics(double beame, const char* projectile, const char* target,const char* ejectile = nullptr, const char* recoil = nullptr, const char* name = "");
   TKinematics(const char* beam, const char* targ, const char* ejec, const char* reco, double eBeam, double ex3=0.0, const char* name="");
   TKinematics(TNucleus* projectile, TNucleus* target, double eBeam, const char* name = "");
   TKinematics(TNucleus* projectile, TNucleus* target, TNucleus* recoil, TNucleus* ejectile, double eBeam, const char* name = "");

--- a/include/TMnemonic.h
+++ b/include/TMnemonic.h
@@ -8,7 +8,7 @@
 
 class TMnemonic : public TObject {
    public:
-		TMnemonic() :fClassType(NULL) {}
+		TMnemonic() :fClassType(nullptr) {}
 		TMnemonic(const char* name) : TMnemonic() { Parse(name); }
 		~TMnemonic() {}
 

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -32,7 +32,7 @@ class TNucleus : public TNamed{
 
   virtual ~TNucleus();
 
-  //static void SetMassFile(const char *tmp = NULL);// {massfile = tmp;} //Sets the mass file to be used
+  //static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
 
   static const char* SortName(const char *name);
   //void SetName(const char *name) { fName = name; }

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -37,7 +37,7 @@ class TParsingDiagnostics : public TObject {
 		TParsingDiagnostics(const TParsingDiagnostics&);
 		~TParsingDiagnostics();
 		static TParsingDiagnostics* Get() {
-			if(fParsingDiagnostics == NULL) {
+			if(fParsingDiagnostics == nullptr) {
 				fParsingDiagnostics = new TParsingDiagnostics;
 			}
 			return fParsingDiagnostics;

--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -32,13 +32,13 @@ public:
                   TList* objects,
                   TList* gates,
                   std::vector<TFile*>& cut_files,
-                  TDirectory* directory=NULL,
+                  TDirectory* directory=nullptr,
                   const char *name="default");
 #endif
  TRuntimeObjects(TList* objects,
                   TList* gates,
                   std::vector<TFile*>& cut_files,
-                  TDirectory* directory=NULL,
+                  TDirectory* directory=nullptr,
                   const char *name="default");
 
 #ifndef __CINT__

--- a/include/TSortingDiagnostics.h
+++ b/include/TSortingDiagnostics.h
@@ -33,7 +33,7 @@ class TSortingDiagnostics : public TObject {
 		TSortingDiagnostics(const TSortingDiagnostics&);
 		~TSortingDiagnostics();
 		static TSortingDiagnostics* Get() {
-			if(fSortingDiagnostics == NULL) {
+			if(fSortingDiagnostics == nullptr) {
 				fSortingDiagnostics = new TSortingDiagnostics;
 			}
 			return fSortingDiagnostics;

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -57,7 +57,7 @@ std::shared_ptr<T> TUnpackedEvent::GetDetector(bool make_if_not_found) {
     fDetectors.push_back(output);
     return output;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 #endif

--- a/include/TZeroDegreeHit.h
+++ b/include/TZeroDegreeHit.h
@@ -48,6 +48,7 @@ class TZeroDegreeHit : public TGRSIDetectorHit {
       Int_t GetCfd() const;
 		Int_t GetRemainder() const;
       Double_t GetTime(const UInt_t& correction_flag = ETimeFlag::kAll, Option_t* opt = "") const;  ///< Returns a time value to the nearest nanosecond!
+		Double_t GetCorrectedTime() const; ///< Returns a time value using the CFD with 1/256 ns intrinsic binning, corrected using GValue
 
       Int_t CalculateCfd(double attenuation, unsigned int delay, int halfsmoothingwindow, unsigned int interpolation_steps); //!<!
       Int_t CalculateCfdAndMonitor(double attenuation, unsigned int delay, int halfsmoothingwindow, unsigned int interpolation_steps, std::vector<Short_t> &monitor); //!<!

--- a/include/VirtualOdb.h
+++ b/include/VirtualOdb.h
@@ -50,7 +50,7 @@ class VirtualOdb {
   /// Read a boolean value, midas type TID_BOOL
   virtual bool     odbReadBool(  const char*name, int index = 0, bool     defaultValue = false) = 0;
   /// Read a string value, midas type TID_STRING
-  virtual const char* odbReadString(const char*name, int index = 0,const char* defaultValue = NULL) = 0;
+  virtual const char* odbReadString(const char*name, int index = 0,const char* defaultValue = nullptr) = 0;
   /// Destructor has to be virtual
   virtual ~VirtualOdb() { /* empty */ }; // dtor
 };

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -666,7 +666,7 @@ bool GCanvas::Process1DArrowKeyPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kMyArrowUp: {
-                       GH1D* ghist = NULL;
+                       GH1D* ghist = nullptr;
                        for(auto hist : hists){
                          if(hist->InheritsFrom(GH1D::Class())){
                            ghist = (GH1D*)hist;
@@ -689,7 +689,7 @@ bool GCanvas::Process1DArrowKeyPress(Event_t *event,UInt_t *keysym) {
                      break;
 
     case kMyArrowDown: {
-                         GH1D* ghist = NULL;
+                         GH1D* ghist = nullptr;
                          for(auto hist : hists){
                            if(hist->InheritsFrom(GH1D::Class())){
                              ghist = (GH1D*)hist;
@@ -922,7 +922,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
         if(GetNMarkers() < 2){
           break;
         }
-        GH1D* ghist = NULL;
+        GH1D* ghist = nullptr;
         for(auto hist : hists){
           if(hist->InheritsFrom(GH1D::Class())){
             ghist = (GH1D*)hist;
@@ -935,7 +935,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
         //  around this we need the bin value, not the bin!   pcb.
         //
         if(ghist){
-          GH1D* proj = NULL;
+          GH1D* proj = nullptr;
           int binlow = fMarkers.at(fMarkers.size()-1)->binx;
           int binhigh = fMarkers.at(fMarkers.size()-2)->binx;
           if(binlow > binhigh){
@@ -982,7 +982,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kKey_P: {
-                   GH1D* ghist = NULL;
+                   GH1D* ghist = nullptr;
                    for(auto hist : hists){
                      if(hist->InheritsFrom(GH1D::Class())){
                        ghist = (GH1D*)hist;
@@ -1255,7 +1255,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kKey_P: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists){
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1313,7 +1313,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_x: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1334,7 +1334,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_X: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1356,7 +1356,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_y: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1380,7 +1380,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_Y: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;

--- a/libraries/GROOT/GH1D.cxx
+++ b/libraries/GROOT/GH1D.cxx
@@ -16,13 +16,13 @@
 #include "GH2D.h"
 
 GH1D::GH1D(const TH1& source)
-  : parent(NULL), projection_axis(-1) {
+  : parent(nullptr), projection_axis(-1) {
   source.Copy(*this);
 }
 
 
 GH1D::GH1D(const TF1& function,Int_t nbinsx,Double_t xlow,Double_t xup) :
-  TH1D(Form("%s_hist",function.GetName()),Form("%s_hist",function.GetName()),nbinsx, xlow, xup), parent(NULL), projection_axis(-1) {
+  TH1D(Form("%s_hist",function.GetName()),Form("%s_hist",function.GetName()),nbinsx, xlow, xup), parent(nullptr), projection_axis(-1) {
 
   //TF1 *f = (TF1*)function.Clone();
   //f->SetRange(xlow,xup);
@@ -54,7 +54,7 @@ bool GH1D::WriteDatFile(const char *outFile){
 
 /*
 GH1D::GH1D(const TH1 *source)
-  : parent(NULL), projection_axis(-1) {
+  : parent(nullptr), projection_axis(-1) {
   if(source->GetDiminsion()>1) {
     return;
   }
@@ -78,7 +78,7 @@ void GH1D::SetOption(Option_t* opt) {
 
 void GH1D::Clear(Option_t* opt) {
   TH1D::Clear(opt);
-  parent = NULL;
+  parent = nullptr;
 }
 
 void GH1D::Print(Option_t* opt) const {
@@ -141,7 +141,7 @@ GH1D* GH1D::GetPrevious(bool DrawEmpty) const {
     prev->GetXaxis()->SetRange(first,last);
     return prev; //gpar->GetPrevious(this,DrawEmpty);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -154,7 +154,7 @@ GH1D* GH1D::GetNext(bool DrawEmpty) const {
     next->GetXaxis()->SetRange(first,last);
     return next; //gpar->GetNext(this,DrawEmpty);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -176,7 +176,7 @@ GH1D* GH1D::Project(double value_low, double value_high) const {
       return gpar->ProjectionX("_px", bin_low, bin_high);
     }
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -213,7 +213,7 @@ GH1D* GH1D::Project_Background(double value_low, double value_high,
                                           mode);
     }
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/libraries/GROOT/GH2Base.cxx
+++ b/libraries/GROOT/GH2Base.cxx
@@ -41,8 +41,8 @@ GH1D* GH2Base::Projection_Background(int axis,
   std::string title;
   std::string name;
   std::string sproj;
-  TH1D* proj = NULL;
-  TH1D* bg_proj = NULL;
+  TH1D* proj = nullptr;
+  TH1D* bg_proj = nullptr;
 
   double xlow,xhigh,bg_xlow,bg_xhigh;
 
@@ -65,7 +65,7 @@ GH1D* GH2Base::Projection_Background(int axis,
     proj    = GetTH2()->ProjectionY("temp1", firstbin, lastbin);
     bg_proj = GetTH2()->ProjectionY("temp2", first_bg_bin, last_bg_bin);
   } else {
-    return NULL;
+    return nullptr;
   }
   name  = Form("%s_%s_%d_%d_bg_%d_%d",GetTH2()->GetName(),sproj.c_str()
                                         ,firstbin,lastbin,
@@ -117,7 +117,7 @@ GH1D* GH2Base::GH2ProjectionX(const char* name,
       actual_name  = Form("%s_projx_%d_%d",GetTH2()->GetName(),firstbin,lastbin);
   }
 
-  GH1D* output = NULL;
+  GH1D* output = nullptr;
   {
     SuppressTH1GDirectory sup;
     TH1D* proj = GetTH2()->ProjectionX("temp", firstbin, lastbin, option);
@@ -177,7 +177,7 @@ GH1D* GH2Base::GH2ProjectionY(const char* name,
 
   }
 
-  GH1D* output = NULL;
+  GH1D* output = nullptr;
   {
     SuppressTH1GDirectory sup;
     TH1D* proj = GetTH2()->ProjectionY("temp", firstbin, lastbin, option);
@@ -416,7 +416,7 @@ GH1D* GH2Base::SummaryProject(int binnum,bool DrawEmpty) {
       return GH2ProjectionX(hist_name.c_str(), binnum, binnum);
   }
 
-  return NULL;
+  return nullptr;
 }
 */
 

--- a/libraries/GROOT/GPeak.cxx
+++ b/libraries/GROOT/GPeak.cxx
@@ -12,7 +12,7 @@
 
 ClassImp(GPeak)
 
-GPeak* GPeak::fLastFit = NULL;
+GPeak* GPeak::fLastFit = nullptr;
 
 GPeak::GPeak(Double_t cent,Double_t xlow,Double_t xhigh,Option_t *opt)
       : TF1("photopeakbg",GRootFunctions::PhotoPeakBG,xlow,xhigh,7),

--- a/libraries/GROOT/GRootCommands.cxx
+++ b/libraries/GROOT/GRootCommands.cxx
@@ -34,8 +34,8 @@
 //#include <TGRUTInt.h>
 #include <GNotifier.h>
 
-TChain* gFragment = NULL;
-TChain* gAnalysis = NULL;
+TChain* gFragment = nullptr;
+TChain* gAnalysis = nullptr;
 
 
 

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -18,9 +18,9 @@ TCal::TCal(const char* name, const char* title) {
 
 TCal::~TCal() {
 	///Default dtor
-	fNuc = NULL;
-	//fgraph = NULL;
-	fHist = NULL;
+	fNuc = nullptr;
+	//fgraph = nullptr;
+	fHist = nullptr;
 }
 
 TCal::TCal(const TCal& copy) : TGraphErrors(copy) {
@@ -132,8 +132,8 @@ void TCal::SetHist(TH1* hist) {
 
 void TCal::Clear(Option_t *opt) {
 	///Clears the calibration. Does not delete nuclei or channels.
-	fNuc = NULL;
-	fChan = NULL;
+	fNuc = nullptr;
+	fChan = nullptr;
 	TGraphErrors::Clear();
 }
 
@@ -164,9 +164,9 @@ void TCal::Print(Option_t *opt) const{
 void TCal::InitTCal() {
 	///Initiallizes the TCal.
 	/* fgraph = new TGraphErrors;*/
-	fFitFunc = NULL;
-	fChan = NULL;
-	fNuc = NULL;
-	fHist = NULL;
+	fFitFunc = nullptr;
+	fChan = nullptr;
+	fNuc = nullptr;
+	fHist = nullptr;
 	Clear();
 }

--- a/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
@@ -7,12 +7,12 @@ ClassImp(TCalManager)
 /// \endcond
 
 TCalManager::TCalManager() {
-	fClass = NULL; //fClass will point to a TClass which is made persistant through a root session within gROOT.
+	fClass = nullptr; //fClass will point to a TClass which is made persistant through a root session within gROOT.
 	//So we don't need to worry about allocating it.
 }
 
 TCalManager::TCalManager(const char* classname) {
-	fClass = NULL;
+	fClass = nullptr;
 	this->SetClass(classname);
 }
 

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -338,11 +338,11 @@ Bool_t TGainMatch::CoarseMatchAll(TCalManager* cm, TH2* mat, Double_t energy1, D
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("CoarseMatchAll","CalManager Pointer is NULL");
+      gm->Error("CoarseMatchAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat) {
-      gm->Error("CoarseMatchAll","TH2 Pointer is NULL");
+      gm->Error("CoarseMatchAll","TH2 Pointer is nullptr");
       return false;
    }
    //Find the range of channels provided
@@ -399,11 +399,11 @@ Bool_t TGainMatch::FineMatchFastAll(TCalManager* cm, TH2* mat1, TPeak* peak1, TH
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("FineMatchFastAll","CalManager Pointer is NULL");
+      gm->Error("FineMatchFastAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat1 || !mat2) {
-      gm->Error("FineMatchFastAll","TH2 Pointer is NULL");
+      gm->Error("FineMatchFastAll","TH2 Pointer is nullptr");
       return false;
    }
    if(!peak1 || !peak2) {
@@ -531,15 +531,15 @@ Bool_t TGainMatch::AlignAll(TCalManager* cm, TH1* hist, TH2* mat, Int_t low_rang
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("AlignAll","CalManager Pointer is NULL");
+      gm->Error("AlignAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat) {
-      gm->Error("AlignAll","TH2 Pointer is NULL");
+      gm->Error("AlignAll","TH2 Pointer is nullptr");
       return false;
    }
    if(!hist) {
-      gm->Error("AlignAll","TH1 Pointer is NULL");
+      gm->Error("AlignAll","TH1 Pointer is nullptr");
       return false;
    }
    //Find the range of channels provided
@@ -577,15 +577,15 @@ Bool_t TGainMatch::FineMatchAll(TCalManager* cm, TH2* charge_mat, TH2* eng_mat, 
 
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("FineMatchAll","CalManager Pointer is NULL");
+      gm->Error("FineMatchAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!charge_mat || !eng_mat) {
-      gm->Error("FineMatchAll","TH2 Pointer is NULL");
+      gm->Error("FineMatchAll","TH2 Pointer is nullptr");
       return false;
    }
   /* if(!testhist) {
-      gm->Error("FineMatchAll","TH1 Pointer is NULL");
+      gm->Error("FineMatchAll","TH1 Pointer is nullptr");
       return false;
    }*/
    Double_t binwidth;

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -162,13 +162,13 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 void TDescant::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the DESCANT Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    ///This is done for both DESCANT and it's suppressors.
-   if(frag == NULL || chan == NULL) {
+   if(frag == nullptr || chan == nullptr) {
       return;
    }
    

--- a/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescantHit.cxx
@@ -8,6 +8,7 @@
 #include "TDescant.h"
 #include "TGRSIOptions.h"
 #include "TChannel.h"
+#include "GValue.h"
 
 /// \cond CLASSIMP
 ClassImp(TDescantHit)
@@ -133,6 +134,13 @@ Double_t TDescantHit::GetTime(const UInt_t& correction_flag,Option_t* opt) const
 	}
 
 	return dTime - 10.*(chan->GetTZero(GetEnergy()));
+}
+
+Double_t TDescantHit::GetCorrectedTime() const {
+	if(GValue::Get(Form("GRSISort.Descant.%d.TimeCorrection", GetDetector())) != nullptr) {
+		return GetTime() - GValue::Value(Form("GRSISort.Descant.%d.TimeCorrection", GetDetector()));
+	}
+	return GetTime();
 }
 
 void TDescantHit::Clear(Option_t *opt)	{

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -158,7 +158,7 @@ void TGRSIDetectorHit::Clear(Option_t* opt) {
   fBitflags       = 0;
   fPPGStatus      = TPPG::kJunk;
   fCycleTimeStamp = 0;
-  fChannel        = NULL;
+  fChannel        = nullptr;
 }
 
 Int_t TGRSIDetectorHit::GetDetector() const {

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -25,7 +25,7 @@ void TGRSIFit::Copy(TObject& obj) const{
 }
 
 void TGRSIFit::Print(Option_t* opt) const {
-   if(strchr(opt,'+') != NULL) {
+   if(strchr(opt,'+') != nullptr) {
       printf("Params Init: %d\n", fInitFlag);
       printf("Good Fit:    %d\n", fGoodFitFlag);
       TNamed::Print(opt);

--- a/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -371,7 +371,7 @@ const char * TMultiPeak::PrintString(Option_t *opt) const {
                                 temp.append(" +/- ");
                                 temp.append(Form("%lf",fd_area));    temp.append("\n"); 
    temp.append("Chi^2/NDF:   ");temp.append(Form("%lf",fchi2/fNdf)); temp.append("\n");
-   //if(strchr(opt,'+') != NULL){
+   //if(strchr(opt,'+') != nullptr){
    //   TF1::Print();
    //   TGRSIFit::Print(opt); //Polymorphise this a bit better
    //}

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -185,7 +185,7 @@ void TPeak::Copy(TObject &obj) const {
 
 Bool_t TPeak::InitParams(TH1* fitHist) {
 //Makes initial guesses at parameters for the fit. Uses the histogram to
-	if(fitHist == NULL) {
+	if(fitHist == nullptr) {
 		return false;
 	}
    Double_t xlow,xhigh,low,high;
@@ -394,7 +394,7 @@ void TPeak::Print(Option_t* opt) const {
    printf("Area: 	      %lf +/- %lf \n", fArea, fDArea);
    printf("FWHM:        %lf +/- %lf \n", GetParameter("sigma")*2.3548, GetParError(GetParNumber("sigma"))*2.3548);
    printf("Chi^2/NDF:   %lf\n",fChi2/fNdf);
-   if(strchr(opt,'+') != NULL) {
+   if(strchr(opt,'+') != nullptr) {
       TF1::Print();
       TGRSIFit::Print(opt); //Polymorphise this a bit better
    }
@@ -411,7 +411,7 @@ const char*  TPeak::PrintString(Option_t* opt) const {
                                 temp.append(" +/- ");
                                 temp.append(Form("%lf",fDArea));    temp.append("\n"); 
    temp.append("Chi^2/NDF:   ");temp.append(Form("%lf",fChi2/fNdf)); temp.append("\n");
-   //if(strchr(opt,'+') != NULL) {
+   //if(strchr(opt,'+') != nullptr) {
    //   TF1::Print();
    TGRSIFit::Print(opt); //Polymorphise this a bit better
    //}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -260,7 +260,7 @@ TGriffinHit* TGriffin::GetGriffinHit(const int& i, const Int_t &gain_type) {
 		if(!gInterpreter)
 			throw grsi::exit_exception(1);
 	}
-	return NULL;
+	return nullptr;
 }
 
 Int_t TGriffin::GetAddbackLowGainMultiplicity() {
@@ -330,14 +330,14 @@ TGriffinHit* TGriffin::GetAddbackHit(const int& i, const Int_t &gain_type) {
 	} else {
 		std::cerr << "Addback hits are out of range" << std::endl;
 		throw grsi::exit_exception(1);
-		return NULL;
+		return nullptr;
 	}
 }
 
 void TGriffin::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	//Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
 	//This is done for both GRIFFIN and it's suppressors.
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 	if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kA) {  }  

--- a/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
+++ b/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
@@ -55,8 +55,8 @@ TKinematics::TKinematics(TNucleus* projectile, TNucleus* target, double ebeam, c
   InitKin();
   fParticle[0] = projectile;
   fParticle[1] = target;
-  fParticle[2] = NULL;
-  fParticle[3] = NULL;
+  fParticle[2] = nullptr;
+  fParticle[3] = nullptr;
   fM[0]=fParticle[0]->GetMass();
   fM[1]=fParticle[1]->GetMass();
   fEBeam = ebeam;
@@ -392,7 +392,7 @@ void TKinematics::FinalCm(){
 // Calculates the recoil and ejectile energies and momenta in the CM frame
 
 //angle of proton in cm system
-  if(fParticle[2]==NULL && fParticle[3]==NULL){
+  if(fParticle[2]==nullptr && fParticle[3]==nullptr){
     fM[2]=fParticle[1]->GetMass();
     fM[3]=fParticle[0]->GetMass();     
   }

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -81,7 +81,7 @@ TLaBrHit* TLaBr::GetLaBrHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 void TLaBr::AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan) {

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -230,7 +230,7 @@ const char* TNucleus::SortName(const char* name){
         break;
       default:
         printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n");
-        return NULL;
+        return nullptr;
     };
   }
   int first_digit  = Name.find_first_of("0123456789 \t\n\r");

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -79,7 +79,7 @@ TPacesHit* TPaces::GetPacesHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 TVector3 TPaces::GetPosition(int DetNbr) {

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -4,16 +4,16 @@
 ClassImp(TPulseAnalyzer)
 /// \endcond
 
-TPulseAnalyzer::TPulseAnalyzer() : cWpar(NULL), spar(NULL), shpar(NULL) {
+TPulseAnalyzer::TPulseAnalyzer() : cWpar(nullptr), spar(nullptr), shpar(nullptr) {
 	Clear();
 }
 
-TPulseAnalyzer::TPulseAnalyzer(const TFragment& fragment,double noise_fac) : cWpar(NULL), spar(NULL), shpar(NULL) {
+TPulseAnalyzer::TPulseAnalyzer(const TFragment& fragment,double noise_fac) : cWpar(nullptr), spar(nullptr), shpar(nullptr) {
 	Clear();
 	SetData(fragment,noise_fac);
 }
 
-TPulseAnalyzer::TPulseAnalyzer(const std::vector<Short_t>& wave,double noise_fac,std::string name) : cWpar(NULL), spar(NULL), shpar(NULL), fName(name) {
+TPulseAnalyzer::TPulseAnalyzer(const std::vector<Short_t>& wave,double noise_fac,std::string name) : cWpar(nullptr), spar(nullptr), shpar(nullptr), fName(name) {
 	Clear();
 	SetData(wave,noise_fac);
 }

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -48,7 +48,7 @@ void TS3::Copy(TObject &rhs) const {
 
 void TS3::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	///This function creates TS3Hits for each fragment and stores them in separate front and back vectors
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 
@@ -311,7 +311,7 @@ TS3Hit *TS3::GetS3Hit(const int& i) {
   } else {
     std::cerr << "S3 pixel hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 
@@ -321,7 +321,7 @@ TS3Hit *TS3::GetRingHit(const int& i) {
   } else {
     std::cerr << "S3 ring hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 
@@ -331,7 +331,7 @@ TS3Hit *TS3::GetSectorHit(const int& i) {
   } else {
     std::cerr << "S3 sector hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -102,5 +102,5 @@ TSceptarHit* TSceptar::GetSceptarHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -85,7 +85,7 @@ TSharc::TSharc(const TSharc& rhs) : TGRSIDetector() {
 }
 
 void TSharc::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
     return;
   }
 /*  if(GetMidasTimestamp() == -1) {

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -72,7 +72,7 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
 }  
 
 void TSiLi::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
 	 return;
   }
 
@@ -119,7 +119,7 @@ TSiLiHit* TSiLi::GetAddbackHit(const int& i) {
   } else {
     std::cerr << "Addback hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -71,5 +71,5 @@ TTACHit* TTAC::GetTACHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -113,7 +113,7 @@ TTigress& TTigress::operator=(const TTigress& rhs) {
     if(!gInterpreter)
       throw grsi::exit_exception(1);
   }
-  return NULL;
+  return nullptr;
   */
 //}
 
@@ -166,7 +166,7 @@ TTigressHit* TTigress::GetAddbackHit(const int& i) {
   } else {
     std::cerr << "Addback hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -205,7 +205,7 @@ void TTigress::BuildHits(){
 }
 
 void TTigress::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 	/*  if(GetMidasTimestamp()==-1) {

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -40,7 +40,7 @@ TTip& TTip::operator=(const TTip& rhs) {
 }
 
 void TTip::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 

--- a/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
+++ b/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
@@ -35,7 +35,7 @@ TTriFoil::TTriFoil(const TTriFoil& rhs) : TDetector() {
 }
 
 void TTriFoil::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
     return;
   }
 

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -61,7 +61,7 @@ void TZeroDegree::Print(Option_t *opt) const	{
 
 void TZeroDegree::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the ZDS Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
-   if(frag == NULL || chan == NULL) {
+   if(frag == nullptr || chan == nullptr) {
       return;
    }
    
@@ -82,5 +82,5 @@ TZeroDegreeHit* TZeroDegree::GetZeroDegreeHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
@@ -8,6 +8,7 @@
 #include "TZeroDegree.h"
 #include "TGRSIOptions.h"
 #include "TChannel.h"
+#include "GValue.h"
 
 /// \cond CLASSIMP
 ClassImp(TZeroDegreeHit)
@@ -87,6 +88,13 @@ Double_t TZeroDegreeHit::GetTime(const UInt_t& correction_flag, Option_t* opt) c
   }
 
   return dTime - 10.*(chan->GetTZero(GetEnergy()));
+}
+
+Double_t TZeroDegreeHit::GetCorrectedTime() const {
+	if(GValue::Get("GRSISort.ZeroDegree.TimeCorrection") != nullptr) {
+		return GetTime() + GValue::Value("GRSISort.ZeroDegree.TimeCorrection");
+	}
+	return GetTime();
 }
 
 void TZeroDegreeHit::Clear(Option_t *opt)	{

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -280,7 +280,7 @@ TChannel* TChannel::GetChannel(unsigned int temp_address) {
 	///Returns the TChannel at the specified address. If the address doesn't exist, returns an empty gChannel.
 
 	TChannel* chan = nullptr;
-	//    if(temp_address == 0 || temp_address == 0xffffffff) {//default (NULL) address, return 0;
+	//    if(temp_address == 0 || temp_address == 0xffffffff) {//default (nullptr) address, return 0;
 	//	      return chan;
 	//    }
 	if(fChannelMap->count(temp_address)==1){// found channel
@@ -321,7 +321,7 @@ TChannel* TChannel::FindChannelByName(const char* ccName){
 		std::string channelName = chan->GetName();
 		if(channelName.compare(0,name.length(),name)==0)
 			break;
-		chan = NULL;
+		chan = nullptr;
 	}
 	// either comes out normally as null or breaks out with some TChannel [SC]
 

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -157,7 +157,7 @@ void TFragment::Print(Option_t *opt) const {
   printf("\tCharge:          0x%08x\n ",   static_cast<Int_t>(GetCharge()));
   printf("\tCFD:             0x%08x\n ",   GetCfd());
   printf("\tZC:              0x%08x\n ",   fZc);   
-  printf("\tTimeStamp:       %lu\n", GetTimeStamp());
+  printf("\tTimeStamp:       %lld\n", GetTimeStamp());
   if(HasWave())
     printf("Has a wave form stored.\n");
   else

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -68,7 +68,7 @@ void TFragment::Clear(Option_t *opt){
 
    fTriggerId.clear();
 
-   fPPG                 = NULL;
+   fPPG                 = nullptr;
    fZc                  = 0;
    fCcShort             = 0;
    fCcLong              = 0;
@@ -103,20 +103,20 @@ Int_t TFragment::Get4GCfd() const { // return a 4G cfd in terms of 1/256 ns sinc
 
 ULong64_t TFragment::GetTimeInCycle() {
 
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
    }
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
       return 0;
    }
    return fPPG->GetTimeInCycle(GetTimeStamp());
 }
 
 ULong64_t TFragment::GetCycleNumber() {
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
    }
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
       return 0;
    }
    return fPPG->GetCycleNumber(GetTimeStamp());
@@ -129,7 +129,7 @@ Short_t TFragment::GetChannelNumber() const {
 }
 
 TPPG* TFragment::GetPPG() {
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 	}
 	return fPPG;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -238,7 +238,7 @@ TGRSIRunInfo::~TGRSIRunInfo() { }
 void TGRSIRunInfo::Print(Option_t *opt) const {
    //Prints the TGRSIRunInfo. Options:
    // a: Print out more details.
-   if(strchr(opt,'a') != NULL){
+   if(strchr(opt,'a') != nullptr){
       printf("\tTGRSIRunInfo Status:\n");
       printf("\t\tRunNumber:    %05i\n",TGRSIRunInfo::Get()->fRunNumber);
       printf("\t\tSubRunNumber: %03i\n",TGRSIRunInfo::Get()->fSubRunNumber);
@@ -553,7 +553,7 @@ Long64_t TGRSIRunInfo::Merge(TCollection *list){
    //An individual file that was submitted to hadd.
    TGRSIRunInfo *runinfo = 0;
 
-   while ((runinfo = static_cast<TGRSIRunInfo*>(it.Next())) != NULL){
+   while ((runinfo = static_cast<TGRSIRunInfo*>(it.Next())) != nullptr){
       //Now we want to loop through each TGRSISortList and find the TGRSISortInfo's stored in there.
       this->Add(runinfo);
    }

--- a/libraries/TGRSIFormat/TMnemonic.cxx
+++ b/libraries/TGRSIFormat/TMnemonic.cxx
@@ -176,7 +176,7 @@ void TMnemonic::Parse(std::string *name){
 	
 	if(fSystem == kSiLi){
 		buf.clear(); buf.assign(*name,7,2);
-		fSegment = (uint16_t)strtol(buf.c_str(), NULL, 16);
+		fSegment = (uint16_t)strtol(buf.c_str(), nullptr, 16);
 	}
 	
 	return;

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -10,7 +10,7 @@ ClassImp(TPPGData)
 ClassImp(TPPG)
 /// \endcond
 
-TPPG* TPPG::fPPG = NULL;
+TPPG* TPPG::fPPG = nullptr;
 
 TPPGData::TPPGData() {
 	Clear();
@@ -83,9 +83,9 @@ TPPG* TPPG::Get() {
 	//The getter for the singleton TPPG. Unfortunately ROOT doesn't allow true 
 	//singletons, so one should take care to always use this method and not
 	//the constructor.
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = static_cast<TPPG*>(gDirectory->Get("TPPG"));
-		if(fPPG == NULL) {
+		if(fPPG == nullptr) {
 			fPPG = new TPPG();
 		}
 	}

--- a/libraries/TGRSIFormat/TParsingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TParsingDiagnostics.cxx
@@ -4,20 +4,20 @@
 
 #include "TChannel.h"
 
-TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = NULL;
+TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = nullptr;
 
 TParsingDiagnostics::TParsingDiagnostics() : TObject() {
-	fIdHist = NULL;
+	fIdHist = nullptr;
 	Clear();
 }
 
 TParsingDiagnostics::TParsingDiagnostics(const TParsingDiagnostics& rhs) : TObject() {
-	fIdHist = NULL;
+	fIdHist = nullptr;
 	Clear();
 }
 
 TParsingDiagnostics::~TParsingDiagnostics() {
-	if(fIdHist != NULL) delete fIdHist;
+	if(fIdHist != nullptr) delete fIdHist;
 }
 
 void TParsingDiagnostics::Copy(TObject& obj) const {
@@ -38,8 +38,8 @@ void TParsingDiagnostics::Copy(TObject& obj) const {
 }
 
 void TParsingDiagnostics::Clear(Option_t* opt) {
-	if(fIdHist != NULL) delete fIdHist;
-	fIdHist = NULL;
+	if(fIdHist != nullptr) delete fIdHist;
+	fIdHist = nullptr;
 	fPPGCycleLength = 0;
 	fNumberOfGoodFragments.clear();
 	fNumberOfBadFragments.clear();
@@ -141,7 +141,7 @@ void TParsingDiagnostics::GoodFragment(std::shared_ptr<const TFragment> frag) {
 
 void TParsingDiagnostics::ReadPPG(TPPG* ppg) {
 	///store different TPPG diagnostics like cycle length, length of each state, offset, how often each state was found
-	if(ppg == NULL) return;
+	if(ppg == nullptr) return;
 	fPPGCycleLength = ppg->GetCycleLength();
 	
 }
@@ -151,11 +151,11 @@ void TParsingDiagnostics::Draw(Option_t* opt) {
 	Short_t maxChannel = std::prev(fNumberOfHits.end())->first;
 
 	//check that the histogram (if it already exists) has the right number of bins
-	if(fIdHist != NULL && fIdHist->GetNbinsX() != maxChannel-minChannel+1) {
+	if(fIdHist != nullptr && fIdHist->GetNbinsX() != maxChannel-minChannel+1) {
 		delete fIdHist;
-		fIdHist = NULL;
+		fIdHist = nullptr;
 	}
-	if(fIdHist == NULL) {
+	if(fIdHist == nullptr) {
 		fIdHist = new TH1F("IdHist","Event survival;channel number;survival rate [%]", maxChannel-minChannel+1, minChannel, maxChannel+1);
 	} else {
 		//the histogram already had the right number of bins, but to be save we set the range

--- a/libraries/TGRSIFormat/TScaler.cxx
+++ b/libraries/TGRSIFormat/TScaler.cxx
@@ -48,7 +48,7 @@ TScaler::TScaler(bool loadIntoMap) {
 	///\param[in] loadIntoMap Flag telling TScaler to load all scaler data into fScalerMap.
    this->Clear();
 	fTree = static_cast<TTree*>(gROOT->FindObject("ScalerTree"));
-	if(fTree != NULL) {
+	if(fTree != nullptr) {
 		fEntries = fTree->GetEntries();
 		fTree->SetBranchAddress("TScalerData", &fScalerData);
 		if(loadIntoMap) {
@@ -63,7 +63,7 @@ TScaler::TScaler(bool loadIntoMap) {
 TScaler::TScaler(TTree* tree, bool loadIntoMap) {
    this->Clear();
 	fTree = tree;
-	if(fTree != NULL) {
+	if(fTree != nullptr) {
 		fEntries = fTree->GetEntries();
 		fTree->SetBranchAddress("TScalerData", &fScalerData);
 		if(loadIntoMap) {
@@ -81,14 +81,14 @@ TScaler::TScaler(const TScaler& rhs) : TObject() {
 
 TScaler::~TScaler(){
    //Clear() deletes histograms which can cause problems with root assuming ownership of all histograms
-	fTree = NULL;
-	fScalerData = NULL;
+	fTree = nullptr;
+	fScalerData = nullptr;
 	fEntries = 0;
    fTimePeriod.clear();
    fNumberOfTimePeriods.clear();
    fTotalTimePeriod = 0;
    fTotalNumberOfTimePeriods.clear();
-	fPPG = NULL;
+	fPPG = nullptr;
 	fHist.clear();
 	fHistRange.clear();
 	fScalerMap.clear();
@@ -109,7 +109,7 @@ void TScaler::Copy(TObject &obj) const {
 std::vector<UInt_t> TScaler::GetScaler(UInt_t address, ULong64_t time) const {
    ///Returns the vector of scaler values for address "address" at the time "time".
    ///If the time is after the last entry, we return the last entry, otherwise we return the following entry (or the current entry if the time is an exact match).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
 		return std::vector<UInt_t>(0);
    }
@@ -160,7 +160,7 @@ UInt_t TScaler::GetScalerDifference(UInt_t address, ULong64_t time, size_t index
    ///Returns the difference between "index"th scaler value for address "address" at the time "time" and the previous scaler value.
    ///If the time is after our last entry, we return the last entry divided by the number of entries,
    ///if this is before the first scaler, we just return the first scaler, otherwise we return the scaler minus the previous scaler.
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
 		return 0;
    }
@@ -218,25 +218,25 @@ UInt_t TScaler::GetScalerDifference(UInt_t address, ULong64_t time, size_t index
 }
 
 void TScaler::Clear(Option_t *opt){
-	fTree = NULL;
-	fScalerData = NULL;
+	fTree = nullptr;
+	fScalerData = nullptr;
 	fEntries = 0;
    fTimePeriod.clear();
    fNumberOfTimePeriods.clear();
    fTotalTimePeriod = 0;
    fTotalNumberOfTimePeriods.clear();
-	fPPG = NULL;
+	fPPG = nullptr;
  	for(auto addrIt = fHist.begin(); addrIt != fHist.end(); ++addrIt) {
-		if(addrIt->second != NULL) {
+		if(addrIt->second != nullptr) {
 			delete (addrIt->second);
-			addrIt->second = NULL;
+			addrIt->second = nullptr;
 		}
 	}
 	fHist.clear();
  	for(auto addrIt = fHistRange.begin(); addrIt != fHistRange.end(); ++addrIt) {
-		if(addrIt->second != NULL) {
+		if(addrIt->second != nullptr) {
 			delete (addrIt->second);
-			addrIt->second = NULL;
+			addrIt->second = nullptr;
 		}
 	}
 	fHistRange.clear();
@@ -246,21 +246,21 @@ void TScaler::Clear(Option_t *opt){
 TH1D* TScaler::Draw(UInt_t address, size_t index, Option_t *option) {
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time in cycle.
 	///Passing "redraw" as option forces re-drawing of the histogram (e.g. for a different index).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	//if the address doesn't exist in the histogram map, insert a null pointer
 	if(fHist.find(address) == fHist.end()) {
-		fHist[address] = NULL;
+		fHist[address] = nullptr;
 	}
 	//try and find the ppg (if we haven't already done so)
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 		//if we can't find the ppg we're done here
-		if(fPPG == NULL) {
-			return NULL;
+		if(fPPG == nullptr) {
+			return nullptr;
 		}
 	}
 
@@ -268,9 +268,9 @@ TH1D* TScaler::Draw(UInt_t address, size_t index, Option_t *option) {
 	opt.ToLower();
 	//if the histogram hasn't been created yet or the "redraw" option has been given, we create the histogram
 	Int_t opt_index = opt.Index("redraw");
-	if(fHist[address] == NULL || opt_index >= 0) {
+	if(fHist[address] == nullptr || opt_index >= 0) {
 		//we only need to create a new histogram if this is the first time drawing it, if we're just re-drawing we can re-use the existing histogram
-		if(fHist[address] == NULL) {
+		if(fHist[address] == nullptr) {
 			//printf("failed to find histogram for address 0x%04x\n",address);
 			int nofBins = fPPG->GetCycleLength()/GetTimePeriod(address);
 			fHist[address] = new TH1D(Form("TScalerHist_%04x",address),Form("scaler %d vs time in cycle for address 0x%04x; time in cycle [ms]; counts/%.0f ms", (int) index, address, 
@@ -309,17 +309,17 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time in cycle.
 	///Passing "redraw" as option forces re-drawing of the histogram (e.g. for a different index).
    ///The "single" options creates spectra for all single addresses in the given range (instead of one accumulative spectrum).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	//try and find the ppg (if we haven't already done so)
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 		//if we can't find the ppg we're done here
-		if(fPPG == NULL) {
-			return NULL;
+		if(fPPG == nullptr) {
+			return nullptr;
 		}
 	}
 
@@ -333,9 +333,9 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 		//draw the whole range of addresses in a single histogram
 		//if the address doesn't exist in the histogram map, insert a null pointer
 		if(fHistRange.find(std::make_pair(lowAddress, highAddress)) == fHistRange.end()) {
-			fHistRange[std::make_pair(lowAddress, highAddress)] = NULL;
+			fHistRange[std::make_pair(lowAddress, highAddress)] = nullptr;
 		}
-		if(fHistRange[std::make_pair(lowAddress, highAddress)] == NULL || draw_index >= 0) {
+		if(fHistRange[std::make_pair(lowAddress, highAddress)] == nullptr || draw_index >= 0) {
 			//printf("failed to find histogram for address range 0x%04x - 0x%04x\n",lowAddress,highAddress);
 			int nofBins = fPPG->GetCycleLength()/GetTimePeriod(lowAddress); //the time period should be the same for all channels
 			fHistRange[std::make_pair(lowAddress, highAddress)] = new TH1D(Form("TScalerHist_%04x_%04x",lowAddress,highAddress),
@@ -423,9 +423,9 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 
 TH1D* TScaler::DrawRawTimes(UInt_t address, Double_t lowtime, Double_t hightime, size_t index, Option_t *option) {
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time.
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	TString opt = option;

--- a/libraries/TGRSIFormat/TScalerQueue.cxx
+++ b/libraries/TGRSIFormat/TScalerQueue.cxx
@@ -13,11 +13,11 @@ std::mutex TDeadtimeScalerQueue::Sorted;
 //                                                            //
 ////////////////////////////////////////////////////////////////
 
-TDeadtimeScalerQueue *TDeadtimeScalerQueue::fDeadtimeScalerQueueClassPointer = NULL;
+TDeadtimeScalerQueue *TDeadtimeScalerQueue::fDeadtimeScalerQueueClassPointer = nullptr;
 
 TDeadtimeScalerQueue *TDeadtimeScalerQueue::Get() {
   ///Get a pointer to the global scaler Q. 
-  if(fDeadtimeScalerQueueClassPointer == NULL) {
+  if(fDeadtimeScalerQueueClassPointer == nullptr) {
 	 fDeadtimeScalerQueueClassPointer = new TDeadtimeScalerQueue;
   }
   return fDeadtimeScalerQueueClassPointer;
@@ -93,7 +93,7 @@ void TDeadtimeScalerQueue::StopStatusUpdate() {
 
 void TDeadtimeScalerQueue::Add(TScalerData* scalerData) {
 	///Add a Scaler to the scaler Queue.
-	if(scalerData == NULL) {
+	if(scalerData == nullptr) {
 		return;
 	}
 
@@ -211,11 +211,11 @@ std::mutex TRateScalerQueue::Sorted;
 //                                                            //
 ////////////////////////////////////////////////////////////////
 
-TRateScalerQueue *TRateScalerQueue::fRateScalerQueueClassPointer = NULL;
+TRateScalerQueue *TRateScalerQueue::fRateScalerQueueClassPointer = nullptr;
 
 TRateScalerQueue *TRateScalerQueue::Get() {
   ///Get a pointer to the global scaler Q. 
-  if(fRateScalerQueueClassPointer == NULL) {
+  if(fRateScalerQueueClassPointer == nullptr) {
 	 fRateScalerQueueClassPointer = new TRateScalerQueue;
   }
   return fRateScalerQueueClassPointer;
@@ -291,7 +291,7 @@ void TRateScalerQueue::StopStatusUpdate() {
 
 void TRateScalerQueue::Add(TScalerData* scalerData) {
 	///Add a Scaler to the scaler Queue.
-	if(scalerData == NULL) {
+	if(scalerData == nullptr) {
 		return;
 	}
 

--- a/libraries/TGRSIFormat/TSortingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TSortingDiagnostics.cxx
@@ -6,7 +6,7 @@
 #include "TChannel.h"
 #include "TGRSIOptions.h"
 
-TSortingDiagnostics* TSortingDiagnostics::fSortingDiagnostics = NULL;
+TSortingDiagnostics* TSortingDiagnostics::fSortingDiagnostics = nullptr;
 
 TSortingDiagnostics::TSortingDiagnostics() : TObject() {
 	Clear();

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -48,6 +48,53 @@ void TGRSISelector::SlaveBegin(TTree * /*tree*/)
    // When running with PROOF SlaveBegin() is called on each slave server.
    // The tree argument is deprecated (on PROOF 0 is passed).
    TString option = GetOption();
+
+	std::cout<<"input list size = "<<fInput->GetEntries()<<std::endl;
+	for(int i = 0; i < fInput->GetEntries(); ++i) {
+		std::cout<<fInput->At(i)->GetName()<<": ";
+		fInput->At(i)->Print();
+	}
+	const char* workingDirectory = "";
+	if(fInput->FindObject("pwd") != nullptr) {
+		workingDirectory = fInput->FindObject("pwd")->GetTitle();
+	}
+	int i = 0;
+	while(fInput->FindObject(Form("calFile%d",i)) != nullptr) {
+		const char* fileName = static_cast<TNamed*>(fInput->FindObject(Form("calFile%d",i)))->GetTitle();
+		if(fileName[0] == 0) {
+			std::cout<<"Error, empty file name!"<<std::endl;
+			break;
+		}
+		// if we have a relative path and a working directory, combine them
+		if(workingDirectory[0] != 0 && fileName[0] != '/') {
+			TChannel::ReadCalFile(Form("%s/%s", workingDirectory, fileName));
+		} else {
+			TChannel::ReadCalFile(fileName);
+		}
+		++i;
+	}
+	i = 0;
+	while(fInput->FindObject(Form("valFile%d",i)) != nullptr) {
+		const char* fileName = static_cast<TNamed*>(fInput->FindObject(Form("valFile%d",i)))->GetTitle();
+		if(fileName[0] == 0) {
+			std::cout<<"Error, empty file name!"<<std::endl;
+			break;
+		}
+		// if we have a relative path and a working directory, combine them
+		if(workingDirectory[0] != 0 && fileName[0] != '/') {
+			GValue::ReadValFile(Form("%s/%s", workingDirectory, fileName));
+		} else {
+			GValue::ReadValFile(fileName);
+		}
+		++i;
+	}
+
+	if(GValue::Size() == 0) {
+		std::cout<<"No g-values!"<<std::flush;
+	} else {
+		std::cout<<GValue::Size()<<" g-values"<<std::endl;
+	}
+
    CreateHistograms();
 }
 

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -13,7 +13,7 @@
 #include "GRootCommands.h"
 
 TGRSIOptions* TGRSIOptions::Get(int argc, char** argv){
-	static TGRSIOptions* item = NULL;
+	static TGRSIOptions* item = nullptr;
 	if(!item) {
 		item = new TGRSIOptions(argc, argv);
 	}

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -44,9 +44,9 @@ ClassImp(TGRSIint)
 extern void PopupLogo(bool);
 extern void WaitLogo();
 
-TGRSIint *TGRSIint::fTGRSIint = NULL;
+TGRSIint *TGRSIint::fTGRSIint = nullptr;
 
-TEnv *TGRSIint::fGRSIEnv = NULL;
+TEnv *TGRSIint::fGRSIEnv = nullptr;
 //std::vector<std::string> *TGRSIint::fInputRootFile  = new std::vector<std::string>;
 //std::vector<std::string> *TGRSIint::fInputMidasFile = new std::vector<std::string>;
 //std::vector<std::string> *TGRSIint::fInputCalFile   = new std::vector<std::string>;
@@ -64,7 +64,7 @@ TGRSIint *TGRSIint::instance(int argc,char** argv, void *options, int numOptions
 
 TGRSIint::TGRSIint(int argc, char **argv,void *options, Int_t numOptions, Bool_t noLogo,const char *appClassName)
   :TRint(appClassName, &argc, argv, options, numOptions,noLogo),
-   fKeepAliveTimer(NULL), main_thread_id(std::this_thread::get_id()), fIsTabComplete(false),
+   fKeepAliveTimer(nullptr), main_thread_id(std::this_thread::get_id()), fIsTabComplete(false),
    fAllowedToTerminate(true),fRootFilesOpened(0),fMidasFilesOpened(0) {
 
       fGRSIEnv = gEnv;
@@ -308,7 +308,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt){
   TString sopt(opt);
   sopt.ToLower();
 
-  TFile* file = NULL;
+  TFile* file = nullptr;
   if(sopt.Contains("recreate") ||
      sopt.Contains("new")) {
     // We are being asked to make a new file.
@@ -393,7 +393,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt){
 TMidasFile* TGRSIint::OpenMidasFile(const std::string& filename) {
   if(!file_exists(filename.c_str())){
     std::cerr << "File \"" << filename << "\" does not exist" << std::endl;
-    return NULL;
+    return nullptr;
   }
 
   TMidasFile* file = new TMidasFile(filename.c_str());

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -5,7 +5,7 @@
 #include "TInterpreter.h"
 
 /// \cond CLASSIMP
-ClassImp(TBGSubtraction);
+ClassImp(TBGSubtraction)
 /// \endcond
 
 

--- a/libraries/THistogramming/DynamicLibrary.cxx
+++ b/libraries/THistogramming/DynamicLibrary.cxx
@@ -62,7 +62,7 @@ DynamicLibrary::~DynamicLibrary() {
 }
 
 DynamicLibrary::DynamicLibrary(DynamicLibrary&& other)
-  : fLibrary(NULL){
+  : fLibrary(nullptr){
   swap(other);
 }
 

--- a/libraries/THistogramming/TCompiledHistograms.cxx
+++ b/libraries/THistogramming/TCompiledHistograms.cxx
@@ -38,7 +38,7 @@ TCompiledHistograms::TCompiledHistograms(std::string input_lib, std::string func
               <<"\"" << input_lib << "\"" << std::endl;
   }
   fLast_modified = get_timestamp();
-  fLast_checked = time(NULL);
+  fLast_checked = time(nullptr);
 }
 
 void TCompiledHistograms::ClearHistograms() {
@@ -117,7 +117,7 @@ void TCompiledHistograms::Reload() {
     TCompiledHistograms other(fLibname,fFunc_name);
     swap_lib(other);
   }
-  fLast_checked = time(NULL);
+  fLast_checked = time(nullptr);
 }
 
 void TCompiledHistograms::swap_lib(TCompiledHistograms& other) {
@@ -132,7 +132,7 @@ void TCompiledHistograms::swap_lib(TCompiledHistograms& other) {
 
 void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag) {
   std::lock_guard<std::mutex> lock(fMutex);
-  if(time(NULL) > fLast_checked + fCheck_every){
+  if(time(nullptr) > fLast_checked + fCheck_every){
     Reload();
   }
 
@@ -146,12 +146,12 @@ void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag) {
 
   fObj.SetFragment(frag);
   fFunc(fObj);
-  fObj.SetFragment(NULL);
+  fObj.SetFragment(nullptr);
 }
 
 void TCompiledHistograms::Fill(std::shared_ptr<TUnpackedEvent> detectors) {
   std::lock_guard<std::mutex> lock(fMutex);
-  if(time(NULL) > fLast_checked + fCheck_every){
+  if(time(nullptr) > fLast_checked + fCheck_every){
     Reload();
   }
 
@@ -165,7 +165,7 @@ void TCompiledHistograms::Fill(std::shared_ptr<TUnpackedEvent> detectors) {
 
   fObj.SetDetectors(detectors);
   fFunc(fObj);
-  fObj.SetDetectors(NULL);
+  fObj.SetDetectors(nullptr);
 }
 
 void TCompiledHistograms::AddCutFile(TFile* cut_file) {
@@ -177,7 +177,7 @@ void TCompiledHistograms::AddCutFile(TFile* cut_file) {
 void TCompiledHistograms::SetDefaultDirectory(TDirectory* dir) {
   fDefault_directory = dir;
 
-  TObject* obj = NULL;
+  TObject* obj = nullptr;
   TIter next(&fObjects);
   while((obj = next())) {
     TH1* hist = dynamic_cast<TH1*>(obj);

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -22,7 +22,7 @@ std::map<std::string,TRuntimeObjects*> TRuntimeObjects::fRuntimeMap;
 TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* objects, TList *gates,
                                  std::vector<TFile*>& cut_files,
                                  TDirectory* directory,const char *name)
-  : fFrag(frag), //detectors(NULL),
+  : fFrag(frag), //detectors(nullptr),
     fObjects(objects), fGates(gates),
     fCut_files(cut_files),
     fDirectory(directory) {
@@ -43,7 +43,7 @@ TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* o
 TRuntimeObjects::TRuntimeObjects(TList* objects, TList *gates,
                                  std::vector<TFile*>& cut_files,
                                  TDirectory* directory,const char *name)
-  : fFrag(NULL), //detectors(0),
+  : fFrag(nullptr), //detectors(0),
     fObjects(objects), fGates(gates),
     fCut_files(cut_files),
     fDirectory(directory) {
@@ -298,7 +298,7 @@ TCutG* TRuntimeObjects::GetCut(const std::string& name) {
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 double TRuntimeObjects::GetVariable(const char* name) {

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -175,7 +175,7 @@ void TAnalysisWriteLoop::AddBranch(TClass* cls){
 void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event) {
 	if(fEventTree) {
 		// Clear pointers from previous writes.
-		// Note that we cannot just set this equal to NULL,
+		// Note that we cannot just set this equal to nullptr,
 		//   because ROOT would then construct a new object.
 		// This contradicts the ROOT documentation for TBranchElement::SetAddress,
 		//   which suggests that a new object would be constructed only when setting the address,
@@ -197,7 +197,7 @@ void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event) {
 			(*fDetMap.at(cls))->ClearTransients();
 			//if(cls == TDescant::Class()) {
 			//	for(int i = 0; i < static_cast<TDescant*>(det)->GetMultiplicity(); ++i) {
-			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == NULL ? " has no debug data": " has debug data")<<std::endl;
+			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == nullptr ? " has no debug data": " has debug data")<<std::endl;
 			//	}
 			//}
 		}

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -59,7 +59,7 @@ void TEventBuildingLoop::ClearQueue() {
 
 bool TEventBuildingLoop::Iteration(){
 	// Pull something off of the input queue.
-	std::shared_ptr<const TFragment> input_frag = NULL;
+	std::shared_ptr<const TFragment> input_frag = nullptr;
 	fInputSize = fInputQueue->Pop(input_frag, 0);
 	if(fInputSize < 0) fInputSize = 0;
 

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -34,8 +34,8 @@ TFragWriteLoop* TFragWriteLoop::Get(std::string name, std::string fOutputFilenam
 
 TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
   : StoppableThread(name),
-    fOutputFile(NULL), fEventTree(NULL), fBadEventTree(NULL), fScalerTree(NULL),
-	 //fEventAddress(NULL), fBadEventAddress(NULL), fScalerAddress(NULL),
+    fOutputFile(nullptr), fEventTree(nullptr), fBadEventTree(nullptr), fScalerTree(nullptr),
+	 //fEventAddress(nullptr), fBadEventAddress(nullptr), fScalerAddress(nullptr),
     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fScalerInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >()) {
@@ -55,7 +55,7 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
     fBadEventTree->Branch("TFragment", &fBadEventAddress);
 
     fScalerTree = new TTree("EpicsTree","EpicsTree");
-	 fScalerAddress = NULL;
+	 fScalerAddress = nullptr;
     fScalerTree->Branch("TEpicsFrag", &fScalerAddress);
 
     TThread::UnLock();
@@ -153,7 +153,7 @@ void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 		fEventAddress->ClearTransients();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fEventTree->Fill();
-		//fEventAddress = NULL;
+		//fEventAddress = nullptr;
 	} else {
 		std::cout<<__PRETTY_FUNCTION__<<": no fragment tree!"<<std::endl;
 	}
@@ -164,7 +164,7 @@ void TFragWriteLoop::WriteBadEvent(std::shared_ptr<const TFragment> event) {
 		*fBadEventAddress = *(event.get());
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fBadEventTree->Fill();
-		//fBadEventAddress = NULL;
+		//fBadEventAddress = nullptr;
 	}
 }
 
@@ -173,7 +173,7 @@ void TFragWriteLoop::WriteScaler(std::shared_ptr<TEpicsFrag> scaler) {
 		fScalerAddress = scaler.get();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fScalerTree->Fill();
-		fScalerAddress = NULL;
+		fScalerAddress = nullptr;
 	}
 }
 

--- a/libraries/TLoops/TFragmentChainLoop.cxx
+++ b/libraries/TLoops/TFragmentChainLoop.cxx
@@ -31,7 +31,7 @@ TFragmentChainLoop* TFragmentChainLoop::Get(std::string name, TChain *chain) {
 TFragmentChainLoop::TFragmentChainLoop(std::string name, TChain *chain)
   : StoppableThread(name),
     fEntriesTotal(chain->GetEntries()),
-    fInputChain(chain), fFragment(NULL), 
+    fInputChain(chain), fFragment(nullptr), 
     fSelfStopping(true) {
   SetupChain();
 }

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -54,6 +54,6 @@ std::shared_ptr<TDetector>  TUnpackedEvent::GetDetector(TClass* cls, bool make_i
     fDetectors.push_back(output);
     return output;
   } else {
-    return NULL;
+    return nullptr;
   }
 }

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -75,19 +75,19 @@ bool TUnpackingLoop::ProcessMidasEvent(TMidasEvent* mEvent)   {
 		switch(mEvent->GetEventId())  {
 			case 1:
 				mEvent->SetBankList();
-				if((banksize = mEvent->LocateBank(NULL,"WFDN",&ptr))>0) {
+				if((banksize = mEvent->LocateBank(nullptr,"WFDN",&ptr))>0) {
 					if(!ProcessTIGRESS((uint32_t*)ptr, banksize, mEvent)) { }
 					//(unsigned int)(mEvent->GetSerialNumber()),
 					//(unsigned int)(mEvent->GetTimeStamp()))) { }
-				} else if((banksize = mEvent->LocateBank(NULL,"GRF1",&ptr))>0) {
+				} else if((banksize = mEvent->LocateBank(nullptr,"GRF1",&ptr))>0) {
 					if(!ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF1, mEvent)) { }
 					//(unsigned int)(mEvent->GetSerialNumber()),
 					//(unsigned int)(mEvent->GetTimeStamp()))) { }
-				} else if((banksize = mEvent->LocateBank(NULL,"GRF2",&ptr))>0) {
+				} else if((banksize = mEvent->LocateBank(nullptr,"GRF2",&ptr))>0) {
 					if(!ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF2, mEvent)) { }
-				} else if((banksize = mEvent->LocateBank(NULL,"GRF3",&ptr))>0) {
+				} else if((banksize = mEvent->LocateBank(nullptr,"GRF3",&ptr))>0) {
 					if(!ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF3, mEvent)) { }
-				} else if((banksize = mEvent->LocateBank(NULL,"GRF4",&ptr))>0) {
+				} else if((banksize = mEvent->LocateBank(nullptr,"GRF4",&ptr))>0) {
 					if(!ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF4, mEvent)) { }
 				} else if(!TGRSIOptions::Get()->SuppressErrors()) {
 					printf(DRED "\nUnknown bank in midas event #%d" RESET_COLOR "\n", mEvent->GetSerialNumber());
@@ -102,7 +102,7 @@ bool TUnpackingLoop::ProcessMidasEvent(TMidasEvent* mEvent)   {
 			case 4:
 			case 5:
 				 mEvent->SetBankList();
-				 if((banksize = mEvent->LocateBank(NULL,"MSRD",&ptr))>0) {
+				 if((banksize = mEvent->LocateBank(nullptr,"MSRD",&ptr))>0) {
 					 if(!ProcessEPICS((float*)ptr, banksize, mEvent)) { }
 				 }
 

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -19,11 +19,11 @@ ClassImp(TMidasEvent)
 TMidasEvent::TMidasEvent()
 {
   //Default constructor
-  fData = NULL;
+  fData = nullptr;
   fAllocatedByUs = false;
 
   fBanksN = 0;
-  fBankList = NULL;
+  fBankList = nullptr;
 
   fEventHeader.fEventId      = 0;
   fEventHeader.fTriggerMask  = 0;
@@ -42,7 +42,7 @@ void TMidasEvent::Copy(TObject& rhs) const{
   static_cast<TMidasEvent&>(rhs).fAllocatedByUs = true;
 
   static_cast<TMidasEvent&>(rhs).fBanksN      = fBanksN;
-  static_cast<TMidasEvent&>(rhs).fBankList    = NULL;
+  static_cast<TMidasEvent&>(rhs).fBankList    = nullptr;
   //if(fBankList) static_cast<TMidasEvent&>(rhs).fBankList    = strdup(fBankList);
   //assert(static_cast<TMidasEvent&>(rhs).fBankList);
 }
@@ -68,11 +68,11 @@ void TMidasEvent::Clear(Option_t *opt) {
    //Clears the TMidasEvent.
   if (fBankList)
     free(fBankList);
-  fBankList = NULL;
+  fBankList = nullptr;
 
   if (fData && fAllocatedByUs)
     free(fData);
-  fData = NULL;
+  fData = nullptr;
 
   fAllocatedByUs = false;
   fBanksN = 0;
@@ -144,7 +144,7 @@ int TMidasEvent::LocateBank(const void *unused, const char *name, void **pdata) 
 
   if (!status)
     {
-      *pdata = NULL;
+      *pdata = nullptr;
       return 0;
     }
 
@@ -158,7 +158,7 @@ static const unsigned TID_MAX = (sizeof(TID_SIZE)/sizeof(TID_SIZE[0]));
 /// \param [in] name Name of the data bank to look for.
 /// \param [out] bklen Number of array elements in this bank.
 /// \param [out] bktype Bank data type (MIDAS TID_xxx).
-/// \param [out] pdata Pointer to bank data, Returns NULL if bank not found.
+/// \param [out] pdata Pointer to bank data, Returns nullptr if bank not found.
 /// \returns 1 if bank found, 0 otherwise.
 ///
 int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdata) const {
@@ -187,12 +187,12 @@ int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdat
     } while ((char*) pbk32 < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
 #endif
 
-    TMidas_BANK32 *pbk32 = NULL;
+    TMidas_BANK32 *pbk32 = nullptr;
 
     while (1) {
       IterateBank32(&pbk32, (char**)pdata);
       //printf("looking for [%s] got [%s]\n", name, pbk32->fName);
-      if (pbk32 == NULL)
+      if (pbk32 == nullptr)
 	break;
 
       if (name[0]==pbk32->fName[0] &&
@@ -231,7 +231,7 @@ int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdat
   //
   // bank not found
   //
-  *pdata = NULL;
+  *pdata = nullptr;
   return 0;
 }
 
@@ -365,9 +365,9 @@ int TMidasEvent::SetBankList() {
 
   fBanksN = 0;
 
-  TMidas_BANK32 *pmbk32 = NULL;
-  TMidas_BANK *pmbk = NULL;
-  char *pdata = NULL;
+  TMidas_BANK32 *pmbk32 = nullptr;
+  TMidas_BANK *pmbk = nullptr;
+  char *pdata = nullptr;
 
   while (1)
     {
@@ -380,7 +380,7 @@ int TMidasEvent::SetBankList() {
       if (IsBank32())
 	{
 	  IterateBank32(&pmbk32, &pdata);
-	  if (pmbk32 == NULL)
+	  if (pmbk32 == nullptr)
 	    break;
 	  memcpy(fBankList+fBanksN*4, pmbk32->fName, 4);
 	  fBanksN++;
@@ -388,7 +388,7 @@ int TMidasEvent::SetBankList() {
       else
 	{
 	  IterateBank(&pmbk, &pdata);
-	  if (pmbk == NULL)
+	  if (pmbk == nullptr)
 	    break;
 	  memcpy(fBankList+fBanksN*4, pmbk->fName, 4);
 	  fBanksN++;
@@ -403,14 +403,14 @@ int TMidasEvent::SetBankList() {
 int TMidasEvent::IterateBank(TMidas_BANK **pbk, char **pdata) const {
   /// Iterates through banks inside an event. The function can be used
   /// to enumerate all banks of an event.
-  /// \param [in] pbk Pointer to the bank header, must be NULL for the
-  /// first call to this function. Returns NULL if no more banks
-  /// \param [in] pdata Pointer to data area of bank. Returns NULL if no more banks
+  /// \param [in] pbk Pointer to the bank header, must be nullptr for the
+  /// first call to this function. Returns nullptr if no more banks
+  /// \param [in] pdata Pointer to data area of bank. Returns nullptr if no more banks
   /// \returns Size of bank in bytes or 0 if no more banks.
   ///
   const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
 
-  if (*pbk == NULL)
+  if (*pbk == nullptr)
     *pbk = (TMidas_BANK *) (event + 1);
   else
     *pbk = (TMidas_BANK *) ((char*) (*pbk + 1) + ((((*pbk)->fDataSize)+7) & ~7));
@@ -419,8 +419,8 @@ int TMidasEvent::IterateBank(TMidas_BANK **pbk, char **pdata) const {
 
   if ((char*) *pbk >=  (char*) event + event->fDataSize + sizeof(TMidas_BANK_HEADER))
     {
-      *pbk = NULL;
-      *pdata = NULL;
+      *pbk = nullptr;
+      *pdata = nullptr;
       return 0;
     }
 
@@ -431,7 +431,7 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
   /// See IterateBank()
 
   const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
-  if (*pbk == NULL)
+  if (*pbk == nullptr)
     *pbk = (TMidas_BANK32 *) (event + 1);
   else {
     uint32_t length = (*pbk)->fDataSize;
@@ -455,8 +455,8 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
       else
 	{
 	  // truncate invalid data
-	  *pbk = NULL;
-	  *pdata = NULL;
+	  *pbk = nullptr;
+	  *pdata = nullptr;
 	  return 0;
 	}
     }
@@ -465,8 +465,8 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
 
   if ((char*) *pbk >= (char*)event  + event->fDataSize + sizeof(TMidas_BANK_HEADER))
     {
-      *pbk = NULL;
-      *pdata = NULL;
+      *pbk = nullptr;
+      *pdata = nullptr;
       return 0;
     }
 

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -30,13 +30,13 @@ TMidasFile::TMidasFile()
   uint32_t endian = 0x12345678;
 
   fFile = -1;
-  fGzFile = NULL;
-  fPoFile = NULL;
+  fGzFile = nullptr;
+  fPoFile = nullptr;
   fLastErrno = 0;
   fCurrentBufferSize = 0;
 
   fOutFile = -1;
-  fOutGzFile = NULL;
+  fOutGzFile = nullptr;
 
   fMaxBufferSize = 1E6;
 
@@ -76,7 +76,7 @@ static int hasSuffix(const char*name,const char*suffix)
 {
    //Checks to see if midas file has suffix.
   const char* s = strstr(name,suffix);
-  if (s == NULL)
+  if (s == nullptr)
     return 0;
 
   return (s-name)+strlen(suffix) == strlen(name);
@@ -124,7 +124,7 @@ bool TMidasFile::Open(const char *filename)
       const char* name = filename + 6;
       const char* s = strstr(name, "/");
 
-      if (s == NULL)
+      if (s == nullptr)
         {
           fLastErrno = -1;
           fLastError.assign("TMidasFile::Open: Invalid ssh:// URI. Should be: ssh://user@host/file/path/...");
@@ -186,7 +186,7 @@ bool TMidasFile::Open(const char *filename)
       fprintf(stderr,"TMidasFile::Open: Reading from pipe: %s\n", pipe.c_str());
       fPoFile = popen(pipe.c_str(), "r");
 
-      if (fPoFile == NULL)
+      if (fPoFile == nullptr)
         {
           fLastErrno = errno;
           fLastError.assign(std::strerror(errno));
@@ -216,7 +216,7 @@ bool TMidasFile::Open(const char *filename)
 #ifdef HAVE_ZLIB
           fGzFile = new gzFile;
           (*(gzFile*)fGzFile) = gzdopen(fFile,"rb");
-          if ((*(gzFile*)fGzFile) == NULL)
+          if ((*(gzFile*)fGzFile) == nullptr)
             {
               fLastErrno = -1;
               fLastError.assign("zlib gzdopen() error");
@@ -272,7 +272,7 @@ bool TMidasFile::OutOpen(const char *filename)
 #ifdef HAVE_ZLIB
       fOutGzFile = new gzFile;
       *(gzFile*)fOutGzFile = gzdopen(fOutFile,"wb");
-      if ((*(gzFile*)fOutGzFile) == NULL)
+      if ((*(gzFile*)fOutGzFile) == nullptr)
 	{
 	  fLastErrno = -1;
 	  fLastError.assign("zlib gzdopen() error");
@@ -506,11 +506,11 @@ void TMidasFile::Close()
    //Midas File.
   if (fPoFile)
     pclose((FILE*)fPoFile);
-  fPoFile = NULL;
+  fPoFile = nullptr;
 #ifdef HAVE_ZLIB
   if (fGzFile)
     gzclose(*(gzFile*)fGzFile);
-  fGzFile = NULL;
+  fGzFile = nullptr;
 #endif
   if (fFile > 0)
     close(fFile);
@@ -531,7 +531,7 @@ void TMidasFile::OutClose()
     gzflush(*(gzFile*)fOutGzFile, Z_FULL_FLUSH);
     gzclose(*(gzFile*)fOutGzFile);
   }
-  fOutGzFile = NULL;
+  fOutGzFile = nullptr;
 #endif
   if (fOutFile > 0)
     close(fOutFile);

--- a/scripts/BremMatrices.cxx
+++ b/scripts/BremMatrices.cxx
@@ -61,9 +61,9 @@ void BremMatrices() {
 }
 #endif
 
-TList *BremMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
-   if(runInfo == NULL) {
-      return NULL;
+TList *BremMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(runInfo == nullptr) {
+      return nullptr;
    }
 
 const Int_t nScDet = 21;
@@ -127,7 +127,7 @@ Bool_t supp_flag[nScDet][nGrDet] = {
    Double_t offStart = 14.5e8;
    Double_t offEnd   = 15.5e8;
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -571,7 +571,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -583,21 +583,21 @@ int main(int argc, char **argv) {
 
    //Get PPG from File
    TPPG* myPPG = (TPPG*)file->Get("TPPG");
-/*   if(myPPG == NULL) {
+/*   if(myPPG == nullptr) {
       printf("Failed to find PPG information in file '%s'!\n",argv[1]);
       return 1;
    }
 */
    //Get run info from File
    TGRSIRunInfo* runInfo = (TGRSIRunInfo*)file->Get("TGRSIRunInfo");
-   if(runInfo == NULL) {
+   if(runInfo == nullptr) {
       printf("Failed to find run information in file '%s'!\n",argv[1]);
       return 1;
    }
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }
@@ -629,8 +629,8 @@ int main(int argc, char **argv) {
       std::cout<<"Limiting processing of analysis tree to "<<entries<<" entries!"<<std::endl;
       list = BremMatrices(tree,myPPG,runInfo, entries, &w);
    }
-   if(list == NULL) {
-      std::cout<<"BremMatrices returned TList* NULL!\n"<<std::endl;
+   if(list == nullptr) {
+      std::cout<<"BremMatrices returned TList* nullptr!\n"<<std::endl;
       return 1;
    }
 

--- a/scripts/CycleMatrices.cxx
+++ b/scripts/CycleMatrices.cxx
@@ -62,9 +62,9 @@ void CycleMatrices() {
 }
 #endif
 
-TList *CycleMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
-   if(runInfo == NULL) {
-      return NULL;
+TList *CycleMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(runInfo == nullptr) {
+      return nullptr;
    }
 
    ///////////////////////////////////// SETUP ///////////////////////////////////////
@@ -101,7 +101,7 @@ TList *CycleMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntr
    Double_t offStart = 14.5e8;
    Double_t offEnd   = 15.5e8;
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -145,16 +145,16 @@ TList *CycleMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntr
    Double_t pMax[4] = {cycleLength,65,1000,2.};
    Int_t pBins[4]= {(Int_t)(cycleLength/10),65,1000,2};
 
-   TH2F* gammaSinglesCyc = NULL;
-   TH2F* gammaSinglesBCyc = NULL;
-   TH2F* gammaSinglesBmCyc = NULL;
-   THnSparseF* pileup = NULL;
-   THnSparseF* gSinglesCyc_chan = NULL;
-   THnSparseF* gbmatrixCyc_chan = NULL;
-   TH1D* gPUTotalCyc = NULL;
-   TH1D* gNPTotalCyc = NULL;
-   TH1D* gPUCyc = NULL;
-   TH2F* betaSinglesCyc = NULL;
+   TH2F* gammaSinglesCyc = nullptr;
+   TH2F* gammaSinglesBCyc = nullptr;
+   TH2F* gammaSinglesBmCyc = nullptr;
+   THnSparseF* pileup = nullptr;
+   THnSparseF* gSinglesCyc_chan = nullptr;
+   THnSparseF* gbmatrixCyc_chan = nullptr;
+   TH1D* gPUTotalCyc = nullptr;
+   TH1D* gNPTotalCyc = nullptr;
+   TH1D* gPUCyc = nullptr;
+   TH2F* betaSinglesCyc = nullptr;
 
    if(ppg){
       gPUTotalCyc = new TH1D("gPUTotalCyc","Total Pileup hits as function of time in cycle", cycleLength/10,0,cycleLength); list->Add(gPUTotalCyc);
@@ -674,7 +674,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -686,21 +686,21 @@ int main(int argc, char **argv) {
 
    //Get PPG from File
    TPPG* myPPG = (TPPG*)file->Get("TPPG");
-   /*   if(myPPG == NULL) {
+   /*   if(myPPG == nullptr) {
         printf("Failed to find PPG information in file '%s'!\n",argv[1]);
         return 1;
         }
         */
    //Get run info from File
    TGRSIRunInfo* runInfo = (TGRSIRunInfo*)file->Get("TGRSIRunInfo");
-   if(runInfo == NULL) {
+   if(runInfo == nullptr) {
       printf("Failed to find run information in file '%s'!\n",argv[1]);
       return 1;
    }
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }
@@ -732,8 +732,8 @@ int main(int argc, char **argv) {
       std::cout<<"Limiting processing of analysis tree to "<<entries<<" entries!"<<std::endl;
       list = CycleMatrices(tree,myPPG,runInfo, entries, &w);
    }
-   if(list == NULL) {
-      std::cout<<"CycleMatrices returned TList* NULL!\n"<<std::endl;
+   if(list == nullptr) {
+      std::cout<<"CycleMatrices returned TList* nullptr!\n"<<std::endl;
       return 1;
    }
 

--- a/scripts/Deadtime.cxx
+++ b/scripts/Deadtime.cxx
@@ -284,7 +284,7 @@ void DoAnalysis(const char*& fname, int& nfile, double *rate, int& nsclr, int& p
   int ppgstat[2]={0,0};
   //generate random seed from system time for use in error analysis
   time_t timer;
-  timer = time(NULL);
+  timer = time(nullptr);
   srand (timer);	
 
   TFile f(fname);

--- a/scripts/DescantMatrices.cxx
+++ b/scripts/DescantMatrices.cxx
@@ -64,9 +64,9 @@ void DescantMatrices() {
 }
 #endif
 
-TList *DescantMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
-   if(runInfo == NULL) {
-      return NULL;
+TList *DescantMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(runInfo == nullptr) {
+      return nullptr;
    }
 
    ///////////////////////////////////// SETUP ///////////////////////////////////////
@@ -115,7 +115,7 @@ TList *DescantMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEn
    Double_t offStart = 14.5e8;
    Double_t offEnd   = 15.5e8;
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -159,16 +159,16 @@ TList *DescantMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEn
    Double_t pMax[4] = {cycleLength,65,1000,2.};
    Int_t pBins[4]= {(Int_t)(cycleLength/10),65,1000,2};
 
-   TH2F* gammaSinglesCyc = NULL;
-   TH2F* gammaSinglesBCyc = NULL;
-   TH2F* gammaSinglesBmCyc = NULL;
-   THnSparseF* pileup = NULL;
-   THnSparseF* gSinglesCyc_chan = NULL;
-   THnSparseF* gbmatrixCyc_chan = NULL;
-   TH1D* gPUTotalCyc = NULL;
-   TH1D* gNPTotalCyc = NULL;
-   TH1D* gPUCyc = NULL;
-   TH2F* betaSinglesCyc = NULL;
+   TH2F* gammaSinglesCyc = nullptr;
+   TH2F* gammaSinglesBCyc = nullptr;
+   TH2F* gammaSinglesBmCyc = nullptr;
+   THnSparseF* pileup = nullptr;
+   THnSparseF* gSinglesCyc_chan = nullptr;
+   THnSparseF* gbmatrixCyc_chan = nullptr;
+   TH1D* gPUTotalCyc = nullptr;
+   TH1D* gNPTotalCyc = nullptr;
+   TH1D* gPUCyc = nullptr;
+   TH2F* betaSinglesCyc = nullptr;
 
    if(ppg){
       gPUTotalCyc = new TH1D("gPUTotalCyc","Total Pileup hits as function of time in cycle", cycleLength/10,0,cycleLength); list->Add(gPUTotalCyc);
@@ -810,7 +810,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -822,21 +822,21 @@ int main(int argc, char **argv) {
 
    //Get PPG from File
    TPPG* myPPG = (TPPG*)file->Get("TPPG");
-   /*   if(myPPG == NULL) {
+   /*   if(myPPG == nullptr) {
         printf("Failed to find PPG information in file '%s'!\n",argv[1]);
         return 1;
         }
         */
    //Get run info from File
    TGRSIRunInfo* runInfo = (TGRSIRunInfo*)file->Get("TGRSIRunInfo");
-   if(runInfo == NULL) {
+   if(runInfo == nullptr) {
       printf("Failed to find run information in file '%s'!\n",argv[1]);
       return 1;
    }
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }
@@ -868,8 +868,8 @@ int main(int argc, char **argv) {
       std::cout<<"Limiting processing of analysis tree to "<<entries<<" entries!"<<std::endl;
       list = DescantMatrices(tree,myPPG,runInfo, entries, &w);
    }
-   if(list == NULL) {
-      std::cout<<"DescantMatrices returned TList* NULL!\n"<<std::endl;
+   if(list == nullptr) {
+      std::cout<<"DescantMatrices returned TList* nullptr!\n"<<std::endl;
       return 1;
    }
 

--- a/scripts/LeanCorrelations.cxx
+++ b/scripts/LeanCorrelations.cxx
@@ -137,7 +137,7 @@ std::vector<std::pair<double,int> > AngleCombinations(double distance = 110., bo
 
 
 
-TList *exAnalysis(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
+TList *exAnalysis(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
    ///////////////////////////////////// SETUP ///////////////////////////////////////
    //Histogram paramaters
    Double_t low = 0;
@@ -169,7 +169,7 @@ TList *exAnalysis(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries
    //Double_t offStart = 14.5e8;
    //Double_t offEnd   = 15.5e8;
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -452,7 +452,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -470,7 +470,7 @@ int main(int argc, char **argv) {
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }

--- a/scripts/LeanMatrices.cxx
+++ b/scripts/LeanMatrices.cxx
@@ -61,9 +61,9 @@ void LeanMatrices() {
 }
 #endif
 
-TList *LeanMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
-   if(runInfo == NULL) {
-      return NULL;
+TList *LeanMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(runInfo == nullptr) {
+      return nullptr;
    }
 
    ///////////////////////////////////// SETUP ///////////////////////////////////////
@@ -100,7 +100,7 @@ TList *LeanMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntri
    Double_t offStart = 14.5e8;
    Double_t offEnd   = 15.5e8;
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -136,12 +136,11 @@ TList *LeanMatrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntri
    TH2F* ggbmatrixBg = new TH2F("ggbmatrixBg","#gamma-#gamma-#beta matrix, background window", nofBins, low, high, nofBins, low, high); list->Add(ggbmatrixBg);
    TH2F* ggbmatrixOff = new TH2F("ggbmatrixOff","#gamma-#gamma-#beta matrix, beam off window", nofBins, low, high, nofBins, low, high); list->Add(ggbmatrixOff);
 
-   TH2F* gammaSinglesCyc = NULL;
-   TH2F* gammaSinglesBCyc = NULL;
-   TH2F* gammaSinglesBmCyc = NULL;
-   TH2F* betaSinglesCyc = NULL;
-   if(ppg) {
-		std::cout<<"creating ppg spectra!"<<std::endl;
+   TH2F* gammaSinglesCyc = nullptr;
+   TH2F* gammaSinglesBCyc = nullptr;
+   TH2F* gammaSinglesBmCyc = nullptr;
+   TH2F* betaSinglesCyc = nullptr;
+   if(ppg){
       gammaSinglesCyc = new TH2F("gammaSinglesCyc", "Cycle time vs. #gamma energy", cycleLength/10.,0.,cycleLength, nofBins,low,high); list->Add(gammaSinglesCyc);
       gammaSinglesBCyc = new TH2F("gammaSinglesBCyc", "Cycle time vs. #beta coinc #gamma energy", cycleLength/10.,0.,cycleLength, nofBins,low,high); list->Add(gammaSinglesBCyc);
       gammaSinglesBmCyc = new TH2F("gammaSinglesBmCyc", "Cycle time vs. #beta coinc #gamma energy (multiple counting of #beta's)", cycleLength/10.,0.,cycleLength, nofBins,low,high); list->Add(gammaSinglesBmCyc);
@@ -521,7 +520,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -533,7 +532,7 @@ int main(int argc, char **argv) {
 
    //Get PPG from File
    TPPG* myPPG = (TPPG*)file->Get("TPPG");
-	if(myPPG == NULL) {
+	if(myPPG == nullptr) {
 		printf("Failed to find PPG information in file '%s'!\n",argv[1]);
 	//} else {
 		//std::cout<<"got PPG "<<myPPG<<" : "<<myPPG->MapIsEmpty()<<std::endl;
@@ -544,14 +543,14 @@ int main(int argc, char **argv) {
 	}
    //Get run info from File
    TGRSIRunInfo* runInfo = (TGRSIRunInfo*)file->Get("TGRSIRunInfo");
-   if(runInfo == NULL) {
+   if(runInfo == nullptr) {
       printf("Failed to find run information in file '%s'!\n",argv[1]);
       return 1;
    }
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }
@@ -568,8 +567,8 @@ int main(int argc, char **argv) {
       std::cout<<"Limiting processing of analysis tree to "<<entries<<" entries!"<<std::endl;
       list = LeanMatrices(tree,myPPG,runInfo, entries, &w);
    }
-   if(list == NULL) {
-      std::cout<<"LeanMatrices returned TList* NULL!\n"<<std::endl;
+   if(list == nullptr) {
+      std::cout<<"LeanMatrices returned TList* nullptr!\n"<<std::endl;
       return 1;
    }
 

--- a/scripts/Mg22Matrices.cxx
+++ b/scripts/Mg22Matrices.cxx
@@ -62,9 +62,9 @@ void Mg22Matrices() {
 }
 #endif
 
-TList *Mg22Matrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = NULL) {
-   if(runInfo == NULL) {
-      return NULL;
+TList *Mg22Matrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(runInfo == nullptr) {
+      return nullptr;
    }
 	ppg = 0;
    ///////////////////////////////////// SETUP ///////////////////////////////////////
@@ -105,7 +105,7 @@ TList *Mg22Matrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntri
    Double_t sparselow[3]   = {0.,0.,-3000.};
    Double_t sparsehigh[3]  = {2000.,2000.,3000};
 
-   if(w == NULL) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -146,10 +146,10 @@ TList *Mg22Matrices(TTree* tree, TPPG* ppg, TGRSIRunInfo* runInfo, long maxEntri
    TH2F* ggbmatrixBg = new TH2F("ggbmatrixBg","#gamma-#gamma-#beta matrix, background window", nofBins, low, high, nofBins, low, high); list->Add(ggbmatrixBg);
    TH2F* ggbmatrixOff = new TH2F("ggbmatrixOff","#gamma-#gamma-#beta matrix, beam off window", nofBins, low, high, nofBins, low, high); list->Add(ggbmatrixOff);
 
-   TH2F* gammaSinglesCyc = NULL;
-   TH2F* gammaSinglesBCyc = NULL;
-   TH2F* gammaSinglesBmCyc = NULL;
-   TH2F* betaSinglesCyc = NULL;
+   TH2F* gammaSinglesCyc = nullptr;
+   TH2F* gammaSinglesBCyc = nullptr;
+   TH2F* gammaSinglesBmCyc = nullptr;
+   TH2F* betaSinglesCyc = nullptr;
    if(ppg){
       gammaSinglesCyc = new TH2F("gammaSinglesCyc", "Cycle time vs. #gamma energy", cycleLength/10.,0.,cycleLength, nofBins,low,high); list->Add(gammaSinglesCyc);
       gammaSinglesBCyc = new TH2F("gammaSinglesBCyc", "Cycle time vs. #beta coinc #gamma energy", cycleLength/10.,0.,ppg->GetCycleLength()/1e5, nofBins,low,high); list->Add(gammaSinglesBCyc);
@@ -538,7 +538,7 @@ int main(int argc, char **argv) {
 
    TFile* file = new TFile(argv[1]);
 
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -550,21 +550,21 @@ int main(int argc, char **argv) {
 
    //Get PPG from File
    TPPG* myPPG = (TPPG*)file->Get("TPPG");
-   /*   if(myPPG == NULL) {
+   /*   if(myPPG == nullptr) {
         printf("Failed to find PPG information in file '%s'!\n",argv[1]);
         return 1;
         }
         */
    //Get run info from File
    TGRSIRunInfo* runInfo = (TGRSIRunInfo*)file->Get("TGRSIRunInfo");
-   if(runInfo == NULL) {
+   if(runInfo == nullptr) {
       printf("Failed to find run information in file '%s'!\n",argv[1]);
       return 1;
    }
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
    TChannel::ReadCalFromTree(tree);
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }
@@ -596,8 +596,8 @@ int main(int argc, char **argv) {
       std::cout<<"Limiting processing of analysis tree to "<<entries<<" entries!"<<std::endl;
       list = Mg22Matrices(tree,myPPG,runInfo, entries, &w);
    }
-   if(list == NULL) {
-      std::cout<<"Mg22Matrices returned TList* NULL!\n"<<std::endl;
+   if(list == nullptr) {
+      std::cout<<"Mg22Matrices returned TList* nullptr!\n"<<std::endl;
       return 1;
    }
 

--- a/util/AnalyzeDataLoss.cxx
+++ b/util/AnalyzeDataLoss.cxx
@@ -24,9 +24,9 @@
 
 #include "TFragment.h"
 
-TList *AnalyzeDataLoss(TTree *tree, long entries = 0, TStopwatch* w = NULL) {
+TList *AnalyzeDataLoss(TTree *tree, long entries = 0, TStopwatch* w = nullptr) {
   
-  if(w == NULL) {
+  if(w == nullptr) {
     w = new TStopwatch;
     w->Start();
   }
@@ -246,7 +246,7 @@ int main(int argc, char **argv) {
    }
 
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -257,14 +257,14 @@ int main(int argc, char **argv) {
 
    TTree* tree = (TTree*) file->Get("FragmentTree");
 
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find fragment tree in file '%s'!\n",argv[1]);
       return 1;
    }
    
    TTree* badtree = (TTree*) file->Get("BadFragmentTree");
 
-   if(badtree == NULL) {
+   if(badtree == nullptr) {
       printf("Failed to find bad fragment tree in file '%s'!\n",argv[1]);
    } else {
 		std::cout<<badtree->GetEntries()<<" bad entries in total = "<<(100.*badtree->GetEntries())/tree->GetEntries()<<"% of the good entries"<<std::endl;
@@ -272,7 +272,7 @@ int main(int argc, char **argv) {
    
    TTree* epicstree = (TTree*) file->Get("EpicsTree");
 
-   if(epicstree == NULL) {
+   if(epicstree == nullptr) {
       printf("Failed to find epics tree in file '%s'!\n",argv[1]);
    } else {
 		std::cout<<epicstree->GetEntries()<<" epics entries"<<std::endl;
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
    
    TPPG* ppg = (TPPG*) file->Get("TPPG");
 
-   if(ppg == NULL) {
+   if(ppg == nullptr) {
       printf("Failed to find ppg in file '%s'!\n",argv[1]);
    } else {
 		std::cout<<ppg->PPGSize()<<" ppg events"<<std::endl;

--- a/util/AnalyzeFragmentTree.C
+++ b/util/AnalyzeFragmentTree.C
@@ -23,9 +23,9 @@
 
 #include "TFragment.h"
 
-TList *AnalyzeFragmentTree(TTree *tree, long entries = 0, TStopwatch* w = NULL) {
+TList *AnalyzeFragmentTree(TTree *tree, long entries = 0, TStopwatch* w = nullptr) {
   
-  if(w == NULL) {
+  if(w == nullptr) {
     w = new TStopwatch;
     w->Start();
   }
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
    }
 
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
 
    TTree* tree = (TTree*) file->Get("FragmentTree");
 
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find fragment tree in file '%s'!\n",argv[1]);
       return 1;
    }

--- a/util/AngularCorrelations.C
+++ b/util/AngularCorrelations.C
@@ -33,7 +33,7 @@ TFitResultPtr FitPeak(Double_t *par, TH1 *h, Float_t &area, Float_t &darea, Doub
 TList* AngularCorrelations(TH1D** slice, TNucleus* nuc, bool verbosity) {
    gSystem->Load("libMathMore");
    if(!nuc)
-      return NULL;
+      return nullptr;
    Double_t counter = 0;
    Double_t par[40];
 
@@ -342,7 +342,7 @@ int main(int argc, char **argv) {
    }
   
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -353,12 +353,12 @@ int main(int argc, char **argv) {
 
    TH3F* hist = (TH3F*) file->Get("angCorr");
 
-   TList *list = NULL;
+   TList *list = nullptr;
    TH1D* slice[51];
-   if(hist == NULL) {
+   if(hist == nullptr) {
       for(int i = 0; i < 51;i++){
          slice[i] =(TH1D*) file->Get(Form("Slice_X_%i",i+1));
-         if(slice[i] == NULL) {
+         if(slice[i] == nullptr) {
             std::cout<<"Failed to find histogram 'angCorr' or slice 'Slice_X_"<<i<<"' in file "<<file->GetName()<<std::endl;
             return 1;
          }
@@ -370,7 +370,7 @@ int main(int argc, char **argv) {
    }
    list = AngularCorrelations(slice, "60Co");
 
-   if(list == NULL) {
+   if(list == nullptr) {
       std::cout<<"Failed to get TList"<<std::endl;
       return 1;
    }

--- a/util/EfficCal.C
+++ b/util/EfficCal.C
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
    abs_flag = atoi(argv[2]);
 
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }

--- a/util/EnergyCal.cxx
+++ b/util/EnergyCal.cxx
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
    }
 
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }

--- a/util/GainMatchGRIFFIN.C
+++ b/util/GainMatchGRIFFIN.C
@@ -161,7 +161,7 @@ void make_calibration_histograms(const char* fragFileName, const char* histFileN
 {
 	// create histograms
 	TFile* f = new TFile(fragFileName);
-	if(f == NULL) {
+	if(f == nullptr) {
 	      	printf("Failed to open file '%s'!\n",fragFileName);
       		return;
    	}
@@ -275,7 +275,7 @@ void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxch
 /*---------------------------------------------------------------*/
 
 	TFile* f = new TFile(histFileName,"update");
-	if(f == NULL) {
+	if(f == nullptr) {
 	      	printf("Failed to open file '%s'!\n",histFileName);
       		return;
    	}
@@ -397,7 +397,7 @@ TGraph* gainmatch_peaks(TH1* hst, vector<double> peakvalues, vector<double> peak
 void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, vector<int> channelstoskip, const char* paramImgName = "GRIFFIN_fitting_params.png", const char* graphImgName="GRIFFIN_calgraph.png", int order = 1)
 {
 	TFile* f = new TFile(ROOTFileName);
-	if(f == NULL) {
+	if(f == nullptr) {
 	      	printf("Failed to open file '%s'!\n",ROOTFileName);
       		return;
    	}
@@ -571,7 +571,7 @@ void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int m
 void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, vector<int> channelstoskip, int xbins = 40e3, double xmin = 0, double xmax = 4000)
 {
 	TFile* fdata = new TFile(fragFile);
-	if(fdata == NULL) {
+	if(fdata == nullptr) {
 	      	printf("Failed to open file '%s'!\n",fragFile);
       		return;
    	}
@@ -668,7 +668,7 @@ TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, int bi
 void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<int> channelstoskip, vector<double> peaks, const char* type = "TSpectrum", double width = 10, bool UseMyList = kFALSE, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png", const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
 {
 	TFile* f = new TFile(testFileName,"update");
-	if(f == NULL) {
+	if(f == nullptr) {
 	      	printf("Failed to open file '%s'!\n",testFileName);
       		return;
    	}
@@ -997,7 +997,7 @@ int main(int argc, char **argv) {
       }
    
       TFile* file = new TFile(argv[i]);
-      if(file == NULL) {
+      if(file == nullptr) {
          printf("Failed to open file '%s'!\n",argv[1]);
          return 1;
       }
@@ -1073,7 +1073,7 @@ int main(int argc, char **argv) {
       }
    
       TFile* file = new TFile(argv[i]);
-      if(file == NULL) {
+      if(file == nullptr) {
          printf("Failed to open file '%s'!\n",argv[1]);
          return 1;
       }

--- a/util/GetTreeEntries.cxx
+++ b/util/GetTreeEntries.cxx
@@ -67,32 +67,32 @@ int main(int argc, char** argv) {
 			//TTAC
 			
 			bool gotGriffin = (tree->FindBranch("TGriffin") != 0);
-			TGriffin* grif = NULL;
+			TGriffin* grif = nullptr;
 			if(gotGriffin)	tree->SetBranchAddress("TGriffin", &grif);
 			long numGriffin = 0;
 
 			bool gotDescant = (tree->FindBranch("TDescant") != 0);
-			TDescant* desc = NULL;
+			TDescant* desc = nullptr;
 			if(gotDescant) tree->SetBranchAddress("TDescant", &desc);
 			long numDescant = 0;
 
 			bool gotLaBr = (tree->FindBranch("TLaBr") != 0);
-			TLaBr* laBr = NULL;
+			TLaBr* laBr = nullptr;
 			if(gotLaBr)	tree->SetBranchAddress("TLaBr", &laBr);
 			long numLaBr = 0;
 
 			bool gotZeroDegree = (tree->FindBranch("TZeroDegree") != 0);
-			TZeroDegree* zd = NULL;
+			TZeroDegree* zd = nullptr;
 			if(gotZeroDegree)	tree->SetBranchAddress("TZeroDegree", &zd);
 			long numZeroDegree = 0;
 
 			bool gotSceptar = (tree->FindBranch("TSceptar") != 0);
-			TSceptar* scep = NULL;
+			TSceptar* scep = nullptr;
 			if(gotSceptar) tree->SetBranchAddress("TSceptar", &scep);
 			long numSceptar = 0;
 
 			bool gotPaces = (tree->FindBranch("TPaces") != 0);
-			TPaces* pace = NULL;
+			TPaces* pace = nullptr;
 			if(gotPaces) tree->SetBranchAddress("TPaces", &pace);
 			long numPaces = 0;
 

--- a/util/MakeMatrices.C
+++ b/util/MakeMatrices.C
@@ -130,8 +130,8 @@ std::vector<std::pair<double,int> > AngleCombinations(double distance = 110., bo
    return result;
 }
    
-TList *MakeMatrices(TTree* tree, int coincLow = 0, int coincHigh = 10, int bg = 100, int nofBins = 4000, double low = 0., double high = 4000., long maxEntries = 0, TStopwatch* w = NULL) {
-   if(w == NULL) {
+TList *MakeMatrices(TTree* tree, int coincLow = 0, int coincHigh = 10, int bg = 100, int nofBins = 4000, double low = 0., double high = 4000., long maxEntries = 0, TStopwatch* w = nullptr) {
+   if(w == nullptr) {
       w = new TStopwatch;
       w->Start();
    }
@@ -961,7 +961,7 @@ int main(int argc, char **argv) {
    }
 
    TFile* file = new TFile(argv[1]);
-   if(file == NULL) {
+   if(file == nullptr) {
       printf("Failed to open file '%s'!\n",argv[1]);
       return 1;
    }
@@ -972,7 +972,7 @@ int main(int argc, char **argv) {
 
    TTree* tree = (TTree*) file->Get("AnalysisTree");
 
-   if(tree == NULL) {
+   if(tree == nullptr) {
       printf("Failed to find analysis tree in file '%s'!\n",argv[1]);
       return 1;
    }

--- a/util/bufferclean.cxx
+++ b/util/bufferclean.cxx
@@ -21,11 +21,11 @@ Bool_t CheckEvent(TMidasEvent *evt){
 
    //Need to put something in that says "if not a Griffin fragment (ie epics) return true"
    void *ptr;
-   int banksize = evt->LocateBank(NULL,"GRF2",&ptr);
+   int banksize = evt->LocateBank(nullptr,"GRF2",&ptr);
    int bank = 2;
 
    if(!banksize){
-      banksize = evt->LocateBank(NULL,"GRF1",&ptr);
+      banksize = evt->LocateBank(nullptr,"GRF1",&ptr);
       bank = 1;
    }
    uint32_t type  = 0xffffffff;

--- a/util/offsetadd.cxx
+++ b/util/offsetadd.cxx
@@ -66,7 +66,7 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    //int data[1024];
   
    void *ptr;
-   int banksize = event->LocateBank(NULL,"GRF1",&ptr);
+   int banksize = event->LocateBank(nullptr,"GRF1",&ptr);
 
    uint32_t type  = 0xffffffff;
    int value = 0xffffffff;
@@ -170,7 +170,7 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    TMidasEvent copyevent = *event;
    copyevent.SetBankList();
 
-   banksize = copyevent.LocateBank(NULL,"GRF1",&ptr);
+   banksize = copyevent.LocateBank(nullptr,"GRF1",&ptr);
    for(int x=0;x<banksize;x++) {
       value = *((int*)ptr+x);
       type  = value & 0xf0000000; 

--- a/util/offsetfind.cxx
+++ b/util/offsetfind.cxx
@@ -29,7 +29,7 @@ class TEventTime {
          event->SetBankList();
   
          void *ptr;
-         int banksize = event->LocateBank(NULL,"GRF1",&ptr);
+         int banksize = event->LocateBank(nullptr,"GRF1",&ptr);
 
          uint32_t type  = 0xffffffff;
          uint32_t value = 0xffffffff;

--- a/util/offsetfix.cxx
+++ b/util/offsetfix.cxx
@@ -36,11 +36,11 @@ class TEventTime {
          event->SetBankList();
   
          void *ptr;
-         int banksize = event->LocateBank(NULL,"GRF2",&ptr);
+         int banksize = event->LocateBank(nullptr,"GRF2",&ptr);
          int bank = 2;
 
          if(!banksize){
-            banksize = event->LocateBank(NULL,"GRF1",&ptr);
+            banksize = event->LocateBank(nullptr,"GRF1",&ptr);
             bank = 1;
          }
          uint32_t type  = 0xffffffff;
@@ -266,9 +266,9 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
             event->SetBankList();
             
 
-               banksize = event->LocateBank(NULL,"GRF2",&ptr);
+               banksize = event->LocateBank(nullptr,"GRF2",&ptr);
             if(!banksize)
-               banksize = event->LocateBank(NULL,"GRF1",&ptr);
+               banksize = event->LocateBank(nullptr,"GRF1",&ptr);
 
             if(banksize>0) {
                int frags = parser.GriffinDataToFragment((uint32_t*)(ptr),banksize,TDataParser::kGRF2,mserial,mtime);
@@ -579,10 +579,10 @@ bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
   
    void *ptr;
    
-   int banksize = event->LocateBank(NULL,"GRF2",&ptr);
+   int banksize = event->LocateBank(nullptr,"GRF2",&ptr);
    int bank = 2;
    if(!banksize){
-      banksize = event->LocateBank(NULL,"GRF1",&ptr);
+      banksize = event->LocateBank(nullptr,"GRF1",&ptr);
       bank =1;
    }
    uint32_t type  = 0xffffffff;
@@ -680,9 +680,9 @@ bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    TMidasEvent copyevent = *event;
    copyevent.SetBankList();
 
-   banksize = copyevent.LocateBank(NULL,"GRF2",&ptr);
+   banksize = copyevent.LocateBank(nullptr,"GRF2",&ptr);
    if(!banksize)
-      banksize = copyevent.LocateBank(NULL,"GRF1",&ptr);
+      banksize = copyevent.LocateBank(nullptr,"GRF1",&ptr);
 
    for(int x=0;x<banksize;x++) {
       value = *((int*)ptr+x);

--- a/util/scripts.C
+++ b/util/scripts.C
@@ -9,7 +9,7 @@
 #include <TTree.h>
 
 // almost any quick analysis will end up using the tree and a fragment
-TTree *tree = NULL;
+TTree *tree = nullptr;
 TFragment *frag = new TFragment;
 
 // construct a TGraph from an arbitrary STL vector, useful for ROOT plotting
@@ -98,7 +98,7 @@ void DrawNext(void)
 {
   static Int_t evno=0;
 
-  if (tree == NULL) {
+  if (tree == nullptr) {
     tree = (TTree*)gROOT->FindObject("FragmentTree");
   }
   tree->SetBranchAddress("TFragment", &frag);
@@ -126,7 +126,7 @@ void DrawNextDescant(void)
 {
   static Int_t evno=0;
 
-  if (tree == NULL) {
+  if (tree == nullptr) {
     tree = (TTree*)gROOT->FindObject("FragmentTree");
   }
   tree->SetBranchAddress("TFragment", &frag);


### PR DESCRIPTION
- Added GRSISort and myAnalysis directories to macro path.
- Added option to use calibration and g-value files via TPROOF::AddInput().
- Added GetCorrectedTime() method to TDescantHit and TZeroDegreeHit.
- Proper clearing and finishing of bad output queue and scaler queue in TDataParser

The last point might be (one) reason why GRISSort sometimes has issues quitting if CTRL-c is used.