### PR TITLE
Added GHSym and option to split/compress large matrices to Root2Rad

### DIFF
--- a/util/Root2Rad.cxx
+++ b/util/Root2Rad.cxx
@@ -62,6 +62,7 @@ struct SpeHeader {
 //the value of all bins in int sizes
 //an integer os bin size * 4           ------- number of char in the histogram.
 
+void AddToList(TList*, TH2*, bool, bool);
 void WriteHist(TH1*, std::fstream*);
 void WriteMat(TH2*, std::fstream*);
 void WriteM4b(TH2*, std::fstream*);
@@ -69,8 +70,17 @@ void WriteM4b(TH2*, std::fstream*);
 int main(int argc, char** argv) {	
 	TFile *infile = new TFile();	
 	if(argc < 2  || !(infile = TFile::Open(argv[1],"read")) )	{
-		printf ( "problem opening file.\nUsage: Root2Rad file.root\n");
+		std::cout<<"problem opening file."<<std::endl
+			      <<"Usage: "<<argv[0]<<" file.root (optional: -s to split large matrices, -c to compress large matrices)"<<std::endl;
 		return 1;
+	}
+
+	bool split = false;
+	bool compress = false;
+	for(int i = 2; i < argc; ++i) {
+		if(strcmp(argv[i], "-s") == 0) split = true;
+		else if(strcmp(argv[i], "-c") == 0) compress = true;
+		else std::cout<<"Unrecognized flag "<<argv[i]<<std::endl;
 	}
 
 	std::string path = infile->GetName();
@@ -86,7 +96,6 @@ int main(int argc, char** argv) {
 		mkdir(path.c_str(),0755);
 	}
 
-
 	//std::string outfilename = infile->GetName();
 	//outfilename.erase(outfilename.find_last_of('.'));
 	//outfilename.append(".spe");
@@ -96,9 +105,9 @@ int main(int argc, char** argv) {
 	TList* keys = infile->GetListOfKeys();
 	keys->Sort();
 	TIter next(keys);
-	TList* histstowrite = new TList();
-	TList* matstowrite = new TList();
-	TList* m4bstowrite = new TList();
+	TList* histsToWrite = new TList();
+	TList* matsToWrite = new TList();
+	TList* m4bsToWrite = new TList();
 	//int counter = 1;
 	while(TKey* currentkey = static_cast<TKey*>(next())) {
 		std::string keytype = currentkey->ReadObj()->IsA()->GetName();
@@ -106,27 +115,27 @@ int main(int argc, char** argv) {
 			//printf("%i currentkey->GetName() = %s\n",counter++, currentkey->GetName());
 			//if((counter-1)%4==0)
 			//	printf("*****************************\n");
-			histstowrite->Add(currentkey->ReadObj());
+			histsToWrite->Add(currentkey->ReadObj());
 		} else if(keytype.compare(0, 4, "TH2C") == 0 || keytype.compare(0, 4, "TH2S") == 0){
-			matstowrite->Add(currentkey->ReadObj());
+			AddToList(matsToWrite, static_cast<TH2*>(currentkey->ReadObj()), split, compress);
 		} else if(keytype.compare(0, 3, "TH2") == 0) {
-			m4bstowrite->Add(currentkey->ReadObj());
+			AddToList(m4bsToWrite, static_cast<TH2*>(currentkey->ReadObj()), split, compress);
 		} else if(keytype.compare(0, 3, "THn") == 0) {
 			THnSparse* hist = ((THnSparse*) (currentkey->ReadObj()));
 			if(hist->GetNdimensions() == 1) {
-				histstowrite->Add(hist->Projection(0));
+				histsToWrite->Add(hist->Projection(0));
 			} else if(hist->GetNdimensions() == 2) {
 				if(keytype.compare(17, 1, "C") == 0 || keytype.compare(17, 1, "S") == 0) {
-					matstowrite->Add(hist->Projection(0,1));
+					AddToList(matsToWrite, hist->Projection(0,1), split, compress);
 				} else {
-					m4bstowrite->Add(hist->Projection(0,1));
+					AddToList(m4bsToWrite, hist->Projection(0,1), split, compress);
 				}
 			}
 		} else if(keytype.compare(0, 5, "GHSym") == 0) {
 			if(keytype.compare(5, 1, "F") == 0) {
-				m4bstowrite->Add(static_cast<GHSymF*>(currentkey->ReadObj())->GetMatrix());
+				AddToList(m4bsToWrite, static_cast<GHSymF*>(currentkey->ReadObj())->GetMatrix(), split, compress);
 			} else if(keytype.compare(5, 1, "D") == 0) {
-				m4bstowrite->Add(static_cast<GHSymD*>(currentkey->ReadObj())->GetMatrix());
+				AddToList(m4bsToWrite, static_cast<GHSymF*>(currentkey->ReadObj())->GetMatrix(), split, compress);
 			} else {
 				std::cout<<"unknown GHSym type "<<keytype<<std::endl;
 			}
@@ -135,9 +144,9 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	//printf("histstowrite->GetSize() = %i\n", histstowrite->GetSize());
+	//printf("histsToWrite->GetSize() = %i\n", histsToWrite->GetSize());
 
-	TIter nexthist(histstowrite);
+	TIter nexthist(histsToWrite);
 	while(TH1* currenthist = static_cast<TH1*>(nexthist())) {
 		std::string outfilename = path + "/";
 		outfilename.append(currenthist->GetName());
@@ -150,7 +159,7 @@ int main(int argc, char** argv) {
 	}
 
 
-	TIter nextmat(matstowrite);
+	TIter nextmat(matsToWrite);
 	while(TH2* currentmat = static_cast<TH2*>(nextmat())) {
 		std::string outfilename = path + "/";
 		outfilename.append(currentmat->GetName());
@@ -163,7 +172,7 @@ int main(int argc, char** argv) {
 	}
 
 
-	TIter nextm4b(m4bstowrite);
+	TIter nextm4b(m4bsToWrite);
 	while(TH2* currentm4b = static_cast<TH2*>(nextm4b())) {
 		std::string outfilename = path + "/";
 		outfilename.append(currentm4b->GetName());
@@ -179,6 +188,56 @@ int main(int argc, char** argv) {
 	//outfile.close();
 
 	return 0;
+}
+
+void AddToList(TList* list, TH2* hist, bool split, bool compress) {
+	if((!split && !compress) || hist->GetXaxis()->GetNbins() <= 4096) {
+		list->Add(hist);
+		return;
+	} else if(split && compress) {
+		TH2* splitHist = static_cast<TH2*>(hist->IsA()->New());
+		splitHist->SetBins(4096, 0., 4096., 4096, 0., 4096.);
+		splitHist->SetName(Form("%s_low", hist->GetName()));
+		for(int binx = 1; binx <= 4096; ++binx) {
+			for(int biny = 1; biny <= 4096; ++biny) {
+				// ignore overflow cells
+				if(binx <= hist->GetXaxis()->GetNbins() && biny <= hist->GetYaxis()->GetNbins()) {
+					splitHist->SetBinContent(binx, biny, hist->GetBinContent(binx, biny));
+				}
+			}
+		}
+		list->Add(splitHist);
+		int rebin = (hist->GetXaxis()->GetNbins() + 4095)/4096;
+		std::cout<<"rebinning "<<hist->GetName()<<" by "<<rebin<<std::endl;
+		list->Add(hist->Rebin2D(rebin, rebin));
+		return;
+	} else if(split) {
+		int nofSplits = (hist->GetXaxis()->GetNbins() + 4095)/4096;
+		TH2* splitHist = static_cast<TH2*>(hist->IsA()->New());
+		splitHist->SetBins(4096, 0., 4096., 4096, 0., 4096.);
+		for(int i = 0; i < nofSplits; ++i) {
+			for(int j = 0; j <= i; ++j) {
+				std::cout<<hist->GetName()<<": x = "<<i*4096<<" - "<<(i+1)*4096<<", y = "<<j*4096<<" - "<<(j+1)*4096<<std::endl;
+				splitHist->Reset();
+				splitHist->SetName(Form("%s_%d_%d", hist->GetName(), i, j));
+				for(int binx = 1; binx <= 4096; ++binx) {
+					for(int biny = 1; biny <= 4096; ++biny) {
+						// ignore overflow cells
+						if(i*4096 + binx <= hist->GetXaxis()->GetNbins() && j*4096 + biny <= hist->GetYaxis()->GetNbins()) {
+							splitHist->SetBinContent(binx, biny, hist->GetBinContent(i*4096 + binx, j*4096 + biny));
+						}
+					}
+				}
+				list->Add(splitHist->Clone(Form("%s_%d_%d", hist->GetName(), i, j)));
+			}
+		}
+		return;
+	} 
+	// only option left now is compress
+	int rebin = (hist->GetXaxis()->GetNbins() + 4095)/4096;
+	std::cout<<"rebinning "<<hist->GetName()<<" by "<<rebin<<std::endl;
+	hist->SetName(Form("%s_rebin%d", hist->GetName(), rebin));
+	list->Add(hist->Rebin2D(rebin, rebin));
 }
 
 void WriteMat(TH2 *mat, std::fstream *outfile) {

--- a/util/Root2Rad.cxx
+++ b/util/Root2Rad.cxx
@@ -25,35 +25,36 @@
 
 
 
-#include<stdint.h>
-#include<fstream>
-#include<iostream>
+#include <stdint.h>
+#include <fstream>
+#include <iostream>
 
-#include<string.h>
-
-#include<TFile.h>
-#include<TH1.h>
-#include<TH2.h>
-#include<TSystem.h>
-#include<TList.h>
-#include<TClass.h>
-#include<TKey.h>
-#include<TTimeStamp.h>
-#include "THnSparse.h"
+#include <string.h>
 
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TSystem.h"
+#include "TList.h"
+#include "TClass.h"
+#include "TKey.h"
+#include "TTimeStamp.h"
+#include "THnSparse.h"
+
 #include "Globals.h"
+#include "GHSym.h"
 
 struct SpeHeader {
-  int32_t buffsize;          /*fortran file, each record starts with record size */            // 14
-  char label[8]; 
-  int32_t size;
-  int32_t junk1;
-  int32_t junk2;
-  int32_t junk3;
-  int32_t buffcheck;         /*fortran file, record ends with record size :) */                // 14
+	int32_t buffsize;          /*fortran file, each record starts with record size */            // 14
+	char label[8]; 
+	int32_t size;
+	int32_t junk1;
+	int32_t junk2;
+	int32_t junk3;
+	int32_t buffcheck;         /*fortran file, record ends with record size :) */                // 14
 } __attribute__((packed));
 
 
@@ -65,27 +66,25 @@ void WriteHist(TH1*, std::fstream*);
 void WriteMat(TH2*, std::fstream*);
 void WriteM4b(TH2*, std::fstream*);
 
-int main(int argc, char** argv)	{	
-
-
+int main(int argc, char** argv) {	
 	TFile *infile = new TFile();	
 	if(argc < 2  || !(infile = TFile::Open(argv[1],"read")) )	{
 		printf ( "problem opening file.\nUsage: Root2Rad file.root\n");
 		return 1;
 	}
 
-   std::string path = infile->GetName();
-   path.erase(path.find_last_of('.'));
+	std::string path = infile->GetName();
+	path.erase(path.find_last_of('.'));
 
 #ifdef OS_DARWIN
-   struct stat st = {0,0,0,0,0,0,0,{0,0},{0,0},{0,0},{0,0},0,0,0,0,0,0,{0}};
+	struct stat st = {0,0,0,0,0,0,0,{0,0},{0,0},{0,0},{0,0},0,0,0,0,0,0,{0}};
 #else
-   struct stat st = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+	struct stat st = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 #endif
 
-   if(stat(path.c_str(),&st)==-1) {
-      mkdir(path.c_str(),0755);
-   }
+	if(stat(path.c_str(),&st)==-1) {
+		mkdir(path.c_str(),0755);
+	}
 
 
 	//std::string outfilename = infile->GetName();
@@ -93,44 +92,54 @@ int main(int argc, char** argv)	{
 	//outfilename.append(".spe");
 	//std::fstream outfile;
 	//outfile.open(outfilename.c_str(), std::ios::out | std::ios::binary);
-	
-	TList *keys = infile->GetListOfKeys();
+
+	TList* keys = infile->GetListOfKeys();
 	keys->Sort();
 	TIter next(keys);
-	TList *histstowrite = new TList();
-	TList *matstowrite = new TList();
-   TList *m4bstowrite = new TList();
+	TList* histstowrite = new TList();
+	TList* matstowrite = new TList();
+	TList* m4bstowrite = new TList();
 	//int counter = 1;
-	while( TKey *currentkey = (TKey*)next() ) {
+	while(TKey* currentkey = static_cast<TKey*>(next())) {
 		std::string keytype = currentkey->ReadObj()->IsA()->GetName();
-		if(keytype.compare(0,3,"TH1")==0)	{
+		if(keytype.compare(0, 3, "TH1") == 0) {
 			//printf("%i currentkey->GetName() = %s\n",counter++, currentkey->GetName());
 			//if((counter-1)%4==0)
 			//	printf("*****************************\n");
 			histstowrite->Add(currentkey->ReadObj());
-      } else if(keytype.compare(0,4,"TH2C")==0 || keytype.compare(0,4,"TH2S")==0){
-         matstowrite->Add(currentkey->ReadObj());
-		} else if(keytype.compare(0,3,"TH2")==0) {
-         m4bstowrite->Add(currentkey->ReadObj());
-		} else if(keytype.compare(0,3,"THn")==0) {
-         THnSparse* hist = ((THnSparse*) (currentkey->ReadObj()));
-         if(hist->GetNdimensions() == 1) {
-			   histstowrite->Add(hist->Projection(0));
-         } else if(hist->GetNdimensions() == 2) {
-		      if(keytype.compare(17,1,"C")==0 || keytype.compare(17,1,"S")==0) {
-               matstowrite->Add(hist->Projection(0,1));
-            } else {
-               m4bstowrite->Add(hist->Projection(0,1));
-            }
-         }
-      }
+		} else if(keytype.compare(0, 4, "TH2C") == 0 || keytype.compare(0, 4, "TH2S") == 0){
+			matstowrite->Add(currentkey->ReadObj());
+		} else if(keytype.compare(0, 3, "TH2") == 0) {
+			m4bstowrite->Add(currentkey->ReadObj());
+		} else if(keytype.compare(0, 3, "THn") == 0) {
+			THnSparse* hist = ((THnSparse*) (currentkey->ReadObj()));
+			if(hist->GetNdimensions() == 1) {
+				histstowrite->Add(hist->Projection(0));
+			} else if(hist->GetNdimensions() == 2) {
+				if(keytype.compare(17, 1, "C") == 0 || keytype.compare(17, 1, "S") == 0) {
+					matstowrite->Add(hist->Projection(0,1));
+				} else {
+					m4bstowrite->Add(hist->Projection(0,1));
+				}
+			}
+		} else if(keytype.compare(0, 5, "GHSym") == 0) {
+			if(keytype.compare(5, 1, "F") == 0) {
+				m4bstowrite->Add(static_cast<GHSymF*>(currentkey->ReadObj())->GetMatrix());
+			} else if(keytype.compare(5, 1, "D") == 0) {
+				m4bstowrite->Add(static_cast<GHSymD*>(currentkey->ReadObj())->GetMatrix());
+			} else {
+				std::cout<<"unknown GHSym type "<<keytype<<std::endl;
+			}
+		} else {
+			std::cout<<"skipping "<<keytype<<std::endl;
+		}
 	}
 
 	//printf("histstowrite->GetSize() = %i\n", histstowrite->GetSize());
-	
+
 	TIter nexthist(histstowrite);
-	while( TH1 *currenthist = (TH1*)nexthist() ) {
-      std::string outfilename = path + "/";
+	while(TH1* currenthist = static_cast<TH1*>(nexthist())) {
+		std::string outfilename = path + "/";
 		outfilename.append(currenthist->GetName());
 		outfilename.append(".spe");
 		std::fstream outfile;
@@ -142,27 +151,27 @@ int main(int argc, char** argv)	{
 
 
 	TIter nextmat(matstowrite);
-	while( TH2 *currentmat = (TH2*)nextmat() ) {
-      std::string outfilename = path + "/";
+	while(TH2* currentmat = static_cast<TH2*>(nextmat())) {
+		std::string outfilename = path + "/";
 		outfilename.append(currentmat->GetName());
 		outfilename.append(".mat");
 		std::fstream outfile;
 		outfile.open(outfilename.c_str(), std::ios::out | std::ios::binary);
 		WriteMat(currentmat, &outfile);
-		printf("\t%s written to file %s.\n",currentmat->GetName(),outfilename.c_str());
+		printf("\t%s written to file %s.\n", currentmat->GetName(), outfilename.c_str());
 		outfile.close();
 	}
 
 
 	TIter nextm4b(m4bstowrite);
-	while( TH2 *currentm4b = (TH2*)nextm4b() ) {
-      std::string outfilename = path + "/";
+	while(TH2* currentm4b = static_cast<TH2*>(nextm4b())) {
+		std::string outfilename = path + "/";
 		outfilename.append(currentm4b->GetName());
 		outfilename.append(".m4b");
 		std::fstream outfile;
 		outfile.open(outfilename.c_str(), std::ios::out | std::ios::binary);
 		WriteM4b(currentm4b, &outfile);
-		printf("\t%s written to file %s.\n",currentm4b->GetName(),outfilename.c_str());
+		printf("\t%s written to file %s.\n", currentm4b->GetName(), outfilename.c_str());
 		outfile.close();
 	}
 
@@ -173,105 +182,86 @@ int main(int argc, char** argv)	{
 }
 
 void WriteMat(TH2 *mat, std::fstream *outfile) {
-   int xbins = mat->GetXaxis()->GetNbins();
-   int ybins = mat->GetYaxis()->GetNbins();
-   
-	TH1D *empty = new TH1D("empty","empty",4096,0,4096);
+	int xbins = mat->GetXaxis()->GetNbins();
+	int ybins = mat->GetYaxis()->GetNbins();
 
-   for(int y=1;y<=4096;y++ ) {
-      uint16_t buffer[4096] = {0};
-		TH1D *proj;
-		if(y<=ybins)
-			proj = mat->ProjectionX("proj",y,y);
-		else
-			proj = empty;
-      for(int x=1;x<=4096;x++ ) {
-         if(x<=xbins)
-            buffer[x-1] = (uint16_t)(proj->GetBinContent(x));//    mat->GetBinContent(x,y));
-         else
-            buffer[x-1] = 0;
-      }
-   	outfile->write((char*)(&buffer),sizeof(buffer));	
-   }
-   delete empty;
+	TH1D* empty = new TH1D("empty", "empty", 4096, 0., 4096.);
+
+	for(int y = 1; y <= 4096; ++y) {
+		uint16_t buffer[4096] = {0};
+		TH1D* proj;
+		if(y <= ybins) proj = mat->ProjectionX("proj", y, y);
+		else  		   proj = empty;
+		for(int x = 1; x <= 4096; ++x) {
+			if(x <= xbins) buffer[x-1] = (uint16_t)(proj->GetBinContent(x));//    mat->GetBinContent(x,y));
+			else				buffer[x-1] = 0;
+		}
+		outfile->write((char*)(&buffer), sizeof(buffer));	
+	}
+	delete empty;
 }
 
 void WriteM4b(TH2 *mat, std::fstream *outfile) {
-   int xbins = mat->GetXaxis()->GetNbins();
-   int ybins = mat->GetYaxis()->GetNbins();
-   
-	TH1D *empty = new TH1D("empty","empty",4096,0,4096);
+	int xbins = mat->GetXaxis()->GetNbins();
+	int ybins = mat->GetYaxis()->GetNbins();
 
-   for(int y=1;y<=4096;y++ ) {
-      uint32_t buffer[4096] = {0};
-		TH1D *proj;
-		if(y<=ybins)
-			proj = mat->ProjectionX("proj",y,y);
-		else
-			proj = empty;
-      for(int x=1;x<=4096;x++ ) {
-         if(x<=xbins)
-            buffer[x-1] = (uint32_t)(proj->GetBinContent(x));//    mat->GetBinContent(x,y));
-         else
-            buffer[x-1] = 0;
-      }
-   	outfile->write((char*)(&buffer),sizeof(buffer));	
-   }
-   delete empty;
+	TH1D* empty = new TH1D("empty", "empty", 4096, 0., 4096.);
+
+	for(int y = 1; y <= 4096; ++y) {
+		uint32_t buffer[4096] = {0};
+		TH1D* proj;
+		if(y <= ybins) proj = mat->ProjectionX("proj", y, y);
+		else           proj = empty;
+		for(int x = 1; x <= 4096; ++x) {
+			if(x <= xbins) buffer[x-1] = (uint32_t)(proj->GetBinContent(x));//    mat->GetBinContent(x,y));
+			else           buffer[x-1] = 0;
+		}
+		outfile->write((char*)(&buffer), sizeof(buffer));	
+	}
+	delete empty;
 }
 
 void WriteHist(TH1 *hist, std::fstream *outfile)	{
 	SpeHeader spehead;
 	spehead.buffsize = 24;
-  	strncpy(spehead.label,hist->GetName(),8); 
+	strncpy(spehead.label,hist->GetName(),8); 
 
-   if(hist->GetRMS() > 16384/2) {
-      while(hist->GetNbinsX()>16384)	{
-	     	hist = hist->Rebin(2);
-         printf(DBLUE "\t!!  %s has been compressed by 2." RESET_COLOR "\n",hist->GetName());
-   	}
-      spehead.size = hist->GetNbinsX();
-   } else if(hist->GetNbinsX()>16384) {
-      spehead.size = 16384;
-   } else {
-      spehead.size = hist->GetNbinsX();
-   }
+	if(hist->GetRMS() > 16384/2) {
+		while(hist->GetNbinsX() > 16384) {
+			hist = hist->Rebin(2);
+			printf(DBLUE "\t!!  %s has been compressed by 2." RESET_COLOR "\n",hist->GetName());
+		}
+		spehead.size = hist->GetNbinsX();
+	} else if(hist->GetNbinsX()>16384) {
+		spehead.size = 16384;
+	} else {
+		spehead.size = hist->GetNbinsX();
+	}
 
-   spehead.junk1 = 1;
+	spehead.junk1 = 1;
 	spehead.junk2 = 1;
 	spehead.junk3 = 1;
 	spehead.buffcheck = 24;         /*fortran file, record ends with record size :) */                // 14
 
-	outfile->write((char*)(&spehead),sizeof(SpeHeader));	
+	outfile->write((char*)(&spehead), sizeof(SpeHeader));	
 
 	int32_t histsizeinbytes = spehead.size *4;
 
-	outfile->write((char*)&histsizeinbytes,sizeof(int32_t));	
+	outfile->write((char*)&histsizeinbytes, sizeof(int32_t));	
 	float bin = 0.0;
-	for(int x=1;x<=spehead.size;x++)	{
-		if(x<=hist->GetNbinsX())	{
+	for(int x = 1; x <= spehead.size; ++x)	{
+		if(x <= hist->GetNbinsX())	{
 			bin = (float)hist->GetBinContent(x);
-			outfile->write((char*)&bin,sizeof(int32_t));	
+			outfile->write((char*)&bin, sizeof(int32_t));	
 		}
 		else {
 			bin = 0.0;
-			outfile->write((char*)&bin,sizeof(int32_t));	
+			outfile->write((char*)&bin, sizeof(int32_t));	
 		}
 	}
 
-	outfile->write((char*)&histsizeinbytes,sizeof(int32_t));	
+	outfile->write((char*)&histsizeinbytes, sizeof(int32_t));	
 
 	return;	
 }
-
-
-
-
-
-
-
-
-
-
-
 


### PR DESCRIPTION
- Only applies to 2D-histograms with more than 4096 bins on the x-axis.
- Assumes that the 2D-histograms are symmetric in the x- and y-axis.
- Program checks for -s (split) and -c (compress) flags.
- If both splitting and compression is selected, one matrix with original binning from bin 0 to 4096, and a compressed one with the full range are produced.
- If only compression is selected, the histogram is rebinned so that it has no more than 4096 bins.
- If only splitting is selected, the histogram is split into 4096x4096 matrices. E.g. if the original matrix has 8192x8192 bins, three matrices are created: both x and y from bins 1-4096, both x and y from bins 4097-8192, and one with x from 4097-8192 and y from 1-4096.