### PR TITLE
Improve GRIFFIN data parser

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -19,7 +19,7 @@
 #include <string>
 
 void Analyze(const char* tree_type, TProof* proof){
-   TGRSIOptions *opt = TGRSIOptions::Get();
+   TGRSIOptions* opt = TGRSIOptions::Get();
    std::vector<std::string> tree_list;
 
    //Loop over all of the file names, find all the files with the tree type in them and are "openable"
@@ -80,7 +80,7 @@ void Analyze(const char* tree_type, TProof* proof){
 
 int main(int argc, char **argv) {
 
-   TGRSIOptions *opt = TGRSIOptions::Get(argc,argv);
+   TGRSIOptions* opt = TGRSIOptions::Get(argc,argv);
 
    //Add the path were we store headers for GRSIProof macros to see
    const char* pPath = getenv("GRSISYS");
@@ -133,11 +133,11 @@ int main(int argc, char **argv) {
 
    proof->AddInput(new TNamed("pwd", getenv("PWD")));
    int i = 0;
-   for(auto valFile = TGRSIOptions::Get()->ValInputFiles().begin(); valFile != TGRSIOptions::Get()->ValInputFiles().end(); ++valFile) {
+   for(auto valFile = opt->ValInputFiles().begin(); valFile != opt->ValInputFiles().end(); ++valFile) {
       proof->AddInput(new TNamed(Form("valFile%d", i++), valFile->c_str()));
    }
    i = 0;
-   for(auto calFile = TGRSIOptions::Get()->CalInputFiles().begin(); calFile != TGRSIOptions::Get()->CalInputFiles().end(); ++calFile) {
+   for(auto calFile = opt->CalInputFiles().begin(); calFile != opt->CalInputFiles().end(); ++calFile) {
       proof->AddInput(new TNamed(Form("calFile%d", i++), calFile->c_str()));
    }
 

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -125,6 +125,7 @@ int main(int argc, char **argv) {
       std::cout << "Can't connect to proof" << std::endl;
       return 0;
    }
+	proof->SetBit(TProof::kUsingSessionGui);
    proof->AddEnvVar("GRSISYS",pPath);
    gInterpreter->AddIncludePath(Form("%s/include",pPath));
    proof->AddIncludePath(Form("%s/include",pPath));
@@ -151,6 +152,4 @@ int main(int argc, char **argv) {
 		std::cout<<"Failed to get logs!"<<std::endl;
 	}
 }
-
-
 

--- a/include/GHSym.h
+++ b/include/GHSym.h
@@ -6,162 +6,162 @@
 #include "TF1.h"
 
 class GHSym : public TH1 {
-	public:
-		GHSym();
-		GHSym(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
-		GHSym(const char* name, const char* title, Int_t nbins, const Double_t* bins);
-		GHSym(const char* name, const char* title, Int_t nbins, const Float_t* bins);
-		~GHSym();
-	
+public:
+	GHSym();
+	GHSym(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
+	GHSym(const char* name, const char* title, Int_t nbins, const Double_t* bins);
+	GHSym(const char* name, const char* title, Int_t nbins, const Float_t* bins);
+	~GHSym();
+
 #if MAJOR_ROOT_VERSION < 6
-		virtual Bool_t    Add(TF1* h1, Double_t c1 = 1., Option_t* option = "");
-		virtual Bool_t    Add(const TH1* h1, Double_t c1 = 1.);
-		virtual Bool_t    Add(const TH1* h1, const TH1* h2, Double_t c1 = 1., Double_t c2 = 1.);
+	virtual Bool_t    Add(TF1* h1, Double_t c1 = 1., Option_t* option = "");
+	virtual Bool_t    Add(const TH1* h1, Double_t c1 = 1.);
+	virtual Bool_t    Add(const TH1* h1, const TH1* h2, Double_t c1 = 1., Double_t c2 = 1.);
 #endif
-		virtual Int_t     BufferEmpty(Int_t action = 0);
-		Int_t					BufferFill(Double_t, Double_t) { return -2; } //MayNotUse
-		virtual Int_t     BufferFill(Double_t x, Double_t y, Double_t w);
-		virtual void      Copy(TObject& hnew) const;
-		virtual Int_t     Fill(Double_t); //MayNotUse
-		virtual Int_t     Fill(const char*, Double_t) { return Fill(0); } //MayNotUse
-		virtual Int_t     Fill(Double_t x, Double_t y);
-		virtual Int_t     Fill(Double_t x, Double_t y, Double_t w);
-		virtual Int_t     Fill(const char* namex, const char* namey, Double_t w);
-		virtual void      FillN(Int_t, const Double_t *, const Double_t *, Int_t) {;} //MayNotUse
-   	virtual void      FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride = 1);
-   	virtual void      FillRandom(const char *fname, Int_t ntimes = 5000);
-   	virtual void      FillRandom(TH1 *h, Int_t ntimes = 5000);
-		virtual Int_t     FindFirstBinAbove(Double_t threshold = 0, Int_t axis = 1) const;
-		virtual Int_t     FindLastBinAbove (Double_t threshold = 0, Int_t axis = 1) const;
-		virtual void      FitSlices(TF1* f1 = nullptr, Int_t firstbin = 0, Int_t lastbin = -1, Int_t cut = 0, Option_t* option = "QNR", TObjArray* arr = nullptr);
-		virtual Int_t     GetBin(Int_t binx, Int_t biny = 0, Int_t binz = 0) const;
-		virtual Double_t  GetBinWithContent2(Double_t c, Int_t& binx, Int_t& biny, Int_t firstxbin = 1, Int_t lastxbin = -1, Int_t firstybin = 1, Int_t lastybin = -1, Double_t maxdiff = 0) const;
-		virtual Double_t  GetCellContent(Int_t binx, Int_t biny) const;
-		virtual Double_t  GetCellError(Int_t binx, Int_t biny) const;
-		virtual Double_t  GetCorrelationFactor(Int_t axis1 = 1, Int_t axis2 = 2) const;
-		virtual Double_t  GetCovariance(Int_t axis1 = 1, Int_t axis2 = 2) const;
-		virtual void      GetRandom2(Double_t& x, Double_t& y);
-		virtual void      GetStats(Double_t* stats) const;
-		virtual Double_t  Integral(Option_t* option = "") const;
-		using TH1::Integral;
-		virtual Double_t  Integral(Int_t firstxbin, Int_t lastxbin, Int_t firstybin, Int_t lastybin, Option_t* option = "") const;
-		virtual Double_t  Integral(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Option_t * ="") const { return 0; }
-		using TH1::IntegralAndError;
-		virtual Double_t  IntegralAndError(Int_t firstxbin, Int_t lastxbin, Int_t firstybin, Int_t lastybin, Double_t & error, Option_t* option = "") const;
-		virtual Double_t  Interpolate(Double_t);
-		virtual Double_t  Interpolate(Double_t, Double_t);
-		virtual Double_t  Interpolate(Double_t, Double_t, Double_t);
-		virtual Double_t  KolmogorovTest(const TH1* h2, Option_t* option = "") const;
-		virtual Long64_t  Merge(TCollection* list);
-		virtual TProfile* Profile(const char *name = "_pf", Int_t firstbin = 1, Int_t lastbin = -1, Option_t* option = "") const;
-		virtual TH1D*     Projection(const char* name = "_pr", Int_t firstBin = 0, Int_t lastBin = -1, Option_t* opt = "") const;
-		virtual void      PutStats(Double_t* stats);
-		virtual GHSym*    Rebin2D(Int_t ngroup = 2, const char* newname = "");
-		virtual void      Reset(Option_t* option="");
-		virtual void      SetCellContent(Int_t binx, Int_t biny, Double_t content);
-		virtual void      SetCellError(Int_t binx, Int_t biny, Double_t error);
-		virtual void      SetShowProjectionX(Int_t nbins = 1);  // *MENU*
-		virtual void      SetShowProjectionY(Int_t nbins = 1);  // *MENU*
-		virtual TH1*      ShowBackground(Int_t niter = 20, Option_t* option = "same");
-		virtual Int_t     ShowPeaks(Double_t sigma = 2, Option_t* option = "", Double_t threshold = 0.05); // *MENU*
-		virtual void      Smooth(Int_t ntimes = 1, Option_t* option = ""); // *MENU*
+	virtual Int_t     BufferEmpty(Int_t action = 0);
+	Int_t					BufferFill(Double_t, Double_t) { return -2; } //MayNotUse
+	virtual Int_t     BufferFill(Double_t x, Double_t y, Double_t w);
+	virtual void      Copy(TObject& hnew) const;
+	virtual Int_t     Fill(Double_t); //MayNotUse
+	virtual Int_t     Fill(const char*, Double_t) { return Fill(0); } //MayNotUse
+	virtual Int_t     Fill(Double_t x, Double_t y);
+	virtual Int_t     Fill(Double_t x, Double_t y, Double_t w);
+	virtual Int_t     Fill(const char* namex, const char* namey, Double_t w);
+	virtual void      FillN(Int_t, const Double_t *, const Double_t *, Int_t) {;} //MayNotUse
+	virtual void      FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride = 1);
+	virtual void      FillRandom(const char *fname, Int_t ntimes = 5000);
+	virtual void      FillRandom(TH1 *h, Int_t ntimes = 5000);
+	virtual Int_t     FindFirstBinAbove(Double_t threshold = 0, Int_t axis = 1) const;
+	virtual Int_t     FindLastBinAbove (Double_t threshold = 0, Int_t axis = 1) const;
+	virtual void      FitSlices(TF1* f1 = nullptr, Int_t firstbin = 0, Int_t lastbin = -1, Int_t cut = 0, Option_t* option = "QNR", TObjArray* arr = nullptr);
+	virtual Int_t     GetBin(Int_t binx, Int_t biny = 0, Int_t binz = 0) const;
+	virtual Double_t  GetBinWithContent2(Double_t c, Int_t& binx, Int_t& biny, Int_t firstxbin = 1, Int_t lastxbin = -1, Int_t firstybin = 1, Int_t lastybin = -1, Double_t maxdiff = 0) const;
+	virtual Double_t  GetCellContent(Int_t binx, Int_t biny) const;
+	virtual Double_t  GetCellError(Int_t binx, Int_t biny) const;
+	virtual Double_t  GetCorrelationFactor(Int_t axis1 = 1, Int_t axis2 = 2) const;
+	virtual Double_t  GetCovariance(Int_t axis1 = 1, Int_t axis2 = 2) const;
+	virtual void      GetRandom2(Double_t& x, Double_t& y);
+	virtual void      GetStats(Double_t* stats) const;
+	virtual Double_t  Integral(Option_t* option = "") const;
+	using TH1::Integral;
+	virtual Double_t  Integral(Int_t firstxbin, Int_t lastxbin, Int_t firstybin, Int_t lastybin, Option_t* option = "") const;
+	virtual Double_t  Integral(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Option_t * ="") const { return 0; }
+	using TH1::IntegralAndError;
+	virtual Double_t  IntegralAndError(Int_t firstxbin, Int_t lastxbin, Int_t firstybin, Int_t lastybin, Double_t & error, Option_t* option = "") const;
+	virtual Double_t  Interpolate(Double_t);
+	virtual Double_t  Interpolate(Double_t, Double_t);
+	virtual Double_t  Interpolate(Double_t, Double_t, Double_t);
+	virtual Double_t  KolmogorovTest(const TH1* h2, Option_t* option = "") const;
+	virtual Long64_t  Merge(TCollection* list);
+	virtual TProfile* Profile(const char *name = "_pf", Int_t firstbin = 1, Int_t lastbin = -1, Option_t* option = "") const;
+	virtual TH1D*     Projection(const char* name = "_pr", Int_t firstBin = 0, Int_t lastBin = -1, Option_t* opt = "") const;
+	virtual void      PutStats(Double_t* stats);
+	virtual GHSym*    Rebin2D(Int_t ngroup = 2, const char* newname = "");
+	virtual void      Reset(Option_t* option="");
+	virtual void      SetCellContent(Int_t binx, Int_t biny, Double_t content);
+	virtual void      SetCellError(Int_t binx, Int_t biny, Double_t error);
+	virtual void      SetShowProjectionX(Int_t nbins = 1);  // *MENU*
+	virtual void      SetShowProjectionY(Int_t nbins = 1);  // *MENU*
+	virtual TH1*      ShowBackground(Int_t niter = 20, Option_t* option = "same");
+	virtual Int_t     ShowPeaks(Double_t sigma = 2, Option_t* option = "", Double_t threshold = 0.05); // *MENU*
+	virtual void      Smooth(Int_t ntimes = 1, Option_t* option = ""); // *MENU*
 
-	protected:
-		using TH1::DoIntegral;
-		virtual Double_t DoIntegral(Int_t ix1, Int_t ix2, Int_t iy1, Int_t iy2, Double_t& err, Option_t* opt, Bool_t doerr = kFALSE) const;
-		Double_t fTsumwy;		//Total Sum of weight*Y
-		Double_t fTsumwy2;	//Total Sum of weight*Y*Y
-		Double_t fTsumwxy;	//Total Sum of weight*X*Y
-		TH2* fMatrix;        //!<! Transient pointer to the 2D-Matrix used in Draw() or GetMatrix()
+protected:
+	using TH1::DoIntegral;
+	virtual Double_t DoIntegral(Int_t ix1, Int_t ix2, Int_t iy1, Int_t iy2, Double_t& err, Option_t* opt, Bool_t doerr = kFALSE) const;
+	Double_t fTsumwy;		//Total Sum of weight*Y
+	Double_t fTsumwy2;	//Total Sum of weight*Y*Y
+	Double_t fTsumwxy;	//Total Sum of weight*X*Y
+	TH2* fMatrix;        //!<! Transient pointer to the 2D-Matrix used in Draw() or GetMatrix()
 
-	private:
-		GHSym(const GHSym&);
-		GHSym& operator=(const GHSym&);
+private:
+	GHSym(const GHSym&);
+	GHSym& operator=(const GHSym&);
 
 	ClassDef(GHSym, 1);
 };
 
 class GHSymF : public GHSym, public TArrayF {
-	public:
-		GHSymF();
-		GHSymF(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
-		GHSymF(const char* name, const char* title, Int_t nbins, const Double_t* bins);
-		GHSymF(const char* name, const char* title, Int_t nbins, const Float_t* bins);
-		GHSymF(const GHSymF&);
-		~GHSymF();
+public:
+	GHSymF();
+	GHSymF(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
+	GHSymF(const char* name, const char* title, Int_t nbins, const Double_t* bins);
+	GHSymF(const char* name, const char* title, Int_t nbins, const Float_t* bins);
+	GHSymF(const GHSymF&);
+	~GHSymF();
 
-		TH2F* GetMatrix(bool force = false);
+	TH2F* GetMatrix(bool force = false);
 
-		virtual void     AddBinContent(Int_t bin) { ++fArray[bin]; }
-		virtual void     AddBinContent(Int_t bin, Double_t w)	{ fArray[bin] += Float_t(w); }
-		virtual void     Copy(TObject& hnew) const;
-		virtual void     Draw(Option_t* option="") { GetMatrix()->Draw(option); }
+	virtual void     AddBinContent(Int_t bin) { ++fArray[bin]; }
+	virtual void     AddBinContent(Int_t bin, Double_t w)	{ fArray[bin] += Float_t(w); }
+	virtual void     Copy(TObject& hnew) const;
+	virtual void     Draw(Option_t* option="") { GetMatrix()->Draw(option); }
 #if MAJOR_ROOT_VERSION < 6
-		virtual TH1*     DrawCopy(Option_t* option = "") const;
+	virtual TH1*     DrawCopy(Option_t* option = "") const;
 #else
-		virtual TH1*     DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const;
+	virtual TH1*     DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const;
 #endif
-		virtual Double_t GetBinContent(Int_t bin) const;
-		virtual Double_t GetBinContent(Int_t binx, Int_t biny) const { return GetBinContent(GetBin(binx,biny)); }
-		virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const { return GetBinContent(GetBin(binx,biny)); }
-		virtual void     Reset(Option_t* option = "");
+	virtual Double_t GetBinContent(Int_t bin) const;
+	virtual Double_t GetBinContent(Int_t binx, Int_t biny) const { return GetBinContent(GetBin(binx,biny)); }
+	virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const { return GetBinContent(GetBin(binx,biny)); }
+	virtual void     Reset(Option_t* option = "");
 #if MAJOR_ROOT_VERSION >= 6
-		virtual Double_t  RetrieveBinContent(Int_t bin) const { return Double_t(fArray[bin]); }
+	virtual Double_t  RetrieveBinContent(Int_t bin) const { return Double_t(fArray[bin]); }
 #endif
-		virtual void     SetBinContent(Int_t bin, Double_t content);
-		virtual void     SetBinContent(Int_t binx, Int_t biny, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
-		virtual void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
-		virtual void     SetBinsLength(Int_t n = -1);
-		GHSymF&    operator=(const GHSymF& h1);
-		friend  GHSymF     operator*(Float_t c1, GHSymF &h1);
-		friend  GHSymF     operator*(GHSymF& h1, Float_t c1) { return operator*(c1,h1); }
-		friend  GHSymF     operator+(GHSymF& h1, GHSymF& h2);
-		friend  GHSymF     operator-(GHSymF& h1, GHSymF& h2);
-		friend  GHSymF     operator*(GHSymF& h1, GHSymF& h2);
-		friend  GHSymF     operator/(GHSymF& h1, GHSymF& h2);
+	virtual void     SetBinContent(Int_t bin, Double_t content);
+	virtual void     SetBinContent(Int_t binx, Int_t biny, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
+	virtual void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
+	virtual void     SetBinsLength(Int_t n = -1);
+	GHSymF&    operator=(const GHSymF& h1);
+	friend  GHSymF     operator*(Float_t c1, GHSymF &h1);
+	friend  GHSymF     operator*(GHSymF& h1, Float_t c1) { return operator*(c1,h1); }
+	friend  GHSymF     operator+(GHSymF& h1, GHSymF& h2);
+	friend  GHSymF     operator-(GHSymF& h1, GHSymF& h2);
+	friend  GHSymF     operator*(GHSymF& h1, GHSymF& h2);
+	friend  GHSymF     operator/(GHSymF& h1, GHSymF& h2);
 
-		ClassDef(GHSymF, 1);
+	ClassDef(GHSymF, 1);
 };
 
 class GHSymD : public GHSym, public TArrayD {
-	public:
-		GHSymD();
-		GHSymD(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
-		GHSymD(const char* name, const char* title, Int_t nbins, const Double_t* bins);
-		GHSymD(const char* name, const char* title, Int_t nbins, const Float_t* bins);
-		GHSymD(const GHSymD&);
-		~GHSymD();
+public:
+	GHSymD();
+	GHSymD(const char* name, const char* title, Int_t nbins, Double_t low, Double_t up);
+	GHSymD(const char* name, const char* title, Int_t nbins, const Double_t* bins);
+	GHSymD(const char* name, const char* title, Int_t nbins, const Float_t* bins);
+	GHSymD(const GHSymD&);
+	~GHSymD();
 
-		TH2D* GetMatrix(bool force = false);
+	TH2D* GetMatrix(bool force = false);
 
-		virtual void     AddBinContent(Int_t bin) { ++fArray[bin]; }
-		virtual void     AddBinContent(Int_t bin, Double_t w)	{ fArray[bin] += w; }
-		virtual void     Copy(TObject& hnew) const;
+	virtual void     AddBinContent(Int_t bin) { ++fArray[bin]; }
+	virtual void     AddBinContent(Int_t bin, Double_t w)	{ fArray[bin] += w; }
+	virtual void     Copy(TObject& hnew) const;
 #if MAJOR_ROOT_VERSION < 6
-		virtual TH1*     DrawCopy(Option_t* option = "") const;
+	virtual TH1*     DrawCopy(Option_t* option = "") const;
 #else
-		virtual TH1*     DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const;
+	virtual TH1*     DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const;
 #endif
-		virtual void     Draw(Option_t* option="") { GetMatrix()->Draw(option); }
-		virtual Double_t GetBinContent(Int_t bin) const;
-		virtual Double_t GetBinContent(Int_t binx, Int_t biny) const { return GetBinContent(GetBin(binx,biny)); }
-		virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const { return GetBinContent(GetBin(binx,biny)); }
-		virtual void     Reset(Option_t* option = "");
+	virtual void     Draw(Option_t* option="") { GetMatrix()->Draw(option); }
+	virtual Double_t GetBinContent(Int_t bin) const;
+	virtual Double_t GetBinContent(Int_t binx, Int_t biny) const { return GetBinContent(GetBin(binx,biny)); }
+	virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const { return GetBinContent(GetBin(binx,biny)); }
+	virtual void     Reset(Option_t* option = "");
 #if MAJOR_ROOT_VERSION >= 6
-		virtual Double_t  RetrieveBinContent(Int_t bin) const { return Double_t(fArray[bin]); }
+	virtual Double_t  RetrieveBinContent(Int_t bin) const { return Double_t(fArray[bin]); }
 #endif
-		virtual void     SetBinContent(Int_t bin, Double_t content);
-		virtual void     SetBinContent(Int_t binx, Int_t biny, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
-		virtual void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
-		virtual void     SetBinsLength(Int_t n = -1);
-		GHSymD&    operator=(const GHSymD& h1);
-		friend  GHSymD     operator*(Float_t c1, GHSymD &h1);
-		friend  GHSymD     operator*(GHSymD& h1, Float_t c1) { return operator*(c1,h1); }
-		friend  GHSymD     operator+(GHSymD& h1, GHSymD& h2);
-		friend  GHSymD     operator-(GHSymD& h1, GHSymD& h2);
-		friend  GHSymD     operator*(GHSymD& h1, GHSymD& h2);
-		friend  GHSymD     operator/(GHSymD& h1, GHSymD& h2);
+	virtual void     SetBinContent(Int_t bin, Double_t content);
+	virtual void     SetBinContent(Int_t binx, Int_t biny, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
+	virtual void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) { SetBinContent(GetBin(binx,biny),content); }
+	virtual void     SetBinsLength(Int_t n = -1);
+	GHSymD&    operator=(const GHSymD& h1);
+	friend  GHSymD     operator*(Float_t c1, GHSymD &h1);
+	friend  GHSymD     operator*(GHSymD& h1, Float_t c1) { return operator*(c1,h1); }
+	friend  GHSymD     operator+(GHSymD& h1, GHSymD& h2);
+	friend  GHSymD     operator-(GHSymD& h1, GHSymD& h2);
+	friend  GHSymD     operator*(GHSymD& h1, GHSymD& h2);
+	friend  GHSymD     operator/(GHSymD& h1, GHSymD& h2);
 
-		ClassDef(GHSymD, 1);
+	ClassDef(GHSymD, 1);
 };
 

--- a/include/TBadFragment.h
+++ b/include/TBadFragment.h
@@ -22,18 +22,20 @@
 class TBadFragment : public TFragment {
 	public:
 		TBadFragment();
-		TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord);
+		TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord, bool multipleErrors);
 		TBadFragment(const TBadFragment&);
 		~TBadFragment();
 
 		std::vector<uint32_t> GetData() const { return fData; }
 		int GetFailedWord() const             { return fFailedWord; }
+		bool GetMultipleErrors() const        { return fMultipleErrors; }
 
 		void Print(Option_t* opt = "") const;
 
 	private:
 		std::vector<uint32_t> fData;
 		int fFailedWord;
+		bool fMultipleErrors;
 
 	/// \cond CLASSIMP
 	ClassDef(TBadFragment, 1);

--- a/include/TBadFragment.h
+++ b/include/TBadFragment.h
@@ -1,0 +1,43 @@
+#ifndef TBADFRAGMENT_H
+#define TBADFRAGMENT_H
+
+/** \addtogroup Sorting
+ *  @{
+ */
+
+#include "TFragment.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TBadFragment
+///
+/// This Class contains all of the information in an event
+/// fragment that wasn't parsed correctly plus which word the
+/// parsing failed on and the data
+///
+/// \author Vinzenz Bildstein 
+/// \date 20. April 2017
+/////////////////////////////////////////////////////////////////
+
+class TBadFragment : public TFragment {
+	public:
+		TBadFragment();
+		TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord);
+		TBadFragment(const TBadFragment&);
+		~TBadFragment();
+
+		std::vector<uint32_t> GetData() const { return fData; }
+		int GetFailedWord() const             { return fFailedWord; }
+
+		void Print(Option_t* opt = "") const;
+
+	private:
+		std::vector<uint32_t> fData;
+		int fFailedWord;
+
+	/// \cond CLASSIMP
+	ClassDef(TBadFragment, 1);
+	/// \endcond
+};
+/*! @} */
+#endif

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -40,6 +40,32 @@
 #include "ThreadsafeQueue.h"
 #include "TEpicsFrag.h"
 
+enum class TDataParserState {
+	kGood,
+	kBadHeader,
+	kMissingWords,
+	kBadScalerLowTS,
+	kBadScalerValue,
+	kBadScalerHighTS,
+	kBadScalerType,
+	kBadTriggerId,
+	kBadLowTS,
+	kBadHighTS,
+	kSecondHeader,
+	kNotSingleCfd,
+	kSizeMismatch,
+	kBadFooter,
+	kFault,
+	kMissingPsd,
+	kMissingCfd,
+	kMissingCharge,
+	kBadBank,
+	kBadModuleType,
+	kEndOfData,
+	kUndefined
+};
+
+
 class TDataParser {
 	public:
 		TDataParser();
@@ -93,6 +119,8 @@ class TDataParser {
 		bool fFragmentHasWaveform;
 
 		TFragmentMap fFragmentMap;
+
+		TDataParserState fState;
 
 #ifndef __CINT__
 		std::atomic_size_t* fItemsPopped;

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -62,6 +62,7 @@ class TDataParser {
 			kBadLowTS,
 			kBadHighTS,
 			kSecondHeader,
+			kWrongNofWords,
 			kNotSingleCfd,
 			kSizeMismatch,
 			kBadFooter,
@@ -122,6 +123,7 @@ class TDataParser {
 		TFragmentMap fFragmentMap;
 
 		EDataParserState fState;
+		std::map<UInt_t, Long64_t> fLastTimeStampMap;
 
 #ifndef __CINT__
 		std::atomic_size_t* fItemsPopped;

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -40,32 +40,6 @@
 #include "ThreadsafeQueue.h"
 #include "TEpicsFrag.h"
 
-enum class TDataParserState {
-	kGood,
-	kBadHeader,
-	kMissingWords,
-	kBadScalerLowTS,
-	kBadScalerValue,
-	kBadScalerHighTS,
-	kBadScalerType,
-	kBadTriggerId,
-	kBadLowTS,
-	kBadHighTS,
-	kSecondHeader,
-	kNotSingleCfd,
-	kSizeMismatch,
-	kBadFooter,
-	kFault,
-	kMissingPsd,
-	kMissingCfd,
-	kMissingCharge,
-	kBadBank,
-	kBadModuleType,
-	kEndOfData,
-	kUndefined
-};
-
-
 class TDataParser {
 	public:
 		TDataParser();
@@ -75,6 +49,33 @@ class TDataParser {
 
 		//ENUM(EBank, char, kWFDN,kGRF1,kGRF2,kGRF3,kFME0,kFME1,kFME2,kFME3);
 		enum EBank { kWFDN=0,kGRF1=1,kGRF2=2,kGRF3=3,kGRF4=4,kFME0=5,kFME1=6,kFME2=7,kFME3=8 };
+
+		enum EDataParserState {
+			kGood,
+			kBadHeader,
+			kMissingWords,
+			kBadScalerLowTS,
+			kBadScalerValue,
+			kBadScalerHighTS,
+			kBadScalerType,
+			kBadTriggerId,
+			kBadLowTS,
+			kBadHighTS,
+			kSecondHeader,
+			kNotSingleCfd,
+			kSizeMismatch,
+			kBadFooter,
+			kFault,
+			kMissingPsd,
+			kMissingCfd,
+			kMissingCharge,
+			kBadBank,
+			kBadModuleType,
+			kEndOfData,
+			kUndefined
+		};
+
+
 
 #ifndef __CINT__
 		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&
@@ -120,7 +121,7 @@ class TDataParser {
 
 		TFragmentMap fFragmentMap;
 
-		TDataParserState fState;
+		EDataParserState fState;
 
 #ifndef __CINT__
 		std::atomic_size_t* fItemsPopped;

--- a/include/TDataParserException.h
+++ b/include/TDataParserException.h
@@ -14,17 +14,19 @@
 
 class TDataParserException : public std::exception {
 	public:
-		TDataParserException(TDataParser::EDataParserState, int);
+		TDataParserException(TDataParser::EDataParserState state, int failedWord, bool multipleErrors);
 		~TDataParserException();
 
 		const char* what() const noexcept;
 
-		int GetFailedWord()               { return fFailedWord; }
+		int GetFailedWord()                            { return fFailedWord; }
 		TDataParser::EDataParserState GetParserState() { return fParserState; }
+		bool GetMultipleErrors()                       { return fMultipleErrors; }
 
 	private:
 		TDataParser::EDataParserState fParserState;
 		int fFailedWord;
+		bool fMultipleErrors;
 		std::string fMessage;
 };
 /*! @} */

--- a/include/TDataParserException.h
+++ b/include/TDataParserException.h
@@ -14,16 +14,16 @@
 
 class TDataParserException : public std::exception {
 	public:
-		TDataParserException(TDataParserState, int);
+		TDataParserException(TDataParser::EDataParserState, int);
 		~TDataParserException();
 
 		const char* what() const noexcept;
 
 		int GetFailedWord()               { return fFailedWord; }
-		TDataParserState GetParserState() { return fParserState; }
+		TDataParser::EDataParserState GetParserState() { return fParserState; }
 
 	private:
-		TDataParserState fParserState;
+		TDataParser::EDataParserState fParserState;
 		int fFailedWord;
 		std::string fMessage;
 };

--- a/include/TDataParserException.h
+++ b/include/TDataParserException.h
@@ -1,0 +1,31 @@
+#ifndef TDATAPARSEREXCEPTION_H
+#define TDATAPARSEREXCEPTION_H
+/** \addtogroup Sorting
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+
+#include <exception>
+#include <string>
+
+#include "TDataParser.h"
+
+class TDataParserException : public std::exception {
+	public:
+		TDataParserException(TDataParserState, int);
+		~TDataParserException();
+
+		const char* what() const noexcept;
+
+		int GetFailedWord()               { return fFailedWord; }
+		TDataParserState GetParserState() { return fParserState; }
+
+	private:
+		TDataParserState fParserState;
+		int fFailedWord;
+		std::string fMessage;
+};
+/*! @} */
+#endif

--- a/include/TFragWriteLoop.h
+++ b/include/TFragWriteLoop.h
@@ -21,6 +21,7 @@
 #include "StoppableThread.h"
 #include "ThreadsafeQueue.h"
 #include "TFragment.h"
+#include "TBadFragment.h"
 #include "TEpicsFrag.h"
 
 class TFragWriteLoop : public StoppableThread {
@@ -67,7 +68,7 @@ class TFragWriteLoop : public StoppableThread {
 		TTree* fScalerTree;
 
 		TFragment*  fEventAddress;
-		TFragment*  fBadEventAddress;
+		TBadFragment*  fBadEventAddress;
 		TEpicsFrag* fScalerAddress;
 
 #ifndef __CINT__

--- a/include/TFragment.h
+++ b/include/TFragment.h
@@ -126,7 +126,7 @@ class TFragment : public TGRSIDetectorHit	{
    Int_t    fZc;                      //!<! Zero-crossing value from 4G (saved in separate branch)
    Int_t    fCcShort;                 //!<! Short integration over waveform peak from 4G (saved in separate branch)
    Int_t    fCcLong;                  //!<! Long integration over waveform tail from 4G (saved in separate branch)
-   UShort_t fNumberOfWords;           //!<! Number of non-waveform words in fragment ; since this is not saved to file, why have it as a member at all???
+   UShort_t fNumberOfWords;           //!<! Number of non-waveform words in fragment, only used for check while parsing the fragment
 
 	static Long64_t fNumberOfFragments;
 

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -126,7 +126,7 @@ class TGRSIDetectorHit : public TObject 	{
       //TODO: Fix Getters to have non-const types
       virtual Int_t   GetCfd()    const               { return fCfd;}                 //!<!
       virtual UInt_t GetAddress() const               { return fAddress; }            //!<!
-      virtual Int_t  GetCharge()  const;                                              //!<!
+      virtual Float_t GetCharge() const;                                              //!<!
       virtual Float_t Charge()    const               { return fCharge; }             //!<!
       virtual Short_t GetKValue() const               { return fKValue; }             //!<!
       const std::vector<Short_t>* GetWaveform() const { return &fWaveform; }          //!<!

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -48,7 +48,6 @@ class TGRSIOptions : public TObject {
 		const std::string& OutputFragmentFile() { return fOutputFragmentFile; }
 		const std::string& OutputAnalysisFile() { return fOutputAnalysisFile; }
 
-
 		const std::string& OutputFilteredFile()        { return fOutputFilteredFile; }
 		const std::string& OutputFragmentHistogramFile(){ return fOutputFragmentHistogramFile; }
 		const std::string& OutputAnalysisHistogramFile(){ return fOutputAnalysisHistogramFile; }
@@ -69,6 +68,7 @@ class TGRSIOptions : public TObject {
 		bool StartGui() const { return fStartGui; }
 
 		bool SuppressErrors() const { return fSuppressErrors; }
+		bool ReconstructTimeStamp() const { return fReconstructTimeStamp; }
 
 		bool CloseAfterSort()     const { return fCloseAfterSort; }
 
@@ -158,6 +158,7 @@ class TGRSIOptions : public TObject {
 		bool fLogErrors;                             ///< Flag to log errors (--log-errors)
 		bool fUseMidFileOdb;                         ///< Flag to read odb from midas
 		bool fSuppressErrors;                        ///< Flag to suppress errors (--suppress-errors)
+		bool fReconstructTimeStamp;                  ///< Flag to reconstruct missing high bits of time stamps (--reconstruct-timestamp)
 
 		bool fMakeAnalysisTree;                      ///< Flag to make analysis tree (-a)
 		bool fProgressDialog;                        ///< Flag to show progress in proof (not used)

--- a/include/TGRSIProof.h
+++ b/include/TGRSIProof.h
@@ -58,9 +58,9 @@ class TGRSIProof : public TProof	{
       const char* pPath = getenv("GRSISYS");
 
       //First set the include path on each slave
-      this->Exec(Form("gInterpreter->AddIncludePath(\"%s/include\")",pPath));
+      Exec(Form("gInterpreter->AddIncludePath(\"%s/include\")",pPath));
       std::cout << "Loading Libraries" << std::endl;
-      this->Exec(Form("gSystem->Load(\"%s/lib/libGRSI.so\");",pPath));
+      Exec(Form("gSystem->Load(\"%s/lib/libGRSI.so\");",pPath));
    }
 
    /// \cond CLASSIMP

--- a/include/TUnpackingLoop.h
+++ b/include/TUnpackingLoop.h
@@ -38,10 +38,10 @@ class TUnpackingLoop : public StoppableThread {
 		void SetRecordDiag(bool temp = true)  { fParser.SetRecordDiag(temp); }
 
 #ifndef __CINT__
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TRawEvent> > >&                        InputQueue()                               { return fInputQueue; }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&  AddGoodOutputQueue(size_t maxSize = 50000) { return fParser.AddGoodOutputQueue(maxSize); }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >&  BadOutputQueue()                           { return fParser.BadOutputQueue(); }
-		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >&       ScalerOutputQueue()                        { return fParser.ScalerOutputQueue(); }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TRawEvent> > >&       InputQueue()                               { return fInputQueue; }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& AddGoodOutputQueue(size_t maxSize = 50000) { return fParser.AddGoodOutputQueue(maxSize); }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment> > >& BadOutputQueue()                           { return fParser.BadOutputQueue(); }
+		std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag> > >&      ScalerOutputQueue()                        { return fParser.ScalerOutputQueue(); }
 #endif
 
 		bool Iteration();

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -1,4 +1,5 @@
 #include "TDataParser.h"
+#include "TDataParserException.h"
 
 #include "TChannel.h"
 #include "Globals.h"
@@ -12,6 +13,7 @@
 #include "Rtypes.h"
 
 #include "TFragment.h"
+#include "TBadFragment.h"
 
 /// \cond CLASSIMP
 //ClassImp(TDataParser)
@@ -59,16 +61,16 @@ void TDataParser::SetFinished() {
 int TDataParser::TigressDataToFragment(uint32_t* data,int size,unsigned int midasSerialNumber, time_t midasTime) {
 	///Converts A MIDAS File from the Tigress DAQ into a TFragment.
 	int NumFragsFound = 0;
-	std::shared_ptr<TFragment> EventFrag = std::make_shared<TFragment>();
-	EventFrag->SetMidasTimeStamp(midasTime);
-	EventFrag->SetMidasId(midasSerialNumber);
+	std::shared_ptr<TFragment> eventFrag = std::make_shared<TFragment>();
+	eventFrag->SetMidasTimeStamp(midasTime);
+	eventFrag->SetMidasId(midasSerialNumber);
 
 	int x = 0;
 	uint32_t dword = *(data+x);
 	uint32_t type = (dword & 0xf0000000)>>28;
 	uint32_t value = (dword & 0x0fffffff);
 
-	if(!SetTIGTriggerID(dword,EventFrag)) {
+	if(!SetTIGTriggerID(dword, eventFrag)) {
 		printf(RED "Setting TriggerId (0x%08x) failed on midas event: " DYELLOW "%i" RESET_COLOR "\n",dword,midasSerialNumber);
 		return -x;
 	}
@@ -76,7 +78,7 @@ int TDataParser::TigressDataToFragment(uint32_t* data,int size,unsigned int mida
 
 	//There can be a tigger bit pattern between the header and the time !   pcb.
 
-	if(!SetTIGTimeStamp((data+x),EventFrag)) {
+	if(!SetTIGTimeStamp((data+x), eventFrag)) {
 		printf(RED "%i Setting TimeStamp failed on midas event: " DYELLOW "%i" RESET_COLOR "\n",x,midasSerialNumber);
 		return -x;
 	}
@@ -89,51 +91,50 @@ int TDataParser::TigressDataToFragment(uint32_t* data,int size,unsigned int mida
 		switch(type) {
 			case 0x0: // raw wave forms.
 				{
-					TChannel* chan = TChannel::GetChannel(EventFrag->GetAddress());
+					TChannel* chan = TChannel::GetChannel(eventFrag->GetAddress());
 					if(!fNoWaveforms)
-						SetTIGWave(value,EventFrag);
+						SetTIGWave(value, eventFrag);
 					if(chan && strncmp("Tr",chan->GetName(),2)==0) {
-						SetTIGWave(value,EventFrag);
+						SetTIGWave(value, eventFrag);
 					} else if(chan && strncmp("RF",chan->GetName(),2)==0) {
-						SetTIGWave(value,EventFrag);
+						SetTIGWave(value, eventFrag);
 					}
 				}
 				break;
 			case 0x1: // trapizodal wave forms.
 				break;
 			case 0x4: // cfd values.  This also ends the the fragment!
-				SetTIGCfd(value,EventFrag);
-				//SetTIGCharge(temp_charge,EventFrag);
-				SetTIGLed(temp_led,EventFrag);
+				SetTIGCfd(value, eventFrag);
+				SetTIGLed(temp_led, eventFrag);
 				///check whether the fragment is 'good'
 
 				if( ((*(data+x+1)) & 0xf0000000) != 0xe0000000) {
-					std::shared_ptr<TFragment> transferfrag = std::make_shared<TFragment>(*EventFrag);
-					EventFrag = std::make_shared<TFragment>();
-					EventFrag->SetMidasTimeStamp(transferfrag->GetMidasTimeStamp());
-					EventFrag->SetMidasId(transferfrag->GetMidasId());
-					EventFrag->SetTriggerId(transferfrag->GetTriggerId());
-					EventFrag->SetTimeStamp(transferfrag->GetTimeStamp());
+					std::shared_ptr<TFragment> transferfrag = std::make_shared<TFragment>(*eventFrag);
+					eventFrag = std::make_shared<TFragment>();
+					eventFrag->SetMidasTimeStamp(transferfrag->GetMidasTimeStamp());
+					eventFrag->SetMidasId(transferfrag->GetMidasId());
+					eventFrag->SetTriggerId(transferfrag->GetTriggerId());
+					eventFrag->SetTimeStamp(transferfrag->GetTimeStamp());
 
 					Push(fGoodOutputQueues, transferfrag);
 					NumFragsFound++;
 
 					// printf("transferfrag = 0x%08x\n",transferfrag); fflush(stdout);
 					// printf("transferfrag->GetTimeStamp() = %lu\n",transferfrag->GetTimeStamp()); fflush(stdout);
-					// printf("EventFrag: = 0x%08x\n",EventFrag); fflush(stdout);
-					// printf("EventFrag->GetTimeStamp() = %lu\n",EventFrag->GetTimeStamp()); fflush(stdout);
+					// printf("eventFrag: = 0x%08x\n",eventFrag); fflush(stdout);
+					// printf("eventFrag->GetTimeStamp() = %lu\n",eventFrag->GetTimeStamp()); fflush(stdout);
 				}
 				else {
-					std::shared_ptr<TFragment> transferfrag = std::make_shared<TFragment>(*EventFrag);
+					std::shared_ptr<TFragment> transferfrag = std::make_shared<TFragment>(*eventFrag);
 					Push(fGoodOutputQueues, transferfrag);
 					NumFragsFound++;
-					EventFrag = 0;
+					eventFrag = 0;
 					return NumFragsFound;
 				}
 
 				break;
 			case 0x5: // raw charge evaluation.
-				SetTIGCharge(value,EventFrag);
+				SetTIGCharge(value,eventFrag);
 				break;
 			case 0x6:
 				temp_led = value;
@@ -142,10 +143,10 @@ int TDataParser::TigressDataToFragment(uint32_t* data,int size,unsigned int mida
 				//SetTIGBitPattern
 				break;
 			case 0xc:
-				SetTIGAddress(value,EventFrag);
+				SetTIGAddress(value,eventFrag);
 				break;
 			case 0xe: // this ends the bank!
-				if(EventFrag) {
+				if(eventFrag) {
 					//printf("this is never called\n"); fflush(stdout);
 					return -x;
 				}
@@ -395,70 +396,80 @@ bool TDataParser::SetTIGTimeStamp(uint32_t* data, std::shared_ptr<TFragment> cur
 
 int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, unsigned int midasSerialNumber, time_t midasTime) {
 	///Converts a Griffin flavoured MIDAS file into a TFragment and returns the number of words processed (or the negative index of the word it failed on)
-	std::shared_ptr<TFragment> EventFrag = std::make_shared<TFragment>();
-	// no need to delete EventFrag, it's a shared_ptr and gets deleted when it goes out of scope
+	std::shared_ptr<TFragment> eventFrag = std::make_shared<TFragment>();
+	// no need to delete eventFrag, it's a shared_ptr and gets deleted when it goes out of scope
 	fFragmentHasWaveform = false;
+	fState = TDataParserState::kGood;
+	int failedWord = -1; // Variable stores which word we failed on (if we fail). This is somewhat duplicate information to fState, but makes things easier to track.
 
 	int x = 0;
-	if(!SetGRIFHeader(data[x++],EventFrag,bank)) {
+	if(!SetGRIFHeader(data[x++],eventFrag,bank)) {
 		printf(DYELLOW "data[0] = 0x%08x" RESET_COLOR "\n",data[0]);
 		TParsingDiagnostics::Get()->BadFragment(-1); //we failed to get a good header, so we don't know which detector type this fragment would've belonged to
-		return -x;
+		// this is the first word, so no need to check is the state/failed word has been set before
+		fState = TDataParserState::kBadHeader;
+		failedWord = x;
 	}
 
-	//printf("parsing griffin fragment: data %p, size %d, bank %d, midas serial %d, fragment %p\n", (void*) data, size, bank, midasSerialNumber, (void*) EventFrag);
-	EventFrag->SetMidasTimeStamp(midasTime);
-	EventFrag->SetMidasId(midasSerialNumber);
+	eventFrag->SetMidasTimeStamp(midasTime);
+	eventFrag->SetMidasId(midasSerialNumber);
 
-	//Changed on 11 Aug 2015 by RD to include PPG events. If the event has ModuleType 4 and address 0xFFFF, it is a PPG event.
-	//if(EventFrag->GetModuleType() == 4 && EventFrag->GetAddress() == 0xFFFF){
-	if((EventFrag->GetModuleType() == 1 || EventFrag->GetModuleType() == 4) && EventFrag->GetAddress() == 0xFFFF){
+	//Changed on 11 Aug 2015 by RD to include PPG events. If the event has ModuleType 4 and address 0xffff, it is a PPG event.
+	if((eventFrag->GetModuleType() == 1 || eventFrag->GetModuleType() == 4) && eventFrag->GetAddress() == 0xffff){
 		return GriffinDataToPPGEvent(data,size,midasSerialNumber,midasTime);
 	}
 	//If the event has detector type 15 (0xf) it's a scaler event.
-	if(EventFrag->GetDetectorType() == 0xf) {
+	if(eventFrag->GetDetectorType() == 0xf) {
 		//a scaler event (trigger or deadtime) has 8 words (including header and trailer), make sure we have at least that much left
 		if(size < 8) {
-			return -x;
+			fState = TDataParserState::kMissingWords;
+			failedWord = x;
+			throw TDataParserException(fState, failedWord);
 		}
-		x = GriffinDataToScalerEvent(data, EventFrag->GetAddress());
-		return x;
+		return GriffinDataToScalerEvent(data, eventFrag->GetAddress());
 	}
 
-	//The Network packet number is for debugging and is not always written to
-	//the midas file.
-	if(SetGRIFNetworkPacket(data[x],EventFrag)) {
-		x++;
+	//The Network packet number is for debugging and is not always written to the midas file.
+	if(SetGRIFNetworkPacket(data[x],eventFrag)) {
+		++x;
 	}
 
 	//The master Filter Pattern is in an unstable state right now and is not
 	//always written to the midas file
-	if(SetGRIFMasterFilterPattern(data[x], EventFrag, bank)) {
-		x++;
+	if(SetGRIFMasterFilterPattern(data[x], eventFrag, bank)) {
+		++x;
 	}
 
 	//We can get multiple filter ids (one fragment can pass multiple filter conditions)
-	//so we have to loop until we don;t find one
-	while(SetGRIFMasterFilterId(data[x],EventFrag)) {
-		x++;
+	//so we have to loop until we don't find one
+	while(SetGRIFMasterFilterId(data[x],eventFrag)) {
+		++x;
 	}
 
 	//The channel trigger ID is in an unstable state right now and is not
 	//always written to the midas file
-	if(!SetGRIFChannelTriggerId(data[x++],EventFrag)) {
-		TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-		return -x;
+	if(!SetGRIFChannelTriggerId(data[x++],eventFrag)) {
+		TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+		if(fState == TDataParserState::kGood) fState = TDataParserState::kBadTriggerId;
+		if(failedWord == -1) failedWord = x-1; // -1 compensates the incrementation in the if-statement
 	}
 
 	//The Network packet number is for debugging and is not always written to
 	//the midas file.
-	if(SetGRIFNetworkPacket(data[x],EventFrag)) {
+	if(SetGRIFNetworkPacket(data[x],eventFrag)) {
 		x++;
 	}
 
-	if(!SetGRIFTimeStampLow(data[x++],EventFrag)) {
-		TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-		return -x;
+	if(!SetGRIFTimeStampLow(data[x++],eventFrag)) {
+		TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+		if(fState == TDataParserState::kGood) fState = TDataParserState::kBadLowTS;
+		if(failedWord == -1) failedWord = x-1; // -1 compensates the incrementation in the if-statement
+	}
+
+	if(!SetGRIFDeadTime(data[x++],eventFrag)) {
+		TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+		if(fState == TDataParserState::kGood) fState = TDataParserState::kBadHighTS;
+		if(failedWord == -1) failedWord = x-1; // -1 compensates the incrementation in the if-statement
 	}
 
 	std::vector<Int_t> tmpCharge;
@@ -475,37 +486,40 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 				//if this happens, we have "accidentally" found another event.
 				//currently the GRIF-C only sets the master/slave port of the address for the first header (of the corrupt event)
 				//so we want to ignore this corrupt event and the next event which has a wrong address
-				//std::cout<<"double header"<<std::endl;
-				TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-				return -(x+1);//+1 to ensure we don't read this header as start of a good event
+				TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+				if(fState == TDataParserState::kGood) {
+					fState = TDataParserState::kSecondHeader;
+					failedWord = x+1; //+1 to ensure we don't read this header as start of a good event
+					Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+					throw TDataParserException(fState, failedWord);
+				} else {
+					Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+					throw TDataParserException(fState, failedWord);
+				}
 				break;
 			case 0xc: //The c packet type is for waveforms
-				if(!fNoWaveforms)
-					SetGRIFWaveForm(value,EventFrag);
-				break;
-			case 0xb: //The b packet type contains the dead-time word
-				SetGRIFDeadTime(value,EventFrag);
+				if(!fNoWaveforms)	SetGRIFWaveForm(value, eventFrag);
 				break;
 			case 0xd:
-				SetGRIFNetworkPacket(dword,EventFrag); // The network packet placement is not yet stable.
+				SetGRIFNetworkPacket(dword, eventFrag); // The network packet placement is not yet stable.
 				break;
 			case 0xe:
 				// changed on 21 Apr 2015 by JKS, when signal processing code from Chris changed the trailer.
 				// change should be backward-compatible
-				if((value & 0x3fff) == (EventFrag->GetChannelId() & 0x3fff)){
-					if(!TGRSIOptions::Get()->SuppressErrors() && (EventFrag->GetModuleType() == 2) && (bank < kGRF3)) {
+				if((value & 0x3fff) == (eventFrag->GetChannelId() & 0x3fff)) {
+					if(!TGRSIOptions::Get()->SuppressErrors() && (eventFrag->GetModuleType() == 2) && (bank < kGRF3)) {
 						// check whether the nios finished and if so whether it finished with an error
 						if(((value>>14) & 0x1) == 0x1) {
 							if(((value>>16) & 0xff) != 0) {
-								printf( BLUE "0x%04x: NIOS code finished with error 0x%02x" RESET_COLOR "\n",EventFrag->GetAddress(), (value>>16) & 0xff);
+								printf( BLUE "0x%04x: NIOS code finished with error 0x%02x" RESET_COLOR "\n",eventFrag->GetAddress(), (value>>16) & 0xff);
 							}
 						}
 					}
 
-					if((EventFrag->GetModuleType() == 1) || (bank > kGRF2)) { //4Gs have this only for banks newer than GRF2
-						EventFrag->SetAcceptedChannelId((value>>14) & 0x3fff);
+					if((eventFrag->GetModuleType() == 1) || (bank > kGRF2)) { //4Gs have this only for banks newer than GRF2
+						eventFrag->SetAcceptedChannelId((value>>14) & 0x3fff);
 					} else {
-						EventFrag->SetAcceptedChannelId(0);
+						eventFrag->SetAcceptedChannelId(0);
 					}
 
 					//the way we insert the fragment(s) depends on the module type and bank:
@@ -515,58 +529,74 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 					//the last two cases can be treated the same since the second case will just have a single length charge, cfd, and IntLengths
 
 					//the first two cases can be treated the same way, so we only need to check for the third case
-					if(EventFrag->GetModuleType() == 1 && bank == kGRF4) {
+					if(eventFrag->GetModuleType() == 1 && bank == kGRF4) {
 						if(tmpCfd.size() != 1) {
-							if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-							Push(*fBadOutputQueue,EventFrag);
-							return -x;
+							if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+							if(fState == TDataParserState::kGood) fState = TDataParserState::kNotSingleCfd;
+							if(failedWord == -1) failedWord = x;
+							Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+							throw TDataParserException(fState, failedWord);
 						}
-						EventFrag->SetCfd(tmpCfd[0]);
-						if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(EventFrag);
-						fFragmentMap.Add(EventFrag, tmpCharge, tmpIntLength);
+						eventFrag->SetCfd(tmpCfd[0]);
+						if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+						fFragmentMap.Add(eventFrag, tmpCharge, tmpIntLength);
 						return x;
 					} else {
 						if(tmpCharge.size() != tmpIntLength.size() || tmpCharge.size() != tmpCfd.size()) {
-							if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-							Push(*fBadOutputQueue,EventFrag);
-							return -x;
+							if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+							if(fState == TDataParserState::kGood) fState = TDataParserState::kSizeMismatch;
+							if(failedWord == -1) failedWord = x;
+							Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+							throw TDataParserException(fState, failedWord);
 						}
 						for(size_t h = 0; h < tmpCharge.size(); ++h) {
-							EventFrag->SetCharge(tmpCharge[h]);
-							EventFrag->SetKValue(tmpIntLength[h]);
-							EventFrag->SetCfd(tmpCfd[h]);
-							if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(EventFrag);
-							Push(fGoodOutputQueues, std::make_shared<TFragment>(*EventFrag));
+							eventFrag->SetCharge(tmpCharge[h]);
+							eventFrag->SetKValue(tmpIntLength[h]);
+							eventFrag->SetCfd(tmpCfd[h]);
+							if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(eventFrag);
+							if(fState == TDataParserState::kGood)	Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));
+							else Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
 						}
 						return x;
 					}
 				} else  {
-					if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-					Push(*fBadOutputQueue,EventFrag);
-					return -x;
+					if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+					if(fState == TDataParserState::kGood) fState = TDataParserState::kBadFooter;
+					if(failedWord == -1) failedWord = x;
+					Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+					throw TDataParserException(fState, failedWord);
 				}
 				break;
 			case 0xf:
 				switch(bank) {
 					case kGRF1: // format from before May 2015 experiments
-						TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-						return -x;
+						TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+						if(fState == TDataParserState::kGood) fState = TDataParserState::kFault;
+						if(failedWord == -1) failedWord = x;
+						Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+						throw TDataParserException(fState, failedWord);
 						break;
 					case kGRF2: // from May 2015 to the end of 2015 0xf denoted a psd-word from a 4G
 						if(x+1 < size) {
-							SetGRIFCc(value, EventFrag);
+							SetGRIFCc(value, eventFrag);
 							++x;
 							dword = data[x];
-							SetGRIFPsd(dword, EventFrag);
+							SetGRIFPsd(dword, eventFrag);
 						} else {
-							TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-							return -x;
+							TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+							if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingPsd;
+							if(failedWord == -1) failedWord = x;
+							Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+							throw TDataParserException(fState, failedWord);
 						}
 						break;
 					case kGRF3: // from 2016 on we're back to reserving 0xf for faults
 					case kGRF4:
-						TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-						return -x;
+						TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+						if(fState == TDataParserState::kGood) fState = TDataParserState::kFault;
+						if(failedWord == -1) failedWord = x;
+						Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+						throw TDataParserException(fState, failedWord);
 						break;
 					default:
 						printf("This bank not yet defined.\n");
@@ -576,24 +606,24 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 
 			default:
 				//these are charge/cfd words which are different depending on module type, and bank number/detector type
-				switch(EventFrag->GetModuleType()) {
+				switch(eventFrag->GetModuleType()) {
 					case 1:
 						switch(bank) { //the GRIF-16 data format depends on the bank number
 							case kGRF1: //bank's 1&2 have n*2 words with (5 high bits IntLength, 26 Charge)(5 low bits IntLength, 26 Cfd)
 							case kGRF2:
 								//read this pair of charge/cfd words, check if the next word is also a charge/cfd word
-								if(((data[x] & 0x80000000) == 0x00000000) && x+1 < size && (data[x+1] & 0x80000000) == 0x0) {
+								if(((data[x] & 0x80000000) == 0x0) && x+1 < size && (data[x+1] & 0x80000000) == 0x0) {
 									Short_t tmp = (data[x] & 0x7c000000) >> 21; //21 = 26 minus space for 5 low bits
 									tmpCharge.push_back((data[x] & 0x03ffffff) | (((data[x] & 0x02000000) == 0x02000000) ? 0xfc000000 : 0x0)); //extend the sign bit of 26bit charge word
 									++x;
 									tmpIntLength.push_back(tmp | ((data[x] & 0x7c000000) >> 26));
 									tmpCfd.push_back(data[x] & 0x03ffffff);
 								} else {
-									//these types of corrupt events quite often end without a trailer which leads to the header of the next event missing the master/slave part of the address
-									//so we look for the next trailer and stop there
-									while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-									TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-									return -x;
+									TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+									if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingCfd;
+									if(failedWord == -1) failedWord = x;
+									Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+									throw TDataParserException(fState, failedWord);
 								}
 								break;
 							case kGRF3: //bank 3 has 2 words with (5 high bits IntLength, 26 Charge)(9 low bits IntLength, 22 Cfd)
@@ -605,15 +635,14 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 									tmpCfd.push_back(data[x] & 0x003fffff);
 									break;
 								} else {
-									//these types of corrupt events quite often end without a trailer which leads to the header of the next event missing the master/slave part of the address
-									//so we look for the next trailer and stop there
-									while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-									TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-									return -x;
+									TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+									if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingCfd;
+									if(failedWord == -1) failedWord = x;
+									Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+									throw TDataParserException(fState, failedWord);
 								}
 								break;
 							case kGRF4: //bank 4 can have more than one integration (up to four), but these have to be combined with other fragments/hits!
-								//std::cout<<"kGRF4: "<<std::flush;
 								//we always have 2 words with (5 high bits IntLength, 26 Charge)(9 low bits IntLength, 22 Cfd)
 								if(x+1 < size && (data[x+1] & 0x80000000) == 0x0) { //check if the next word is also a charge/cfd word
 									Short_t tmp = ((data[x] & 0x7c000000) >> 17) | (((data[x] & 0x40000000) == 0x40000000) ? 0xc000 : 0x0); //17 = 26 minus space for 9 low bits; signed, so we extend the sign bit from 14 (31) to 16 bits
@@ -622,24 +651,20 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 									} else {
 										tmpCharge.push_back((data[x] & 0x01ffffff) | (((data[x] & 0x01000000) == 0x01000000) ? 0xfe000000 : 0x0)); //extend the sign bit of 25bit charge word
 									}
-									//std::cout<<"0x"<<std::hex<<data[x]<<": charge = 0x"<<tmpCharge.back()<<", k = "<<tmp<<std::endl;
 									++x;
 									tmpIntLength.push_back(tmp | ((data[x] & 0x7fc00000) >> 22));
 									tmpCfd.push_back(data[x] & 0x003fffff);
-									//std::cout<<"0x"<<std::hex<<data[x]<<": cfd = 0x"<<tmpCfd.back()<<", k = "<<tmpIntLength.back()<<std::endl;
-									//std::cout<<"found 2 words (0x"<<std::hex<<tmpCharge.back()<<"/0x"<<tmpIntLength.back()<<"/0x"<<tmpCfd.back()<<std::dec<<")"<<std::endl;
 									//check if we have two more words (X & XI) with (8 num hits, 2 reserved, 14 IntLength2)(31 Charge2); x has already been incremented once!
 									if(x+2 < size && (data[x+1] & 0x80000000) == 0x0 && (data[x+2] & 0x80000000) == 0x0) {
 										++x;
 										tmpIntLength.push_back((data[x] & 0x3fff) | (((data[x] & 0x2000) == 0x2000) ? 0xc000 : 0x0));
-										//EventFrag->SetNumberOfPileups((data[x] >> 16) & 0xff);
+										//eventFrag->SetNumberOfPileups((data[x] >> 16) & 0xff);
 										++x;
 										if((data[x] & 0x02000000) == 0x02000000) { // overflow bit was set
 											tmpCharge.push_back(std::numeric_limits<int>::max());
 										} else {
 											tmpCharge.push_back((data[x] & 0x01ffffff) | (((data[x] & 0x01000000) == 0x01000000) ? 0xfe000000 : 0x0)); //extend the sign bit of 25bit charge word
 										}
-										//std::cout<<"found 4 words (0x"<<std::hex<<tmpCharge.back()<<"/0x"<<tmpIntLength.back()<<"/0x"<<tmpCfd.back()<<std::dec<<")"<<std::endl;
 										//check if we have two more words (XI & XIII) with (14 IntLength4, 2 reserved, 14 IntLength3)(31 Charge3); x has already been incremented thrice!
 										if(x+2 < size && (data[x+1] & 0x80000000) == 0x0 && (data[x+2] & 0x80000000) == 0x0) {
 											++x;
@@ -663,33 +688,31 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 												tmpIntLength.pop_back();
 											}
 										} else if((data[x+1] & 0x80000000) == 0x0) { //5 words
-											//std::cout<<"5 words!"<<std::endl;
-											//while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-											//TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-											//return -x;
 											++x;
 										}
 									} else if((data[x+1] & 0x80000000) == 0x0) { //3 words
-										//std::cout<<"3 words (0x"<<std::hex<<data[x]<<")"<<std::endl;
-										//while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-										//TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-										//return -x;
 										++x;
 									}
 								} else {
 									//these types of corrupt events quite often end without a trailer which leads to the header of the next event missing the master/slave part of the address
 									//so we look for the next trailer and stop there
-									//std::cout<<"1 word (0x"<<std::hex<<data[x]<<")"<<std::endl;
 									while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-									TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-									return -x;
+									TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+									if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingCharge;
+									if(failedWord == -1) failedWord = x;
+									Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+									throw TDataParserException(fState, failedWord);
 								}
 								break;
 							default:
 								if(!TGRSIOptions::Get()->SuppressErrors()) {
 									printf(DRED "Error, back type %d not implemented yet" RESET_COLOR "\n", bank);
 								}
-								return -x;
+								TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+								if(fState == TDataParserState::kGood) fState = TDataParserState::kBadBank;
+								if(failedWord == -1) failedWord = x;
+								Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+								throw TDataParserException(fState, failedWord);
 								break;
 						}
 						break;
@@ -702,42 +725,55 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
 							tmpIntLength.push_back(tmp | ((data[x] & 0x7c000000) >> 26));
 							tmpCfd.push_back(data[x] & 0x03ffffff);
 						} else {
-							//these types of corrupt events quite often end without a trailer which leads to the header of the next event missing the master/slave part of the address
-							//so we look for the next trailer and stop there
-							while(x < size && (data[x] & 0xf0000000) != 0xe0000000) ++x;
-							TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-							return -x;
+							TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+							if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingCfd;
+							if(failedWord == -1) failedWord = x;
+							Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+							throw TDataParserException(fState, failedWord);
 						}
 						//for descant types (6,10,11) there are two more words for banks > GRF2 (bank GRF2 used 0xf packet and bank GRF1 never had descant)
-						if(bank > kGRF2 && (EventFrag->GetDetectorType() == 6 || EventFrag->GetDetectorType() == 10 || EventFrag->GetDetectorType() == 11)) {
+						if(bank > kGRF2 && (eventFrag->GetDetectorType() == 6 || eventFrag->GetDetectorType() == 10 || eventFrag->GetDetectorType() == 11)) {
 							++x;
 							if(x+1 < size && (data[x+1] & 0x80000000) == 0x0) {
-								SetGRIFCc(value, EventFrag);
+								SetGRIFCc(value, eventFrag);
 								++x;
 								dword = data[x];
-								SetGRIFPsd(dword, EventFrag);
+								SetGRIFPsd(dword, eventFrag);
 							} else {
-								TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-								return -x;
+								TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+								if(fState == TDataParserState::kGood) fState = TDataParserState::kMissingPsd;
+								if(failedWord == -1) failedWord = x;
+								Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+								throw TDataParserException(fState, failedWord);
 							}
 						}
 						break;
 					default:
 						if(!TGRSIOptions::Get()->SuppressErrors()) {
-							printf(DRED "Error, module type %d not implemented yet" RESET_COLOR "\n", EventFrag->GetModuleType());
+							printf(DRED "Error, module type %d not implemented yet" RESET_COLOR "\n", eventFrag->GetModuleType());
 						}
-						return -x;
-				}//switch(EventFrag->GetModuleType())
+						TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+						if(fState == TDataParserState::kGood) fState = TDataParserState::kBadModuleType;
+						if(failedWord == -1) failedWord = x;
+						Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+						throw TDataParserException(fState, failedWord);
+				}//switch(eventFrag->GetModuleType())
 				break;
 		}//switch(packet)
 	}//for(;x<size;x++)
 
-	TParsingDiagnostics::Get()->BadFragment(EventFrag->GetDetectorType());
-	Push(*fBadOutputQueue,EventFrag);
+	TParsingDiagnostics::Get()->BadFragment(eventFrag->GetDetectorType());
+	if(fState == TDataParserState::kGood) fState = TDataParserState::kEndOfData;
+	if(failedWord == -1) failedWord = x;
+	Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord));
+	throw TDataParserException(fState, failedWord);
 	return -x;
 }
 
 bool TDataParser::SetGRIFHeader(uint32_t value, std::shared_ptr<TFragment> frag, EBank bank) {
+	if((value&0xf0000000) != 0x80000000) {
+		return false;
+	}
 	switch(bank){
 		case kGRF1: // header format from before May 2015 experiments
 			//Sets:
@@ -746,9 +782,6 @@ bool TDataParser::SetGRIFHeader(uint32_t value, std::shared_ptr<TFragment> frag,
 			//     Number of Pileups
 			//     Channel Address
 			//     Detector Type
-			if( (value&0xf0000000) != 0x80000000) {
-				return false;
-			}
 			//frag->SetNumberOfFilters((value &0x0f000000)>> 24);
 			frag->SetModuleType((value &0x00e00000)>> 21);
 			frag->SetNumberOfPileups((value &0x001c0000)>> 18);
@@ -765,9 +798,6 @@ bool TDataParser::SetGRIFHeader(uint32_t value, std::shared_ptr<TFragment> frag,
 			//     Number of Pileups
 			//     Channel Address
 			//     Detector Type
-			if( (value&0xf0000000) != 0x80000000) {
-				return false;
-			}
 			frag->SetNumberOfPileups((value &0x0c000000)>> 26);
 			frag->SetModuleType((value &0x03800000)>> 23);
 			//frag->SetNumberOfFilters((value &0x00700000)>> 20);
@@ -777,9 +807,6 @@ bool TDataParser::SetGRIFHeader(uint32_t value, std::shared_ptr<TFragment> frag,
 			break;
 		case kGRF3:
 		case kGRF4:
-			if( (value&0xf0000000) != 0x80000000) {
-				return false;
-			}
 			frag->SetModuleType((value &0x0e000000)>> 25);
 			frag->SetNumberOfWords((value &0x01f00000)>> 20);
 			frag->SetAddress((value &0x000ffff0)>> 4);
@@ -796,7 +823,7 @@ bool TDataParser::SetGRIFHeader(uint32_t value, std::shared_ptr<TFragment> frag,
 
 bool TDataParser::SetGRIFMasterFilterPattern(uint32_t value, std::shared_ptr<TFragment> frag, EBank bank) {
 	///Sets the Griffin Master Filter Pattern
-	if( (value &0xc0000000) != 0x00000000) {
+	if((value &0xc0000000) != 0x00000000) {
 		return false;
 	}
 	switch(bank) {
@@ -819,7 +846,7 @@ bool TDataParser::SetGRIFMasterFilterPattern(uint32_t value, std::shared_ptr<TFr
 
 bool TDataParser::SetGRIFMasterFilterId(uint32_t value,std::shared_ptr<TFragment> frag) {
 	///Sets the Griffin master filter ID and PPG
-	if( (value &0x80000000) != 0x00000000) {
+	if((value &0x80000000) != 0x00000000) {
 		return false;
 	}
 
@@ -829,7 +856,7 @@ bool TDataParser::SetGRIFMasterFilterId(uint32_t value,std::shared_ptr<TFragment
 
 bool TDataParser::SetGRIFChannelTriggerId(uint32_t value, std::shared_ptr<TFragment> frag) {
 	///Sets the Griffin Channel Trigger ID
-	if( (value &0xf0000000) != 0x90000000) {
+	if((value &0xf0000000) != 0x90000000) {
 		return false;
 	}
 	frag->SetChannelId(value & 0x0fffffff);
@@ -838,7 +865,7 @@ bool TDataParser::SetGRIFChannelTriggerId(uint32_t value, std::shared_ptr<TFragm
 
 bool TDataParser::SetGRIFNetworkPacket(uint32_t value, std::shared_ptr<TFragment> frag) {
 	///Ignores the network packet number (for now)
-	if( (value &0xf0000000) != 0xd0000000) {
+	if((value &0xf0000000) != 0xd0000000) {
 		return false;
 	}
 	if( (value&0x0f000000) == 0x0f000000 && frag->GetNetworkPacketNumber() > 0 ) {
@@ -855,7 +882,7 @@ bool TDataParser::SetGRIFNetworkPacket(uint32_t value, std::shared_ptr<TFragment
 
 bool TDataParser::SetGRIFTimeStampLow(uint32_t value, std::shared_ptr<TFragment> frag) {
 	///Sets the lower 28 bits of the griffin time stamp
-	if( (value &0xf0000000) != 0xa0000000) {
+	if((value &0xf0000000) != 0xa0000000) {
 		return false;
 	}
 	//we always get the lower 28 bits first
@@ -993,6 +1020,7 @@ int TDataParser::GriffinDataToScalerEvent(uint32_t* data, int address) {
 	TScalerData* scalerEvent = new TScalerData;
 	scalerEvent->SetAddress(address);
 	int  x = 1; //We have already read the header so we can skip the 0th word.
+	int failedWord = -1;
 
 	//we expect a word starting with 0xd containing the network packet id
 	//this is a different format than the others because it will not always be in the scaler word
@@ -1003,20 +1031,26 @@ int TDataParser::GriffinDataToScalerEvent(uint32_t* data, int address) {
 	//we expect a word starting with 0xa containing the 28 lowest bits of the timestamp
 	if(!SetScalerLowTimeStamp(data[x++],scalerEvent)) {
 		TParsingDiagnostics::Get()->BadFragment(-3); //use detector type -3 for scaler data
-		return -x;
+		fState = TDataParserState::kBadScalerLowTS;
+		failedWord = x;
+		throw TDataParserException(fState, failedWord);
 	}
 	//followed by four scaler words (32 bits each)
 	for(int i = 0; i < 4; ++i) {
 		if(!SetScalerValue(i, data[x++], scalerEvent)) {
 			TParsingDiagnostics::Get()->BadFragment(-3); //use detector type -3 for scaler data
-			return -x;
+			fState = TDataParserState::kBadScalerValue;
+			failedWord = x;
+			throw TDataParserException(fState, failedWord);
 		}
 	}
 	//and finally the trailer word with the highest 24 bits of the timestamp
 	int scalerType = 0;
 	if(!SetScalerHighTimeStamp(data[x++],scalerEvent,scalerType)) {
 		TParsingDiagnostics::Get()->BadFragment(-3); //use detector type -3 for scaler data
-		return -x;
+		fState = TDataParserState::kBadScalerHighTS;
+		failedWord = x;
+		throw TDataParserException(fState, failedWord);
 	}
 
 	if(scalerType == 0) { //deadtime scaler
@@ -1027,7 +1061,9 @@ int TDataParser::GriffinDataToScalerEvent(uint32_t* data, int address) {
 		TRateScalerQueue::Get()->Add(scalerEvent);
 	} else { //unknown scaler type
 		TParsingDiagnostics::Get()->BadFragment(-3); //use detector type -3 for scaler data
-		return -x;
+		fState = TDataParserState::kBadScalerType;
+		failedWord = x;
+		throw TDataParserException(fState, failedWord);
 	}
 
 	TParsingDiagnostics::Get()->GoodFragment(-3); //use detector type -3 for scaler data
@@ -1075,50 +1111,48 @@ int TDataParser::EightPIDataToFragment(uint32_t stream,uint32_t* data,
 		int size,unsigned int midasSerialNumber, time_t midasTime) {
 
 	int NumFragsFound = 0;
-	//TFragment* EventFrag = new TFragment();
-	//EventFrag->MidasTimeStamp = midasTime;
-	//EventFrag->MidasId = midasSerialNumber;
+	//TFragment* eventFrag = new TFragment();
+	//eventFrag->MidasTimeStamp = midasTime;
+	//eventFrag->MidasId = midasSerialNumber;
 
 
 	for(int i=0;i<size;i++) {
 		if( (data[i]==0xff06) || (data[i]==0xff16) ) { //found a fifo...
-			i+=1; //lets get the next int.
+			i++; //lets get the next int.
 			int fifowords =  data[i] & 0x00001fff;
-			i+=1;
+			i++;
 			int fifoserial = data[i] & 0x000000ff;
-			i+=1;
-			if(stream == 0)
+			i++;
+			if(stream == 0) {
 				printf(DBLUE "%i  GOOD FIFO,      fifowords = %i      fifoserial = %i   " RESET_COLOR  "\n",stream,fifowords,fifoserial);
-			else if(stream == 1)
+			} else if(stream == 1) {
 				printf(DGREEN "%i  GOOD FIFO,      fifowords = %i      fifoserial = %i   " RESET_COLOR  "\n",stream,fifowords,fifoserial);
-			else if(stream == 2)
+			} else if(stream == 2) {
 				printf(DRED "%i  GOOD FIFO,      fifowords = %i      fifoserial = %i   " RESET_COLOR  "\n",stream,fifowords,fifoserial);
-			else if(stream == 3)
+			} else if(stream == 3) {
 				printf(DYELLOW "%i  GOOD FIFO,      fifowords = %i      fifoserial = %i   " RESET_COLOR  "\n",stream,fifowords,fifoserial);
+			}
 			//at this point am looking at the actual fera bank.
 			//   ->convert to an arry of shorts.
 			//   ->iterate
 			bool extrafifo = false;
 			unsigned short* words = reinterpret_cast<unsigned short*>(data+i);
-			if(fifowords%2!=0) {
-				fifowords += 1;
+			if(fifowords%2 != 0) {
+				fifowords++;
 				extrafifo = true;
 			}
 			printf(DMAGENTA "i = %i    2*size =  %i   fifowords  = %i  " RESET_COLOR  "\n",i,2*size,fifowords);
 
-			for(int j=0;j<fifowords;j+=2) {
+			for(int j = 0; j < fifowords; j+=2) {
 				unsigned short temp = words[j];
 				words[j] = words[j+1];
 				words[j+1] = temp;
 			}
 
-
 			NumFragsFound += FifoToFragment(words,fifowords,extrafifo,midasSerialNumber,midasTime);
-			i+= (fifowords/2);
+			i += (fifowords/2);
 		}
 	}
-
-
 
 	return 1;
 }
@@ -1129,9 +1163,9 @@ int TDataParser::FifoToFragment(unsigned short* data,int size,bool zerobuffer,
 	//	if(size<10) //this is too short to be anything useful
 	//		return 0;
 	//
-	//	TFragment* EventFrag = new TFragment();
-	//	EventFrag->MidasTimeStamp = midasTime;
-	//	EventFrag->MidasId = midasSerialNumber;
+	//	TFragment* eventFrag = new TFragment();
+	//	eventFrag->MidasTimeStamp = midasTime;
+	//	eventFrag->MidasId = midasSerialNumber;
 	//
 	//
 	//	printf("\t");
@@ -1152,17 +1186,17 @@ int TDataParser::FifoToFragment(unsigned short* data,int size,bool zerobuffer,
 	//		ulm = size-8;
 	//	type = data[ulm];
 	//	if((type &0xfff0) != 0xff20) { //not a ulm, bad things are happening.
-	//		if(EventFrag) delete EventFrag;
+	//		if(eventFrag) delete eventFrag;
 	//		printf("here??   ulm = %i   0x%04x  \n",ulm,type);
 	//		return 0;
 	//	} else {
-	//		EventFrag->DetectorType = (type&0x000f);
+	//		eventFrag->DetectorType = (type&0x000f);
 	//		value = data[ulm+1];
-	//		EventFrag->PPG = (value&0x3ff);
-	//		EventFrag->TriggerBitPattern = (value&0xf000)>>11;
-	//		EventFrag->TimeStampLow  = data[ulm+2]*65536 +data[ulm+3];
-	//		EventFrag->TimeStampHigh = data[ulm+4]*65536 +data[ulm+5];
-	//		EventFrag->TriggerId     = data[ulm+6]*65536 +data[ulm+7];
+	//		eventFrag->PPG = (value&0x3ff);
+	//		eventFrag->TriggerBitPattern = (value&0xf000)>>11;
+	//		eventFrag->TimeStampLow  = data[ulm+2]*65536 +data[ulm+3];
+	//		eventFrag->TimeStampHigh = data[ulm+4]*65536 +data[ulm+5];
+	//		eventFrag->TriggerId     = data[ulm+6]*65536 +data[ulm+7];
 	//	}
 	//	size = ulm;  //only look at what is left.
 	//	for(int x=0;x<size;x++) {
@@ -1180,7 +1214,7 @@ int TDataParser::FifoToFragment(unsigned short* data,int size,bool zerobuffer,
 	//					int temp = ((value&0x7c00)>>10) << 16;
 	//					temp += ((value&0x00ff) << 8) + (value2&0x00ff);
 	//					//printf("size = %i | ulm = %i | x = %i  | temp = 0x%08x \n",size,ulm,x,temp);
-	//					EventFrag->Cfd.push_back(temp);
+	//					eventFrag->Cfd.push_back(temp);
 	//				}
 	//				printf(DGREEN "ENDED TDC LOOP  data[%i] = 0x%04x" RESET_COLOR "\n",x,data[x]);
 	//				break;
@@ -1188,24 +1222,24 @@ int TDataParser::FifoToFragment(unsigned short* data,int size,bool zerobuffer,
 	//			case 0x8050: // Ortect AD114 single channel ?
 	//			case 0x8060:
 	//				value = data[++x];
-	//				if(EventFrag->DetectorType==0) {
+	//				if(eventFrag->DetectorType==0) {
 	//					int temp = (type&0x001f) << 16;
 	//					temp += value&0x3fff;
 	//					//printf("temp = %08x\n",temp);
-	//					EventFrag->PulseHeight.push_back(temp);
-	//					EventFrag->ChannelNumber = 0;
-	//					//EventFrag->ChannelNumber  = (type&0x001f); //clear as mud.
-	//					//EventFrag->ChannelAddress = 0x0000 + EventFrag->ChannelNumber;
-	//					//EventFrag->PulseHeight.push_back(value&0x3fff);
-	//				} else if (EventFrag->DetectorType==3){
+	//					eventFrag->PulseHeight.push_back(temp);
+	//					eventFrag->ChannelNumber = 0;
+	//					//eventFrag->ChannelNumber  = (type&0x001f); //clear as mud.
+	//					//eventFrag->ChannelAddress = 0x0000 + eventFrag->ChannelNumber;
+	//					//eventFrag->PulseHeight.push_back(value&0x3fff);
+	//				} else if (eventFrag->DetectorType==3){
 	//					int temp = (type&0x001f) << 16;
 	//					temp += value&0x3fff;
 	//					//printf("temp = %08x\n",temp);
-	//					EventFrag->PulseHeight.push_back(temp);
-	//					EventFrag->ChannelNumber = 3;
-	//					//EventFrag->ChannelNumber  = (type&0x001f); //clear as mud.
-	//					//EventFrag->ChannelAddress = 0x3000 + EventFrag->ChannelNumber;
-	//					//EventFrag->PulseHeight.push_back(value&0x3fff);
+	//					eventFrag->PulseHeight.push_back(temp);
+	//					eventFrag->ChannelNumber = 3;
+	//					//eventFrag->ChannelNumber  = (type&0x001f); //clear as mud.
+	//					//eventFrag->ChannelAddress = 0x3000 + eventFrag->ChannelNumber;
+	//					//eventFrag->PulseHeight.push_back(value&0x3fff);
 	//				}
 	//				//printf("value = 0x%04x\n",value);
 	//				break;
@@ -1213,16 +1247,16 @@ int TDataParser::FifoToFragment(unsigned short* data,int size,bool zerobuffer,
 	//
 	//		};
 	//	}
-	//	EventFrag->Print();
+	//	eventFrag->Print();
 	//
 	//
-	//	fGoodOutputQueue->Add(EventFrag);
+	//	fGoodOutputQueue->Add(eventFrag);
 	//
 	return 1;
 }
 
 int TDataParser::FippsToFragment(std::vector<char> data) {
-	int32_t* ptr = reinterpret_cast<int32_t*>(data.data());
+	uint32_t* ptr = reinterpret_cast<uint32_t*>(data.data());
 
 	int eventsRead = 0;
 	std::shared_ptr<TFragment> eventFrag = std::make_shared<TFragment>();
@@ -1244,10 +1278,10 @@ int TDataParser::FippsToFragment(std::vector<char> data) {
 		eventFrag->SetTimeStamp(tmpTimestamp);
 		if((ptr[i+2] & 0x7fff) == 0) {
 			if(fRecordDiag) TParsingDiagnostics::Get()->BadFragment(99);
-         Push(*fBadOutputQueue,eventFrag);
+			Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, ptr, data.size()/4, i+2));
 			continue;
 		}
-		eventFrag->SetCharge(ptr[i+2] & 0x7fff);
+		eventFrag->SetCharge(static_cast<int32_t>(ptr[i+2] & 0x7fff));
 		if(fRecordDiag) TParsingDiagnostics::Get()->GoodFragment(eventFrag);
 		Push(fGoodOutputQueues, std::make_shared<TFragment>(*eventFrag));
 		++eventsRead;

--- a/libraries/TDataParser/TDataParserException.cxx
+++ b/libraries/TDataParser/TDataParserException.cxx
@@ -1,0 +1,91 @@
+#include "TDataParserException.h"
+#include "TDataParser.h"
+
+TDataParserException::TDataParserException(TDataParserState state, int failedWord)
+	: fParserState(state), fFailedWord(failedWord) {
+	/// default constructor for TDataParserException, stores the data parser state and the word the parser failed on
+	/// and creates a message based on them that can be accessed via TDataParserException::what()
+	std::ostringstream stream;
+	stream<<"TDataParser failed on "<<fFailedWord<<". word: ";
+	switch(fParserState) {
+		case TDataParserState::kGood:
+			stream<<"state is good, no idea what went wrong!"<<std::endl;
+			break;
+		case TDataParserState::kBadHeader:
+			stream<<"bad header (either not high nibble 0x8 or an undefined bank)"<<std::endl;
+			break;
+		case TDataParserState::kMissingWords:
+			stream<<"missing scaler words"<<std::endl;
+			break;
+		case TDataParserState::kBadScalerLowTS:
+			stream<<"bad scaler word with low time stamp bits (high nibble not 0xa)"<<std::endl;
+			break;
+		case TDataParserState::kBadScalerValue:
+			stream<<"bad scaler value (should never happen?)"<<std::endl;
+			break;
+		case TDataParserState::kBadScalerHighTS:
+			stream<<"bad scaler word with high time stamp bits (either high nibble not 0xe or the 8 LSB don't match the 8 LSB of time stamp)"<<std::endl;
+			break;
+		case TDataParserState::kBadScalerType:
+			stream<<"undefined scaler type"<<std::endl;
+			break;
+		case TDataParserState::kBadTriggerId:
+			stream<<"bad word with channel trigger ID (high nibble not 0x9)"<<std::endl;
+			break;
+		case TDataParserState::kBadLowTS:
+			stream<<"bad word with low time stamp bits (high nibble not 0xa)"<<std::endl;
+			break;
+		case TDataParserState::kBadHighTS:
+			stream<<"bad word with deadtime/high bits of time stamp (should never happen?)"<<std::endl;
+			break;
+		case TDataParserState::kSecondHeader:
+			stream<<"found a second header (w/o finding a footer first)"<<std::endl;
+			break;
+		case TDataParserState::kNotSingleCfd:
+			stream<<"expected a single cfd word, got either none or multiple ones"<<std::endl;
+			break;
+		case TDataParserState::kSizeMismatch:
+			stream<<"number of charge, cfd, and integration length words doesn't match"<<std::endl;
+			break;
+		case TDataParserState::kBadFooter:
+			stream<<"bad footer (mismatch between lowest 14 bits of channel trigger ID)"<<std::endl;
+			break;
+		case TDataParserState::kFault:
+			stream<<"found a fault word (high nibble 0xf) from the DAQ"<<std::endl;
+			break;
+		case TDataParserState::kMissingPsd:
+			stream<<"missing psd words"<<std::endl;
+			break;
+		case TDataParserState::kMissingCfd:
+			stream<<"missing the cfd word (second word w/o MSB set)"<<std::endl;
+			break;
+		case TDataParserState::kMissingCharge:
+			stream<<"missing charge words (should be at least two words w/o MSB set"<<std::endl;
+			break;
+		case TDataParserState::kBadBank:
+			stream<<"undefined bank"<<std::endl;
+			break;
+		case TDataParserState::kBadModuleType:
+			stream<<"undefined module type"<<std::endl;
+			break;
+		case TDataParserState::kEndOfData:
+			stream<<"reached end of bank data but not end of fragment"<<std::endl;
+			break;
+		case TDataParserState::kUndefined:
+			stream<<"undefined state, should not be possible?"<<std::endl;
+			break;
+		default:
+			break;
+	};
+
+	fMessage = stream.str();
+}
+
+TDataParserException::~TDataParserException() {
+	/// default destructor
+}
+
+const char* TDataParserException::what() const noexcept {
+	/// return message string built in default constructor
+	return fMessage.c_str();
+}

--- a/libraries/TDataParser/TDataParserException.cxx
+++ b/libraries/TDataParser/TDataParserException.cxx
@@ -1,12 +1,18 @@
 #include "TDataParserException.h"
 #include "TDataParser.h"
 
-TDataParserException::TDataParserException(TDataParser::EDataParserState state, int failedWord)
-	: fParserState(state), fFailedWord(failedWord) {
+TDataParserException::TDataParserException(TDataParser::EDataParserState state, int failedWord, bool multipleErrors)
+	: fParserState(state), fFailedWord(failedWord), fMultipleErrors(multipleErrors) {
 	/// default constructor for TDataParserException, stores the data parser state and the word the parser failed on
 	/// and creates a message based on them that can be accessed via TDataParserException::what()
 	std::ostringstream stream;
-	stream<<"TDataParser failed on "<<fFailedWord<<". word: ";
+	stream<<"TDataParser failed ";
+	if(fMultipleErrors) {
+		stream<<"on multiple words, first was ";
+	} else {
+		stream<<"only on ";
+	}
+	stream<<fFailedWord<<". word: ";
 	switch(fParserState) {
 		case TDataParser::EDataParserState::kGood:
 			stream<<"state is good, no idea what went wrong!"<<std::endl;
@@ -40,6 +46,9 @@ TDataParserException::TDataParserException(TDataParser::EDataParserState state, 
 			break;
 		case TDataParser::EDataParserState::kSecondHeader:
 			stream<<"found a second header (w/o finding a footer first)"<<std::endl;
+			break;
+		case TDataParser::EDataParserState::kWrongNofWords:
+			stream<<"wrong number of words"<<std::endl;
 			break;
 		case TDataParser::EDataParserState::kNotSingleCfd:
 			stream<<"expected a single cfd word, got either none or multiple ones"<<std::endl;

--- a/libraries/TDataParser/TDataParserException.cxx
+++ b/libraries/TDataParser/TDataParserException.cxx
@@ -1,77 +1,77 @@
 #include "TDataParserException.h"
 #include "TDataParser.h"
 
-TDataParserException::TDataParserException(TDataParserState state, int failedWord)
+TDataParserException::TDataParserException(TDataParser::EDataParserState state, int failedWord)
 	: fParserState(state), fFailedWord(failedWord) {
 	/// default constructor for TDataParserException, stores the data parser state and the word the parser failed on
 	/// and creates a message based on them that can be accessed via TDataParserException::what()
 	std::ostringstream stream;
 	stream<<"TDataParser failed on "<<fFailedWord<<". word: ";
 	switch(fParserState) {
-		case TDataParserState::kGood:
+		case TDataParser::EDataParserState::kGood:
 			stream<<"state is good, no idea what went wrong!"<<std::endl;
 			break;
-		case TDataParserState::kBadHeader:
+		case TDataParser::EDataParserState::kBadHeader:
 			stream<<"bad header (either not high nibble 0x8 or an undefined bank)"<<std::endl;
 			break;
-		case TDataParserState::kMissingWords:
+		case TDataParser::EDataParserState::kMissingWords:
 			stream<<"missing scaler words"<<std::endl;
 			break;
-		case TDataParserState::kBadScalerLowTS:
+		case TDataParser::EDataParserState::kBadScalerLowTS:
 			stream<<"bad scaler word with low time stamp bits (high nibble not 0xa)"<<std::endl;
 			break;
-		case TDataParserState::kBadScalerValue:
+		case TDataParser::EDataParserState::kBadScalerValue:
 			stream<<"bad scaler value (should never happen?)"<<std::endl;
 			break;
-		case TDataParserState::kBadScalerHighTS:
+		case TDataParser::EDataParserState::kBadScalerHighTS:
 			stream<<"bad scaler word with high time stamp bits (either high nibble not 0xe or the 8 LSB don't match the 8 LSB of time stamp)"<<std::endl;
 			break;
-		case TDataParserState::kBadScalerType:
+		case TDataParser::EDataParserState::kBadScalerType:
 			stream<<"undefined scaler type"<<std::endl;
 			break;
-		case TDataParserState::kBadTriggerId:
+		case TDataParser::EDataParserState::kBadTriggerId:
 			stream<<"bad word with channel trigger ID (high nibble not 0x9)"<<std::endl;
 			break;
-		case TDataParserState::kBadLowTS:
+		case TDataParser::EDataParserState::kBadLowTS:
 			stream<<"bad word with low time stamp bits (high nibble not 0xa)"<<std::endl;
 			break;
-		case TDataParserState::kBadHighTS:
+		case TDataParser::EDataParserState::kBadHighTS:
 			stream<<"bad word with deadtime/high bits of time stamp (should never happen?)"<<std::endl;
 			break;
-		case TDataParserState::kSecondHeader:
+		case TDataParser::EDataParserState::kSecondHeader:
 			stream<<"found a second header (w/o finding a footer first)"<<std::endl;
 			break;
-		case TDataParserState::kNotSingleCfd:
+		case TDataParser::EDataParserState::kNotSingleCfd:
 			stream<<"expected a single cfd word, got either none or multiple ones"<<std::endl;
 			break;
-		case TDataParserState::kSizeMismatch:
+		case TDataParser::EDataParserState::kSizeMismatch:
 			stream<<"number of charge, cfd, and integration length words doesn't match"<<std::endl;
 			break;
-		case TDataParserState::kBadFooter:
+		case TDataParser::EDataParserState::kBadFooter:
 			stream<<"bad footer (mismatch between lowest 14 bits of channel trigger ID)"<<std::endl;
 			break;
-		case TDataParserState::kFault:
+		case TDataParser::EDataParserState::kFault:
 			stream<<"found a fault word (high nibble 0xf) from the DAQ"<<std::endl;
 			break;
-		case TDataParserState::kMissingPsd:
+		case TDataParser::EDataParserState::kMissingPsd:
 			stream<<"missing psd words"<<std::endl;
 			break;
-		case TDataParserState::kMissingCfd:
+		case TDataParser::EDataParserState::kMissingCfd:
 			stream<<"missing the cfd word (second word w/o MSB set)"<<std::endl;
 			break;
-		case TDataParserState::kMissingCharge:
+		case TDataParser::EDataParserState::kMissingCharge:
 			stream<<"missing charge words (should be at least two words w/o MSB set"<<std::endl;
 			break;
-		case TDataParserState::kBadBank:
+		case TDataParser::EDataParserState::kBadBank:
 			stream<<"undefined bank"<<std::endl;
 			break;
-		case TDataParserState::kBadModuleType:
+		case TDataParser::EDataParserState::kBadModuleType:
 			stream<<"undefined module type"<<std::endl;
 			break;
-		case TDataParserState::kEndOfData:
+		case TDataParser::EDataParserState::kEndOfData:
 			stream<<"reached end of bank data but not end of fragment"<<std::endl;
 			break;
-		case TDataParserState::kUndefined:
+		case TDataParser::EDataParserState::kUndefined:
 			stream<<"undefined state, should not be possible?"<<std::endl;
 			break;
 		default:

--- a/libraries/TDataParser/TDataParserException.cxx
+++ b/libraries/TDataParser/TDataParserException.cxx
@@ -42,7 +42,7 @@ TDataParserException::TDataParserException(TDataParser::EDataParserState state, 
 			stream<<"bad word with low time stamp bits (high nibble not 0xa)"<<std::endl;
 			break;
 		case TDataParser::EDataParserState::kBadHighTS:
-			stream<<"bad word with deadtime/high bits of time stamp (should never happen?)"<<std::endl;
+			stream<<"bad word with deadtime/high time stamp bits (high nibble not 0xb)"<<std::endl;
 			break;
 		case TDataParser::EDataParserState::kSecondHeader:
 			stream<<"found a second header (w/o finding a footer first)"<<std::endl;

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -72,8 +72,7 @@ Double_t TGRSIDetectorHit::GetTime(const UInt_t& correction_flag,Option_t* opt) 
 
 int TGRSIDetectorHit::GetCharge() const {
   TChannel *chan = GetChannel();
-  if(!chan )
-    return std::floor(Charge());
+  if(!chan) return std::floor(Charge());
   if(fKValue>0){
     return std::floor(Charge()/((Float_t)fKValue));// this will use the integration value
   } else if(chan->UseCalFileIntegration()) {
@@ -83,8 +82,7 @@ int TGRSIDetectorHit::GetCharge() const {
 }
 
 double TGRSIDetectorHit::GetEnergy(Option_t* opt) const {
-  if(TestHitBit(kIsEnergySet))
-    return fEnergy;
+  if(TestHitBit(kIsEnergySet)) return fEnergy;
   TChannel* chan = GetChannel();
   if(!chan) {
     //Error("GetEnergy","No TChannel exists for address 0x%08x",GetAddress());

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -49,52 +49,52 @@ Double_t TGRSIDetectorHit::GetTime(const UInt_t& correction_flag,Option_t* opt) 
   if(IsTimeSet())
     return fTime;
 
-  TChannel* chan = GetChannel();
-  if(!chan) {
+  TChannel* channel = GetChannel();
+  if(channel == nullptr) {
     Error("GetTime","No TChannel exists for address 0x%08x",GetAddress());
     return SetTime(10.*(static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
   }
-	switch(chan->GetDigitizerType()) {
+	switch(channel->GetDigitizerType()) {
 		Double_t dTime;
 		case TMnemonic::kGRF16:
 			dTime = (GetTimeStamp()&(~0x3ffff))*10. + (GetCfd() + gRandom->Uniform())/1.6;//CFD is in 10/16th of a nanosecond
-			return SetTime(dTime - 10.*(chan->GetTZero(GetEnergy())));
+			return SetTime(dTime - 10.*(channel->GetTZero(GetEnergy())));
 		case TMnemonic::kGRF4G:
 			dTime = GetTimeStamp()*10. + (fCfd>>22) + ((fCfd & 0x3fffff) + gRandom->Uniform())/256.;
-			return SetTime(dTime - 10.*(chan->GetTZero(GetEnergy())));
+			return SetTime(dTime - 10.*(channel->GetTZero(GetEnergy())));
 		default:
 		   dTime = static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform());
-		   return SetTime(10.*(dTime - chan->GetTZero(GetEnergy())));
+		   return SetTime(10.*(dTime - channel->GetTZero(GetEnergy())));
 	}
 	return 0.;
 }
 
 
-int TGRSIDetectorHit::GetCharge() const {
-  TChannel *chan = GetChannel();
-  if(!chan) return std::floor(Charge());
+Float_t TGRSIDetectorHit::GetCharge() const {
+  TChannel* channel = GetChannel();
+  if(channel == nullptr) return Charge();
   if(fKValue>0){
-    return std::floor(Charge()/((Float_t)fKValue));// this will use the integration value
-  } else if(chan->UseCalFileIntegration()) {
-    return std::floor(Charge())/((Float_t)chan->GetIntegration());// this will use the integration value
-  }                                                               // in the TChannel if it exists.
-  return std::floor(Charge());// this will use no integration value
+    return Charge()/((Float_t)fKValue);// this will use the integration value
+  } else if(channel->UseCalFileIntegration()) {
+    return Charge()/((Float_t)channel->GetIntegration();// this will use the integration value
+  }                                                  // in the TChannel if it exists.
+  return Charge();// this will use no integration value
 }
 
 double TGRSIDetectorHit::GetEnergy(Option_t* opt) const {
   if(TestHitBit(kIsEnergySet)) return fEnergy;
-  TChannel* chan = GetChannel();
-  if(!chan) {
+  TChannel* channel = GetChannel();
+  if(channel == nullptr) {
     //Error("GetEnergy","No TChannel exists for address 0x%08x",GetAddress());
     return SetEnergy((Double_t)(Charge()));
   }
   if(fKValue >0) {
-    return SetEnergy(chan->CalibrateENG(Charge(),(int)fKValue));
-  } else if(chan->UseCalFileIntegration()) {
-    return SetEnergy(chan->CalibrateENG(Charge(),0));  // this will use the integration value
+    return SetEnergy(channel->CalibrateENG(Charge(),(int)fKValue));
+  } else if(channel->UseCalFileIntegration()) {
+    return SetEnergy(channel->CalibrateENG(Charge(),0));  // this will use the integration value
                                             // in the TChannel if it exists.
   }
-  return SetEnergy(chan->CalibrateENG(Charge()));
+  return SetEnergy(channel->CalibrateENG(Charge()));
 }
 
 void TGRSIDetectorHit::Copy(TObject& rhs) const {
@@ -131,9 +131,9 @@ void TGRSIDetectorHit::Print(Option_t* opt) const {
   //fPosition.Print();
 }
 
-const char *TGRSIDetectorHit::GetName() const {
-  TChannel *channel = GetChannel();
-  if(!channel)
+const char* TGRSIDetectorHit::GetName() const {
+  TChannel* channel = GetChannel();
+  if(channel == nullptr)
      return Class()->ClassName();
   else
      return channel->GetName();
@@ -161,7 +161,7 @@ void TGRSIDetectorHit::Clear(Option_t* opt) {
 Int_t TGRSIDetectorHit::GetDetector() const {
 
   TChannel* channel = GetChannel();
-  if(!channel) {
+  if(channel == nullptr) {
     Error("GetDetector","No TChannel exists for address 0x%08x",GetAddress());
     return -1;
   }
@@ -170,8 +170,8 @@ Int_t TGRSIDetectorHit::GetDetector() const {
 }
 
 Int_t TGRSIDetectorHit::GetSegment() const {
-   TChannel *channel = GetChannel();
-   if(!channel){
+   TChannel* channel = GetChannel();
+   if(channel == nullptr){
       Error("GetSegment","No TChannel exists for address %08x",GetAddress());
       return -1;
    }
@@ -179,14 +179,14 @@ Int_t TGRSIDetectorHit::GetSegment() const {
 }
 
 Int_t TGRSIDetectorHit::GetCrystal() const {
-  TChannel *channel = GetChannel();
+  TChannel* channel = GetChannel();
   if(channel)
     return channel->GetCrystalNumber();
   return -1;
 }
 
 UShort_t TGRSIDetectorHit::GetArrayNumber() const {
-  TChannel *channel = GetChannel();
+  TChannel* channel = GetChannel();
   if(channel) {
     return (GetDetector()-1)*4 + GetCrystal();
   }

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -1,4 +1,4 @@
-// TFragment.h TChannel.h TGRSIRunInfo.h TGRSISortInfo.h TPPG.h TEpicsFrag.h TScaler.h TScalerQueue.h TParsingDiagnostics.h TGRSIUtilities.h TMnemonic.h TSortingDiagnostics.h TTransientBits.h
+// TFragment.h TBadFragment.h TChannel.h TGRSIRunInfo.h TGRSISortInfo.h TPPG.h TEpicsFrag.h TScaler.h TScalerQueue.h TParsingDiagnostics.h TGRSIUtilities.h TMnemonic.h TSortingDiagnostics.h TTransientBits.h
 
 
 #ifdef __CINT__
@@ -13,6 +13,7 @@
 //#pragma link C++ class std::vector<UShort_t>+;
 
 #pragma link C++ class TFragment+;
+#pragma link C++ class TBadFragment+;
 
 #pragma link C++ class TEpicsFrag+;
 #pragma link C++ class TChannel-;

--- a/libraries/TGRSIFormat/TBadFragment.cxx
+++ b/libraries/TGRSIFormat/TBadFragment.cxx
@@ -8,7 +8,7 @@ TBadFragment::TBadFragment() : TFragment() {
 	Clear();
 }
 
-TBadFragment::TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord)
+TBadFragment::TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord, bool multipleErrors)
 	: TFragment(fragment) {
 	/// Construct a bad fragment from a fragment, the data it was created from, the size of that data, and the word the parser failed on.
 	/// The data is only copied up to and including the next header word (high nibble 0x8).
@@ -21,6 +21,7 @@ TBadFragment::TBadFragment(TFragment& fragment, uint32_t* data, int size, int fa
 	// only copy data up to the next header (including that header)
 	fData.insert(fData.begin(), data, data+numWords+1);
 	fFailedWord = failedWord;
+	fMultipleErrors = multipleErrors;
 }
 
 TBadFragment::TBadFragment(const TBadFragment& rhs) : TFragment(rhs) {
@@ -37,7 +38,7 @@ void TBadFragment::Print(Option_t*) const {
 	/// Print out all fields of the fragment using TFragment::Print() and then print the raw data with the failed words highlighted/
 	TFragment::Print();
 
-	std::cout<<"Raw data:"<<std::endl;
+	std::cout<<"Raw data with "<<(fMultipleErrors ? "multiple errors":"single error")<<":"<<std::endl;
 	size_t i;
 	for(i = 0; i < fData.size(); ++i) {
 		if(i == static_cast<size_t>(fFailedWord)) std::cout<<ALERTTEXT;

--- a/libraries/TGRSIFormat/TBadFragment.cxx
+++ b/libraries/TGRSIFormat/TBadFragment.cxx
@@ -1,0 +1,50 @@
+#include "TBadFragment.h"
+
+TBadFragment::TBadFragment() : TFragment() {
+	/// Default constructor
+#if MAJOR_ROOT_VERSION < 6
+	Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
+	Clear();
+}
+
+TBadFragment::TBadFragment(TFragment& fragment, uint32_t* data, int size, int failedWord)
+	: TFragment(fragment) {
+	/// Construct a bad fragment from a fragment, the data it was created from, the size of that data, and the word the parser failed on.
+	/// The data is only copied up to and including the next header word (high nibble 0x8).
+	fData.clear();
+	// skipping the first word, we search for the next header
+	int numWords;
+	for(numWords = 1; numWords < size; ++numWords) {
+		if((data[numWords] & 0xf0000000) == 0x80000000) break;
+	}
+	// only copy data up to the next header (including that header)
+	fData.insert(fData.begin(), data, data+numWords+1);
+	fFailedWord = failedWord;
+}
+
+TBadFragment::TBadFragment(const TBadFragment& rhs) : TFragment(rhs) {
+	/// Copy constructor
+	fData = rhs.fData;
+	fFailedWord = rhs.fFailedWord;
+}
+
+TBadFragment::~TBadFragment() {
+	/// Destructor, does nothing for now.
+}
+
+void TBadFragment::Print(Option_t*) const {
+	/// Print out all fields of the fragment using TFragment::Print() and then print the raw data with the failed words highlighted/
+	TFragment::Print();
+
+	std::cout<<"Raw data:"<<std::endl;
+	size_t i;
+	for(i = 0; i < fData.size(); ++i) {
+		if(i == static_cast<size_t>(fFailedWord)) std::cout<<ALERTTEXT;
+		std::cout<<"0x"<<std::setw(8)<<std::setfill('0')<<std::hex<<fData[i]<<std::dec;
+		if(i == static_cast<size_t>(fFailedWord)) std::cout<<RESET_COLOR;
+		if(i%10 == 9) std::cout<<std::endl;
+		else          std::cout<<" ";
+	}
+	if(i%10 != 0) std::cout<<std::endl; // add newline if the last data word didn't have one
+}

--- a/libraries/TGRSIFormat/TFragment.cxx
+++ b/libraries/TGRSIFormat/TFragment.cxx
@@ -13,7 +13,7 @@ ClassImp(TFragment)
 Long64_t TFragment::fNumberOfFragments = 0;
 
 TFragment::TFragment() : TGRSIDetectorHit() {
-   // Default Constructor
+   /// Default constructor
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
@@ -21,6 +21,7 @@ TFragment::TFragment() : TGRSIDetectorHit() {
 }
 
 TFragment::TFragment(const TFragment& rhs) : TGRSIDetectorHit(rhs) {
+	/// Copy constructor
    //first copy all "normal" data members
    fMidasTimeStamp = rhs.fMidasTimeStamp;
    fMidasId = rhs.fMidasId;
@@ -46,11 +47,11 @@ TFragment::TFragment(const TFragment& rhs) : TGRSIDetectorHit(rhs) {
 }
 
 TFragment::~TFragment(){
-   // Default destructor does nothing right now
+   /// Default destructor does nothing right now
 }
 
 void TFragment::Clear(Option_t *opt){  
-   // Clears all fields of the TFragment
+   /// Clears all fields of the TFragment
    TGRSIDetectorHit::Clear(opt);
 
    fMidasTimeStamp      = 0;
@@ -135,8 +136,8 @@ TPPG* TFragment::GetPPG() {
 	return fPPG;
 }
 
-void TFragment::Print(Option_t *opt) const {
-  //Prints out all fields of the TFragment
+void TFragment::Print(Option_t*) const {
+  ///Prints out all fields of the TFragment
 
   TChannel *chan = GetChannel();
   char buff[20];

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -111,6 +111,7 @@ void TGRSIOptions::Print(Option_t* opt) const {
 		<<"fLogErrors: "<<fLogErrors<<std::endl
 		<<"fUseMidFileOdb: "<<fUseMidFileOdb<<std::endl
 		<<"fSuppressErrors: "<<fSuppressErrors<<std::endl
+		<<"fReconstructTimeStamp: "<<fReconstructTimeStamp<<std::endl
 		<<std::endl
 		<<"fMakeAnalysisTree: "<<fMakeAnalysisTree<<std::endl
 		<<"fProgressDialog: "<<fProgressDialog<<std::endl
@@ -256,6 +257,7 @@ void TGRSIOptions::Load(int argc, char** argv) {
 	parser.option("ignore-epics", &fIgnoreEpics);
 	parser.option("ignore-scaler", &fIgnoreScaler);
 	parser.option("suppress-error suppress-errors suppress_error suppress_errors", &fSuppressErrors);
+	parser.option("reconstruct-timestamp reconstruct-time-stamp", &fReconstructTimeStamp);
 
 	parser.option("fragment-size", &fFragmentWriteQueueSize)
 		.description("size of fragment write queue")

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -16,6 +16,8 @@
 #include "TGRSIOptions.h"
 #include "TParsingDiagnostics.h"
 
+#include "TBadFragment.h"
+
 TFragWriteLoop* TFragWriteLoop::Get(std::string name, std::string fOutputFilename){
   if(name.length()==0){
     name = "write_loop";
@@ -51,8 +53,8 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
     fEventTree->Branch("TFragment", &fEventAddress);
 
     fBadEventTree = new TTree("BadFragmentTree","BadFragmentTree");
-	 fBadEventAddress = new TFragment;
-    fBadEventTree->Branch("TFragment", &fBadEventAddress);
+	 fBadEventAddress = new TBadFragment;
+    fBadEventTree->Branch("TBadFragment", &fBadEventAddress);
 
     fScalerTree = new TTree("EpicsTree","EpicsTree");
 	 fScalerAddress = nullptr;
@@ -161,10 +163,9 @@ void TFragWriteLoop::WriteEvent(std::shared_ptr<const TFragment> event) {
 
 void TFragWriteLoop::WriteBadEvent(std::shared_ptr<const TFragment> event) {
 	if(fBadEventTree) {
-		*fBadEventAddress = *(event.get());
+		*fBadEventAddress = *static_cast<const TBadFragment*>(event.get());
 		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fBadEventTree->Fill();
-		//fBadEventAddress = nullptr;
 	}
 }
 


### PR DESCRIPTION
- After encoutering an error in parsing, the reason and which word this occured on are stored, but instead of ending here we continue to try and parse the event until the next header is found.
- Bad fragment are stored in their own class, derived from fragments, but with two additional members. The raw data for this fragment up to and including the next header, and the word the parser failed on. These bad fragments have a print-statement that also prints the raw data with the failed word highlighted.
- When the parser fails a TDataParserException is thrown which holds the state of the parser, i.e. why it failed, and the which word it failed on. The exception provides a message with this information.
- Fixed an error in the processing of the midas event where the wrong word was highlighted when the parser failed to parse the event.