### PR TITLE
Fixed makefile to work on computer with TXML

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -84,7 +84,9 @@ int main(int argc, char **argv) {
 
    //Add the path were we store headers for GRSIProof macros to see
    const char* pPath = getenv("GRSISYS");
+	gROOT->SetMacroPath(Form("%s",pPath));
    gROOT->SetMacroPath(Form("%s/GRSIProof",pPath));
+	gROOT->SetMacroPath(Form("%s/myAnalysis",pPath));
    gInterpreter->AddIncludePath(Form("%s/include",pPath));
    //The first thing we want to do is see if we can compile the macros that are passed to us
    if(!opt->MacroInputFiles().size()){
@@ -127,6 +129,16 @@ int main(int argc, char **argv) {
    gInterpreter->AddIncludePath(Form("%s/include",pPath));
    proof->AddIncludePath(Form("%s/include",pPath));
    proof->AddDynamicPath(Form("%s/lib",pPath));
+
+   proof->AddInput(new TNamed("pwd", getenv("PWD")));
+   int i = 0;
+   for(auto valFile = TGRSIOptions::Get()->ValInputFiles().begin(); valFile != TGRSIOptions::Get()->ValInputFiles().end(); ++valFile) {
+      proof->AddInput(new TNamed(Form("valFile%d", i++), valFile->c_str()));
+   }
+   i = 0;
+   for(auto calFile = TGRSIOptions::Get()->CalInputFiles().begin(); calFile != TGRSIOptions::Get()->CalInputFiles().end(); ++calFile) {
+      proof->AddInput(new TNamed(Form("calFile%d", i++), calFile->c_str()));
+   }
 
    Analyze("FragmentTree",proof);
    Analyze("AnalysisTree",proof);

--- a/include/ArgParser.h
+++ b/include/ArgParser.h
@@ -28,7 +28,7 @@ public:
   virtual bool matches(const std::string& flag) const = 0;
   virtual void parse_item(const std::vector<std::string>& arguments) = 0;
   virtual int num_arguments() const = 0;
-  virtual std::string printable(int description_column = -1, int* chars_before_desc=NULL) const = 0;
+  virtual std::string printable(int description_column = -1, int* chars_before_desc=nullptr) const = 0;
   virtual bool is_required() const = 0;
   bool is_present() const {return present_;}
   virtual std::string flag_name() const = 0;
@@ -116,7 +116,7 @@ public:
 
   virtual ArgParseConfig& default_value(T value) = 0;
 
-  virtual std::string printable(int description_column = -1, int* chars_before_desc=NULL) const {
+  virtual std::string printable(int description_column = -1, int* chars_before_desc=nullptr) const {
     std::stringstream ss;
 
     ss << "  ";

--- a/include/GH1D.h
+++ b/include/GH1D.h
@@ -10,15 +10,15 @@ class TF1;
 
 class GH1D : public TH1D {
 public:
-  GH1D() : TH1D(), parent(NULL), projection_axis(-1) { }
+  GH1D() : TH1D(), parent(nullptr), projection_axis(-1) { }
   GH1D(const TVectorD& v)
-    : TH1D(v), parent(NULL), projection_axis(-1) { }
+    : TH1D(v), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, const Float_t* xbins)
-    : TH1D(name, title, nbinsx, xbins), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xbins), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, const Double_t* xbins)
-    : TH1D(name, title, nbinsx, xbins), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xbins), parent(nullptr), projection_axis(-1) { }
   GH1D(const char* name, const char* title, Int_t nbinsx, Double_t xlow, Double_t xup)
-    : TH1D(name, title, nbinsx, xlow, xup), parent(NULL), projection_axis(-1) { }
+    : TH1D(name, title, nbinsx, xlow, xup), parent(nullptr), projection_axis(-1) { }
 
   GH1D(const TF1& function,Int_t nbinsx,Double_t xlow,Double_t xup);
 

--- a/include/GH2Base.h
+++ b/include/GH2Base.h
@@ -84,7 +84,7 @@ public:
   class iterator {
   public:
   iterator(GH2Base* mat, bool at_end = false)
-    : fMat(mat), fFirst(mat->GetNext(NULL)), fCurr(at_end ? NULL : fFirst) { }
+    : fMat(mat), fFirst(mat->GetNext(nullptr)), fCurr(at_end ? nullptr : fFirst) { }
 
     GH1D& operator*() const {
       return *fCurr;

--- a/include/GSnapshot.h
+++ b/include/GSnapshot.h
@@ -11,10 +11,10 @@ class GSnapshot {
  public:
   static GSnapshot& Get();
 
-  GSnapshot(const char* snapshot_dir = NULL);
+  GSnapshot(const char* snapshot_dir = nullptr);
   ~GSnapshot() { }
 
-  void Snapshot(TCanvas *canvas=NULL);
+  void Snapshot(TCanvas *canvas=nullptr);
 
  private:
   std::string fSnapshotDir;

--- a/include/TDataLoop.h
+++ b/include/TDataLoop.h
@@ -73,7 +73,7 @@ class TDataLoop : public StoppableThread  {
 		std::mutex fSourceMutex;
 #endif
 
-#ifdef HASXML
+#ifdef HAS_XML
 		TXMLOdb* fOdb;
 #endif
 

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -41,120 +41,124 @@
 #include "TEpicsFrag.h"
 
 class TDataParser {
-public:
-  TDataParser();
-  ~TDataParser();
-  void SetNoWaveForms(bool temp = true) { fNoWaveforms = temp; }
-  void SetRecordDiag(bool temp = true) { fRecordDiag = temp; }
+	public:
+		TDataParser();
+		~TDataParser();
+		void SetNoWaveForms(bool temp = true) { fNoWaveforms = temp; }
+		void SetRecordDiag(bool temp = true) { fRecordDiag = temp; }
 
-  //ENUM(EBank, char, kWFDN,kGRF1,kGRF2,kGRF3,kFME0,kFME1,kFME2,kFME3);
-  enum EBank { kWFDN=0,kGRF1=1,kGRF2=2,kGRF3=3,kGRF4=4,kFME0=5,kFME1=6,kFME2=7,kFME3=8 };
+		//ENUM(EBank, char, kWFDN,kGRF1,kGRF2,kGRF3,kFME0,kFME1,kFME2,kFME3);
+		enum EBank { kWFDN=0,kGRF1=1,kGRF2=2,kGRF3=3,kGRF4=4,kFME0=5,kFME1=6,kFME2=7,kFME3=8 };
 
 #ifndef __CINT__
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&
-  AddGoodOutputQueue(size_t maxSize = 50000) { 
-	  std::stringstream name; name<<"good_frag_queue_"<<fGoodOutputQueues.size();
-     fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >(name.str(), maxSize));
-     return fGoodOutputQueues.back(); 
-  }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&
+			AddGoodOutputQueue(size_t maxSize = 50000) { 
+				std::stringstream name; name<<"good_frag_queue_"<<fGoodOutputQueues.size();
+				fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >(name.str(), maxSize));
+				return fGoodOutputQueues.back(); 
+			}
 
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& BadOutputQueue() { return fBadOutputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& BadOutputQueue() { return fBadOutputQueue; }
 
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerOutputQueue() { return fScalerOutputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >& ScalerOutputQueue() { return fScalerOutputQueue; }
 #endif
-  void ClearQueue();
-  size_t ItemsPushed() { if(fGoodOutputQueues.size() > 0) return fGoodOutputQueues.back()->ItemsPushed(); return std::numeric_limits<std::size_t>::max(); }
-  void SetFinished();
-  std::string OutputQueueStatus();
+		void ClearQueue();
+		size_t ItemsPushed() { if(fGoodOutputQueues.size() > 0) return fGoodOutputQueues.back()->ItemsPushed(); return std::numeric_limits<std::size_t>::max(); }
+		void SetFinished();
+		std::string OutputQueueStatus();
 
-	void SetStatusVariables(std::atomic_size_t* itemsPopped, std::atomic_long* inputSize) {
-		fItemsPopped = itemsPopped;
-		fInputSize = inputSize;
-	}
-private:
 #ifndef __CINT__
-  std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fGoodOutputQueues;
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fBadOutputQueue;
-  std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > > fScalerOutputQueue;
+		void SetStatusVariables(std::atomic_size_t* itemsPopped, std::atomic_long* inputSize) {
+			fItemsPopped = itemsPopped;
+			fInputSize = inputSize;
+		}
 #endif
-
-  bool fNoWaveforms;         ///< The flag to turn wave_forms on or off
-  bool fRecordDiag;         ///< The flag to turn on diagnostics recording
-  TChannel* gChannel;
-
-  const unsigned long fMaxTriggerId; ///< The last trigger ID Called
-  unsigned long fLastMidasId;        ///< The last MIDAS ID in the midas file
-  unsigned long fLastTriggerId;      ///< The last Trigged ID in the MIDAS File
-  unsigned long fLastNetworkPacket;  ///< The last network packet recieved.
-
-  std::map<int,int> fFragmentIdMap;
-  bool fFragmentHasWaveform;
-
-  TFragmentMap fFragmentMap;
-
-  std::atomic_size_t* fItemsPopped;
-  std::atomic_long* fInputSize;
-
-public:
+	private:
 #ifndef __CINT__
-  void Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& queue, std::shared_ptr<TFragment> frag);
-  void Push(ThreadsafeQueue<std::shared_ptr<const TFragment> >& queue, std::shared_ptr<TFragment> frag);
+		std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > > fGoodOutputQueues;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > fBadOutputQueue;
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > > fScalerOutputQueue;
 #endif
 
-  int TigressDataToFragment(uint32_t *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-  int GriffinDataToFragment(uint32_t *data, int size, EBank bank, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-  int GriffinDataToPPGEvent(uint32_t *data, int size, unsigned int midasSerialNumber=0, time_t midasTime=0);
-  int GriffinDataToScalerEvent(uint32_t *data, int address);
+		bool fNoWaveforms;         ///< The flag to turn wave_forms on or off
+		bool fRecordDiag;         ///< The flag to turn on diagnostics recording
+		TChannel* gChannel;
 
-  int EPIXToScalar(float *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-  int SCLRToScalar(uint32_t *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-  int EightPIDataToFragment(uint32_t stream, uint32_t* data,
-                            int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
-  int FifoToFragment(unsigned short *data, int size, bool zerobuffer=false,
-                     unsigned int midasSerialNumber=0, time_t midasTime=0);
-  int FippsToFragment(std::vector<char> data);
+		const unsigned long fMaxTriggerId; ///< The last trigger ID Called
+		unsigned long fLastMidasId;        ///< The last MIDAS ID in the midas file
+		unsigned long fLastTriggerId;      ///< The last Trigged ID in the MIDAS File
+		unsigned long fLastNetworkPacket;  ///< The last network packet recieved.
 
-private:
-  //utility
+		std::map<int,int> fFragmentIdMap;
+		bool fFragmentHasWaveform;
+
+		TFragmentMap fFragmentMap;
+
 #ifndef __CINT__
-  void DeleteAll(std::vector<std::shared_ptr<const TFragment> >*);
-  void GRIFNormalizeFrags(std::vector<std::shared_ptr<const TFragment> > *Frags);
+		std::atomic_size_t* fItemsPopped;
+		std::atomic_long* fInputSize;
 #endif
 
-private:
+	public:
 #ifndef __CINT__
-  void SetTIGWave(uint32_t, std::shared_ptr<TFragment>);
-  void SetTIGAddress(uint32_t, std::shared_ptr<TFragment>);
-  void SetTIGCfd(uint32_t, std::shared_ptr<TFragment>);
-  void SetTIGCharge(uint32_t, std::shared_ptr<TFragment>);
-  void SetTIGLed(uint32_t, std::shared_ptr<TFragment>);
-
-  bool SetTIGTriggerID(uint32_t, std::shared_ptr<TFragment>);
-  bool SetTIGTimeStamp(uint32_t*, std::shared_ptr<TFragment>);
-
-  bool SetGRIFHeader(uint32_t, std::shared_ptr<TFragment>, EBank);
-  bool SetGRIFMasterFilterPattern(uint32_t, std::shared_ptr<TFragment>, EBank);
-  bool SetGRIFMasterFilterId(uint32_t, std::shared_ptr<TFragment>);
-  bool SetGRIFChannelTriggerId(uint32_t, std::shared_ptr<TFragment>);
-  bool SetGRIFTimeStampLow(uint32_t, std::shared_ptr<TFragment>);
-  bool SetGRIFNetworkPacket(uint32_t, std::shared_ptr<TFragment>);
-
-  bool SetGRIFPsd(uint32_t, std::shared_ptr<TFragment>);
-  bool SetGRIFCc(uint32_t, std::shared_ptr<TFragment>);
-
-  bool SetGRIFWaveForm(uint32_t,std::shared_ptr<TFragment>);
-  bool SetGRIFDeadTime(uint32_t,std::shared_ptr<TFragment>);
+		void Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& queue, std::shared_ptr<TFragment> frag);
+		void Push(ThreadsafeQueue<std::shared_ptr<const TFragment> >& queue, std::shared_ptr<TFragment> frag);
 #endif
 
-  bool SetNewPPGPattern(uint32_t,TPPGData*);
-  bool SetOldPPGPattern(uint32_t,TPPGData*);
-  bool SetPPGNetworkPacket(uint32_t,TPPGData*);
-  bool SetPPGLowTimeStamp(uint32_t,TPPGData*);
-  bool SetPPGHighTimeStamp(uint32_t,TPPGData*);
-  bool SetScalerNetworkPacket(uint32_t, TScalerData*);
-  bool SetScalerLowTimeStamp(uint32_t, TScalerData*);
-  bool SetScalerHighTimeStamp(uint32_t, TScalerData*, int&);
-  bool SetScalerValue(int, uint32_t, TScalerData*);
+		int TigressDataToFragment(uint32_t *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
+		int GriffinDataToFragment(uint32_t *data, int size, EBank bank, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
+		int GriffinDataToPPGEvent(uint32_t *data, int size, unsigned int midasSerialNumber=0, time_t midasTime=0);
+		int GriffinDataToScalerEvent(uint32_t *data, int address);
+
+		int EPIXToScalar(float *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
+		int SCLRToScalar(uint32_t *data, int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
+		int EightPIDataToFragment(uint32_t stream, uint32_t* data,
+				int size, unsigned int midasSerialNumber = 0, time_t midasTime = 0);
+		int FifoToFragment(unsigned short *data, int size, bool zerobuffer=false,
+				unsigned int midasSerialNumber=0, time_t midasTime=0);
+		int FippsToFragment(std::vector<char> data);
+
+	private:
+		//utility
+#ifndef __CINT__
+		void DeleteAll(std::vector<std::shared_ptr<const TFragment> >*);
+		void GRIFNormalizeFrags(std::vector<std::shared_ptr<const TFragment> > *Frags);
+#endif
+
+	private:
+#ifndef __CINT__
+		void SetTIGWave(uint32_t, std::shared_ptr<TFragment>);
+		void SetTIGAddress(uint32_t, std::shared_ptr<TFragment>);
+		void SetTIGCfd(uint32_t, std::shared_ptr<TFragment>);
+		void SetTIGCharge(uint32_t, std::shared_ptr<TFragment>);
+		void SetTIGLed(uint32_t, std::shared_ptr<TFragment>);
+
+		bool SetTIGTriggerID(uint32_t, std::shared_ptr<TFragment>);
+		bool SetTIGTimeStamp(uint32_t*, std::shared_ptr<TFragment>);
+
+		bool SetGRIFHeader(uint32_t, std::shared_ptr<TFragment>, EBank);
+		bool SetGRIFMasterFilterPattern(uint32_t, std::shared_ptr<TFragment>, EBank);
+		bool SetGRIFMasterFilterId(uint32_t, std::shared_ptr<TFragment>);
+		bool SetGRIFChannelTriggerId(uint32_t, std::shared_ptr<TFragment>);
+		bool SetGRIFTimeStampLow(uint32_t, std::shared_ptr<TFragment>);
+		bool SetGRIFNetworkPacket(uint32_t, std::shared_ptr<TFragment>);
+
+		bool SetGRIFPsd(uint32_t, std::shared_ptr<TFragment>);
+		bool SetGRIFCc(uint32_t, std::shared_ptr<TFragment>);
+
+		bool SetGRIFWaveForm(uint32_t,std::shared_ptr<TFragment>);
+		bool SetGRIFDeadTime(uint32_t,std::shared_ptr<TFragment>);
+#endif
+
+		bool SetNewPPGPattern(uint32_t,TPPGData*);
+		bool SetOldPPGPattern(uint32_t,TPPGData*);
+		bool SetPPGNetworkPacket(uint32_t,TPPGData*);
+		bool SetPPGLowTimeStamp(uint32_t,TPPGData*);
+		bool SetPPGHighTimeStamp(uint32_t,TPPGData*);
+		bool SetScalerNetworkPacket(uint32_t, TScalerData*);
+		bool SetScalerLowTimeStamp(uint32_t, TScalerData*);
+		bool SetScalerHighTimeStamp(uint32_t, TScalerData*, int&);
+		bool SetScalerValue(int, uint32_t, TScalerData*);
 };
 /*! @} */
 #endif

--- a/include/TFipps.h
+++ b/include/TFipps.h
@@ -90,8 +90,7 @@ class TFipps : public TGRSIDetector {
 		static const Double_t gCrossTalkPar[2][4][4]; //!<! 
 		static Double_t CTCorrectedEnergy(const TFippsHit* const energy_to_correct, const TFippsHit* const other_energy, Bool_t time_constraint = true);
 		Bool_t IsCrossTalkSet() const;
-		void FixLowGainCrossTalk();
-		void FixHighGainCrossTalk();
+		void FixCrossTalk();
 
 	private:
 		//This is where the general untouchable functions live.
@@ -99,7 +98,6 @@ class TFipps : public TGRSIDetector {
 		std::vector<TFippsHit> 	*GetAddbackVector(); //!<!
 		std::vector<UShort_t> 		*GetAddbackFragVector(); //!<!
 		void SetAddback(bool flag = true) const;
-		void FixCrossTalk();
 		void SetCrossTalk(bool flag = true) const;
 
 	public:

--- a/include/TFragmentMap.h
+++ b/include/TFragmentMap.h
@@ -26,8 +26,10 @@
 
 class TFragmentMap {
    public:
+#ifndef __CINT__
       TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > > >& goodOutputQueue,
             std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& badOutputQueue);
+#endif
 
       ~TFragmentMap() {};
 #ifndef __CINT__

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -152,7 +152,7 @@ class TGRSIDetectorHit : public TObject 	{
       Long64_t GetCycleTimeStamp() const;
 
       void ClearEnergy()  { fEnergy  = 0.0;  SetHitBit(kIsEnergySet,false); }
-      void ClearChannel() { fChannel = NULL; SetHitBit(kIsChannelSet,false); }
+      void ClearChannel() { fChannel = nullptr; SetHitBit(kIsChannelSet,false); }
 
       static TVector3 *GetBeamDirection() { return &fBeamDirection; }
 

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -9,7 +9,7 @@
 
 class TGRSIOptions : public TObject {
 	public:
-		static TGRSIOptions* Get(int argc = 0, char** argv = NULL);
+		static TGRSIOptions* Get(int argc = 0, char** argv = nullptr);
 
 		void Clear(Option_t* opt = "");
 		void Load(int argc, char** argv);

--- a/include/TKinematics.h
+++ b/include/TKinematics.h
@@ -23,7 +23,7 @@
 
 class TKinematics : public TNamed {
 public:
-  TKinematics(double beame, const char* projectile, const char* target,const char* ejectile = NULL, const char* recoil = NULL, const char* name = "");
+  TKinematics(double beame, const char* projectile, const char* target,const char* ejectile = nullptr, const char* recoil = nullptr, const char* name = "");
   TKinematics(const char* beam, const char* targ, const char* ejec, const char* reco, double eBeam, double ex3=0.0, const char* name="");
   TKinematics(TNucleus* projectile, TNucleus* target, double eBeam, const char* name = "");
   TKinematics(TNucleus* projectile, TNucleus* target, TNucleus* recoil, TNucleus* ejectile, double eBeam, const char* name = "");

--- a/include/TLstEvent.h
+++ b/include/TLstEvent.h
@@ -38,7 +38,6 @@ class TLstEvent : public TRawEvent {
 
 		char* GetData(); ///< return pointer to the data buffer
 
-		void AllocateData(); ///< allocate data buffer using the existing event header
 		void SetData(std::vector<char>& dataBuffer); ///< set an externally allocated data buffer
 
 		int  SwapBytes(bool); ///< convert event data between little-endian (Linux-x86) and big endian (MacOS-PPC) 

--- a/include/TLstFile.h
+++ b/include/TLstFile.h
@@ -30,35 +30,39 @@
 /// Reader for MIDAS .mid files
 
 class TLstFile : public TRawFile {
-public:
-  enum EOpenType {
-    kRead,
-    kWrite
-  };
+	public:
+		enum EOpenType {
+			kRead,
+			kWrite
+		};
 
-  TLstFile(); ///< default constructor
-  TLstFile(const char* filename, EOpenType open_type = kRead);
-  virtual ~TLstFile(); ///< destructor
+		TLstFile(); ///< default constructor
+		TLstFile(const char* filename, EOpenType open_type = kRead);
+		virtual ~TLstFile(); ///< destructor
 
-  bool Open(const char* filename); ///< Open input file
+		bool Open(const char* filename); ///< Open input file
 
-  void Close(); ///< Close input file
+		void Close(); ///< Close input file
 
-  using TObject::Read;
-  using TObject::Write;
-  int  Read(std::shared_ptr<TRawEvent> event); ///< Read one event from the file
-  std::string Status(bool long_file_description = true);
+		using TObject::Read;
+		using TObject::Write;
+#ifndef __CINT__
+		int  Read(std::shared_ptr<TRawEvent> event); ///< Read one event from the file
+#endif
+		std::string Status(bool long_file_description = true);
 
-  int	GetRunNumber();
-  int	GetSubRunNumber();
+		int	GetRunNumber();
+		int	GetSubRunNumber();
 
-	std::shared_ptr<TRawEvent> NewEvent() { return std::make_shared<TLstEvent>(); }
+#ifndef __CINT__
+		std::shared_ptr<TRawEvent> NewEvent() { return std::make_shared<TLstEvent>(); }
+#endif
 
-protected:
+	protected:
 
-/// \cond CLASSIMP
-	ClassDef(TLstFile,0) //Used to open and write Midas Files
-/// \endcond
+		/// \cond CLASSIMP
+		ClassDef(TLstFile,0) //Used to open and write Midas Files
+		/// \endcond
 };
 /*! @} */
 #endif // TLstFile.h

--- a/include/TMidasFile.h
+++ b/include/TMidasFile.h
@@ -30,72 +30,82 @@
 /// Reader for MIDAS .mid files
 
 class TMidasFile : public TRawFile {
-public:
-  enum EOpenType {
-    kRead,
-    kWrite
-  };
+	public:
+		enum EOpenType {
+			kRead,
+			kWrite
+		};
 
-  TMidasFile(); ///< default constructor
-  TMidasFile(const char* filename, EOpenType open_type = kRead);
-  virtual ~TMidasFile(); ///< destructor
+		TMidasFile(); ///< default constructor
+		TMidasFile(const char* filename, EOpenType open_type = kRead);
+		virtual ~TMidasFile(); ///< destructor
 
-  bool Open(const char* filename); ///< Open input file
-  bool OutOpen(const char* filename); ///< Open output file
+		bool Open(const char* filename); ///< Open input file
+		bool OutOpen(const char* filename); ///< Open output file
 
-  void Close(); ///< Close input file
-  void OutClose(); ///< Close output file
+		void Close(); ///< Close input file
+		void OutClose(); ///< Close output file
 
-  using TObject::Read;
-  using TObject::Write;
-  int  Read(std::shared_ptr<TRawEvent> event); ///< Read one event from the file
-  bool Write(TMidasEvent* event,Option_t* opt =""); ///< Write one event to the output file
-  std::string Status(bool long_file_description = true);
+		using TObject::Read;
+		using TObject::Write;
+#ifndef __CINT__
+		int  Read(std::shared_ptr<TRawEvent> event); ///< Read one event from the file
+		bool Write(std::shared_ptr<TMidasEvent> event,Option_t* opt =""); ///< Write one event to the output file
+#endif
+		std::string Status(bool long_file_description = true);
 
-  void FillBuffer(TMidasEvent* event, Option_t* opt=""); //Fill buffer to write out chunks of data
-  bool WriteBuffer();
-  //int GetBufferSize() const { return fWriteBuffer.size(); }
+#ifndef __CINT__
+		void FillBuffer(std::shared_ptr<TMidasEvent> event, Option_t* opt=""); //Fill buffer to write out chunks of data
+#endif
+		bool WriteBuffer();
+		//int GetBufferSize() const { return fWriteBuffer.size(); }
 
-  const char* GetFilename()  const { return fFilename.c_str();  } ///< Get the name of this file
-  int         GetLastErrno() const { return fLastErrno; }         ///< Get error value for the last file error
-  const char* GetLastError() const { return fLastError.c_str(); } ///< Get error text for the last file error
+		const char* GetFilename()  const { return fFilename.c_str();  } ///< Get the name of this file
+		int         GetLastErrno() const { return fLastErrno; }         ///< Get error value for the last file error
+		const char* GetLastError() const { return fLastError.c_str(); } ///< Get error text for the last file error
 
-  std::shared_ptr<TMidasEvent> GetFirstEvent() { return fFirstEvent; }
+#ifndef __CINT__
+		std::shared_ptr<TMidasEvent> GetFirstEvent() { return fFirstEvent; }
+#endif
 
-  int	GetRunNumber();
-  int	GetSubRunNumber();
+		int	GetRunNumber();
+		int	GetSubRunNumber();
 
-  void SetMaxBufferSize(int maxsize);
+		void SetMaxBufferSize(int maxsize);
 
-	std::shared_ptr<TRawEvent> NewEvent() { return std::make_shared<TMidasEvent>(); }
+#ifndef __CINT__
+		std::shared_ptr<TRawEvent> NewEvent() { return std::make_shared<TMidasEvent>(); }
+#endif
 
-protected:
-  void ReadMoreBytes(size_t bytes);
+	protected:
+		void ReadMoreBytes(size_t bytes);
 
-  std::shared_ptr<TMidasEvent> fFirstEvent;
+#ifndef __CINT__
+		std::shared_ptr<TMidasEvent> fFirstEvent;
+#endif
 
-  std::string fOutFilename; ///< name of the currently open file
+		std::string fOutFilename; ///< name of the currently open file
 
-  std::vector<char> fWriteBuffer;
-  uint32_t fCurrentBufferSize;
-  uint32_t fMaxBufferSize;
+		std::vector<char> fWriteBuffer;
+		uint32_t fCurrentBufferSize;
+		uint32_t fMaxBufferSize;
 
-  int         fLastErrno; ///< errno from the last operation
-  std::string fLastError; ///< error string from last errno
-protected:
-  int currentEventNumber;
+		int         fLastErrno; ///< errno from the last operation
+		std::string fLastError; ///< error string from last errno
+	protected:
+		int currentEventNumber;
 
-  bool fDoByteSwap; ///< "true" if file has to be byteswapped
+		bool fDoByteSwap; ///< "true" if file has to be byteswapped
 
-  int         fFile; ///< open input file descriptor
-  void*       fGzFile; ///< zlib compressed input file reader
-  void*       fPoFile; ///< popen() input file reader
-  int         fOutFile; ///< open output file descriptor
-  void*       fOutGzFile; ///< zlib compressed output file reader
+		int         fFile; ///< open input file descriptor
+		void*       fGzFile; ///< zlib compressed input file reader
+		void*       fPoFile; ///< popen() input file reader
+		int         fOutFile; ///< open output file descriptor
+		void*       fOutGzFile; ///< zlib compressed output file reader
 
-/// \cond CLASSIMP
-	ClassDef(TMidasFile,0) //Used to open and write Midas Files
-/// \endcond
+		/// \cond CLASSIMP
+		ClassDef(TMidasFile,0) //Used to open and write Midas Files
+			/// \endcond
 };
 /*! @} */
 #endif // TMidasFile.h

--- a/include/TMnemonic.h
+++ b/include/TMnemonic.h
@@ -8,7 +8,7 @@
 
 class TMnemonic : public TObject {
    public:
-		TMnemonic() :fClassType(NULL) {}
+		TMnemonic() :fClassType(nullptr) {}
 		TMnemonic(const char* name) : TMnemonic() { Parse(name); }
 		~TMnemonic() {}
 

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -32,7 +32,7 @@ class TNucleus : public TNamed{
 
   virtual ~TNucleus();
 
-  //static void SetMassFile(const char *tmp = NULL);// {massfile = tmp;} //Sets the mass file to be used
+  //static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
 
   static const char* SortName(const char *name);
   //void SetName(const char *name) { fName = name; }

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -37,7 +37,7 @@ class TParsingDiagnostics : public TObject {
 		TParsingDiagnostics(const TParsingDiagnostics&);
 		~TParsingDiagnostics();
 		static TParsingDiagnostics* Get() {
-			if(fParsingDiagnostics == NULL) {
+			if(fParsingDiagnostics == nullptr) {
 				fParsingDiagnostics = new TParsingDiagnostics;
 			}
 			return fParsingDiagnostics;

--- a/include/TRawFile.h
+++ b/include/TRawFile.h
@@ -47,7 +47,9 @@ public:
 
   using TObject::Read;
   using TObject::Write;
+#ifndef __CINT__
   virtual int  Read(std::shared_ptr<TRawEvent> event) = 0; ///< Read one event from the file
+#endif
   virtual std::string Status(bool long_file_description = true) = 0;
 
   virtual const char* GetFilename()  const { return fFilename.c_str();  } ///< Get the name of this file
@@ -58,7 +60,9 @@ public:
   virtual size_t GetBytesRead() { return fBytesRead; }
   virtual size_t GetFileSize()  { return fFileSize; }
 
+#ifndef __CINT__
   virtual std::shared_ptr<TRawEvent> NewEvent() = 0;
+#endif
 
 protected:
   std::string fFilename; ///< name of the currently open file

--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -32,13 +32,13 @@ public:
                   TList* objects,
                   TList* gates,
                   std::vector<TFile*>& cut_files,
-                  TDirectory* directory=NULL,
+                  TDirectory* directory=nullptr,
                   const char *name="default");
 #endif
  TRuntimeObjects(TList* objects,
                   TList* gates,
                   std::vector<TFile*>& cut_files,
-                  TDirectory* directory=NULL,
+                  TDirectory* directory=nullptr,
                   const char *name="default");
 
 #ifndef __CINT__

--- a/include/TSortingDiagnostics.h
+++ b/include/TSortingDiagnostics.h
@@ -33,7 +33,7 @@ class TSortingDiagnostics : public TObject {
 		TSortingDiagnostics(const TSortingDiagnostics&);
 		~TSortingDiagnostics();
 		static TSortingDiagnostics* Get() {
-			if(fSortingDiagnostics == NULL) {
+			if(fSortingDiagnostics == nullptr) {
 				fSortingDiagnostics = new TSortingDiagnostics;
 			}
 			return fSortingDiagnostics;

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -57,7 +57,7 @@ std::shared_ptr<T> TUnpackedEvent::GetDetector(bool make_if_not_found) {
     fDetectors.push_back(output);
     return output;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 #endif

--- a/include/TXMLOdb.h
+++ b/include/TXMLOdb.h
@@ -23,7 +23,7 @@
 
 #include "Globals.h"
 
-#ifdef HASXML
+#ifdef HAS_XML
 #include "TXMLNode.h"
 #include "TXMLDocument.h"
 #include "TDOMParser.h"

--- a/include/VirtualOdb.h
+++ b/include/VirtualOdb.h
@@ -50,7 +50,7 @@ class VirtualOdb {
   /// Read a boolean value, midas type TID_BOOL
   virtual bool     odbReadBool(  const char*name, int index = 0, bool     defaultValue = false) = 0;
   /// Read a string value, midas type TID_STRING
-  virtual const char* odbReadString(const char*name, int index = 0,const char* defaultValue = NULL) = 0;
+  virtual const char* odbReadString(const char*name, int index = 0,const char* defaultValue = nullptr) = 0;
   /// Destructor has to be virtual
   virtual ~VirtualOdb() { /* empty */ }; // dtor
 };

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -666,7 +666,7 @@ bool GCanvas::Process1DArrowKeyPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kMyArrowUp: {
-                       GH1D* ghist = NULL;
+                       GH1D* ghist = nullptr;
                        for(auto hist : hists){
                          if(hist->InheritsFrom(GH1D::Class())){
                            ghist = (GH1D*)hist;
@@ -689,7 +689,7 @@ bool GCanvas::Process1DArrowKeyPress(Event_t *event,UInt_t *keysym) {
                      break;
 
     case kMyArrowDown: {
-                         GH1D* ghist = NULL;
+                         GH1D* ghist = nullptr;
                          for(auto hist : hists){
                            if(hist->InheritsFrom(GH1D::Class())){
                              ghist = (GH1D*)hist;
@@ -922,7 +922,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
         if(GetNMarkers() < 2){
           break;
         }
-        GH1D* ghist = NULL;
+        GH1D* ghist = nullptr;
         for(auto hist : hists){
           if(hist->InheritsFrom(GH1D::Class())){
             ghist = (GH1D*)hist;
@@ -935,7 +935,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
         //  around this we need the bin value, not the bin!   pcb.
         //
         if(ghist){
-          GH1D* proj = NULL;
+          GH1D* proj = nullptr;
           int binlow = fMarkers.at(fMarkers.size()-1)->binx;
           int binhigh = fMarkers.at(fMarkers.size()-2)->binx;
           if(binlow > binhigh){
@@ -982,7 +982,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kKey_P: {
-                   GH1D* ghist = NULL;
+                   GH1D* ghist = nullptr;
                    for(auto hist : hists){
                      if(hist->InheritsFrom(GH1D::Class())){
                        ghist = (GH1D*)hist;
@@ -1255,7 +1255,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
       break;
 
     case kKey_P: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists){
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1313,7 +1313,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_x: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1334,7 +1334,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_X: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1356,7 +1356,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_y: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;
@@ -1380,7 +1380,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t *event,UInt_t *keysym) {
                  break;
 
     case kKey_Y: {
-                   GH2D* ghist = NULL;
+                   GH2D* ghist = nullptr;
                    for(auto hist : hists) {
                      if(hist->InheritsFrom(GH2Base::Class())){
                        ghist = (GH2D*)hist;

--- a/libraries/GROOT/GH1D.cxx
+++ b/libraries/GROOT/GH1D.cxx
@@ -16,13 +16,13 @@
 #include "GH2D.h"
 
 GH1D::GH1D(const TH1& source)
-  : parent(NULL), projection_axis(-1) {
+  : parent(nullptr), projection_axis(-1) {
   source.Copy(*this);
 }
 
 
 GH1D::GH1D(const TF1& function,Int_t nbinsx,Double_t xlow,Double_t xup) :
-  TH1D(Form("%s_hist",function.GetName()),Form("%s_hist",function.GetName()),nbinsx, xlow, xup), parent(NULL), projection_axis(-1) {
+  TH1D(Form("%s_hist",function.GetName()),Form("%s_hist",function.GetName()),nbinsx, xlow, xup), parent(nullptr), projection_axis(-1) {
 
   //TF1 *f = (TF1*)function.Clone();
   //f->SetRange(xlow,xup);
@@ -54,7 +54,7 @@ bool GH1D::WriteDatFile(const char *outFile){
 
 /*
 GH1D::GH1D(const TH1 *source)
-  : parent(NULL), projection_axis(-1) {
+  : parent(nullptr), projection_axis(-1) {
   if(source->GetDiminsion()>1) {
     return;
   }
@@ -78,7 +78,7 @@ void GH1D::SetOption(Option_t* opt) {
 
 void GH1D::Clear(Option_t* opt) {
   TH1D::Clear(opt);
-  parent = NULL;
+  parent = nullptr;
 }
 
 void GH1D::Print(Option_t* opt) const {
@@ -141,7 +141,7 @@ GH1D* GH1D::GetPrevious(bool DrawEmpty) const {
     prev->GetXaxis()->SetRange(first,last);
     return prev; //gpar->GetPrevious(this,DrawEmpty);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -154,7 +154,7 @@ GH1D* GH1D::GetNext(bool DrawEmpty) const {
     next->GetXaxis()->SetRange(first,last);
     return next; //gpar->GetNext(this,DrawEmpty);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -176,7 +176,7 @@ GH1D* GH1D::Project(double value_low, double value_high) const {
       return gpar->ProjectionX("_px", bin_low, bin_high);
     }
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -213,7 +213,7 @@ GH1D* GH1D::Project_Background(double value_low, double value_high,
                                           mode);
     }
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/libraries/GROOT/GH2Base.cxx
+++ b/libraries/GROOT/GH2Base.cxx
@@ -41,8 +41,8 @@ GH1D* GH2Base::Projection_Background(int axis,
   std::string title;
   std::string name;
   std::string sproj;
-  TH1D* proj = NULL;
-  TH1D* bg_proj = NULL;
+  TH1D* proj = nullptr;
+  TH1D* bg_proj = nullptr;
 
   double xlow,xhigh,bg_xlow,bg_xhigh;
 
@@ -65,7 +65,7 @@ GH1D* GH2Base::Projection_Background(int axis,
     proj    = GetTH2()->ProjectionY("temp1", firstbin, lastbin);
     bg_proj = GetTH2()->ProjectionY("temp2", first_bg_bin, last_bg_bin);
   } else {
-    return NULL;
+    return nullptr;
   }
   name  = Form("%s_%s_%d_%d_bg_%d_%d",GetTH2()->GetName(),sproj.c_str()
                                         ,firstbin,lastbin,
@@ -117,7 +117,7 @@ GH1D* GH2Base::GH2ProjectionX(const char* name,
       actual_name  = Form("%s_projx_%d_%d",GetTH2()->GetName(),firstbin,lastbin);
   }
 
-  GH1D* output = NULL;
+  GH1D* output = nullptr;
   {
     SuppressTH1GDirectory sup;
     TH1D* proj = GetTH2()->ProjectionX("temp", firstbin, lastbin, option);
@@ -177,7 +177,7 @@ GH1D* GH2Base::GH2ProjectionY(const char* name,
 
   }
 
-  GH1D* output = NULL;
+  GH1D* output = nullptr;
   {
     SuppressTH1GDirectory sup;
     TH1D* proj = GetTH2()->ProjectionY("temp", firstbin, lastbin, option);
@@ -416,7 +416,7 @@ GH1D* GH2Base::SummaryProject(int binnum,bool DrawEmpty) {
       return GH2ProjectionX(hist_name.c_str(), binnum, binnum);
   }
 
-  return NULL;
+  return nullptr;
 }
 */
 

--- a/libraries/GROOT/GPeak.cxx
+++ b/libraries/GROOT/GPeak.cxx
@@ -12,7 +12,7 @@
 
 ClassImp(GPeak)
 
-GPeak* GPeak::fLastFit = NULL;
+GPeak* GPeak::fLastFit = nullptr;
 
 GPeak::GPeak(Double_t cent,Double_t xlow,Double_t xhigh,Option_t *opt)
       : TF1("photopeakbg",GRootFunctions::PhotoPeakBG,xlow,xhigh,7),

--- a/libraries/GROOT/GRootCommands.cxx
+++ b/libraries/GROOT/GRootCommands.cxx
@@ -34,8 +34,8 @@
 //#include <TGRUTInt.h>
 #include <GNotifier.h>
 
-TChain* gFragment = NULL;
-TChain* gAnalysis = NULL;
+TChain* gFragment = nullptr;
+TChain* gAnalysis = nullptr;
 
 
 

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -24,7 +24,7 @@ TDataParser::TDataParser()
     fMaxTriggerId(1024*1024*16),
     fLastMidasId(0), fLastTriggerId(0), fLastNetworkPacket(0),
     fFragmentHasWaveform(false),
-    fFragmentMap(fGoodOutputQueues, fBadOutputQueue), fItemsPopped(NULL), fInputSize(NULL) {
+    fFragmentMap(fGoodOutputQueues, fBadOutputQueue), fItemsPopped(nullptr), fInputSize(nullptr) {
   gChannel = new TChannel;
 }
 
@@ -1217,13 +1217,13 @@ int TDataParser::FippsToFragment(std::vector<char> data) {
 	int eventsRead = 0;
 	std::shared_ptr<TFragment> eventFrag = std::make_shared<TFragment>();
 	Long64_t tmpTimestamp;
-	if(fItemsPopped != NULL && fInputSize != NULL) {
+	if(fItemsPopped != nullptr && fInputSize != nullptr) {
 		*fItemsPopped = 0;
 		*fInputSize = data.size()/16;
 	}
 
 	for(size_t i = 0; i+3 < data.size()/4; i += 4) {
-		if(fItemsPopped != NULL && fInputSize != NULL) {
+		if(fItemsPopped != nullptr && fInputSize != nullptr) {
 			++(*fItemsPopped);
 			--(*fInputSize);
 		}

--- a/libraries/TGRSIAnalysis/TCal/TCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCal.cxx
@@ -18,9 +18,9 @@ TCal::TCal(const char* name, const char* title) {
 
 TCal::~TCal() {
 	///Default dtor
-	fNuc = NULL;
-	//fgraph = NULL;
-	fHist = NULL;
+	fNuc = nullptr;
+	//fgraph = nullptr;
+	fHist = nullptr;
 }
 
 TCal::TCal(const TCal& copy) : TGraphErrors(copy) {
@@ -132,8 +132,8 @@ void TCal::SetHist(TH1* hist) {
 
 void TCal::Clear(Option_t *opt) {
 	///Clears the calibration. Does not delete nuclei or channels.
-	fNuc = NULL;
-	fChan = NULL;
+	fNuc = nullptr;
+	fChan = nullptr;
 	TGraphErrors::Clear();
 }
 
@@ -164,9 +164,9 @@ void TCal::Print(Option_t *opt) const{
 void TCal::InitTCal() {
 	///Initiallizes the TCal.
 	/* fgraph = new TGraphErrors;*/
-	fFitFunc = NULL;
-	fChan = NULL;
-	fNuc = NULL;
-	fHist = NULL;
+	fFitFunc = nullptr;
+	fChan = nullptr;
+	fNuc = nullptr;
+	fHist = nullptr;
 	Clear();
 }

--- a/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
@@ -7,12 +7,12 @@ ClassImp(TCalManager)
 /// \endcond
 
 TCalManager::TCalManager() {
-	fClass = NULL; //fClass will point to a TClass which is made persistant through a root session within gROOT.
+	fClass = nullptr; //fClass will point to a TClass which is made persistant through a root session within gROOT.
 	//So we don't need to worry about allocating it.
 }
 
 TCalManager::TCalManager(const char* classname) {
-	fClass = NULL;
+	fClass = nullptr;
 	this->SetClass(classname);
 }
 

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -341,11 +341,11 @@ Bool_t TGainMatch::CoarseMatchAll(TCalManager* cm, TH2* mat, Double_t energy1, D
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("CoarseMatchAll","CalManager Pointer is NULL");
+      gm->Error("CoarseMatchAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat) {
-      gm->Error("CoarseMatchAll","TH2 Pointer is NULL");
+      gm->Error("CoarseMatchAll","TH2 Pointer is nullptr");
       return false;
    }
    //Find the range of channels provided
@@ -402,11 +402,11 @@ Bool_t TGainMatch::FineMatchFastAll(TCalManager* cm, TH2* mat1, TPeak* peak1, TH
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("FineMatchFastAll","CalManager Pointer is NULL");
+      gm->Error("FineMatchFastAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat1 || !mat2) {
-      gm->Error("FineMatchFastAll","TH2 Pointer is NULL");
+      gm->Error("FineMatchFastAll","TH2 Pointer is nullptr");
       return false;
    }
    if(!peak1 || !peak2) {
@@ -539,15 +539,15 @@ Bool_t TGainMatch::AlignAll(TCalManager* cm, TH1* hist, TH2* mat, Int_t low_rang
    std::vector<Int_t> badlist;
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("AlignAll","CalManager Pointer is NULL");
+      gm->Error("AlignAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!mat) {
-      gm->Error("AlignAll","TH2 Pointer is NULL");
+      gm->Error("AlignAll","TH2 Pointer is nullptr");
       return false;
    }
    if(!hist) {
-      gm->Error("AlignAll","TH1 Pointer is NULL");
+      gm->Error("AlignAll","TH1 Pointer is nullptr");
       return false;
    }
    //Find the range of channels provided
@@ -585,15 +585,15 @@ Bool_t TGainMatch::FineMatchAll(TCalManager* cm, TH2* charge_mat, TH2* eng_mat, 
 
    TGainMatch* gm = new TGainMatch;
    if(!cm) {
-      gm->Error("FineMatchAll","CalManager Pointer is NULL");
+      gm->Error("FineMatchAll","CalManager Pointer is nullptr");
       return false;
    }
    if(!charge_mat || !eng_mat) {
-      gm->Error("FineMatchAll","TH2 Pointer is NULL");
+      gm->Error("FineMatchAll","TH2 Pointer is nullptr");
       return false;
    }
   /* if(!testhist) {
-      gm->Error("FineMatchAll","TH1 Pointer is NULL");
+      gm->Error("FineMatchAll","TH1 Pointer is nullptr");
       return false;
    }*/
    Double_t binwidth;

--- a/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
+++ b/libraries/TGRSIAnalysis/TDescant/TDescant.cxx
@@ -162,13 +162,13 @@ TDescantHit* TDescant::GetDescantHit(const Int_t& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 void TDescant::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the DESCANT Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
    ///This is done for both DESCANT and it's suppressors.
-   if(frag == NULL || chan == NULL) {
+   if(frag == nullptr || chan == nullptr) {
       return;
    }
    

--- a/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
@@ -178,7 +178,7 @@ TFippsHit* TFipps::GetFippsHit(const int& i) {
 		if(!gInterpreter)
 			throw grsi::exit_exception(1);
 	}
-	return NULL;
+	return nullptr;
 }
 
 Int_t TFipps::GetAddbackMultiplicity()  {
@@ -232,14 +232,14 @@ TFippsHit* TFipps::GetAddbackHit(const int& i) {
 	} else {
 		std::cerr << "Addback hits are out of range" << std::endl;
 		throw grsi::exit_exception(1);
-		return NULL;
+		return nullptr;
 	}
 }
 
 void TFipps::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	//Builds the FIPPS Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
 	//This is done for both FIPPS and it's suppressors.
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -158,7 +158,7 @@ void TGRSIDetectorHit::Clear(Option_t* opt) {
   fBitflags       = 0;
   fPPGStatus      = TPPG::kJunk;
   fCycleTimeStamp = 0;
-  fChannel        = NULL;
+  fChannel        = nullptr;
 }
 
 Int_t TGRSIDetectorHit::GetDetector() const {

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -25,7 +25,7 @@ void TGRSIFit::Copy(TObject& obj) const{
 }
 
 void TGRSIFit::Print(Option_t* opt) const {
-   if(strchr(opt,'+') != NULL) {
+   if(strchr(opt,'+') != nullptr) {
       printf("Params Init: %d\n", fInitFlag);
       printf("Good Fit:    %d\n", fGoodFitFlag);
       TNamed::Print(opt);

--- a/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -371,7 +371,7 @@ const char * TMultiPeak::PrintString(Option_t *opt) const {
                                 temp.append(" +/- ");
                                 temp.append(Form("%lf",fd_area));    temp.append("\n"); 
    temp.append("Chi^2/NDF:   ");temp.append(Form("%lf",fchi2/fNdf)); temp.append("\n");
-   //if(strchr(opt,'+') != NULL){
+   //if(strchr(opt,'+') != nullptr){
    //   TF1::Print();
    //   TGRSIFit::Print(opt); //Polymorphise this a bit better
    //}

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -185,7 +185,7 @@ void TPeak::Copy(TObject &obj) const {
 
 Bool_t TPeak::InitParams(TH1* fitHist) {
 //Makes initial guesses at parameters for the fit. Uses the histogram to
-	if(fitHist == NULL) {
+	if(fitHist == nullptr) {
 		return false;
 	}
    Double_t xlow,xhigh,low,high;
@@ -394,7 +394,7 @@ void TPeak::Print(Option_t* opt) const {
    printf("Area: 	      %lf +/- %lf \n", fArea, fDArea);
    printf("FWHM:        %lf +/- %lf \n", GetParameter("sigma")*2.3548, GetParError(GetParNumber("sigma"))*2.3548);
    printf("Chi^2/NDF:   %lf\n",fChi2/fNdf);
-   if(strchr(opt,'+') != NULL) {
+   if(strchr(opt,'+') != nullptr) {
       TF1::Print();
       TGRSIFit::Print(opt); //Polymorphise this a bit better
    }
@@ -411,7 +411,7 @@ const char*  TPeak::PrintString(Option_t* opt) const {
                                 temp.append(" +/- ");
                                 temp.append(Form("%lf",fDArea));    temp.append("\n"); 
    temp.append("Chi^2/NDF:   ");temp.append(Form("%lf",fChi2/fNdf)); temp.append("\n");
-   //if(strchr(opt,'+') != NULL) {
+   //if(strchr(opt,'+') != nullptr) {
    //   TF1::Print();
    TGRSIFit::Print(opt); //Polymorphise this a bit better
    //}

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -260,7 +260,7 @@ TGriffinHit* TGriffin::GetGriffinHit(const int& i, const Int_t &gain_type) {
 		if(!gInterpreter)
 			throw grsi::exit_exception(1);
 	}
-	return NULL;
+	return nullptr;
 }
 
 Int_t TGriffin::GetAddbackLowGainMultiplicity() {
@@ -330,14 +330,14 @@ TGriffinHit* TGriffin::GetAddbackHit(const int& i, const Int_t &gain_type) {
 	} else {
 		std::cerr << "Addback hits are out of range" << std::endl;
 		throw grsi::exit_exception(1);
-		return NULL;
+		return nullptr;
 	}
 }
 
 void TGriffin::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	//Builds the GRIFFIN Hits directly from the TFragment. Basically, loops through the hits for an event and sets observables. 
 	//This is done for both GRIFFIN and it's suppressors.
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 	if(chan->GetMnemonic()->OutputSensor() == TMnemonic::kA) {  }  

--- a/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
+++ b/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
@@ -55,8 +55,8 @@ TKinematics::TKinematics(TNucleus* projectile, TNucleus* target, double ebeam, c
   InitKin();
   fParticle[0] = projectile;
   fParticle[1] = target;
-  fParticle[2] = NULL;
-  fParticle[3] = NULL;
+  fParticle[2] = nullptr;
+  fParticle[3] = nullptr;
   fM[0]=fParticle[0]->GetMass();
   fM[1]=fParticle[1]->GetMass();
   fEBeam = ebeam;
@@ -392,7 +392,7 @@ void TKinematics::FinalCm(){
 // Calculates the recoil and ejectile energies and momenta in the CM frame
 
 //angle of proton in cm system
-  if(fParticle[2]==NULL && fParticle[3]==NULL){
+  if(fParticle[2]==nullptr && fParticle[3]==nullptr){
     fM[2]=fParticle[1]->GetMass();
     fM[3]=fParticle[0]->GetMass();     
   }

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -81,7 +81,7 @@ TLaBrHit* TLaBr::GetLaBrHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 void TLaBr::AddFragment(std::shared_ptr<const TFragment> frag, TChannel *chan) {

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -230,7 +230,7 @@ const char* TNucleus::SortName(const char* name){
         break;
       default:
         printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n");
-        return NULL;
+        return nullptr;
     };
   }
   int first_digit  = Name.find_first_of("0123456789 \t\n\r");

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -79,7 +79,7 @@ TPacesHit* TPaces::GetPacesHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }
 
 TVector3 TPaces::GetPosition(int DetNbr) {

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -4,16 +4,16 @@
 ClassImp(TPulseAnalyzer)
 /// \endcond
 
-TPulseAnalyzer::TPulseAnalyzer() : cWpar(NULL), spar(NULL), shpar(NULL) {
+TPulseAnalyzer::TPulseAnalyzer() : cWpar(nullptr), spar(nullptr), shpar(nullptr) {
 	Clear();
 }
 
-TPulseAnalyzer::TPulseAnalyzer(const TFragment& fragment,double noise_fac) : cWpar(NULL), spar(NULL), shpar(NULL) {
+TPulseAnalyzer::TPulseAnalyzer(const TFragment& fragment,double noise_fac) : cWpar(nullptr), spar(nullptr), shpar(nullptr) {
 	Clear();
 	SetData(fragment,noise_fac);
 }
 
-TPulseAnalyzer::TPulseAnalyzer(const std::vector<Short_t>& wave,double noise_fac,std::string name) : cWpar(NULL), spar(NULL), shpar(NULL), fName(name) {
+TPulseAnalyzer::TPulseAnalyzer(const std::vector<Short_t>& wave,double noise_fac,std::string name) : cWpar(nullptr), spar(nullptr), shpar(nullptr), fName(name) {
 	Clear();
 	SetData(wave,noise_fac);
 }

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -48,7 +48,7 @@ void TS3::Copy(TObject &rhs) const {
 
 void TS3::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
 	///This function creates TS3Hits for each fragment and stores them in separate front and back vectors
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 
@@ -311,7 +311,7 @@ TS3Hit *TS3::GetS3Hit(const int& i) {
   } else {
     std::cerr << "S3 pixel hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 
@@ -321,7 +321,7 @@ TS3Hit *TS3::GetRingHit(const int& i) {
   } else {
     std::cerr << "S3 ring hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 
@@ -331,7 +331,7 @@ TS3Hit *TS3::GetSectorHit(const int& i) {
   } else {
     std::cerr << "S3 sector hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }  
 

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -102,5 +102,5 @@ TSceptarHit* TSceptar::GetSceptarHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -85,7 +85,7 @@ TSharc::TSharc(const TSharc& rhs) : TGRSIDetector() {
 }
 
 void TSharc::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
     return;
   }
 /*  if(GetMidasTimestamp() == -1) {

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -72,7 +72,7 @@ TSiLiHit * TSiLi::GetSiLiHit(const int& i)   {
 }  
 
 void TSiLi::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
 	 return;
   }
 
@@ -119,7 +119,7 @@ TSiLiHit* TSiLi::GetAddbackHit(const int& i) {
   } else {
     std::cerr << "Addback hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -71,5 +71,5 @@ TTACHit* TTAC::GetTACHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -113,7 +113,7 @@ TTigress& TTigress::operator=(const TTigress& rhs) {
     if(!gInterpreter)
       throw grsi::exit_exception(1);
   }
-  return NULL;
+  return nullptr;
   */
 //}
 
@@ -166,7 +166,7 @@ TTigressHit* TTigress::GetAddbackHit(const int& i) {
   } else {
     std::cerr << "Addback hits are out of range" << std::endl;
     throw grsi::exit_exception(1);
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -205,7 +205,7 @@ void TTigress::BuildHits(){
 }
 
 void TTigress::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 	/*  if(GetMidasTimestamp()==-1) {

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -40,7 +40,7 @@ TTip& TTip::operator=(const TTip& rhs) {
 }
 
 void TTip::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-	if(frag == NULL || chan == NULL) {
+	if(frag == nullptr || chan == nullptr) {
 		return;
 	}
 

--- a/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
+++ b/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
@@ -35,7 +35,7 @@ TTriFoil::TTriFoil(const TTriFoil& rhs) : TDetector() {
 }
 
 void TTriFoil::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
-  if(frag == NULL || chan == NULL) {
+  if(frag == nullptr || chan == nullptr) {
     return;
   }
 

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -61,7 +61,7 @@ void TZeroDegree::Print(Option_t *opt) const	{
 
 void TZeroDegree::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan) {
    ///Builds the ZDS Hits directly from the TFragment. Basically, loops through the data for an event and sets observables.
-   if(frag == NULL || chan == NULL) {
+   if(frag == nullptr || chan == nullptr) {
       return;
    }
    
@@ -82,5 +82,5 @@ TZeroDegreeHit* TZeroDegree::GetZeroDegreeHit(const int& i) {
       std::cerr << ClassName() << " is out of range: " << oor.what() << std::endl;
       throw grsi::exit_exception(1);
    }
-   return NULL;
+   return nullptr;
 }

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -280,7 +280,7 @@ TChannel* TChannel::GetChannel(unsigned int temp_address) {
 	///Returns the TChannel at the specified address. If the address doesn't exist, returns an empty gChannel.
 
 	TChannel* chan = nullptr;
-	//    if(temp_address == 0 || temp_address == 0xffffffff) {//default (NULL) address, return 0;
+	//    if(temp_address == 0 || temp_address == 0xffffffff) {//default (nullptr) address, return 0;
 	//	      return chan;
 	//    }
 	if(fChannelMap->count(temp_address)==1){// found channel
@@ -321,7 +321,7 @@ TChannel* TChannel::FindChannelByName(const char* ccName){
 		std::string channelName = chan->GetName();
 		if(channelName.compare(0,name.length(),name)==0)
 			break;
-		chan = NULL;
+		chan = nullptr;
 	}
 	// either comes out normally as null or breaks out with some TChannel [SC]
 

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -68,7 +68,7 @@ void TFragment::Clear(Option_t *opt){
 
    fTriggerId.clear();
 
-   fPPG                 = NULL;
+   fPPG                 = nullptr;
    fZc                  = 0;
    fCcShort             = 0;
    fCcLong              = 0;
@@ -103,20 +103,20 @@ Int_t TFragment::Get4GCfd() const { // return a 4G cfd in terms of 1/256 ns sinc
 
 ULong64_t TFragment::GetTimeInCycle() {
 
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
    }
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
       return 0;
    }
    return fPPG->GetTimeInCycle(GetTimeStamp());
 }
 
 ULong64_t TFragment::GetCycleNumber() {
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
    }
-   if(fPPG == NULL) {
+   if(fPPG == nullptr) {
       return 0;
    }
    return fPPG->GetCycleNumber(GetTimeStamp());
@@ -129,7 +129,7 @@ Short_t TFragment::GetChannelNumber() const {
 }
 
 TPPG* TFragment::GetPPG() {
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 	}
 	return fPPG;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -240,7 +240,7 @@ TGRSIRunInfo::~TGRSIRunInfo() { }
 void TGRSIRunInfo::Print(Option_t *opt) const {
    //Prints the TGRSIRunInfo. Options:
    // a: Print out more details.
-   if(strchr(opt,'a') != NULL){
+   if(strchr(opt,'a') != nullptr){
       printf("\tTGRSIRunInfo Status:\n");
       printf("\t\tRunNumber:    %05i\n",TGRSIRunInfo::Get()->fRunNumber);
       printf("\t\tSubRunNumber: %03i\n",TGRSIRunInfo::Get()->fSubRunNumber);
@@ -563,7 +563,7 @@ Long64_t TGRSIRunInfo::Merge(TCollection *list){
    //An individual file that was submitted to hadd.
    TGRSIRunInfo *runinfo = 0;
 
-   while ((runinfo = static_cast<TGRSIRunInfo*>(it.Next())) != NULL){
+   while ((runinfo = static_cast<TGRSIRunInfo*>(it.Next())) != nullptr){
       //Now we want to loop through each TGRSISortList and find the TGRSISortInfo's stored in there.
       this->Add(runinfo);
    }

--- a/libraries/TGRSIFormat/TMnemonic.cxx
+++ b/libraries/TGRSIFormat/TMnemonic.cxx
@@ -179,7 +179,7 @@ void TMnemonic::Parse(std::string *name){
 	
 	if(fSystem == kSiLi){
 		buf.clear(); buf.assign(*name,7,2);
-		fSegment = (uint16_t)strtol(buf.c_str(), NULL, 16);
+		fSegment = (uint16_t)strtol(buf.c_str(), nullptr, 16);
 	}
 	
 	return;

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -10,7 +10,7 @@ ClassImp(TPPGData)
 ClassImp(TPPG)
 /// \endcond
 
-TPPG* TPPG::fPPG = NULL;
+TPPG* TPPG::fPPG = nullptr;
 
 TPPGData::TPPGData() {
 	Clear();
@@ -83,9 +83,9 @@ TPPG* TPPG::Get() {
 	//The getter for the singleton TPPG. Unfortunately ROOT doesn't allow true 
 	//singletons, so one should take care to always use this method and not
 	//the constructor.
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = static_cast<TPPG*>(gDirectory->Get("TPPG"));
-		if(fPPG == NULL) {
+		if(fPPG == nullptr) {
 			fPPG = new TPPG();
 		}
 	}

--- a/libraries/TGRSIFormat/TParsingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TParsingDiagnostics.cxx
@@ -4,20 +4,20 @@
 
 #include "TChannel.h"
 
-TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = NULL;
+TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = nullptr;
 
 TParsingDiagnostics::TParsingDiagnostics() : TObject() {
-	fIdHist = NULL;
+	fIdHist = nullptr;
 	Clear();
 }
 
 TParsingDiagnostics::TParsingDiagnostics(const TParsingDiagnostics& rhs) : TObject() {
-	fIdHist = NULL;
+	fIdHist = nullptr;
 	Clear();
 }
 
 TParsingDiagnostics::~TParsingDiagnostics() {
-	if(fIdHist != NULL) delete fIdHist;
+	if(fIdHist != nullptr) delete fIdHist;
 }
 
 void TParsingDiagnostics::Copy(TObject& obj) const {
@@ -38,8 +38,8 @@ void TParsingDiagnostics::Copy(TObject& obj) const {
 }
 
 void TParsingDiagnostics::Clear(Option_t* opt) {
-	if(fIdHist != NULL) delete fIdHist;
-	fIdHist = NULL;
+	if(fIdHist != nullptr) delete fIdHist;
+	fIdHist = nullptr;
 	fPPGCycleLength = 0;
 	fNumberOfGoodFragments.clear();
 	fNumberOfBadFragments.clear();
@@ -141,7 +141,7 @@ void TParsingDiagnostics::GoodFragment(std::shared_ptr<const TFragment> frag) {
 
 void TParsingDiagnostics::ReadPPG(TPPG* ppg) {
 	///store different TPPG diagnostics like cycle length, length of each state, offset, how often each state was found
-	if(ppg == NULL) return;
+	if(ppg == nullptr) return;
 	fPPGCycleLength = ppg->GetCycleLength();
 	
 }
@@ -151,11 +151,11 @@ void TParsingDiagnostics::Draw(Option_t* opt) {
 	Short_t maxChannel = std::prev(fNumberOfHits.end())->first;
 
 	//check that the histogram (if it already exists) has the right number of bins
-	if(fIdHist != NULL && fIdHist->GetNbinsX() != maxChannel-minChannel+1) {
+	if(fIdHist != nullptr && fIdHist->GetNbinsX() != maxChannel-minChannel+1) {
 		delete fIdHist;
-		fIdHist = NULL;
+		fIdHist = nullptr;
 	}
-	if(fIdHist == NULL) {
+	if(fIdHist == nullptr) {
 		fIdHist = new TH1F("IdHist","Event survival;channel number;survival rate [%]", maxChannel-minChannel+1, minChannel, maxChannel+1);
 	} else {
 		//the histogram already had the right number of bins, but to be save we set the range

--- a/libraries/TGRSIFormat/TScaler.cxx
+++ b/libraries/TGRSIFormat/TScaler.cxx
@@ -48,7 +48,7 @@ TScaler::TScaler(bool loadIntoMap) {
 	///\param[in] loadIntoMap Flag telling TScaler to load all scaler data into fScalerMap.
    this->Clear();
 	fTree = static_cast<TTree*>(gROOT->FindObject("ScalerTree"));
-	if(fTree != NULL) {
+	if(fTree != nullptr) {
 		fEntries = fTree->GetEntries();
 		fTree->SetBranchAddress("TScalerData", &fScalerData);
 		if(loadIntoMap) {
@@ -63,7 +63,7 @@ TScaler::TScaler(bool loadIntoMap) {
 TScaler::TScaler(TTree* tree, bool loadIntoMap) {
    this->Clear();
 	fTree = tree;
-	if(fTree != NULL) {
+	if(fTree != nullptr) {
 		fEntries = fTree->GetEntries();
 		fTree->SetBranchAddress("TScalerData", &fScalerData);
 		if(loadIntoMap) {
@@ -81,14 +81,14 @@ TScaler::TScaler(const TScaler& rhs) : TObject() {
 
 TScaler::~TScaler(){
    //Clear() deletes histograms which can cause problems with root assuming ownership of all histograms
-	fTree = NULL;
-	fScalerData = NULL;
+	fTree = nullptr;
+	fScalerData = nullptr;
 	fEntries = 0;
    fTimePeriod.clear();
    fNumberOfTimePeriods.clear();
    fTotalTimePeriod = 0;
    fTotalNumberOfTimePeriods.clear();
-	fPPG = NULL;
+	fPPG = nullptr;
 	fHist.clear();
 	fHistRange.clear();
 	fScalerMap.clear();
@@ -109,7 +109,7 @@ void TScaler::Copy(TObject &obj) const {
 std::vector<UInt_t> TScaler::GetScaler(UInt_t address, ULong64_t time) const {
    ///Returns the vector of scaler values for address "address" at the time "time".
    ///If the time is after the last entry, we return the last entry, otherwise we return the following entry (or the current entry if the time is an exact match).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
 		return std::vector<UInt_t>(0);
    }
@@ -160,7 +160,7 @@ UInt_t TScaler::GetScalerDifference(UInt_t address, ULong64_t time, size_t index
    ///Returns the difference between "index"th scaler value for address "address" at the time "time" and the previous scaler value.
    ///If the time is after our last entry, we return the last entry divided by the number of entries,
    ///if this is before the first scaler, we just return the first scaler, otherwise we return the scaler minus the previous scaler.
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
 		return 0;
    }
@@ -218,25 +218,25 @@ UInt_t TScaler::GetScalerDifference(UInt_t address, ULong64_t time, size_t index
 }
 
 void TScaler::Clear(Option_t *opt){
-	fTree = NULL;
-	fScalerData = NULL;
+	fTree = nullptr;
+	fScalerData = nullptr;
 	fEntries = 0;
    fTimePeriod.clear();
    fNumberOfTimePeriods.clear();
    fTotalTimePeriod = 0;
    fTotalNumberOfTimePeriods.clear();
-	fPPG = NULL;
+	fPPG = nullptr;
  	for(auto addrIt = fHist.begin(); addrIt != fHist.end(); ++addrIt) {
-		if(addrIt->second != NULL) {
+		if(addrIt->second != nullptr) {
 			delete (addrIt->second);
-			addrIt->second = NULL;
+			addrIt->second = nullptr;
 		}
 	}
 	fHist.clear();
  	for(auto addrIt = fHistRange.begin(); addrIt != fHistRange.end(); ++addrIt) {
-		if(addrIt->second != NULL) {
+		if(addrIt->second != nullptr) {
 			delete (addrIt->second);
-			addrIt->second = NULL;
+			addrIt->second = nullptr;
 		}
 	}
 	fHistRange.clear();
@@ -246,21 +246,21 @@ void TScaler::Clear(Option_t *opt){
 TH1D* TScaler::Draw(UInt_t address, size_t index, Option_t *option) {
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time in cycle.
 	///Passing "redraw" as option forces re-drawing of the histogram (e.g. for a different index).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	//if the address doesn't exist in the histogram map, insert a null pointer
 	if(fHist.find(address) == fHist.end()) {
-		fHist[address] = NULL;
+		fHist[address] = nullptr;
 	}
 	//try and find the ppg (if we haven't already done so)
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 		//if we can't find the ppg we're done here
-		if(fPPG == NULL) {
-			return NULL;
+		if(fPPG == nullptr) {
+			return nullptr;
 		}
 	}
 
@@ -268,9 +268,9 @@ TH1D* TScaler::Draw(UInt_t address, size_t index, Option_t *option) {
 	opt.ToLower();
 	//if the histogram hasn't been created yet or the "redraw" option has been given, we create the histogram
 	Int_t opt_index = opt.Index("redraw");
-	if(fHist[address] == NULL || opt_index >= 0) {
+	if(fHist[address] == nullptr || opt_index >= 0) {
 		//we only need to create a new histogram if this is the first time drawing it, if we're just re-drawing we can re-use the existing histogram
-		if(fHist[address] == NULL) {
+		if(fHist[address] == nullptr) {
 			//printf("failed to find histogram for address 0x%04x\n",address);
 			int nofBins = fPPG->GetCycleLength()/GetTimePeriod(address);
 			fHist[address] = new TH1D(Form("TScalerHist_%04x",address),Form("scaler %d vs time in cycle for address 0x%04x; time in cycle [ms]; counts/%.0f ms", (int) index, address, 
@@ -309,17 +309,17 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time in cycle.
 	///Passing "redraw" as option forces re-drawing of the histogram (e.g. for a different index).
    ///The "single" options creates spectra for all single addresses in the given range (instead of one accumulative spectrum).
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	//try and find the ppg (if we haven't already done so)
-	if(fPPG == NULL) {
+	if(fPPG == nullptr) {
 		fPPG = TPPG::Get();//static_cast<TPPG*>(gROOT->FindObject("TPPG"));
 		//if we can't find the ppg we're done here
-		if(fPPG == NULL) {
-			return NULL;
+		if(fPPG == nullptr) {
+			return nullptr;
 		}
 	}
 
@@ -333,9 +333,9 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 		//draw the whole range of addresses in a single histogram
 		//if the address doesn't exist in the histogram map, insert a null pointer
 		if(fHistRange.find(std::make_pair(lowAddress, highAddress)) == fHistRange.end()) {
-			fHistRange[std::make_pair(lowAddress, highAddress)] = NULL;
+			fHistRange[std::make_pair(lowAddress, highAddress)] = nullptr;
 		}
-		if(fHistRange[std::make_pair(lowAddress, highAddress)] == NULL || draw_index >= 0) {
+		if(fHistRange[std::make_pair(lowAddress, highAddress)] == nullptr || draw_index >= 0) {
 			//printf("failed to find histogram for address range 0x%04x - 0x%04x\n",lowAddress,highAddress);
 			int nofBins = fPPG->GetCycleLength()/GetTimePeriod(lowAddress); //the time period should be the same for all channels
 			fHistRange[std::make_pair(lowAddress, highAddress)] = new TH1D(Form("TScalerHist_%04x_%04x",lowAddress,highAddress),
@@ -423,9 +423,9 @@ TH1D* TScaler::Draw(UInt_t lowAddress, UInt_t highAddress, size_t index, Option_
 
 TH1D* TScaler::DrawRawTimes(UInt_t address, Double_t lowtime, Double_t hightime, size_t index, Option_t *option) {
 	///Draw scaler differences (i.e. current scaler minus last scaler) vs. time.
-   if(fTree == NULL || fEntries == 0) {
+   if(fTree == nullptr || fEntries == 0) {
       printf("Empty\n");
-		return NULL;
+		return nullptr;
    }
 
 	TString opt = option;

--- a/libraries/TGRSIFormat/TScalerQueue.cxx
+++ b/libraries/TGRSIFormat/TScalerQueue.cxx
@@ -13,11 +13,11 @@ std::mutex TDeadtimeScalerQueue::Sorted;
 //                                                            //
 ////////////////////////////////////////////////////////////////
 
-TDeadtimeScalerQueue *TDeadtimeScalerQueue::fDeadtimeScalerQueueClassPointer = NULL;
+TDeadtimeScalerQueue *TDeadtimeScalerQueue::fDeadtimeScalerQueueClassPointer = nullptr;
 
 TDeadtimeScalerQueue *TDeadtimeScalerQueue::Get() {
   ///Get a pointer to the global scaler Q. 
-  if(fDeadtimeScalerQueueClassPointer == NULL) {
+  if(fDeadtimeScalerQueueClassPointer == nullptr) {
 	 fDeadtimeScalerQueueClassPointer = new TDeadtimeScalerQueue;
   }
   return fDeadtimeScalerQueueClassPointer;
@@ -93,7 +93,7 @@ void TDeadtimeScalerQueue::StopStatusUpdate() {
 
 void TDeadtimeScalerQueue::Add(TScalerData* scalerData) {
 	///Add a Scaler to the scaler Queue.
-	if(scalerData == NULL) {
+	if(scalerData == nullptr) {
 		return;
 	}
 
@@ -211,11 +211,11 @@ std::mutex TRateScalerQueue::Sorted;
 //                                                            //
 ////////////////////////////////////////////////////////////////
 
-TRateScalerQueue *TRateScalerQueue::fRateScalerQueueClassPointer = NULL;
+TRateScalerQueue *TRateScalerQueue::fRateScalerQueueClassPointer = nullptr;
 
 TRateScalerQueue *TRateScalerQueue::Get() {
   ///Get a pointer to the global scaler Q. 
-  if(fRateScalerQueueClassPointer == NULL) {
+  if(fRateScalerQueueClassPointer == nullptr) {
 	 fRateScalerQueueClassPointer = new TRateScalerQueue;
   }
   return fRateScalerQueueClassPointer;
@@ -291,7 +291,7 @@ void TRateScalerQueue::StopStatusUpdate() {
 
 void TRateScalerQueue::Add(TScalerData* scalerData) {
 	///Add a Scaler to the scaler Queue.
-	if(scalerData == NULL) {
+	if(scalerData == nullptr) {
 		return;
 	}
 

--- a/libraries/TGRSIFormat/TSortingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TSortingDiagnostics.cxx
@@ -6,7 +6,7 @@
 #include "TChannel.h"
 #include "TGRSIOptions.h"
 
-TSortingDiagnostics* TSortingDiagnostics::fSortingDiagnostics = NULL;
+TSortingDiagnostics* TSortingDiagnostics::fSortingDiagnostics = nullptr;
 
 TSortingDiagnostics::TSortingDiagnostics() : TObject() {
 	Clear();

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -13,7 +13,7 @@
 #include "GRootCommands.h"
 
 TGRSIOptions* TGRSIOptions::Get(int argc, char** argv){
-	static TGRSIOptions* item = NULL;
+	static TGRSIOptions* item = nullptr;
 	if(!item) {
 		item = new TGRSIOptions(argc, argv);
 	}

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -44,9 +44,9 @@ ClassImp(TGRSIint)
 extern void PopupLogo(bool);
 extern void WaitLogo();
 
-TGRSIint *TGRSIint::fTGRSIint = NULL;
+TGRSIint *TGRSIint::fTGRSIint = nullptr;
 
-TEnv *TGRSIint::fGRSIEnv = NULL;
+TEnv *TGRSIint::fGRSIEnv = nullptr;
 //std::vector<std::string> *TGRSIint::fInputRootFile  = new std::vector<std::string>;
 //std::vector<std::string> *TGRSIint::fInputMidasFile = new std::vector<std::string>;
 //std::vector<std::string> *TGRSIint::fInputCalFile   = new std::vector<std::string>;
@@ -64,7 +64,7 @@ TGRSIint *TGRSIint::instance(int argc,char** argv, void *options, int numOptions
 
 TGRSIint::TGRSIint(int argc, char **argv,void *options, Int_t numOptions, Bool_t noLogo,const char *appClassName)
   :TRint(appClassName, &argc, argv, options, numOptions,noLogo),
-   fKeepAliveTimer(NULL), main_thread_id(std::this_thread::get_id()), fIsTabComplete(false),
+   fKeepAliveTimer(nullptr), main_thread_id(std::this_thread::get_id()), fIsTabComplete(false),
    fAllowedToTerminate(true),fRootFilesOpened(0),fMidasFilesOpened(0) {
 
       fGRSIEnv = gEnv;
@@ -312,7 +312,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt){
   TString sopt(opt);
   sopt.ToLower();
 
-  TFile* file = NULL;
+  TFile* file = nullptr;
   if(sopt.Contains("recreate") ||
      sopt.Contains("new")) {
     // We are being asked to make a new file.
@@ -397,7 +397,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt){
 TMidasFile* TGRSIint::OpenMidasFile(const std::string& filename) {
   if(!file_exists(filename.c_str())){
     std::cerr << "File \"" << filename << "\" does not exist" << std::endl;
-    return NULL;
+    return nullptr;
   }
 
   TMidasFile* file = new TMidasFile(filename.c_str());
@@ -421,7 +421,7 @@ TMidasFile* TGRSIint::OpenMidasFile(const std::string& filename) {
 TLstFile* TGRSIint::OpenLstFile(const std::string& filename) {
   if(!file_exists(filename.c_str())){
     std::cerr << "File \"" << filename << "\" does not exist" << std::endl;
-    return NULL;
+    return nullptr;
   }
 
   TLstFile* file = new TLstFile(filename.c_str());

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -429,7 +429,7 @@ void TBGSubtraction::DrawOnNewCanvas(){
 void TBGSubtraction::WriteHistograms() {
    //Find if there is a file name
    const char *file_name = fWrite2FileName->GetText();
-   if(file_name == NULL){
+   if(file_name == nullptr){
       std::cout << "Please enter a file name" << std::endl;
       return;
    }
@@ -437,19 +437,19 @@ void TBGSubtraction::WriteHistograms() {
    TFile f(file_name,"Update");
    std::cout << "Writing " << fHistogramDescription->GetText() << " histograms to " << f.GetName() << std::endl;
    if(fSubtractedHist){
-      if(fHistogramDescription->GetText() != NULL)
+      if(fHistogramDescription->GetText() != nullptr)
          fSubtractedHist->SetTitle(fHistogramDescription->GetText());
       fSubtractedHist->Write();
    }
 
    if(fBGHist){
-      if(fHistogramDescription->GetText() != NULL)
+      if(fHistogramDescription->GetText() != nullptr)
          fBGHist->SetTitle(Form("%s Background",fHistogramDescription->GetText()));
 
       fBGHist->Write();
    }
    if(fGateHist){
-      if(fHistogramDescription->GetText() != NULL)
+      if(fHistogramDescription->GetText() != nullptr)
          fGateHist->SetTitle(Form("%s Gate only",fHistogramDescription->GetText()));
    
       fGateHist->Write();

--- a/libraries/THistogramming/DynamicLibrary.cxx
+++ b/libraries/THistogramming/DynamicLibrary.cxx
@@ -62,7 +62,7 @@ DynamicLibrary::~DynamicLibrary() {
 }
 
 DynamicLibrary::DynamicLibrary(DynamicLibrary&& other)
-  : fLibrary(NULL){
+  : fLibrary(nullptr){
   swap(other);
 }
 

--- a/libraries/THistogramming/TCompiledHistograms.cxx
+++ b/libraries/THistogramming/TCompiledHistograms.cxx
@@ -38,7 +38,7 @@ TCompiledHistograms::TCompiledHistograms(std::string input_lib, std::string func
               <<"\"" << input_lib << "\"" << std::endl;
   }
   fLast_modified = get_timestamp();
-  fLast_checked = time(NULL);
+  fLast_checked = time(nullptr);
 }
 
 void TCompiledHistograms::ClearHistograms() {
@@ -117,7 +117,7 @@ void TCompiledHistograms::Reload() {
     TCompiledHistograms other(fLibname,fFunc_name);
     swap_lib(other);
   }
-  fLast_checked = time(NULL);
+  fLast_checked = time(nullptr);
 }
 
 void TCompiledHistograms::swap_lib(TCompiledHistograms& other) {
@@ -132,7 +132,7 @@ void TCompiledHistograms::swap_lib(TCompiledHistograms& other) {
 
 void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag) {
   std::lock_guard<std::mutex> lock(fMutex);
-  if(time(NULL) > fLast_checked + fCheck_every){
+  if(time(nullptr) > fLast_checked + fCheck_every){
     Reload();
   }
 
@@ -146,12 +146,12 @@ void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag) {
 
   fObj.SetFragment(frag);
   fFunc(fObj);
-  fObj.SetFragment(NULL);
+  fObj.SetFragment(nullptr);
 }
 
 void TCompiledHistograms::Fill(std::shared_ptr<TUnpackedEvent> detectors) {
   std::lock_guard<std::mutex> lock(fMutex);
-  if(time(NULL) > fLast_checked + fCheck_every){
+  if(time(nullptr) > fLast_checked + fCheck_every){
     Reload();
   }
 
@@ -165,7 +165,7 @@ void TCompiledHistograms::Fill(std::shared_ptr<TUnpackedEvent> detectors) {
 
   fObj.SetDetectors(detectors);
   fFunc(fObj);
-  fObj.SetDetectors(NULL);
+  fObj.SetDetectors(nullptr);
 }
 
 void TCompiledHistograms::AddCutFile(TFile* cut_file) {
@@ -177,7 +177,7 @@ void TCompiledHistograms::AddCutFile(TFile* cut_file) {
 void TCompiledHistograms::SetDefaultDirectory(TDirectory* dir) {
   fDefault_directory = dir;
 
-  TObject* obj = NULL;
+  TObject* obj = nullptr;
   TIter next(&fObjects);
   while((obj = next())) {
     TH1* hist = dynamic_cast<TH1*>(obj);

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -22,7 +22,7 @@ std::map<std::string,TRuntimeObjects*> TRuntimeObjects::fRuntimeMap;
 TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* objects, TList *gates,
                                  std::vector<TFile*>& cut_files,
                                  TDirectory* directory,const char *name)
-  : fFrag(frag), //detectors(NULL),
+  : fFrag(frag), //detectors(nullptr),
     fObjects(objects), fGates(gates),
     fCut_files(cut_files),
     fDirectory(directory) {
@@ -43,7 +43,7 @@ TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* o
 TRuntimeObjects::TRuntimeObjects(TList* objects, TList *gates,
                                  std::vector<TFile*>& cut_files,
                                  TDirectory* directory,const char *name)
-  : fFrag(NULL), //detectors(0),
+  : fFrag(nullptr), //detectors(0),
     fObjects(objects), fGates(gates),
     fCut_files(cut_files),
     fDirectory(directory) {
@@ -298,7 +298,7 @@ TCutG* TRuntimeObjects::GetCut(const std::string& name) {
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 double TRuntimeObjects::GetVariable(const char* name) {

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -175,7 +175,7 @@ void TAnalysisWriteLoop::AddBranch(TClass* cls){
 void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event) {
 	if(fEventTree) {
 		// Clear pointers from previous writes.
-		// Note that we cannot just set this equal to NULL,
+		// Note that we cannot just set this equal to nullptr,
 		//   because ROOT would then construct a new object.
 		// This contradicts the ROOT documentation for TBranchElement::SetAddress,
 		//   which suggests that a new object would be constructed only when setting the address,
@@ -197,7 +197,7 @@ void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event) {
 			(*fDetMap.at(cls))->ClearTransients();
 			//if(cls == TDescant::Class()) {
 			//	for(int i = 0; i < static_cast<TDescant*>(det)->GetMultiplicity(); ++i) {
-			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == NULL ? " has no debug data": " has debug data")<<std::endl;
+			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == nullptr ? " has no debug data": " has debug data")<<std::endl;
 			//	}
 			//}
 		}

--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -14,7 +14,7 @@ TDataLoop::TDataLoop(std::string name,TRawFile* source)
 	: StoppableThread(name),
 	fSource(source), fSelfStopping(true),
 	fOutputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TRawEvent> > >("midas_queue"))
-#ifdef HASXML
+#ifdef HAS_XML
 	, fOdb(0) 
 #endif
 {
@@ -44,7 +44,7 @@ TDataLoop *TDataLoop::Get(std::string name,TRawFile* source) {
 }
 
 void TDataLoop::SetFileOdb(char* data, int size) {
-#ifdef HASXML
+#ifdef HAS_XML
 	//check if we have already set the TChannels....
 	//
 	if(fOdb) {
@@ -87,7 +87,7 @@ void TDataLoop::SetFileOdb(char* data, int size) {
 }
 
 void TDataLoop::SetGRIFFOdb() {
-#ifdef HASXML
+#ifdef HAS_XML
 	std::string path = "/DAQ/MSC";
 	printf("using GRIFFIN path to analyzer info: %s...\n",path.c_str());
 
@@ -142,7 +142,7 @@ void TDataLoop::SetGRIFFOdb() {
 }
 
 void TDataLoop::SetTIGOdb()  {
-#ifdef HASXML
+#ifdef HAS_XML
 	std::string typepath = "/Equipment/Trigger/settings/Detector Settings";
 	std::map<int,std::pair<std::string,std::string> >typemap;
 	TXMLNode* typenode = fOdb->FindPath(typepath.c_str());

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -59,7 +59,7 @@ void TEventBuildingLoop::ClearQueue() {
 
 bool TEventBuildingLoop::Iteration(){
 	// Pull something off of the input queue.
-	std::shared_ptr<const TFragment> input_frag = NULL;
+	std::shared_ptr<const TFragment> input_frag = nullptr;
 	fInputSize = fInputQueue->Pop(input_frag, 0);
 	if(fInputSize < 0) fInputSize = 0;
 

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -34,8 +34,8 @@ TFragWriteLoop* TFragWriteLoop::Get(std::string name, std::string fOutputFilenam
 
 TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
   : StoppableThread(name),
-    fOutputFile(NULL), fEventTree(NULL), fBadEventTree(NULL), fScalerTree(NULL),
-	 //fEventAddress(NULL), fBadEventAddress(NULL), fScalerAddress(NULL),
+    fOutputFile(nullptr), fEventTree(nullptr), fBadEventTree(nullptr), fScalerTree(nullptr),
+	 //fEventAddress(nullptr), fBadEventAddress(nullptr), fScalerAddress(nullptr),
     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment> > >()),
     fScalerInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >()) {
@@ -55,7 +55,7 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
     fBadEventTree->Branch("TFragment", &fBadEventAddress);
 
     fScalerTree = new TTree("EpicsTree","EpicsTree");
-	 fScalerAddress = NULL;
+	 fScalerAddress = nullptr;
     fScalerTree->Branch("TEpicsFrag", &fScalerAddress);
 
     TThread::UnLock();
@@ -153,7 +153,7 @@ void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 		fEventAddress->ClearTransients();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fEventTree->Fill();
-		//fEventAddress = NULL;
+		//fEventAddress = nullptr;
 	} else {
 		std::cout<<__PRETTY_FUNCTION__<<": no fragment tree!"<<std::endl;
 	}
@@ -164,7 +164,7 @@ void TFragWriteLoop::WriteBadEvent(std::shared_ptr<const TFragment> event) {
 		*fBadEventAddress = *(event.get());
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fBadEventTree->Fill();
-		//fBadEventAddress = NULL;
+		//fBadEventAddress = nullptr;
 	}
 }
 
@@ -173,7 +173,7 @@ void TFragWriteLoop::WriteScaler(std::shared_ptr<TEpicsFrag> scaler) {
 		fScalerAddress = scaler.get();
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fScalerTree->Fill();
-		fScalerAddress = NULL;
+		fScalerAddress = nullptr;
 	}
 }
 

--- a/libraries/TLoops/TFragmentChainLoop.cxx
+++ b/libraries/TLoops/TFragmentChainLoop.cxx
@@ -31,7 +31,7 @@ TFragmentChainLoop* TFragmentChainLoop::Get(std::string name, TChain *chain) {
 TFragmentChainLoop::TFragmentChainLoop(std::string name, TChain *chain)
   : StoppableThread(name),
     fEntriesTotal(chain->GetEntries()),
-    fInputChain(chain), fFragment(NULL), 
+    fInputChain(chain), fFragment(nullptr), 
     fSelfStopping(true) {
   SetupChain();
 }

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -54,6 +54,6 @@ std::shared_ptr<TDetector>  TUnpackedEvent::GetDetector(TClass* cls, bool make_i
     fDetectors.push_back(output);
     return output;
   } else {
-    return NULL;
+    return nullptr;
   }
 }

--- a/libraries/TMidas/LinkDef.h
+++ b/libraries/TMidas/LinkDef.h
@@ -1,4 +1,4 @@
-// TRawEvent.h TRawFile.h TMidasEvent.h  TMidasFile.h TLstEvent.h TLstFile.h TXMLOdb.h  
+// TXMLOdb.h TRawEvent.h TRawFile.h TMidasEvent.h TMidasFile.h TLstEvent.h TLstFile.h
 
 
 #ifdef __CINT__
@@ -12,17 +12,13 @@
 //#pragma link C++ class TMidasStructs+;
 //#pragma link C++ class TMidasBanks+;
 
+#pragma link C++ class TXMLOdb+;
 #pragma link C++ class TRawEvent+;
 #pragma link C++ class TRawFile+;
 #pragma link C++ class TMidasEvent+;
 #pragma link C++ class TMidasFile+;
 #pragma link C++ class TLstEvent+;
 #pragma link C++ class TLstFile+;
-#pragma link C++ class TXMLOdb+;
 
 #endif
-
-
-
-
 

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -19,11 +19,11 @@ ClassImp(TMidasEvent)
 
 TMidasEvent::TMidasEvent() {
   //Default constructor
-  fData = NULL;
+  fData = nullptr;
   fAllocatedByUs = false;
 
   fBanksN = 0;
-  fBankList = NULL;
+  fBankList = nullptr;
 
   fEventHeader.fEventId      = 0;
   fEventHeader.fTriggerMask  = 0;
@@ -42,7 +42,7 @@ void TMidasEvent::Copy(TObject& rhs) const {
   static_cast<TMidasEvent&>(rhs).fAllocatedByUs = true;
 
   static_cast<TMidasEvent&>(rhs).fBanksN      = fBanksN;
-  static_cast<TMidasEvent&>(rhs).fBankList    = NULL;
+  static_cast<TMidasEvent&>(rhs).fBankList    = nullptr;
   //if(fBankList) static_cast<TMidasEvent&>(rhs).fBankList    = strdup(fBankList);
   //assert(static_cast<TMidasEvent&>(rhs).fBankList);
 }
@@ -68,11 +68,11 @@ void TMidasEvent::Clear(Option_t *opt) {
    //Clears the TMidasEvent.
   if (fBankList)
     free(fBankList);
-  fBankList = NULL;
+  fBankList = nullptr;
 
   if (fData && fAllocatedByUs)
     free(fData);
-  fData = NULL;
+  fData = nullptr;
 
   fAllocatedByUs = false;
   fBanksN = 0;
@@ -144,7 +144,7 @@ int TMidasEvent::LocateBank(const void *unused, const char *name, void **pdata) 
 
   if (!status)
     {
-      *pdata = NULL;
+      *pdata = nullptr;
       return 0;
     }
 
@@ -158,7 +158,7 @@ static const unsigned TID_MAX = (sizeof(TID_SIZE)/sizeof(TID_SIZE[0]));
 /// \param [in] name Name of the data bank to look for.
 /// \param [out] bklen Number of array elements in this bank.
 /// \param [out] bktype Bank data type (MIDAS TID_xxx).
-/// \param [out] pdata Pointer to bank data, Returns NULL if bank not found.
+/// \param [out] pdata Pointer to bank data, Returns nullptr if bank not found.
 /// \returns 1 if bank found, 0 otherwise.
 ///
 int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdata) const {
@@ -187,12 +187,12 @@ int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdat
     } while ((char*) pbk32 < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
 #endif
 
-    TMidas_BANK32 *pbk32 = NULL;
+    TMidas_BANK32 *pbk32 = nullptr;
 
     while (1) {
       IterateBank32(&pbk32, (char**)pdata);
       //printf("looking for [%s] got [%s]\n", name, pbk32->fName);
-      if (pbk32 == NULL)
+      if (pbk32 == nullptr)
 	break;
 
       if (name[0]==pbk32->fName[0] &&
@@ -231,7 +231,7 @@ int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdat
   //
   // bank not found
   //
-  *pdata = NULL;
+  *pdata = nullptr;
   return 0;
 }
 
@@ -365,9 +365,9 @@ int TMidasEvent::SetBankList() {
 
   fBanksN = 0;
 
-  TMidas_BANK32 *pmbk32 = NULL;
-  TMidas_BANK *pmbk = NULL;
-  char *pdata = NULL;
+  TMidas_BANK32 *pmbk32 = nullptr;
+  TMidas_BANK *pmbk = nullptr;
+  char *pdata = nullptr;
 
   while (1)
     {
@@ -380,7 +380,7 @@ int TMidasEvent::SetBankList() {
       if (IsBank32())
 	{
 	  IterateBank32(&pmbk32, &pdata);
-	  if (pmbk32 == NULL)
+	  if (pmbk32 == nullptr)
 	    break;
 	  memcpy(fBankList+fBanksN*4, pmbk32->fName, 4);
 	  fBanksN++;
@@ -388,7 +388,7 @@ int TMidasEvent::SetBankList() {
       else
 	{
 	  IterateBank(&pmbk, &pdata);
-	  if (pmbk == NULL)
+	  if (pmbk == nullptr)
 	    break;
 	  memcpy(fBankList+fBanksN*4, pmbk->fName, 4);
 	  fBanksN++;
@@ -403,14 +403,14 @@ int TMidasEvent::SetBankList() {
 int TMidasEvent::IterateBank(TMidas_BANK **pbk, char **pdata) const {
   /// Iterates through banks inside an event. The function can be used
   /// to enumerate all banks of an event.
-  /// \param [in] pbk Pointer to the bank header, must be NULL for the
-  /// first call to this function. Returns NULL if no more banks
-  /// \param [in] pdata Pointer to data area of bank. Returns NULL if no more banks
+  /// \param [in] pbk Pointer to the bank header, must be nullptr for the
+  /// first call to this function. Returns nullptr if no more banks
+  /// \param [in] pdata Pointer to data area of bank. Returns nullptr if no more banks
   /// \returns Size of bank in bytes or 0 if no more banks.
   ///
   const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
 
-  if (*pbk == NULL)
+  if (*pbk == nullptr)
     *pbk = (TMidas_BANK *) (event + 1);
   else
     *pbk = (TMidas_BANK *) ((char*) (*pbk + 1) + ((((*pbk)->fDataSize)+7) & ~7));
@@ -419,8 +419,8 @@ int TMidasEvent::IterateBank(TMidas_BANK **pbk, char **pdata) const {
 
   if ((char*) *pbk >=  (char*) event + event->fDataSize + sizeof(TMidas_BANK_HEADER))
     {
-      *pbk = NULL;
-      *pdata = NULL;
+      *pbk = nullptr;
+      *pdata = nullptr;
       return 0;
     }
 
@@ -431,7 +431,7 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
   /// See IterateBank()
 
   const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
-  if (*pbk == NULL)
+  if (*pbk == nullptr)
     *pbk = (TMidas_BANK32 *) (event + 1);
   else {
     uint32_t length = (*pbk)->fDataSize;
@@ -455,8 +455,8 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
       else
 	{
 	  // truncate invalid data
-	  *pbk = NULL;
-	  *pdata = NULL;
+	  *pbk = nullptr;
+	  *pdata = nullptr;
 	  return 0;
 	}
     }
@@ -465,8 +465,8 @@ int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
 
   if ((char*) *pbk >= (char*)event  + event->fDataSize + sizeof(TMidas_BANK_HEADER))
     {
-      *pbk = NULL;
-      *pdata = NULL;
+      *pbk = nullptr;
+      *pdata = nullptr;
       return 0;
     }
 
@@ -629,15 +629,15 @@ int TMidasEvent::Process(TDataParser& parser) {
 		switch(GetEventId())  {
 			case 1:
 				SetBankList();
-				if((banksize = LocateBank(NULL,"WFDN",&ptr))>0) {
+				if((banksize = LocateBank(nullptr,"WFDN",&ptr))>0) {
 					frags = ProcessTIGRESS((uint32_t*)ptr, banksize, parser);
-				} else if((banksize = LocateBank(NULL,"GRF1",&ptr))>0) {
+				} else if((banksize = LocateBank(nullptr,"GRF1",&ptr))>0) {
 					frags = ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF1, parser);
-				} else if((banksize = LocateBank(NULL,"GRF2",&ptr))>0) {
+				} else if((banksize = LocateBank(nullptr,"GRF2",&ptr))>0) {
 					frags = ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF2, parser);
-				} else if((banksize = LocateBank(NULL,"GRF3",&ptr))>0) {
+				} else if((banksize = LocateBank(nullptr,"GRF3",&ptr))>0) {
 					frags = ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF3, parser);
-				} else if((banksize = LocateBank(NULL,"GRF4",&ptr))>0) {
+				} else if((banksize = LocateBank(nullptr,"GRF4",&ptr))>0) {
 					frags = ProcessGRIFFIN((uint32_t*)ptr,banksize,TDataParser::EBank::kGRF4, parser);
 				} else if(!TGRSIOptions::Get()->SuppressErrors()) {
 					printf(DRED "\nUnknown bank in midas event #%d" RESET_COLOR "\n", GetSerialNumber());
@@ -652,7 +652,7 @@ int TMidasEvent::Process(TDataParser& parser) {
 			case 4:
 			case 5:
 				 SetBankList();
-				 if((banksize = LocateBank(NULL,"MSRD",&ptr))>0) {
+				 if((banksize = LocateBank(nullptr,"MSRD",&ptr))>0) {
 					 frags = ProcessEPICS((float*)ptr, banksize, parser);
 				 }
 

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -24,62 +24,60 @@
 ClassImp(TMidasFile)
 /// \endcond
 
-TMidasFile::TMidasFile()
-{
-   //Default Constructor
-  uint32_t endian = 0x12345678;
+TMidasFile::TMidasFile() {
+	//Default Constructor
+	uint32_t endian = 0x12345678;
 
-  fFile = -1;
-  fGzFile = NULL;
-  fPoFile = NULL;
-  fLastErrno = 0;
-  fCurrentBufferSize = 0;
+	fFile = -1;
+	fGzFile = nullptr;
+	fPoFile = nullptr;
+	fLastErrno = 0;
+	fCurrentBufferSize = 0;
 
-  fOutFile = -1;
-  fOutGzFile = NULL;
+	fOutFile = -1;
+	fOutGzFile = nullptr;
 
-  fMaxBufferSize = 1E6;
+	fMaxBufferSize = 1E6;
 
-  currentEventNumber = 0;
-  fBytesRead = 0;
-  fFileSize = 0;
+	currentEventNumber = 0;
+	fBytesRead = 0;
+	fFileSize = 0;
 
-  fDoByteSwap = *(char*)(&endian) != 0x78;
+	fDoByteSwap = *(char*)(&endian) != 0x78;
+
+	fFirstEvent = std::make_shared<TMidasEvent>();
 }
 
 TMidasFile::TMidasFile(const char* filename, EOpenType open_type)
-  : TMidasFile() {
-  switch(open_type) {
-    case kRead:
-      Open(filename);
-      break;
+	: TMidasFile() {
+		switch(open_type) {
+			case kRead:
+				Open(filename);
+				break;
 
-    case kWrite:
-      OutOpen(filename);
-      break;
-  }
-}
+			case kWrite:
+				OutOpen(filename);
+				break;
+		}
+	}
 
-TMidasFile::~TMidasFile()
-{
-   //Default dtor. It closes the read in midas file as well as the output midas file.
-  Close();
-  OutClose();
+TMidasFile::~TMidasFile() {
+	//Default dtor. It closes the read in midas file as well as the output midas file.
+	Close();
+	OutClose();
 }
 
 std::string TMidasFile::Status(bool long_file_description) {
-  return Form(HIDE_CURSOR " Processing event %i have processed %.2fMB/%.2f MB              " SHOW_CURSOR "\r",
-              currentEventNumber,(fBytesRead/1000000.0),(fFileSize/1000000.0));
+	return Form(HIDE_CURSOR " Processing event %i have processed %.2fMB/%.2f MB              " SHOW_CURSOR "\r",
+			currentEventNumber,(fBytesRead/1000000.0),(fFileSize/1000000.0));
 }
 
-static int hasSuffix(const char*name,const char*suffix)
-{
-   //Checks to see if midas file has suffix.
-  const char* s = strstr(name,suffix);
-  if (s == NULL)
-    return 0;
+static int hasSuffix(const char*name, const char*suffix) {
+	//Checks to see if midas file has suffix.
+	const char* s = strstr(name,suffix);
+	if(s == nullptr) return 0;
 
-  return (s-name)+strlen(suffix) == strlen(name);
+	return (s-name)+strlen(suffix) == strlen(name);
 }
 
 /// Open a midas .mid file with given file name.
@@ -99,228 +97,199 @@ static int hasSuffix(const char*name,const char*suffix)
 ///
 /// \param[in] filename The file to open.
 /// \returns "true" for succes, "false" for error, use GetLastError() to see why
-bool TMidasFile::Open(const char *filename)
-{
+bool TMidasFile::Open(const char *filename) {
+	if(fFile > 0) Close();
 
-  if (fFile > 0)
-    Close();
+	fFilename = filename;
 
-  fFilename = filename;
-
-  std::string pipe;
+	std::string pipe;
 
 
-  std::ifstream in(GetFilename(), std::ifstream::in | std::ifstream::binary);
-  in.seekg(0, std::ifstream::end);
-  fFileSize = in.tellg();
-  in.close();
+	std::ifstream in(GetFilename(), std::ifstream::in | std::ifstream::binary);
+	in.seekg(0, std::ifstream::end);
+	fFileSize = in.tellg();
+	in.close();
 
-  // Do we need these?
-  //signal(SIGPIPE,SIG_IGN); // crash if reading from closed pipe
-  //signal(SIGXFSZ,SIG_IGN); // crash if reading from file >2GB without O_LARGEFILE
+	// Do we need these?
+	//signal(SIGPIPE,SIG_IGN); // crash if reading from closed pipe
+	//signal(SIGXFSZ,SIG_IGN); // crash if reading from file >2GB without O_LARGEFILE
 
-  if (strncmp(filename, "ssh://", 6) == 0)
-    {
-      const char* name = filename + 6;
-      const char* s = strstr(name, "/");
+	if(strncmp(filename, "ssh://", 6) == 0) {
+		const char* name = filename + 6;
+		const char* s = strstr(name, "/");
 
-      if (s == NULL)
-        {
-          fLastErrno = -1;
-          fLastError.assign("TMidasFile::Open: Invalid ssh:// URI. Should be: ssh://user@host/file/path/...");
-          return false;
-        }
+		if(s == nullptr) {
+			fLastErrno = -1;
+			fLastError.assign("TMidasFile::Open: Invalid ssh:// URI. Should be: ssh://user@host/file/path/...");
+			return false;
+		}
 
-      const char* remoteFile = s + 1;
+		const char* remoteFile = s + 1;
 
-      std::string remoteHost;
-      for (s=name; *s != '/'; s++)
-        remoteHost += *s;
+		std::string remoteHost;
+		for(s=name; *s != '/'; s++) {
+			remoteHost += *s;
+		}
 
-      pipe = "ssh -e none -T -x -n ";
-      pipe += remoteHost;
-      pipe += " dd if=";
-      pipe += remoteFile;
-      pipe += " bs=1024k";
+		pipe = "ssh -e none -T -x -n ";
+		pipe += remoteHost;
+		pipe += " dd if=";
+		pipe += remoteFile;
+		pipe += " bs=1024k";
 
-      if (hasSuffix(remoteFile,".gz"))
-        pipe += " | gzip -dc";
-      else if (hasSuffix(remoteFile,".bz2"))
-        pipe += " | bzip2 -dc";
-    }
-  else if (strncmp(filename, "dccp://", 7) == 0)
-    {
-      const char* name = filename + 7;
+		if(hasSuffix(remoteFile,".gz")) {
+			pipe += " | gzip -dc";
+		} else if(hasSuffix(remoteFile,".bz2")) {
+			pipe += " | bzip2 -dc";
+		}
+	} else if(strncmp(filename, "dccp://", 7) == 0) {
+		const char* name = filename + 7;
 
-      pipe = "dccp ";
-      pipe += name;
-      pipe += " /dev/fd/1";
+		pipe = "dccp ";
+		pipe += name;
+		pipe += " /dev/fd/1";
 
-      if (hasSuffix(filename,".gz"))
-        pipe += " | gzip -dc";
-      else if (hasSuffix(filename,".bz2"))
-        pipe += " | bzip2 -dc";
-    }
-  else if (strncmp(filename, "pipein://", 9) == 0)
-    {
-      pipe = filename + 9;
-    }
+		if(hasSuffix(filename,".gz"))
+			pipe += " | gzip -dc";
+		else if(hasSuffix(filename,".bz2"))
+			pipe += " | bzip2 -dc";
+	} else if(strncmp(filename, "pipein://", 9) == 0) {
+		pipe = filename + 9;
 #if 0 // read compressed files using the zlib library
-  else if (hasSuffix(filename, ".gz"))
-    {
-      pipe = "gzip -dc ";
-      pipe += filename;
-    }
+	} else if(hasSuffix(filename, ".gz")) {
+		pipe = "gzip -dc ";
+		pipe += filename;
 #endif
-  else if (hasSuffix(filename, ".bz2"))
-    {
-      pipe = "bzip2 -dc ";
-      pipe += filename;
-    }
-  // Note: We cannot use "cat" in a similar way to offload, and must open it directly.
-  //       "cat" ends immediately on end-of-file, making live histograms impossible.
-  //       "tail -fn +1" has the opposite problem, and will never end, stalling in read().
+	} else if(hasSuffix(filename, ".bz2")) {
+		pipe = "bzip2 -dc ";
+		pipe += filename;
+	}
+	// Note: We cannot use "cat" in a similar way to offload, and must open it directly.
+	//       "cat" ends immediately on end-of-file, making live histograms impossible.
+	//       "tail -fn +1" has the opposite problem, and will never end, stalling in read().
 
-  if (pipe.length() > 0)
-    {
-      fprintf(stderr,"TMidasFile::Open: Reading from pipe: %s\n", pipe.c_str());
-      fPoFile = popen(pipe.c_str(), "r");
+	if(pipe.length() > 0) {
+		fprintf(stderr,"TMidasFile::Open: Reading from pipe: %s\n", pipe.c_str());
+		fPoFile = popen(pipe.c_str(), "r");
 
-      if (fPoFile == NULL)
-        {
-          fLastErrno = errno;
-          fLastError.assign(std::strerror(errno));
-          return false;
-        }
+		if(fPoFile == nullptr) {
+			fLastErrno = errno;
+			fLastError.assign(std::strerror(errno));
+			return false;
+		}
 
-      fFile = fileno((FILE*)fPoFile);
-    }
-  else
-    {
+		fFile = fileno((FILE*)fPoFile);
+	} else {
 #ifndef O_LARGEFILE
 #define O_LARGEFILE 0
 #endif
 
-      fFile = open(filename, O_RDONLY | O_LARGEFILE);
+		fFile = open(filename, O_RDONLY | O_LARGEFILE);
 
-      if (fFile <= 0)
-        {
-          fLastErrno = errno;
-          fLastError.assign(std::strerror(errno));
-          return false;
-        }
+		if(fFile <= 0) {
+			fLastErrno = errno;
+			fLastError.assign(std::strerror(errno));
+			return false;
+		}
 
-      if (hasSuffix(filename, ".gz"))
-        {
-          // this is a compressed file
+		if(hasSuffix(filename, ".gz")) {
+			// this is a compressed file
 #ifdef HAVE_ZLIB
-          fGzFile = new gzFile;
-          (*(gzFile*)fGzFile) = gzdopen(fFile,"rb");
-          if ((*(gzFile*)fGzFile) == NULL)
-            {
-              fLastErrno = -1;
-              fLastError.assign("zlib gzdopen() error");
-              return false;
-            }
+			fGzFile = new gzFile;
+			(*(gzFile*)fGzFile) = gzdopen(fFile,"rb");
+			if((*(gzFile*)fGzFile) == nullptr) {
+				fLastErrno = -1;
+				fLastError.assign("zlib gzdopen() error");
+				return false;
+			}
 #else
-          fLastErrno = -1;
-          fLastError.assign("Do not know how to read compressed MIDAS files");
-          return false;
+			fLastErrno = -1;
+			fLastError.assign("Do not know how to read compressed MIDAS files");
+			return false;
 #endif
-        }
-    }
+		}
+	}
 
-  Read(fFirstEvent);
-  TGRSIRunInfo::SetRunInfo(GetRunNumber(),GetSubRunNumber());
-  TGRSIRunInfo::SetGRSIVersion(GRSI_RELEASE);
+	Read(fFirstEvent);
+	TGRSIRunInfo::SetRunInfo(GetRunNumber(),GetSubRunNumber());
+	TGRSIRunInfo::SetGRSIVersion(GRSI_RELEASE);
 
-  return true;
+	return true;
 }
 
 bool TMidasFile::OutOpen(const char *filename)
 {
-  /// Open a midas .mid file for OUTPUT with given file name.
-  ///
-  /// Remote files not yet implemented
-  ///
-  /// \param [in] filename The file to open.
-  /// \returns "true" for succes, "false" for error, use GetLastError() to see why
+	/// Open a midas .mid file for OUTPUT with given file name.
+	///
+	/// Remote files not yet implemented
+	///
+	/// \param [in] filename The file to open.
+	/// \returns "true" for succes, "false" for error, use GetLastError() to see why
 
-  if (fOutFile > 0)
-    OutClose();
+	if(fOutFile > 0)
+		OutClose();
 
-  fOutFilename = filename;
+	fOutFilename = filename;
 
-  printf ("Attempting normal open of file %s\n", filename);
-  //fOutFile = open(filename, O_CREAT |  O_WRONLY | O_LARGEFILE , S_IRUSR| S_IWUSR | S_IRGRP | S_IROTH );
-  //fOutFile = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY | O_LARGEFILE, 0644);
-  fOutFile = open (filename, O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, 0644);
+	printf ("Attempting normal open of file %s\n", filename);
+	//fOutFile = open(filename, O_CREAT |  O_WRONLY | O_LARGEFILE , S_IRUSR| S_IWUSR | S_IRGRP | S_IROTH );
+	//fOutFile = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY | O_LARGEFILE, 0644);
+	fOutFile = open (filename, O_WRONLY | O_CREAT | O_TRUNC | O_LARGEFILE, 0644);
 
-  if (fOutFile <= 0)
-    {
-      fLastErrno = errno;
-      fLastError.assign(std::strerror(errno));
-      return false;
-    }
+	if(fOutFile <= 0) {
+		fLastErrno = errno;
+		fLastError.assign(std::strerror(errno));
+		return false;
+	}
 
-  printf("Opened output file %s ; return fOutFile is %i\n",filename,fOutFile);
+	printf("Opened output file %s ; return fOutFile is %i\n",filename,fOutFile);
 
-  if (hasSuffix(filename, ".gz"))
-    // (hasSuffix(filename, ".dummy"))
-    {
-      // this is a compressed file
+	if(hasSuffix(filename, ".gz")) {
+		// (hasSuffix(filename, ".dummy"))
+		// this is a compressed file
 #ifdef HAVE_ZLIB
-      fOutGzFile = new gzFile;
-      *(gzFile*)fOutGzFile = gzdopen(fOutFile,"wb");
-      if ((*(gzFile*)fOutGzFile) == NULL)
-	{
-	  fLastErrno = -1;
-	  fLastError.assign("zlib gzdopen() error");
-	  return false;
-	}
-      printf("Opened gz file successfully\n");
-      if (1)
-	{
-	  if (gzsetparams(*(gzFile*)fOutGzFile, 1, Z_DEFAULT_STRATEGY) != Z_OK) {
-	    printf("Cannot set gzparams\n");
-	    fLastErrno = -1;
-	    fLastError.assign("zlib gzsetparams() error");
-	    return false;
-	  }
-	  printf("setparams for gz file successfully\n");
-	}
+		fOutGzFile = new gzFile;
+		*(gzFile*)fOutGzFile = gzdopen(fOutFile,"wb");
+		if((*(gzFile*)fOutGzFile) == nullptr) {
+			fLastErrno = -1;
+			fLastError.assign("zlib gzdopen() error");
+			return false;
+		}
+		printf("Opened gz file successfully\n");
+		if(1) {
+			if(gzsetparams(*(gzFile*)fOutGzFile, 1, Z_DEFAULT_STRATEGY) != Z_OK) {
+				printf("Cannot set gzparams\n");
+				fLastErrno = -1;
+				fLastError.assign("zlib gzsetparams() error");
+				return false;
+			}
+			printf("setparams for gz file successfully\n");
+		}
 #else
-      fLastErrno = -1;
-      fLastError.assign("Do not know how to write compressed MIDAS files");
-      return false;
+		fLastErrno = -1;
+		fLastError.assign("Do not know how to write compressed MIDAS files");
+		return false;
 #endif
-    }
-  return true;
+	}
+	return true;
 }
 
 
-static int readpipe(int fd, char* buf, int length)
-{
-  int count = 0;
-  while (length > 0)
-    {
-      int rd = read(fd, buf, length);
-      if (rd > 0)
-        {
-          buf += rd;
-          length -= rd;
-          count += rd;
-        }
-      else if (rd == 0)
-        {
-          return count;
-        }
-      else
-        {
-          return -1;
-        }
-    }
-  return count;
+static int readpipe(int fd, char* buf, int length) {
+	int count = 0;
+	while (length > 0) {
+		int rd = read(fd, buf, length);
+		if(rd > 0) {
+			buf += rd;
+			length -= rd;
+			count += rd;
+		} else if(rd == 0) {
+			return count;
+		} else {
+			return -1;
+		}
+	}
+	return count;
 }
 
 /// \param [in] midasEvent Pointer to an empty TMidasEvent
@@ -329,272 +298,264 @@ static int readpipe(int fd, char* buf, int length)
 ///  EDITED FROM THE ORIGINAL TO RETURN TOTAL SUCESSFULLY BYTES READ INSTEAD OF TRUE/FALSE,  PCB
 ///
 int TMidasFile::Read(std::shared_ptr<TRawEvent> event) {
+	if(event == nullptr) {
+		return -1;
+	}
 	std::shared_ptr<TMidasEvent> midasEvent = std::static_pointer_cast<TMidasEvent>(event);
-  if(fReadBuffer.size() < sizeof(TMidas_EVENT_HEADER)) {
-    ReadMoreBytes(sizeof(TMidas_EVENT_HEADER) - fReadBuffer.size());
-  }
+	if(fReadBuffer.size() < sizeof(TMidas_EVENT_HEADER)) {
+		ReadMoreBytes(sizeof(TMidas_EVENT_HEADER) - fReadBuffer.size());
+	}
 
-  if(fReadBuffer.size() < sizeof(TMidas_EVENT_HEADER)) {
-    return 0;
-  }
+	if(fReadBuffer.size() < sizeof(TMidas_EVENT_HEADER)) {
+		return 0;
+	}
 
-  midasEvent->Clear();
-  memcpy((char*)midasEvent->GetEventHeader(),fReadBuffer.data(),sizeof(TMidas_EVENT_HEADER));
-  if (fDoByteSwap){
-    printf("Swapping bytes\n");
-    midasEvent->SwapBytesEventHeader();
-  }
-  if (!midasEvent->IsGoodSize()) {
-    fLastErrno = -1;
-    fLastError.assign("Invalid event size");
-    return 0;
-  }
+	midasEvent->Clear();
+	memcpy((char*)midasEvent->GetEventHeader(),fReadBuffer.data(),sizeof(TMidas_EVENT_HEADER));
+	if(fDoByteSwap) {
+		printf("Swapping bytes\n");
+		midasEvent->SwapBytesEventHeader();
+	}
+	if(!midasEvent->IsGoodSize()) {
+		fLastErrno = -1;
+		fLastError.assign("Invalid event size");
+		return 0;
+	}
 
-  size_t event_size = midasEvent->GetDataSize();
-  size_t total_size = sizeof(TMidas_EVENT_HEADER) + event_size;
+	size_t event_size = midasEvent->GetDataSize();
+	size_t total_size = sizeof(TMidas_EVENT_HEADER) + event_size;
 
-  if(fReadBuffer.size() < total_size) {
-    ReadMoreBytes(total_size - fReadBuffer.size());
-  }
+	if(fReadBuffer.size() < total_size) {
+		ReadMoreBytes(total_size - fReadBuffer.size());
+	}
 
-  if(fReadBuffer.size() < total_size) {
-    return 0;
-  }
+	if(fReadBuffer.size() < total_size) {
+		return 0;
+	}
 
-  memcpy(midasEvent->GetData(), fReadBuffer.data() + sizeof(TMidas_EVENT_HEADER), event_size);
-  midasEvent->SwapBytes(false);
+	memcpy(midasEvent->GetData(), fReadBuffer.data() + sizeof(TMidas_EVENT_HEADER), event_size);
+	midasEvent->SwapBytes(false);
 
-  size_t bytes_read = fReadBuffer.size();
-  fBytesRead += bytes_read;
-  currentEventNumber++;
-  fReadBuffer.clear();
+	size_t bytes_read = fReadBuffer.size();
+	fBytesRead += bytes_read;
+	currentEventNumber++;
+	fReadBuffer.clear();
 
-  return bytes_read;
+	return bytes_read;
 }
 
 void TMidasFile::ReadMoreBytes(size_t bytes) {
-  size_t initial_size = fReadBuffer.size();
-  fReadBuffer.resize(initial_size + bytes);
-  size_t rd = 0;
-  if (fGzFile) {
+	size_t initial_size = fReadBuffer.size();
+	fReadBuffer.resize(initial_size + bytes);
+	size_t rd = 0;
+	if(fGzFile) {
 #ifdef HAVE_ZLIB
-    rd = gzread(*(gzFile*)fGzFile, fReadBuffer.data() + initial_size, bytes);
+		rd = gzread(*(gzFile*)fGzFile, fReadBuffer.data() + initial_size, bytes);
 #else
-    assert(!"Cannot get here");
+		assert(!"Cannot get here");
 #endif
-  } else {
-    rd = readpipe(fFile, fReadBuffer.data() + initial_size, bytes);
-  }
+	} else {
+		rd = readpipe(fFile, fReadBuffer.data() + initial_size, bytes);
+	}
 
-  fReadBuffer.resize(initial_size + rd);
+	fReadBuffer.resize(initial_size + rd);
 
-  if (rd == 0) {
-    fLastErrno = 0;
-    fLastError.assign("EOF");
-  } else if (rd != bytes) {
-    fLastErrno = errno;
-    fLastError.assign(std::strerror(errno));
-  }
+	if(rd == 0) {
+		fLastErrno = 0;
+		fLastError.assign("EOF");
+	} else if(rd != bytes) {
+		fLastErrno = errno;
+		fLastError.assign(std::strerror(errno));
+	}
 }
 
-void TMidasFile::FillBuffer(TMidasEvent *midasEvent, Option_t *opt){
-//Fills A buffer to be written to a midas file.
+void TMidasFile::FillBuffer(std::shared_ptr<TMidasEvent> midasEvent, Option_t *opt){
+	//Fills a buffer to be written to a midas file.
 
 
-   //Not the prettiest way to do this but it works.
-   //It seems to be filling in the wrong order of bits, but this does it correctly
-   //There is a byte swap happening at some point in this process. Might have to put something
-   //in here that protects against "Endian-ness"
-   fWriteBuffer.push_back((char)(midasEvent->GetEventId()&0xFF));
-   fWriteBuffer.push_back((char)(midasEvent->GetEventId() >> 8));
+	//Not the prettiest way to do this but it works.
+	//It seems to be filling in the wrong order of bits, but this does it correctly
+	//There is a byte swap happening at some point in this process. Might have to put something
+	//in here that protects against "Endian-ness"
+	fWriteBuffer.push_back((char)(midasEvent->GetEventId()&0xFF));
+	fWriteBuffer.push_back((char)(midasEvent->GetEventId() >> 8));
 
-   fWriteBuffer.push_back((char)(midasEvent->GetTriggerMask()&0xFF));
-   fWriteBuffer.push_back((char)(midasEvent->GetTriggerMask() >> 8));
+	fWriteBuffer.push_back((char)(midasEvent->GetTriggerMask()&0xFF));
+	fWriteBuffer.push_back((char)(midasEvent->GetTriggerMask() >> 8));
 
-   fWriteBuffer.push_back((char)(midasEvent->GetSerialNumber() & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetSerialNumber() >> 8) & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetSerialNumber() >> 16) & 0xFF));
-   fWriteBuffer.push_back((char)(midasEvent->GetSerialNumber() >> 24));
+	fWriteBuffer.push_back((char)(midasEvent->GetSerialNumber() & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetSerialNumber() >> 8) & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetSerialNumber() >> 16) & 0xFF));
+	fWriteBuffer.push_back((char)(midasEvent->GetSerialNumber() >> 24));
 
-   fWriteBuffer.push_back((char)(midasEvent->GetTimeStamp() & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetTimeStamp() >> 8) & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetTimeStamp() >> 16) & 0xFF));
-   fWriteBuffer.push_back((char)(midasEvent->GetTimeStamp() >> 24));
+	fWriteBuffer.push_back((char)(midasEvent->GetTimeStamp() & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetTimeStamp() >> 8) & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetTimeStamp() >> 16) & 0xFF));
+	fWriteBuffer.push_back((char)(midasEvent->GetTimeStamp() >> 24));
 
-   fWriteBuffer.push_back((char)(midasEvent->GetDataSize() & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetDataSize() >> 8) & 0xFF));
-   fWriteBuffer.push_back((char)((midasEvent->GetDataSize() >> 16) & 0xFF));
-   fWriteBuffer.push_back((char)(midasEvent->GetDataSize() >> 24));
+	fWriteBuffer.push_back((char)(midasEvent->GetDataSize() & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetDataSize() >> 8) & 0xFF));
+	fWriteBuffer.push_back((char)((midasEvent->GetDataSize() >> 16) & 0xFF));
+	fWriteBuffer.push_back((char)(midasEvent->GetDataSize() >> 24));
 
-   for(size_t i=0; i<midasEvent->GetDataSize();i++){
-      fWriteBuffer.push_back(midasEvent->GetData()[i]);
-   }
+	for(size_t i=0; i<midasEvent->GetDataSize();i++) {
+		fWriteBuffer.push_back(midasEvent->GetData()[i]);
+	}
 
-   fCurrentBufferSize += midasEvent->GetDataSize() + sizeof(TMidas_EVENT_HEADER);
+	fCurrentBufferSize += midasEvent->GetDataSize() + sizeof(TMidas_EVENT_HEADER);
 
-   if(fWriteBuffer.size() >  fMaxBufferSize)
-      WriteBuffer();
+	if(fWriteBuffer.size() >  fMaxBufferSize)
+		WriteBuffer();
 }
 
 bool TMidasFile::WriteBuffer(){
-   //Writes a buffer of TMidasEvents to the output file.
-   int wr = -2;
+	//Writes a buffer of TMidasEvents to the output file.
+	int wr = -2;
 
-   if (fOutGzFile){
-      #ifdef HAVE_ZLIB
-         wr = gzwrite(*(gzFile*)fOutGzFile, fWriteBuffer.data(), fCurrentBufferSize);
-      #else
-         assert(!"Cannot get here");
-      #endif
-   }
-   else{
-      wr = write(fOutFile, fWriteBuffer.data(), fCurrentBufferSize);
-   }
-   fCurrentBufferSize = 0;
-   fWriteBuffer.clear();
+	if(fOutGzFile) {
+#ifdef HAVE_ZLIB
+		wr = gzwrite(*(gzFile*)fOutGzFile, fWriteBuffer.data(), fCurrentBufferSize);
+#else
+		assert(!"Cannot get here");
+#endif
+	} else {
+		wr = write(fOutFile, fWriteBuffer.data(), fCurrentBufferSize);
+	}
+	fCurrentBufferSize = 0;
+	fWriteBuffer.clear();
 
-   return wr;
+	return wr;
 }
 
-bool TMidasFile::Write(TMidasEvent *midasEvent,Option_t *opt)
-{
-   //Writes an individual TMidasEvent to the output TMidasFile. This will
-   //write to a zipped file if the output file is defined as a zipped file.
-  int wr = -2;
+bool TMidasFile::Write(std::shared_ptr<TMidasEvent> midasEvent,Option_t *opt) {
+	//Writes an individual TMidasEvent to the output TMidasFile. This will
+	//write to a zipped file if the output file is defined as a zipped file.
+	int wr = -2;
 
-  if (fOutGzFile)
+	if(fOutGzFile) {
 #ifdef HAVE_ZLIB
-    wr = gzwrite(*(gzFile*)fOutGzFile, (char*)midasEvent->GetEventHeader(), sizeof(TMidas_EVENT_HEADER));
+		wr = gzwrite(*(gzFile*)fOutGzFile, (char*)midasEvent->GetEventHeader(), sizeof(TMidas_EVENT_HEADER));
 #else
-    assert(!"Cannot get here");
+	assert(!"Cannot get here");
 #endif
-  else
-    wr = write(fOutFile, (char*)midasEvent->GetEventHeader(), sizeof(TMidas_EVENT_HEADER));
+	} else {
+		wr = write(fOutFile, (char*)midasEvent->GetEventHeader(), sizeof(TMidas_EVENT_HEADER));
+	}
 
-  if(wr !=  sizeof(TMidas_EVENT_HEADER)){
-    printf("TMidasFile: error on write event header, return %i, size requested %lu\n",wr,sizeof(TMidas_EVENT_HEADER));
-    return false;
-  }
+	if(wr !=  sizeof(TMidas_EVENT_HEADER)) {
+		printf("TMidasFile: error on write event header, return %i, size requested %lu\n",wr,sizeof(TMidas_EVENT_HEADER));
+		return false;
+	}
 
-  if(strncmp(opt,"q",1)!=0)
-    printf("Written event header to outfile , return is %i\n",wr);
+	if(strncmp(opt,"q",1)!=0) {
+		printf("Written event header to outfile , return is %i\n",wr);
+	}
 
-  if (fOutGzFile)
+	if(fOutGzFile) {
 #ifdef HAVE_ZLIB
-    wr = gzwrite(*(gzFile*)fOutGzFile, (char*)midasEvent->GetData(), midasEvent->GetDataSize());
+		wr = gzwrite(*(gzFile*)fOutGzFile, (char*)midasEvent->GetData(), midasEvent->GetDataSize());
 #else
-    assert(!"Cannot get here");
+	assert(!"Cannot get here");
 #endif
-  else
-    wr = write(fOutFile, (char*)midasEvent->GetData(), midasEvent->GetDataSize());
+	} else {
+		wr = write(fOutFile, (char*)midasEvent->GetData(), midasEvent->GetDataSize());
+	}
 
-  if(strncmp(opt,"q",1)!=0)
-    printf("Written event to outfile , return is %d\n",wr);
+	if(strncmp(opt,"q",1)!=0) {
+		printf("Written event to outfile , return is %d\n",wr);
+	}
 
-  return wr;
+	return wr;
 }
 
 void TMidasFile::SetMaxBufferSize(int maxsize) {
-   //Sets the maximum buffer size for the TMidasEvents to be written to
-   //an output TMidasFile.
-   fMaxBufferSize = maxsize;
+	//Sets the maximum buffer size for the TMidasEvents to be written to
+	//an output TMidasFile.
+	fMaxBufferSize = maxsize;
 }
 
-void TMidasFile::Close()
-{
-   //Closes the input midas file. Use OutClose() to close the output
-   //Midas File.
-  if (fPoFile)
-    pclose((FILE*)fPoFile);
-  fPoFile = NULL;
+void TMidasFile::Close() {
+	//Closes the input midas file. Use OutClose() to close the output
+	//Midas File.
+	if(fPoFile) pclose((FILE*)fPoFile);
+	fPoFile = nullptr;
 #ifdef HAVE_ZLIB
-  if (fGzFile)
-    gzclose(*(gzFile*)fGzFile);
-  fGzFile = NULL;
+	if(fGzFile) gzclose(*(gzFile*)fGzFile);
+	fGzFile = nullptr;
 #endif
-  if (fFile > 0)
-    close(fFile);
+	if(fFile > 0) close(fFile);
 
-  fFile = -1;
-  fFilename = "";
+	fFile = -1;
+	fFilename = "";
 }
 
-void TMidasFile::OutClose()
-{
-   //Closes the output midas file. Use Close() to close the read-in midas file
+void TMidasFile::OutClose() {
+	//Closes the output midas file. Use Close() to close the read-in midas file
 
-   if(fWriteBuffer.size()){
-      WriteBuffer();
-   }
+	if(fWriteBuffer.size()) {
+		WriteBuffer();
+	}
 #ifdef HAVE_ZLIB
-  if (fOutGzFile) {
-    gzflush(*(gzFile*)fOutGzFile, Z_FULL_FLUSH);
-    gzclose(*(gzFile*)fOutGzFile);
-  }
-  fOutGzFile = NULL;
+	if(fOutGzFile) {
+		gzflush(*(gzFile*)fOutGzFile, Z_FULL_FLUSH);
+		gzclose(*(gzFile*)fOutGzFile);
+	}
+	fOutGzFile = nullptr;
 #endif
-  if (fOutFile > 0)
-    close(fOutFile);
-  fOutFile = -1;
-  fOutFilename = "";
+	if(fOutFile > 0) close(fOutFile);
+	fOutFile = -1;
+	fOutFilename = "";
 }
 
 
 int TMidasFile::GetRunNumber() {
-   //Parse the run number from the current TMidasFile. This assumes a format of
-   //run#####_###.mid or run#####.mid.
-   if(fFilename.length()==0) {
-      return 0;
-   }
-   std::size_t foundslash = fFilename.rfind('/');
-   std::size_t found = fFilename.rfind(".mid");
-   if(found == std::string::npos) {
-      return 0;
-   }
-   std::size_t found2 = fFilename.rfind('-');
-   if((found2 < foundslash && foundslash != std::string::npos) || found2 == std::string::npos)
-      found2 = fFilename.rfind('_');
-//   printf("found 2 = %i\n",found2);
-   if(found2 < foundslash && foundslash != std::string::npos)
-      found2 = std::string::npos;
-   std::string temp;
-   if(found2 == std::string::npos || fFilename.compare(found2+4,4,".mid") !=0 ) {
-      temp = fFilename.substr(found-5,5);
-   }
-   else {
-      temp = fFilename.substr(found-9,5);
-   }
-   //printf(" %s \t %i \n",temp.c_str(),atoi(temp.c_str()));
-   return atoi(temp.c_str());
+	//Parse the run number from the current TMidasFile. This assumes a format of
+	//run#####_###.mid or run#####.mid.
+	if(fFilename.length()==0) {
+		return 0;
+	}
+	std::size_t foundslash = fFilename.rfind('/');
+	std::size_t found = fFilename.rfind(".mid");
+	if(found == std::string::npos) {
+		return 0;
+	}
+	std::size_t found2 = fFilename.rfind('-');
+	if((found2 < foundslash && foundslash != std::string::npos) || found2 == std::string::npos) {
+		found2 = fFilename.rfind('_');
+	}
+	//   printf("found 2 = %i\n",found2);
+	if(found2 < foundslash && foundslash != std::string::npos) {
+		found2 = std::string::npos;
+	}
+	std::string temp;
+	if(found2 == std::string::npos || fFilename.compare(found2+4,4,".mid") !=0 ) {
+		temp = fFilename.substr(found-5,5);
+	} else {
+		temp = fFilename.substr(found-9,5);
+	}
+	//printf(" %s \t %i \n",temp.c_str(),atoi(temp.c_str()));
+	return atoi(temp.c_str());
 }
 
 
 int TMidasFile::GetSubRunNumber()	{
-   //Parse the sub run number from the current TMidasFile. This assumes a format of
-   //run#####_###.mid or run#####.mid.
-   if(fFilename.length()==0)
-      return -1;
-   std::size_t foundslash = fFilename.rfind('/');
-   std::size_t found = fFilename.rfind("-");
-   if((found < foundslash && foundslash != std::string::npos) || found == std::string::npos)
-      found = fFilename.rfind('_');
-   if(found < foundslash && foundslash != std::string::npos)
-      found = std::string::npos;
-   if(found != std::string::npos) {
-      std::string temp = fFilename.substr(found+1,3);
-      //printf("%i \n",atoi(temp.c_str()));
-      return atoi(temp.c_str());
-   }
-   return -1;
+	//Parse the sub run number from the current TMidasFile. This assumes a format of
+	//run#####_###.mid or run#####.mid.
+	if(fFilename.length() == 0) return -1;
+	std::size_t foundslash = fFilename.rfind('/');
+	std::size_t found = fFilename.rfind("-");
+	if((found < foundslash && foundslash != std::string::npos) || found == std::string::npos) {
+		found = fFilename.rfind('_');
+	}
+	if(found < foundslash && foundslash != std::string::npos) {
+		found = std::string::npos;
+	}
+	if(found != std::string::npos) {
+		std::string temp = fFilename.substr(found+1,3);
+		//printf("%i \n",atoi(temp.c_str()));
+		return atoi(temp.c_str());
+	}
+	return -1;
 }
-
-
-
-
-
-
-
-
-
 
 // end

--- a/libraries/TMidas/TXMLOdb.cxx
+++ b/libraries/TMidas/TXMLOdb.cxx
@@ -1,12 +1,14 @@
-#ifdef HASXML
+#ifdef HAS_XML
 #include "TXMLOdb.h"
 
 #include "TList.h"
 #include "TXMLAttr.h"
 
+ClassImp(TXMLOdb)
+
 char TXMLOdb::fTextBuffer[256];
 
-TXMLOdb::TXMLOdb(char* buffer,int size)   {
+TXMLOdb::TXMLOdb(char* buffer,int size) {
    fOdb = 0;
    fDoc = 0;
    std::ifstream input;
@@ -29,9 +31,7 @@ TXMLOdb::TXMLOdb(char* buffer,int size)   {
       fprintf(stderr,"XmlOdb::XmlOdb: Malformed ODB dump: cannot find <odb> tag\n");
       return;
    }  
-   
 }
-
 
 TXMLOdb::~TXMLOdb()  {
    if(fParser)

--- a/makefile
+++ b/makefile
@@ -72,13 +72,16 @@ CFLAGS    += -MMD -MP $(INCLUDES)
 LINKFLAGS += -Llib $(addprefix -l,$(LIBRARY_NAMES)) -Wl,-rpath,\$$ORIGIN/../lib
 LINKFLAGS += $(shell root-config --glibs) -lSpectrum -lPyROOT -lMinuit -lGuiHtml -lTreePlayer -lX11 -lXpm -lProof
 
+# RCFLAGS are being used for rootcint
 ifeq ($(MATHMORE_INSTALLED),yes)
   CFLAGS += -DHAS_MATHMORE
+  RCFLAGS += -DHAS_MATHMORE
   LINKFLAGS += -lMathMore
 endif
 
 ifeq ($(XML_INSTALLED),yes)
-  CFLAGS += -DHASXML
+  CFLAGS += -DHAS_XML
+  RCFLAGS += -DHAS_XML
   LINKFLAGS += -lXMLParser -lXMLIO
 endif
 
@@ -190,7 +193,7 @@ find_linkdef = $(shell $(FIND) $(1) -name "*LinkDef.h")
 define library_template
 .build/$(1)/$(notdir $(1))Dict.cxx: $(1)/LinkDef.h $$(call dict_header_files,$(1)/LinkDef.h) 
 	@mkdir -p $$(dir $$@)
-	$$(call run_and_test,rootcint -f $$@ -c $$(INCLUDES) -p $$(notdir $$(filter-out $$<,$$^)) $$<,$$@,$$(COM_COLOR),$$(BLD_STRING) ,$$(OBJ_COLOR))
+	$$(call run_and_test,rootcint -f $$@ -c $$(INCLUDES) $$(RCFLAGS) -p $$(notdir $$(filter-out $$<,$$^)) $$<,$$@,$$(COM_COLOR),$$(BLD_STRING) ,$$(OBJ_COLOR))
 
 .build/$(1)/LibDictionary.o: .build/$(1)/$(notdir $(1))Dict.cxx
 	$$(call run_and_test,$$(CPP) -fPIC -c $$< -o $$@ $$(CFLAGS),$$@,$$(COM_COLOR),$$(COM_STRING),$$(OBJ_COLOR) )

--- a/util/bufferclean.cxx
+++ b/util/bufferclean.cxx
@@ -13,7 +13,7 @@
 
 UInt_t chanId_threshold = 100;
 
-Bool_t CheckEvent(TMidasEvent *evt){
+Bool_t CheckEvent(std::shared_ptr<TMidasEvent> evt){
    //This function does not work if a Midas event contains multiple fragments
    static std::map<Int_t, Bool_t> triggermap; //Map of Digitizer vs have we had a triggerId < threshold yet?
    //First parse the  Midas Event.
@@ -106,12 +106,12 @@ Bool_t CheckEvent(TMidasEvent *evt){
 }
 
 
-/*void AddToQueue(TMidasEvent* evt){
+/*void AddToQueue(std::shared_ptr<TMidasEvent> evt){
    evtQ.push(evt);
 }
 */
 
-void Write(TMidasEvent *evt,TMidasFile *outfile){
+void Write(std::shared_ptr<TMidasEvent> evt, TMidasFile *outfile){
    outfile->FillBuffer(evt);
 
   // if(outfile->GetBufferSize() > 100000){
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
 
    UInt_t num_bad_evt =0;
    UInt_t num_evt =0;
-   TMidasEvent *event = new TMidasEvent;//need to new for each event
+	std::shared_ptr<TMidasEvent> event = std::make_shared<TMidasEvent>();//need to new for each event
 
    while(true) {
       bytes = file->Read(event);
@@ -218,5 +218,5 @@ int main(int argc, char **argv) {
    //delete outfile;
 
 }
-//void WriteEventToFile(TMidasFile*,TMidasEvent*,Option_t);
+//void WriteEventToFile(TMidasFile*,std::shared_ptr<TMidasEvent> Option_t);
 

--- a/util/offsetadd.cxx
+++ b/util/offsetadd.cxx
@@ -6,9 +6,9 @@
 
 #include <iostream>
 
-//void WriteEventToFile(TMidasFile*,TMidasEvent*,Option_t);
+//void WriteEventToFile(TMidasFile*,std::shared_ptr<TMidasEvent>,Option_t);
 
-void ProcessEvent(TMidasEvent*,TMidasFile*);
+void ProcessEvent(std::shared_ptr<TMidasEvent>,TMidasFile*);
 
 int main(int argc, char **argv) {
 
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 
    TMidasFile *infile  = new TMidasFile;
    TMidasFile *outfile = new TMidasFile;
-   TMidasEvent *event  = new TMidasEvent;
+	std::shared_ptr<TMidasEvent> event = std::make_shared<TMidasEvent>();
    
    if(argv[1] == argv[2]){
       printf("ERROR: Cannot overwrite midas file %s\n",argv[1]);
@@ -51,12 +51,12 @@ int main(int argc, char **argv) {
 }
 
 
-//void WriteEventToFile(TMidasFile *outfile,TMidasEvent *event) {
+//void WriteEventToFile(TMidasFile *outfile,std::shared_ptr<TMidasEvent> event) {
 //   outfile->Write(event);
 //}
 
 
-void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
+void ProcessEvent(std::shared_ptr<TMidasEvent> event,TMidasFile *outfile) {
    if(event->GetEventId() !=1 ) {
       outfile->Write(event,"q");
       return;
@@ -167,10 +167,10 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
 //   event->Print("a");
 //   printf(RESET_COLOR);
 
-   TMidasEvent copyevent = *event;
-   copyevent.SetBankList();
+	std::shared_ptr<TMidasEvent> copyevent = std::make_shared<TMidasEvent>(*event);
+   copyevent->SetBankList();
 
-   banksize = copyevent.LocateBank(NULL,"GRF1",&ptr);
+   banksize = copyevent->LocateBank(NULL,"GRF1",&ptr);
    for(int x=0;x<banksize;x++) {
       value = *((int*)ptr+x);
       type  = value & 0xf0000000; 
@@ -198,10 +198,10 @@ void ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    }
    //printf("===================\n");
 
-   outfile->Write(&copyevent,"q");
+   outfile->Write(copyevent,"q");
 
 //   printf(DBLUE);
-//   copyevent.Print("a");
+//   copyevent->Print("a");
 //   printf(RESET_COLOR);
 
 }

--- a/util/offsetfind.cxx
+++ b/util/offsetfind.cxx
@@ -1,13 +1,13 @@
 //g++ offsetfind.cxx `root-config --cflags --libs` -I${GRSISYS}/include -L${GRSISYS}/libraries -lMidasFormat -lXMLParser  -ooffsetfind
 
 
-#include"TMidasFile.h"
-#include"TMidasEvent.h"
-#include"GFile.h"
-#include"TFragment.h"
-#include"TTree.h"
-#include"TChannel.h"
-#include"TH2D.h"
+#include "TMidasFile.h"
+#include "TMidasEvent.h"
+#include "GFile.h"
+#include "TFragment.h"
+#include "TTree.h"
+#include "TChannel.h"
+#include "TH2D.h"
 #include "TTreeIndex.h"
 #include "TVirtualIndex.h"
 #include "Globals.h"
@@ -16,16 +16,13 @@
 #include "TString.h"
 #include "TPolyMarker.h"
 
-#include<TMidasFile.h>
-#include<TMidasEvent.h>
-#include<vector>
-
+#include <vector>
 #include <iostream>
 
 
 class TEventTime {
    public: 
-      TEventTime(TMidasEvent* event){
+      TEventTime(std::shared_ptr<TMidasEvent> event){
          event->SetBankList();
   
          void *ptr;
@@ -146,7 +143,7 @@ std::map<int,int> TEventTime::digmap;
 int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
    int events_read = 0;
    const int total_events = 1E7;
-   TMidasEvent *event  = new TMidasEvent;
+	std::shared_ptr<TMidasEvent> event = std::make_shared<TMidasEvent>();
    eventQ->reserve(total_events);
 
    while(infile->Read(event)>0 && eventQ->size()<total_events) {
@@ -175,7 +172,6 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
    }
    TEventTime::OrderDigitizerMap();
    printf("\n");
-   delete event;
    return 0;
 }
 

--- a/util/offsetfix.cxx
+++ b/util/offsetfix.cxx
@@ -1,14 +1,15 @@
 //g++ offsetfind.cxx `root-config --cflags --libs` -I${GRSISYS}/include -L${GRSISYS}/libraries -lMidasFormat -lXMLParser -lSpectrum  -ooffsetfind
 
 
-#include"TMidasFile.h"
-#include"TMidasEvent.h"
-#include"TFile.h"
-#include"TFragment.h"
-#include"TTree.h"
-#include"TSpectrum.h"
-#include"TChannel.h"
-#include"TH2D.h"
+#include "TMidasFile.h"
+#include "TMidasEvent.h"
+#include "TFile.h"
+#include "TFragment.h"
+#include "TDataParser.h"
+#include "TTree.h"
+#include "TSpectrum.h"
+#include "TChannel.h"
+#include "TH2D.h"
 #include "TTreeIndex.h"
 #include "TVirtualIndex.h"
 #include "Globals.h"
@@ -19,11 +20,7 @@
 #include "TStopwatch.h"
 #include "TSystem.h"
 
-#include<TMidasFile.h>
-#include<TMidasEvent.h>
-#include<vector>
-#include<TDataParser.h>
-
+#include <vector>
 #include <iostream>
 #include <fstream>
 
@@ -32,7 +29,7 @@ Bool_t SplitMezz = false;
 
 class TEventTime {
    public: 
-      TEventTime(TMidasEvent* event){
+      TEventTime(std::shared_ptr<TMidasEvent> event){
          event->SetBankList();
   
          void *ptr;
@@ -217,7 +214,7 @@ std::map<uint32_t,int> TEventTime::digmap;
 std::map<uint32_t,bool> TEventTime::digset;
 std::map<uint32_t,int64_t> TEventTime::correctionmap;
 
-void PrintError(TMidasEvent *event, int frags,bool verb){
+void PrintError(std::shared_ptr<TMidasEvent> event, int frags,bool verb){
    if(verb){
       printf(DRED "\n//**********************************************//" RESET_COLOR "\n");
       printf(DRED "\nBad things are happening. Failed on datum %i" RESET_COLOR "\n", (-1*frags));
@@ -231,7 +228,7 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
    const int total_events = 1E6;
    //const int event_start = 1E5;
    const int event_start = 1E5;
-   TMidasEvent *event  = new TMidasEvent;
+	std::shared_ptr<TMidasEvent> event  = std::make_shared<TMidasEvent>();
    eventQ->reserve(total_events);
    void *ptr;
    int banksize;
@@ -289,7 +286,6 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
    }
    TEventTime::OrderDigitizerMap();
    printf("\n");
-   delete event;
    return 0;
 }
 
@@ -568,7 +564,7 @@ void GetTimeDiff(std::vector<TEventTime*> *eventQ){
 
 }
 
-bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
+bool ProcessEvent(std::shared_ptr<TMidasEvent> event,TMidasFile *outfile) {
    if(event->GetEventId() !=1 ) {
       outfile->FillBuffer(event);
       return false;
@@ -677,12 +673,12 @@ bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
 //   event->Print("a");
 //   printf(RESET_COLOR);
 
-   TMidasEvent copyevent = *event;
-   copyevent.SetBankList();
+	std::shared_ptr<TMidasEvent> copyevent = std::make_shared<TMidasEvent>(*event);
+   copyevent->SetBankList();
 
-   banksize = copyevent.LocateBank(NULL,"GRF2",&ptr);
+   banksize = copyevent->LocateBank(NULL,"GRF2",&ptr);
    if(!banksize)
-      banksize = copyevent.LocateBank(NULL,"GRF1",&ptr);
+      banksize = copyevent->LocateBank(NULL,"GRF1",&ptr);
 
    for(int x=0;x<banksize;x++) {
       value = *((int*)ptr+x);
@@ -711,7 +707,7 @@ bool ProcessEvent(TMidasEvent *event,TMidasFile *outfile) {
    }
    //printf("===================\n");
 
-   outfile->FillBuffer(&copyevent);
+   outfile->FillBuffer(copyevent);
 
 //   printf(DBLUE);
 //   copyevent.Print("a");
@@ -734,7 +730,7 @@ void WriteEvents(TMidasFile* file) {
    TStopwatch w;
    w.Start();
 
-   TMidasEvent* event = new TMidasEvent;
+	std::shared_ptr<TMidasEvent> event = std::make_shared<TMidasEvent>();
 
    while(true) {
       bytes = file->Read(event);
@@ -774,7 +770,6 @@ void WriteEvents(TMidasFile* file) {
    }
    printf("\n");
    
-   delete event;
    file->WriteBuffer();
 
 }


### PR DESCRIPTION
The changes we had made to make grsisort work on a computer with root that has no XML support compiled in, broke compiling grsisort on a computer with root that has XML support. The missing -DHAS_XML flag was not passed on to rootcint, leading it to believe that there is no TXMLOdb class. I've fixed this by using a new RCFLAGS variable in the makefile to pass defines to rootcint.