### PR TITLE
TMidasEvent::Process calls TMidasEvent::Print on parsing error

### DIFF
--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -71,19 +71,13 @@ bool TUnpackingLoop::Iteration(){
 		fInputSize = error;
 		++fItemsPopped;
 	}
-
+	
 	int frags = event->Process(fParser);
 	if(frags > 0) {
 		fFragsReadFromRaw += frags;
 		fGoodFragsRead += frags;
-	} else  {
+	} else {
 		fFragsReadFromRaw += 1;   // if the midas bank fails, we assume it only had one frag in it... this is just used for a print statement.
-		if(!TGRSIOptions::Get()->SuppressErrors()) {
-			if(std::dynamic_pointer_cast<TMidasEvent>(event) != nullptr) {
-				if(std::dynamic_pointer_cast<TMidasEvent>(event)->GetEventId() < 0x8000) std::dynamic_pointer_cast<TMidasEvent>(event)->SetBankList();
-			}
-			event->Print(Form("a%i",(-1*frags)-1));
-		}
 	}
 
 	return true;

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -254,7 +254,7 @@ void TMidasEvent::Print(const char *option) const {
 	} else {
 		printf("Banks: %s\n", fBankList);
 
-		for (int i = 0; i < fBanksN * 4; i += 4) {
+		for(int i = 0; i < fBanksN * 4; i += 4) {
 			int bankLength = 0;
 			int bankType = 0;
 			void *pdata = 0;
@@ -623,7 +623,14 @@ int TMidasEvent::Process(TDataParser& parser) {
 		};
 	}
 	catch(const std::bad_alloc&) {   }
-	//printf("I AM HERE!\n");fflush(stdout);
+	
+	// if we failed to get any fragments and this is not a start-of-run or end-of-run event
+	// we print an error message (unless these are suppressed)
+	if(frags <= 0 && GetEventId() < 0x8000 && !TGRSIOptions::Get()->SuppressErrors()) {
+		SetBankList();
+		Print(Form("a%i",(-1*frags)-1));
+	}
+
 	return frags;
 }
 


### PR DESCRIPTION
- This call was made from TUnpackingLoop::Process which only deals with
  raw files. Moving it made a lot of checks easier or unnecessary.