### PR TITLE
Fixed error in TChannel::GetSegmentNumber() 

### DIFF
--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -175,70 +175,46 @@ void TChannel::OverWriteChannel(TChannel* chan){
 }
 
 void TChannel::AppendChannel(TChannel* chan){
-	///Sets the current TChannel to chan
-	if(chan->GetIntegration()!=0) 
-		this->SetIntegration(chan->GetIntegration()); 
-	if(chan->GetNumber()!=0)
-		this->SetNumber(chan->GetNumber());
-	if(chan->GetStream()!=0)
-		this->SetStream(chan->GetStream());
-	if(chan->GetUserInfoNumber()!=0 && chan->GetUserInfoNumber()!=-1)
-		this->SetUserInfoNumber(chan->GetUserInfoNumber());
-	if(strlen(chan->GetName())>0) {
-	  this->SetName(chan->GetName());
-	}
-	if(strlen(chan->GetDigitizerTypeString())>0)
-		this->SetDigitizerType(chan->GetDigitizerTypeString());
-   if(chan->GetTimeOffset() != 0.0)
-      this->SetTimeOffset(chan->GetTimeOffset());
+   ///Sets the current TChannel to chan
+   if(chan->GetIntegration()!= 0) SetIntegration(chan->GetIntegration()); 
+	if(chan->GetNumber()!= 0) SetNumber(chan->GetNumber());
+	if(chan->GetStream()!= 0) SetStream(chan->GetStream());
+	if(chan->GetUserInfoNumber() != 0 && chan->GetUserInfoNumber() != -1) SetUserInfoNumber(chan->GetUserInfoNumber());
+	if(strlen(chan->GetName()) > 0) {
+      SetName(chan->GetName());
+   }
+   if(strlen(chan->GetDigitizerTypeString())>0) SetDigitizerType(chan->GetDigitizerTypeString());
+   if(chan->GetTimeOffset() != 0.0) SetTimeOffset(chan->GetTimeOffset());
 
-	if(chan->GetENGCoeff().size()>0)
-		this->SetENGCoefficients(chan->GetENGCoeff());
-	if(chan->GetCFDCoeff().size()>0)
-		this->SetCFDCoefficients(chan->GetCFDCoeff());
-	if(chan->GetLEDCoeff().size()>0)
-		this->SetLEDCoefficients(chan->GetLEDCoeff());
-	if(chan->GetTIMECoeff().size()>0)
-		this->SetTIMECoefficients(chan->GetTIMECoeff());
-	if(chan->GetEFFCoeff().size()>0)
-		this->SetEFFCoefficients(chan->GetEFFCoeff());
-   if(chan->GetCTCoeff().size()>0)
-      this->SetCTCoefficients(chan->GetCTCoeff());
+   if(chan->GetENGCoeff().size() > 0) SetENGCoefficients(chan->GetENGCoeff());
+   if(chan->GetCFDCoeff().size() > 0) SetCFDCoefficients(chan->GetCFDCoeff());
+   if(chan->GetLEDCoeff().size() > 0) SetLEDCoefficients(chan->GetLEDCoeff());
+   if(chan->GetTIMECoeff().size() > 0) SetTIMECoefficients(chan->GetTIMECoeff());
+   if(chan->GetEFFCoeff().size() > 0) SetEFFCoefficients(chan->GetEFFCoeff());
+   if(chan->GetCTCoeff().size() > 0) SetCTCoefficients(chan->GetCTCoeff());
 
-	if(chan->GetENGChi2() != 0.0)
-		this->SetENGChi2(chan->GetENGChi2());
-	if(chan->GetCFDChi2() != 0.0)
-		this->SetCFDChi2(chan->GetCFDChi2());
-	if(chan->GetLEDChi2() != 0.0)
-		this->SetLEDChi2(chan->GetLEDChi2());
-	if(chan->GetTIMEChi2() != 0.0)
-		this->SetTIMEChi2(chan->GetTIMEChi2());
-	if(chan->GetEFFChi2() != 0.0)
-		this->SetEFFChi2(chan->GetEFFChi2());
+	if(chan->GetENGChi2() != 0.0) SetENGChi2(chan->GetENGChi2());
+	if(chan->GetCFDChi2() != 0.0) SetCFDChi2(chan->GetCFDChi2());
+	if(chan->GetLEDChi2() != 0.0) SetLEDChi2(chan->GetLEDChi2());
+	if(chan->GetTIMEChi2() != 0.0) SetTIMEChi2(chan->GetTIMEChi2());
+	if(chan->GetEFFChi2() != 0.0) SetEFFChi2(chan->GetEFFChi2());
 
-	if(chan->UseCalFileIntegration())
-		this->SetUseCalFileIntegration(chan->UseCalFileIntegration());
+	if(chan->UseCalFileIntegration()) SetUseCalFileIntegration(chan->UseCalFileIntegration());
   
-  if(chan->GetDetectorNumber()>-1)
-    this->SetDetectorNumber(chan->GetDetectorNumber());
-  if(chan->GetSegmentNumber()>-1)
-  	this->SetSegmentNumber(chan->GetSegmentNumber());
-  if(chan->GetCrystalNumber()>-1)
-  	this->SetCrystalNumber(chan->GetCrystalNumber());
+   if(chan->GetDetectorNumber() > -1)   SetDetectorNumber(chan->GetDetectorNumber());
+   if(chan->GetSegmentNumber() > -1) 	SetSegmentNumber(chan->GetSegmentNumber());
+   if(chan->GetCrystalNumber() > -1) 	SetCrystalNumber(chan->GetCrystalNumber());
 
-  this->SetClassType(chan->GetClassType());
+   SetClassType(chan->GetClassType());
 
 	return;
 }
 
 int TChannel::UpdateChannel(TChannel* chan,Option_t* opt) {
 	///If there is information in the chan, the current TChannel with the same address is updated with that information.
-	if(!chan)
-		return 0;
+	if(chan == nullptr) return 0;
 	TChannel* oldchan = GetChannel(chan->GetAddress()); // look for already existing channel at this address
-	if(oldchan==0)
-		return 0;
-
+	if(oldchan == nullptr) return 0;
 	oldchan->AppendChannel(chan);
 
 	return 0;
@@ -934,7 +910,6 @@ void TChannel::SaveToSelf(const char* fname) {
 
 
 Int_t TChannel::ParseInputData(const char* inputdata,Option_t* opt) {
-
 	std::istringstream infile(inputdata);
 
 	TChannel* channel = nullptr;
@@ -976,7 +951,7 @@ Int_t TChannel::ParseInputData(const char* inputdata,Option_t* opt) {
 			brace_open = false;
 			if(channel) {// && (channel->GetAddress()!=0) ) 
 				TChannel* currentchan = GetChannel(channel->GetAddress());      
-				if(!currentchan){
+				if(currentchan == nullptr) {
 					AddChannel(channel);// consider using a default option here
 					newchannels++;
 				} else {
@@ -1207,7 +1182,6 @@ int TChannel::WriteToRoot(TFile* fileptr) {
 	ParseInputData(savedata.c_str(),"q");
 	SaveToSelf(savedata.c_str());
 
-
 	//printf("1 Number of Channels: %i\n",GetNumberOfChannels());
 	//gDirectory->ls();
 	//TChannel::DeleteAllChannels();
@@ -1230,19 +1204,23 @@ int TChannel::GetDetectorNumber() const {
 }
 
 int TChannel::GetSegmentNumber() const {
-	if(fSegmentNumber>-1)
-		return fSegmentNumber;
+	if(fSegmentNumber > -1) return fSegmentNumber;
 
 	std::string name = GetName();
-	TString str = name[9];
-	if(str.IsDigit()){
-		std::string buf;
-		buf.clear(); buf.assign(name,7,3);
-		fSegmentNumber = (int32_t)atoi(buf.c_str());
-	}
-	else{   
-		fSegmentNumber = (int32_t)fMnemonic.Segment();
-	}
+   if(name.length() < 10) {
+      fSegmentNumber = 0;
+   } else {
+      TString str = name[9];
+      if(str.IsDigit()) {
+         std::string buf;
+         buf.clear(); 
+         buf.assign(name,7,3);
+         fSegmentNumber = (int32_t)atoi(buf.c_str());
+      } else {   
+         fSegmentNumber = (int32_t)fMnemonic.Segment();
+      }
+   }
+
 	return fSegmentNumber;
 }
 

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -77,6 +77,7 @@ bool TUnpackingLoop::Iteration(){
 	} else  {
 		fFragsReadFromRaw += 1;   // if the midas bank fails, we assume it only had one frag in it... this is just used for a print statement.
 		if(!TGRSIOptions::Get()->SuppressErrors()) {
+			event->SetBankList();
 			event->Print(Form("a%i",(-1*frags)-1));
 		}
 	}

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -18,137 +18,132 @@ ClassImp(TMidasEvent)
 /// \endcond
 
 TMidasEvent::TMidasEvent() {
-  //Default constructor
-  fData = nullptr;
-  fAllocatedByUs = false;
+	//Default constructor
+	fData = nullptr;
+	fAllocatedByUs = false;
 
-  fBanksN = 0;
-  fBankList = nullptr;
+	fBanksN = 0;
+	fBankList = nullptr;
 
-  fEventHeader.fEventId      = 0;
-  fEventHeader.fTriggerMask  = 0;
-  fEventHeader.fSerialNumber = 0;
-  fEventHeader.fTimeStamp    = 0;
-  fEventHeader.fDataSize     = 0;
+	fEventHeader.fEventId      = 0;
+	fEventHeader.fTriggerMask  = 0;
+	fEventHeader.fSerialNumber = 0;
+	fEventHeader.fTimeStamp    = 0;
+	fEventHeader.fDataSize     = 0;
 }
 
 void TMidasEvent::Copy(TObject& rhs) const {
-   //Copies the entire TMidasEvent. This includes the bank information.
-  static_cast<TMidasEvent&>(rhs).fEventHeader = fEventHeader;
+	//Copies the entire TMidasEvent. This includes the bank information.
+	static_cast<TMidasEvent&>(rhs).fEventHeader = fEventHeader;
 
-  static_cast<TMidasEvent&>(rhs).fData        = (char*)malloc(static_cast<TMidasEvent&>(rhs).fEventHeader.fDataSize);
-  assert(static_cast<TMidasEvent&>(rhs).fData);
-  memcpy(static_cast<TMidasEvent&>(rhs).fData, fData, static_cast<TMidasEvent&>(rhs).fEventHeader.fDataSize);
-  static_cast<TMidasEvent&>(rhs).fAllocatedByUs = true;
+	static_cast<TMidasEvent&>(rhs).fData        = (char*)malloc(static_cast<TMidasEvent&>(rhs).fEventHeader.fDataSize);
+	assert(static_cast<TMidasEvent&>(rhs).fData);
+	memcpy(static_cast<TMidasEvent&>(rhs).fData, fData, static_cast<TMidasEvent&>(rhs).fEventHeader.fDataSize);
+	static_cast<TMidasEvent&>(rhs).fAllocatedByUs = true;
 
-  static_cast<TMidasEvent&>(rhs).fBanksN      = fBanksN;
-  static_cast<TMidasEvent&>(rhs).fBankList    = nullptr;
-  //if(fBankList) static_cast<TMidasEvent&>(rhs).fBankList    = strdup(fBankList);
-  //assert(static_cast<TMidasEvent&>(rhs).fBankList);
+	static_cast<TMidasEvent&>(rhs).fBanksN      = fBanksN;
+	static_cast<TMidasEvent&>(rhs).fBankList    = nullptr;
+	//if(fBankList) static_cast<TMidasEvent&>(rhs).fBankList    = strdup(fBankList);
+	//assert(static_cast<TMidasEvent&>(rhs).fBankList);
 }
 
 TMidasEvent::TMidasEvent(const TMidasEvent &rhs) : TRawEvent() {
-   //Copy ctor.
-  rhs.Copy(*this);
+	//Copy ctor.
+	rhs.Copy(*this);
 }
 
 TMidasEvent::~TMidasEvent() {
-  Clear();
+	Clear();
 }
 
 TMidasEvent& TMidasEvent::operator=(const TMidasEvent &rhs) {
-  if (&rhs != this)
-    Clear();
+	if(&rhs != this) Clear();
 
-  rhs.Copy(*this);
-  return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
 void TMidasEvent::Clear(Option_t *opt) {
-   //Clears the TMidasEvent.
-  if (fBankList)
-    free(fBankList);
-  fBankList = nullptr;
+	//Clears the TMidasEvent.
+	if(fBankList) free(fBankList);
+	fBankList = nullptr;
 
-  if (fData && fAllocatedByUs)
-    free(fData);
-  fData = nullptr;
+	if(fData && fAllocatedByUs) free(fData);
+	fData = nullptr;
 
-  fAllocatedByUs = false;
-  fBanksN = 0;
+	fAllocatedByUs = false;
+	fBanksN = 0;
 
-  fEventHeader.fEventId      = 0;
-  fEventHeader.fTriggerMask  = 0;
-  fEventHeader.fSerialNumber = 0;
-  fEventHeader.fTimeStamp    = 0;
-  fEventHeader.fDataSize     = 0;
+	fEventHeader.fEventId      = 0;
+	fEventHeader.fTriggerMask  = 0;
+	fEventHeader.fSerialNumber = 0;
+	fEventHeader.fTimeStamp    = 0;
+	fEventHeader.fDataSize     = 0;
 }
 
 void TMidasEvent::SetData(uint32_t size, char* data) {
-   //Sets the data in the TMidasEvent as the data argument passed into
-   //this function.
-  fEventHeader.fDataSize = size;
-  assert(!fAllocatedByUs);
-  assert(IsGoodSize());
-  fData = data;
-  fAllocatedByUs = false;
-  SwapBytes(false);
+	//Sets the data in the TMidasEvent as the data argument passed into
+	//this function.
+	fEventHeader.fDataSize = size;
+	assert(!fAllocatedByUs);
+	assert(IsGoodSize());
+	fData = data;
+	fAllocatedByUs = false;
+	SwapBytes(false);
 }
 
 uint16_t TMidasEvent::GetEventId() const {
-  return fEventHeader.fEventId;
+	return fEventHeader.fEventId;
 }
 
 uint16_t TMidasEvent::GetTriggerMask() const {
-  return fEventHeader.fTriggerMask;
+	return fEventHeader.fTriggerMask;
 }
 
 uint32_t TMidasEvent::GetSerialNumber() const {
-  return fEventHeader.fSerialNumber;
+	return fEventHeader.fSerialNumber;
 }
 
 uint32_t TMidasEvent::GetTimeStamp() const {
-  return fEventHeader.fTimeStamp;
+	return fEventHeader.fTimeStamp;
 }
 
 uint32_t TMidasEvent::GetDataSize() const {
-  return fEventHeader.fDataSize;
+	return fEventHeader.fDataSize;
 }
 
 char* TMidasEvent::GetData() {
-   //Allocates the data if it has not been already, and then
-   //returns the allocated data.
-  if (!fData)
-    AllocateData();
-  return fData;
+	//Allocates the data if it has not been already, and then
+	//returns the allocated data.
+	if(!fData) AllocateData();
+	return fData;
 }
 
 TMidas_EVENT_HEADER *TMidasEvent::GetEventHeader() {
-  return &fEventHeader;
+	return &fEventHeader;
 }
 
 bool TMidasEvent::IsGoodSize() const {
-  return fEventHeader.fDataSize > 0 && fEventHeader.fDataSize <= 500 * 1024 * 1024;
+	return fEventHeader.fDataSize > 0 && fEventHeader.fDataSize <= 500 * 1024 * 1024;
 }
 
 bool TMidasEvent::IsBank32() const {
-  return ((TMidas_BANK_HEADER *)fData)->fFlags & (1<<4);
+	return ((TMidas_BANK_HEADER *)fData)->fFlags & (1<<4);
 }
 
 int TMidasEvent::LocateBank(const void *unused, const char *name, void **pdata) const {
-  /// See FindBank()
+	/// See FindBank()
 
-  int bktype, bklen;
+	int bktype, bklen;
 
-  int status = FindBank(name, &bklen, &bktype, pdata);
+	int status = FindBank(name, &bklen, &bktype, pdata);
 
-  if (!status)
-    {
-      *pdata = nullptr;
-      return 0;
-    }
+	if(!status) {
+		*pdata = nullptr;
+		return 0;
+	}
 
-  return bklen;
+	return bklen;
 }
 
 static const unsigned TID_SIZE[] = {0, 1, 1, 1, 2, 2, 4, 4, 4, 4, 8, 1, 0, 0, 0, 0, 0};
@@ -162,315 +157,300 @@ static const unsigned TID_MAX = (sizeof(TID_SIZE)/sizeof(TID_SIZE[0]));
 /// \returns 1 if bank found, 0 otherwise.
 ///
 int TMidasEvent::FindBank(const char* name, int *bklen, int *bktype, void **pdata) const {
-  const TMidas_BANK_HEADER *pbkh = (const TMidas_BANK_HEADER*)fData;
-  TMidas_BANK *pbk;
-  //uint32_t dname;
+	const TMidas_BANK_HEADER *pbkh = (const TMidas_BANK_HEADER*)fData;
+	TMidas_BANK *pbk;
+	//uint32_t dname;
 
-  if (((pbkh->fFlags & (1<<4)) > 0)) {
+	if(((pbkh->fFlags & (1<<4)) > 0)) {
 #if 0
-    TMidas_BANK32 *pbk32;
-    pbk32 = (TMidas_BANK32 *) (pbkh + 1);
-    memcpy(&dname, name, 4);
-    do {
-      if (*((uint32_t *) pbk32->fName) == dname) {
-        *pdata = pbk32 + 1;
-        if (TID_SIZE[pbk32->fType & 0xFF] == 0)
-          *bklen = pbk32->fDataSize;
-        else
-          *bklen = pbk32->fDataSize / TID_SIZE[pbk32->fType & 0xFF];
+		TMidas_BANK32 *pbk32;
+		pbk32 = (TMidas_BANK32 *) (pbkh + 1);
+		memcpy(&dname, name, 4);
+		do {
+			if(*((uint32_t *) pbk32->fName) == dname) {
+				*pdata = pbk32 + 1;
+				if(TID_SIZE[pbk32->fType & 0xFF] == 0)
+					*bklen = pbk32->fDataSize;
+				else
+					*bklen = pbk32->fDataSize / TID_SIZE[pbk32->fType & 0xFF];
 
-        *bktype = pbk32->fType;
-        return 1;
-      }
-      pbk32 = (TMidas_BANK32 *) ((char*) (pbk32 + 1) +
-                          (((pbk32->fDataSize)+7) & ~7));
-    } while ((char*) pbk32 < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
+				*bktype = pbk32->fType;
+				return 1;
+			}
+			pbk32 = (TMidas_BANK32 *) ((char*) (pbk32 + 1) +
+					(((pbk32->fDataSize)+7) & ~7));
+		} while ((char*) pbk32 < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
 #endif
 
-    TMidas_BANK32 *pbk32 = nullptr;
+		TMidas_BANK32 *pbk32 = nullptr;
 
-    while (1) {
-      IterateBank32(&pbk32, (char**)pdata);
-      //printf("looking for [%s] got [%s]\n", name, pbk32->fName);
-      if (pbk32 == nullptr)
-	break;
+		while (1) {
+			IterateBank32(&pbk32, (char**)pdata);
+			//printf("looking for [%s] got [%s]\n", name, pbk32->fName);
+			if(pbk32 == nullptr)
+				break;
 
-      if (name[0]==pbk32->fName[0] &&
-	  name[1]==pbk32->fName[1] &&
-	  name[2]==pbk32->fName[2] &&
-	  name[3]==pbk32->fName[3]) {
+			if(name[0]==pbk32->fName[0] &&
+					name[1]==pbk32->fName[1] &&
+					name[2]==pbk32->fName[2] &&
+					name[3]==pbk32->fName[3]) {
 
-	if (TID_SIZE[pbk32->fType & 0xFF] == 0)
-	  *bklen = pbk32->fDataSize;
-	else
-	  *bklen = pbk32->fDataSize / TID_SIZE[pbk32->fType & 0xFF];
+				if(TID_SIZE[pbk32->fType & 0xFF] == 0)
+					*bklen = pbk32->fDataSize;
+				else
+					*bklen = pbk32->fDataSize / TID_SIZE[pbk32->fType & 0xFF];
 
-	*bktype = pbk32->fType;
-	return 1;
-      }
-    }
-  } else {
-    pbk = (TMidas_BANK *) (pbkh + 1);
-    do {
-      if (name[0]==pbk->fName[0] &&
-	  name[1]==pbk->fName[1] &&
-	  name[2]==pbk->fName[2] &&
-	  name[3]==pbk->fName[3]) {
-        *pdata = pbk + 1;
-        if (TID_SIZE[pbk->fType & 0xFF] == 0)
-          *bklen = pbk->fDataSize;
-        else
-          *bklen = pbk->fDataSize / TID_SIZE[pbk->fType & 0xFF];
+				*bktype = pbk32->fType;
+				return 1;
+			}
+		}
+	} else {
+		pbk = (TMidas_BANK *) (pbkh + 1);
+		do {
+			if(name[0]==pbk->fName[0] &&
+					name[1]==pbk->fName[1] &&
+					name[2]==pbk->fName[2] &&
+					name[3]==pbk->fName[3]) {
+				*pdata = pbk + 1;
+				if(TID_SIZE[pbk->fType & 0xFF] == 0)
+					*bklen = pbk->fDataSize;
+				else
+					*bklen = pbk->fDataSize / TID_SIZE[pbk->fType & 0xFF];
 
-        *bktype = pbk->fType;
-        return 1;
-      }
-      pbk = (TMidas_BANK *) ((char*) (pbk + 1) + (((pbk->fDataSize)+7) & ~7));
-    } while ((char*) pbk < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
-  }
-  //
-  // bank not found
-  //
-  *pdata = nullptr;
-  return 0;
+				*bktype = pbk->fType;
+				return 1;
+			}
+			pbk = (TMidas_BANK *) ((char*) (pbk + 1) + (((pbk->fDataSize)+7) & ~7));
+		} while ((char*) pbk < (char*) pbkh + pbkh->fDataSize + sizeof(TMidas_BANK_HEADER));
+	}
+	//
+	// bank not found
+	//
+	*pdata = nullptr;
+	return 0;
 }
 
 void TMidasEvent::Print(const char *option) const {
-  /// Print data held in this class.
-  /// \param [in] option If 'a' (for "all") then the raw data will be
-  /// printed out too.
-  ///
+	/// Print data held in this class.
+	/// \param [in] option If 'a' (for "all") then the raw data will be
+	/// printed out too.
+	///
 
-  time_t t = (time_t)fEventHeader.fTimeStamp;
+	const_cast<TMidasEvent*>(this)->SetBankList();
+	time_t t = (time_t)fEventHeader.fTimeStamp;
 
-  printf("Event start:\n");
-  printf("  event id:       0x%04x\n", fEventHeader.fEventId);
-  printf("  trigger mask:   0x%04x\n", fEventHeader.fTriggerMask);
-  printf("  serial number:%8d\n", fEventHeader.fSerialNumber);
-  printf("  time stamp:     %d, %s", fEventHeader.fTimeStamp, ctime(&t));
-  printf("  data size:    %8d\n", fEventHeader.fDataSize);
-  if ((fEventHeader.fEventId & 0xffff) == 0x8000)
-    {
-      printf("Begin of run %d\n", fEventHeader.fSerialNumber);
-    }
-  else if ((fEventHeader.fEventId & 0xffff) == 0x8001)
-    {
-      printf("End of run %d\n", fEventHeader.fSerialNumber);
-    }
-  else if (fBanksN <= 0)
-    {
-      printf("TMidasEvent::Print: Use SetBankList() before Print() to print bank data\n");
-    }
-  else
-    {
-      printf("Banks: %s\n", fBankList);
+	printf("Event start:\n");
+	printf("  event id:       0x%04x\n", fEventHeader.fEventId);
+	printf("  trigger mask:   0x%04x\n", fEventHeader.fTriggerMask);
+	printf("  serial number:%8d\n", fEventHeader.fSerialNumber);
+	printf("  time stamp:     %d, %s", fEventHeader.fTimeStamp, ctime(&t));
+	printf("  data size:    %8d\n", fEventHeader.fDataSize);
+	if((fEventHeader.fEventId & 0xffff) == 0x8000) {
+		printf("Begin of run %d\n", fEventHeader.fSerialNumber);
+	} else if((fEventHeader.fEventId & 0xffff) == 0x8001) {
+		printf("End of run %d\n", fEventHeader.fSerialNumber);
+	} else if(fBanksN <= 0) {
+		printf("TMidasEvent::Print: Use SetBankList() before Print() to print bank data\n");
+	} else {
+		printf("Banks: %s\n", fBankList);
 
-      for (int i = 0; i < fBanksN * 4; i += 4)
-	{
-	  int bankLength = 0;
-	  int bankType = 0;
-	  void *pdata = 0;
-	  int found = FindBank(&fBankList[i], &bankLength, &bankType, &pdata);
+		for (int i = 0; i < fBanksN * 4; i += 4) {
+			int bankLength = 0;
+			int bankType = 0;
+			void *pdata = 0;
+			int found = FindBank(&fBankList[i], &bankLength, &bankType, &pdata);
 
-	  printf("Bank %c%c%c%c, length %6d, type %2d\n",
-		 fBankList[i], fBankList[i+1], fBankList[i+2], fBankList[i+3],
-		 bankLength, bankType);
+			printf("Bank %c%c%c%c, length %6d, type %2d\n",
+					fBankList[i], fBankList[i+1], fBankList[i+2], fBankList[i+3],
+					bankLength, bankType);
 
-	  int highlight = -1;
-	  if(strlen(option)>1) {
-		highlight = atoi(option+1);
-		//printf("highlight = %i\n",highlight);
-	  }
+			int highlight = -1;
+			if(strlen(option)>1) {
+				highlight = atoi(option+1);
+				//printf("highlight = %i\n",highlight);
+			}
 
 
-	  if (option[0] == 'a' && found)
-	    switch (bankType)
-	      {
-	      case 4: // TID_WORD
-		for (int j = 0; j < bankLength; j++) {
-		  if(j==highlight)
-			  printf(ALERTTEXT "0x%04x" RESET_COLOR "%c", ((uint16_t*)pdata)[j], (j%10==9)?'\n':' ');
-		   else
-			  printf("0x%04x%c", ((uint16_t*)pdata)[j], (j%10==9)?'\n':' ');
+			if(option[0] == 'a' && found)
+				switch (bankType) {
+					case 4: // TID_WORD
+						for (int j = 0; j < bankLength; j++) {
+							if(j==highlight)
+								printf(ALERTTEXT "0x%04x" RESET_COLOR "%c", ((uint16_t*)pdata)[j], (j%10==9)?'\n':' ');
+							else
+								printf("0x%04x%c", ((uint16_t*)pdata)[j], (j%10==9)?'\n':' ');
+						}
+						printf("\n");
+						break;
+					case 6: // TID_DWORD
+						for (int j = 0; j < bankLength; j++) {
+							if(j==highlight)
+								printf(ALERTTEXT "0x%08x" RESET_COLOR "%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
+							else
+								printf("0x%08x%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
+						}
+						printf("\n");
+						break;
+					case 7: // TID_nd280 (like a DWORD?)
+						for (int j = 0; j < bankLength; j++) {
+							if(j==highlight)
+								printf(ALERTTEXT "0x%08x" RESET_COLOR "%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
+							else
+								printf("0x%08x%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
+						}
+						printf("\n");
+						break;
+					case 9: // TID_FLOAT
+						for (int j = 0; j < bankLength; j++) {
+							if(j==highlight)
+								printf(ALERTTEXT "%.8g" RESET_COLOR "%c", ((float*)pdata)[j], (j%10==9)?'\n':' ');
+							else
+								printf("%.8g%c", ((float*)pdata)[j], (j%10==9)?'\n':' ');
+						}
+						printf("\n");
+						break;
+					case 10: // TID_DOUBLE
+						for (int j = 0; j < bankLength; j++) {
+							if(j==highlight)
+								printf(ALERTTEXT "%.16g" RESET_COLOR "%c", ((double*)pdata)[j], (j%10==9)?'\n':' ');
+							else
+								printf("%.16g%c", ((double*)pdata)[j], (j%10==9)?'\n':' ');
+						}
+						printf("\n");
+						break;
+					default:
+						printf("TMidasEvent::Print: Do not know how to print bank of type %d\n", bankType);
+						break;
+				}
 		}
-		printf("\n");
-		break;
-	      case 6: // TID_DWORD
-		for (int j = 0; j < bankLength; j++) {
-		  if(j==highlight)
-			  printf(ALERTTEXT "0x%08x" RESET_COLOR "%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
-		   else
-			  printf("0x%08x%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
-		}
-		printf("\n");
-		break;
-	      case 7: // TID_nd280 (like a DWORD?)
-		for (int j = 0; j < bankLength; j++) {
-		  if(j==highlight)
-			  printf(ALERTTEXT "0x%08x" RESET_COLOR "%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
-		   else
-			  printf("0x%08x%c", ((uint32_t*)pdata)[j], (j%10==9)?'\n':' ');
-		}
-		printf("\n");
-		break;
-	      case 9: // TID_FLOAT
-		for (int j = 0; j < bankLength; j++) {
-		  if(j==highlight)
-			  printf(ALERTTEXT "%.8g" RESET_COLOR "%c", ((float*)pdata)[j], (j%10==9)?'\n':' ');
-		   else
-			  printf("%.8g%c", ((float*)pdata)[j], (j%10==9)?'\n':' ');
-		}
-		printf("\n");
-		break;
-	      case 10: // TID_DOUBLE
-		for (int j = 0; j < bankLength; j++) {
-		  if(j==highlight)
-			  printf(ALERTTEXT "%.16g" RESET_COLOR "%c", ((double*)pdata)[j], (j%10==9)?'\n':' ');
-		   else
-			  printf("%.16g%c", ((double*)pdata)[j], (j%10==9)?'\n':' ');
-		}
-		printf("\n");
-		break;
-	      default:
-		printf("TMidasEvent::Print: Do not know how to print bank of type %d\n", bankType);
-		break;
-	      }
 	}
-    }
 }
 
 void TMidasEvent::AllocateData() {
-   //Allocates space for the data from the event header if it is a good size
-  assert(!fAllocatedByUs);
-  assert(IsGoodSize());
-  fData = (char*)malloc(fEventHeader.fDataSize);
-  assert(fData);
-  fAllocatedByUs = true;
+	//Allocates space for the data from the event header if it is a good size
+	assert(!fAllocatedByUs);
+	assert(IsGoodSize());
+	fData = (char*)malloc(fEventHeader.fDataSize);
+	assert(fData);
+	fAllocatedByUs = true;
 }
 
 const char* TMidasEvent::GetBankList() const {
-  return fBankList;
+	return fBankList;
 }
 
 int TMidasEvent::SetBankList() {
-   //Sets the bank list by Iterating of the banks.
-   //See IterateBank32 and IterateBank
-  if (fEventHeader.fEventId <= 0)
-    return 0;
+	//Sets the bank list by Iterating of the banks.
+	//See IterateBank32 and IterateBank
+	if(fEventHeader.fEventId <= 0)
+		return 0;
 
-  if (fBankList)
-    return fBanksN;
+	if(fBankList)
+		return fBanksN;
 
-  int listSize = 0;
+	int listSize = 0;
 
-  fBanksN = 0;
+	fBanksN = 0;
 
-  TMidas_BANK32 *pmbk32 = nullptr;
-  TMidas_BANK *pmbk = nullptr;
-  char *pdata = nullptr;
+	TMidas_BANK32 *pmbk32 = nullptr;
+	TMidas_BANK *pmbk = nullptr;
+	char *pdata = nullptr;
 
-  while (1)
-    {
-      if (fBanksN*4 >= listSize)
-	{
-	  listSize += 400;
-	  fBankList = (char*)realloc(fBankList, listSize);
+	while (1) {
+		if(fBanksN*4 >= listSize) {
+			listSize += 400;
+			fBankList = (char*)realloc(fBankList, listSize);
+		}
+
+		if(IsBank32()) {
+			IterateBank32(&pmbk32, &pdata);
+			if(pmbk32 == nullptr)
+				break;
+			memcpy(fBankList+fBanksN*4, pmbk32->fName, 4);
+			fBanksN++;
+		} else
+		{
+			IterateBank(&pmbk, &pdata);
+			if(pmbk == nullptr)
+				break;
+			memcpy(fBankList+fBanksN*4, pmbk->fName, 4);
+			fBanksN++;
+		}
 	}
 
-      if (IsBank32())
-	{
-	  IterateBank32(&pmbk32, &pdata);
-	  if (pmbk32 == nullptr)
-	    break;
-	  memcpy(fBankList+fBanksN*4, pmbk32->fName, 4);
-	  fBanksN++;
-	}
-      else
-	{
-	  IterateBank(&pmbk, &pdata);
-	  if (pmbk == nullptr)
-	    break;
-	  memcpy(fBankList+fBanksN*4, pmbk->fName, 4);
-	  fBanksN++;
-	}
-    }
+	fBankList[fBanksN*4] = 0;
 
-  fBankList[fBanksN*4] = 0;
-
-  return fBanksN;
+	return fBanksN;
 }
 
 int TMidasEvent::IterateBank(TMidas_BANK **pbk, char **pdata) const {
-  /// Iterates through banks inside an event. The function can be used
-  /// to enumerate all banks of an event.
-  /// \param [in] pbk Pointer to the bank header, must be nullptr for the
-  /// first call to this function. Returns nullptr if no more banks
-  /// \param [in] pdata Pointer to data area of bank. Returns nullptr if no more banks
-  /// \returns Size of bank in bytes or 0 if no more banks.
-  ///
-  const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
+	/// Iterates through banks inside an event. The function can be used
+	/// to enumerate all banks of an event.
+	/// \param [in] pbk Pointer to the bank header, must be nullptr for the
+	/// first call to this function. Returns nullptr if no more banks
+	/// \param [in] pdata Pointer to data area of bank. Returns nullptr if no more banks
+	/// \returns Size of bank in bytes or 0 if no more banks.
+	///
+	const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
 
-  if (*pbk == nullptr)
-    *pbk = (TMidas_BANK *) (event + 1);
-  else
-    *pbk = (TMidas_BANK *) ((char*) (*pbk + 1) + ((((*pbk)->fDataSize)+7) & ~7));
+	if(*pbk == nullptr)
+		*pbk = (TMidas_BANK *) (event + 1);
+	else
+		*pbk = (TMidas_BANK *) ((char*) (*pbk + 1) + ((((*pbk)->fDataSize)+7) & ~7));
 
-  *pdata = (char*)((*pbk) + 1);
+	*pdata = (char*)((*pbk) + 1);
 
-  if ((char*) *pbk >=  (char*) event + event->fDataSize + sizeof(TMidas_BANK_HEADER))
-    {
-      *pbk = nullptr;
-      *pdata = nullptr;
-      return 0;
-    }
+	if((char*) *pbk >=  (char*) event + event->fDataSize + sizeof(TMidas_BANK_HEADER)) {
+		*pbk = nullptr;
+		*pdata = nullptr;
+		return 0;
+	}
 
-  return (*pbk)->fDataSize;
+	return (*pbk)->fDataSize;
 }
 
 int TMidasEvent::IterateBank32(TMidas_BANK32 **pbk, char **pdata) const {
-  /// See IterateBank()
+	/// See IterateBank()
 
-  const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
-  if (*pbk == nullptr)
-    *pbk = (TMidas_BANK32 *) (event + 1);
-  else {
-    uint32_t length = (*pbk)->fDataSize;
-    uint32_t length_adjusted = (length+7) & ~7;
-    //printf("length %6d 0x%08x, 0x%08x\n", length, length, length_adjusted);
-    *pbk = (TMidas_BANK32 *) ((char*) (*pbk + 1) + length_adjusted);
-  }
-
-  TMidas_BANK32 *bk4 = (TMidas_BANK32*)(((char*) *pbk) + 4);
-
-  //printf("iterate bank32: pbk 0x%p, align %d, type %d %d, name [%s], next [%s], TID_MAX %d\n", *pbk, (int)( ((uint64_t)(*pbk))&7), (*pbk)->fType, bk4->fType, (*pbk)->fName, bk4->fName, TID_MAX);
-
-  if ((*pbk)->fType > TID_MAX) // bad - unknown bank type - it's invalid MIDAS file?
-    {
-      if (bk4->fType <= TID_MAX) // okey, this is a malformed T2K/ND280 data file
-	{
-	  *pbk = bk4;
-
-	  //printf("iterate bank32: pbk 0x%p, align %d, type %d, name [%s]\n", *pbk, (int)(((uint64_t)(*pbk))&7), (*pbk)->fType, (*pbk)->fName);
+	const TMidas_BANK_HEADER* event = (const TMidas_BANK_HEADER*)fData;
+	if(*pbk == nullptr)
+		*pbk = (TMidas_BANK32 *) (event + 1);
+	else {
+		uint32_t length = (*pbk)->fDataSize;
+		uint32_t length_adjusted = (length+7) & ~7;
+		//printf("length %6d 0x%08x, 0x%08x\n", length, length, length_adjusted);
+		*pbk = (TMidas_BANK32 *) ((char*) (*pbk + 1) + length_adjusted);
 	}
-      else
+
+	TMidas_BANK32 *bk4 = (TMidas_BANK32*)(((char*) *pbk) + 4);
+
+	//printf("iterate bank32: pbk 0x%p, align %d, type %d %d, name [%s], next [%s], TID_MAX %d\n", *pbk, (int)( ((uint64_t)(*pbk))&7), (*pbk)->fType, bk4->fType, (*pbk)->fName, bk4->fName, TID_MAX);
+
+	if((*pbk)->fType > TID_MAX) // bad - unknown bank type - it's invalid MIDAS file?
 	{
-	  // truncate invalid data
-	  *pbk = nullptr;
-	  *pdata = nullptr;
-	  return 0;
+		if(bk4->fType <= TID_MAX) // okey, this is a malformed T2K/ND280 data file
+		{
+			*pbk = bk4;
+
+			//printf("iterate bank32: pbk 0x%p, align %d, type %d, name [%s]\n", *pbk, (int)(((uint64_t)(*pbk))&7), (*pbk)->fType, (*pbk)->fName);
+		} else
+		{
+			// truncate invalid data
+			*pbk = nullptr;
+			*pdata = nullptr;
+			return 0;
+		}
 	}
-    }
 
-  *pdata = (char*)((*pbk) + 1);
+	*pdata = (char*)((*pbk) + 1);
 
-  if ((char*) *pbk >= (char*)event  + event->fDataSize + sizeof(TMidas_BANK_HEADER))
-    {
-      *pbk = nullptr;
-      *pdata = nullptr;
-      return 0;
-    }
+	if((char*) *pbk >= (char*)event  + event->fDataSize + sizeof(TMidas_BANK_HEADER)) {
+		*pbk = nullptr;
+		*pdata = nullptr;
+		return 0;
+	}
 
-  return (*pbk)->fDataSize;
+	return (*pbk)->fDataSize;
 }
 
 typedef uint8_t BYTE;
@@ -478,147 +458,147 @@ typedef uint8_t BYTE;
 /// Byte swapping routine.
 ///
 #define QWORD_SWAP(x) { BYTE _tmp;       \
-_tmp= *((BYTE *)(x));                    \
-*((BYTE *)(x)) = *(((BYTE *)(x))+7);     \
-*(((BYTE *)(x))+7) = _tmp;               \
-_tmp= *(((BYTE *)(x))+1);                \
-*(((BYTE *)(x))+1) = *(((BYTE *)(x))+6); \
-*(((BYTE *)(x))+6) = _tmp;               \
-_tmp= *(((BYTE *)(x))+2);                \
-*(((BYTE *)(x))+2) = *(((BYTE *)(x))+5); \
-*(((BYTE *)(x))+5) = _tmp;               \
-_tmp= *(((BYTE *)(x))+3);                \
-*(((BYTE *)(x))+3) = *(((BYTE *)(x))+4); \
-*(((BYTE *)(x))+4) = _tmp; }
+	_tmp= *((BYTE *)(x));                    \
+	*((BYTE *)(x)) = *(((BYTE *)(x))+7);     \
+	*(((BYTE *)(x))+7) = _tmp;               \
+	_tmp= *(((BYTE *)(x))+1);                \
+	*(((BYTE *)(x))+1) = *(((BYTE *)(x))+6); \
+	*(((BYTE *)(x))+6) = _tmp;               \
+	_tmp= *(((BYTE *)(x))+2);                \
+	*(((BYTE *)(x))+2) = *(((BYTE *)(x))+5); \
+	*(((BYTE *)(x))+5) = _tmp;               \
+	_tmp= *(((BYTE *)(x))+3);                \
+	*(((BYTE *)(x))+3) = *(((BYTE *)(x))+4); \
+	*(((BYTE *)(x))+4) = _tmp; }
 
 /// Byte swapping routine.
 ///
 #define DWORD_SWAP(x) { BYTE _tmp;       \
-_tmp= *((BYTE *)(x));                    \
-*((BYTE *)(x)) = *(((BYTE *)(x))+3);     \
-*(((BYTE *)(x))+3) = _tmp;               \
-_tmp= *(((BYTE *)(x))+1);                \
-*(((BYTE *)(x))+1) = *(((BYTE *)(x))+2); \
-*(((BYTE *)(x))+2) = _tmp; }
+	_tmp= *((BYTE *)(x));                    \
+	*((BYTE *)(x)) = *(((BYTE *)(x))+3);     \
+	*(((BYTE *)(x))+3) = _tmp;               \
+	_tmp= *(((BYTE *)(x))+1);                \
+	*(((BYTE *)(x))+1) = *(((BYTE *)(x))+2); \
+	*(((BYTE *)(x))+2) = _tmp; }
 
 /// Byte swapping routine.
 ///
 #define WORD_SWAP(x) { BYTE _tmp;        \
-_tmp= *((BYTE *)(x));                    \
-*((BYTE *)(x)) = *(((BYTE *)(x))+1);     \
-*(((BYTE *)(x))+1) = _tmp; }
+	_tmp= *((BYTE *)(x));                    \
+	*((BYTE *)(x)) = *(((BYTE *)(x))+1);     \
+	*(((BYTE *)(x))+1) = _tmp; }
 
 void TMidasEvent::SwapBytesEventHeader() {
-  //Swaps bytes in the header for endian-ness reasons
-  WORD_SWAP(&fEventHeader.fEventId);
-  WORD_SWAP(&fEventHeader.fTriggerMask);
-  DWORD_SWAP(&fEventHeader.fSerialNumber);
-  DWORD_SWAP(&fEventHeader.fTimeStamp);
-  DWORD_SWAP(&fEventHeader.fDataSize);
+	//Swaps bytes in the header for endian-ness reasons
+	WORD_SWAP(&fEventHeader.fEventId);
+	WORD_SWAP(&fEventHeader.fTriggerMask);
+	DWORD_SWAP(&fEventHeader.fSerialNumber);
+	DWORD_SWAP(&fEventHeader.fTimeStamp);
+	DWORD_SWAP(&fEventHeader.fDataSize);
 }
 
 int TMidasEvent::SwapBytes(bool force) {
-  //Swaps bytes for endian-ness reasons
-  TMidas_BANK_HEADER *pbh;
-  TMidas_BANK *pbk;
-  TMidas_BANK32 *pbk32;
-  void *pdata;
-  uint16_t type;
+	//Swaps bytes for endian-ness reasons
+	TMidas_BANK_HEADER *pbh;
+	TMidas_BANK *pbk;
+	TMidas_BANK32 *pbk32;
+	void *pdata;
+	uint16_t type;
 
-  pbh = (TMidas_BANK_HEADER *) fData;
+	pbh = (TMidas_BANK_HEADER *) fData;
 
-  uint32_t dssw = pbh->fDataSize;
+	uint32_t dssw = pbh->fDataSize;
 
-  DWORD_SWAP(&dssw);
+	DWORD_SWAP(&dssw);
 
-  //printf("SwapBytes %d, flags 0x%x 0x%x\n", force, pbh->fFlags, pbh->fDataSize);
-  //printf("evh.datasize: 0x%08x, SwapBytes: %d, pbh.flags: 0x%08x, pbh.datasize: 0x%08x swapped 0x%08x\n", fEventHeader.fDataSize, force, pbh->fFlags, pbh->fDataSize, dssw);
+	//printf("SwapBytes %d, flags 0x%x 0x%x\n", force, pbh->fFlags, pbh->fDataSize);
+	//printf("evh.datasize: 0x%08x, SwapBytes: %d, pbh.flags: 0x%08x, pbh.datasize: 0x%08x swapped 0x%08x\n", fEventHeader.fDataSize, force, pbh->fFlags, pbh->fDataSize, dssw);
 
-  //
-  // only swap if flags in high 16-bit
-  //
-  if (pbh->fFlags < 0x10000 && ! force)
-    return 0;
+	//
+	// only swap if flags in high 16-bit
+	//
+	if(pbh->fFlags < 0x10000 && ! force)
+		return 0;
 
-  if (pbh->fDataSize == 0x6d783f3c) // string "<xml..." in wrong-endian format
-    return 1;
+	if(pbh->fDataSize == 0x6d783f3c) // string "<xml..." in wrong-endian format
+		return 1;
 
-  if (pbh->fDataSize == 0x3c3f786d) // string "<xml..."
-    return 1;
+	if(pbh->fDataSize == 0x3c3f786d) // string "<xml..."
+		return 1;
 
-  if (dssw > fEventHeader.fDataSize + 100) // swapped data size looks wrong. do not swap.
-    return 1;
+	if(dssw > fEventHeader.fDataSize + 100) // swapped data size looks wrong. do not swap.
+		return 1;
 
-  //
-  // swap bank header
-  //
-  DWORD_SWAP(&pbh->fDataSize);
-  DWORD_SWAP(&pbh->fFlags);
-  //
-  // check for 32-bit banks
-  //
-  bool b32 = IsBank32();
+	//
+	// swap bank header
+	//
+	DWORD_SWAP(&pbh->fDataSize);
+	DWORD_SWAP(&pbh->fFlags);
+	//
+	// check for 32-bit banks
+	//
+	bool b32 = IsBank32();
 
-  pbk = (TMidas_BANK *) (pbh + 1);
-  pbk32 = (TMidas_BANK32 *) pbk;
-  //
-  // scan event
-  //
-  while ((char*) pbk < (char*) pbh + pbh->fDataSize + sizeof(TMidas_BANK_HEADER)) {
-    //
-    // swap bank header
-    //
-    if (b32) {
-      DWORD_SWAP(&pbk32->fType);
-      DWORD_SWAP(&pbk32->fDataSize);
-      pdata = pbk32 + 1;
-      type = (uint16_t) pbk32->fType;
-    } else {
-      WORD_SWAP(&pbk->fType);
-      WORD_SWAP(&pbk->fDataSize);
-      pdata = pbk + 1;
-      type = pbk->fType;
-    }
-    //
-    // pbk points to next bank
-    //
-    if (b32) {
-      assert(pbk32->fDataSize < fEventHeader.fDataSize + 100);
-      pbk32 = (TMidas_BANK32 *) ((char*) (pbk32 + 1) +
-                          (((pbk32->fDataSize)+7) & ~7));
-      pbk = (TMidas_BANK *) pbk32;
-    } else {
-      assert(pbk->fDataSize < fEventHeader.fDataSize + 100);
-      pbk = (TMidas_BANK *) ((char*) (pbk + 1) +  (((pbk->fDataSize)+7) & ~7));
-      pbk32 = (TMidas_BANK32 *) pbk;
-    }
+	pbk = (TMidas_BANK *) (pbh + 1);
+	pbk32 = (TMidas_BANK32 *) pbk;
+	//
+	// scan event
+	//
+	while ((char*) pbk < (char*) pbh + pbh->fDataSize + sizeof(TMidas_BANK_HEADER)) {
+		//
+		// swap bank header
+		//
+		if(b32) {
+			DWORD_SWAP(&pbk32->fType);
+			DWORD_SWAP(&pbk32->fDataSize);
+			pdata = pbk32 + 1;
+			type = (uint16_t) pbk32->fType;
+		} else {
+			WORD_SWAP(&pbk->fType);
+			WORD_SWAP(&pbk->fDataSize);
+			pdata = pbk + 1;
+			type = pbk->fType;
+		}
+		//
+		// pbk points to next bank
+		//
+		if(b32) {
+			assert(pbk32->fDataSize < fEventHeader.fDataSize + 100);
+			pbk32 = (TMidas_BANK32 *) ((char*) (pbk32 + 1) +
+					(((pbk32->fDataSize)+7) & ~7));
+			pbk = (TMidas_BANK *) pbk32;
+		} else {
+			assert(pbk->fDataSize < fEventHeader.fDataSize + 100);
+			pbk = (TMidas_BANK *) ((char*) (pbk + 1) +  (((pbk->fDataSize)+7) & ~7));
+			pbk32 = (TMidas_BANK32 *) pbk;
+		}
 
-    switch (type) {
-    case 4:
-    case 5:
-      while (pdata < pbk) {
-        WORD_SWAP(pdata);
-        pdata = ((char*)pdata) + 2;
-      }
-      break;
-    case 6:
-    case 7:
-    case 8:
-    case 9:
-      while (pdata < pbk) {
-        DWORD_SWAP(pdata);
-        pdata = ((char*)pdata) + 4;
-      }
-      break;
-    case 10:
-      while (pdata < pbk) {
-        QWORD_SWAP(pdata);
-        pdata = ((char*)pdata) + 8;
-      }
-      break;
-    }
-  }
-  return 1;
+		switch (type) {
+			case 4:
+			case 5:
+				while (pdata < pbk) {
+					WORD_SWAP(pdata);
+					pdata = ((char*)pdata) + 2;
+				}
+				break;
+			case 6:
+			case 7:
+			case 8:
+			case 9:
+				while (pdata < pbk) {
+					DWORD_SWAP(pdata);
+					pdata = ((char*)pdata) + 4;
+				}
+				break;
+			case 10:
+				while (pdata < pbk) {
+					QWORD_SWAP(pdata);
+					pdata = ((char*)pdata) + 8;
+				}
+				break;
+		}
+	}
+	return 1;
 }
 
 int TMidasEvent::Process(TDataParser& parser) {
@@ -651,10 +631,10 @@ int TMidasEvent::Process(TDataParser& parser) {
 				break;
 			case 4:
 			case 5:
-				 SetBankList();
-				 if((banksize = LocateBank(nullptr,"MSRD",&ptr))>0) {
-					 frags = ProcessEPICS((float*)ptr, banksize, parser);
-				 }
+				SetBankList();
+				if((banksize = LocateBank(nullptr,"MSRD",&ptr))>0) {
+					frags = ProcessEPICS((float*)ptr, banksize, parser);
+				}
 
 				break;
 		};

--- a/scripts/GateBG.C
+++ b/scripts/GateBG.C
@@ -15,7 +15,6 @@ TH1* NewProjectionXBGP(TH2* matrix, Double_t gate_low, Double_t gate_high, Doubl
 
    //The peak should have came from the y-axis projection. We need to use this histogram to do things like get bin width, and the coord->bin mapping
    TH1* y_projection = matrix->ProjectionY();
-   Double_t bin_width = y_projection->GetBinWidth(1);
 
    //Integrate the background 
    Double_t bg_counts_under_peak = background_hist->Integral( gate_low_bin,gate_high_bin);

--- a/scripts/GriffinCTFix.cxx
+++ b/scripts/GriffinCTFix.cxx
@@ -84,21 +84,15 @@ double *CrossTalkFix(int det, double energy, TFile* in_file) {
        //This loop turns the addback plot and TCut into the TGraphErrors
       for(int i=1;i<=xbins;i++) {
          bool inside_yet = false;
-         int low_bin_in_cut = 0;
-         int high_bin_in_cut = 0;
          for(int j=1;j<=ybins;j++) {
             double xc = mat->GetXaxis()->GetBinCenter(i);
             double yc = mat->GetYaxis()->GetBinCenter(j);
             if(cut.IsInside(xc,yc)) {
-               if(!inside_yet){
-                  low_bin_in_cut = j;
+               if(!inside_yet) {
                   inside_yet = true;
                }
                cmat->Fill(xc,yc,mat->GetBinContent(i,j));
             } 
-            else if(inside_yet){
-               high_bin_in_cut = j;
-            }
          }
          cmat->GetXaxis()->SetRange(i,i);
          //This makes sure that there are at least 4 counts in the "y bin". I'd prefer this to be higher,


### PR DESCRIPTION
- TChannel::GetSegmentNumber() assumed that the name of the channel would always be
  10 characters long. This lead to a std::out_of_range error when TChannel were written
  with names less than 10 characters (like "Empty").
- TChannel::GetSegmentNumber() now sets and returns zero as segment number if the name
  has less than 10 characters.
- This fixes the issue #837.
- Also fixed compiler warnings about unused variables.
