### PR TITLE
Moved Analysis Options from TGRSIRunInfo to TGRSIOptions

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -79,7 +79,6 @@ void Analyze(const char* tree_type, TProof* proof){
 
 
 int main(int argc, char **argv) {
-
    TGRSIOptions* opt = TGRSIOptions::Get(argc,argv);
 
    //Add the path were we store headers for GRSIProof macros to see
@@ -131,6 +130,7 @@ int main(int argc, char **argv) {
    proof->AddIncludePath(Form("%s/include",pPath));
    proof->AddDynamicPath(Form("%s/lib",pPath));
 
+	proof->AddInput(opt->AnalysisOptions());
    proof->AddInput(new TNamed("pwd", getenv("PWD")));
    int i = 0;
    for(auto valFile = opt->ValInputFiles().begin(); valFile != opt->ValInputFiles().end(); ++valFile) {

--- a/include/ArgParser.h
+++ b/include/ArgParser.h
@@ -23,7 +23,7 @@ struct ParseError : public std::runtime_error {
  */
 class ArgParseItem {
 public:
-   ArgParseItem() : present_(false) {}
+   ArgParseItem(bool firstPass) : present_(false), fFirstPass(firstPass) {}
    virtual ~ArgParseItem() {}
    virtual bool matches(const std::string& flag) const                = 0;
    virtual void parse_item(const std::vector<std::string>& arguments) = 0;
@@ -33,8 +33,9 @@ public:
    bool                is_present() const { return present_; }
    virtual std::string flag_name() const = 0;
 
-   void parse(const std::string& name, const std::vector<std::string>& arguments, bool ignore_num_arguments = false)
+   void parse(const std::string& name, const std::vector<std::string>& arguments, bool firstPass, bool ignore_num_arguments = false)
    {
+		if(firstPass != fFirstPass) return;
       if(!ignore_num_arguments) {
          if((num_arguments() == -1 && arguments.size() == 0) ||
              (num_arguments() != -1 && arguments.size() != size_t(num_arguments()))) {
@@ -55,13 +56,16 @@ public:
 
 private:
    bool present_;
+	bool fFirstPass;
 };
 
 template <typename T>
 class ArgParseConfig : public ArgParseItem {
 public:
-   ArgParseConfig(std::string flag_list) : desc(""), required_(false)
+   ArgParseConfig(std::string flag_list, bool firstPass) : ArgParseItem(firstPass)
    {
+		desc = "";
+		required_ = false;
       std::stringstream ss(flag_list);
       while (!ss.eof()) {
          std::string temp;
@@ -180,7 +184,7 @@ protected:
 template <typename T>
 class ArgParseConfigT : public ArgParseConfig<T> {
 public:
-   ArgParseConfigT(std::string flag, T* output_location) : ArgParseConfig<T>(flag), fOutput_location(output_location) {}
+   ArgParseConfigT(std::string flag, T* output_location, bool firstPass) : ArgParseConfig<T>(flag, firstPass), fOutput_location(output_location) {}
 
    virtual ArgParseConfig<T>& default_value(T value)
    {
@@ -203,8 +207,8 @@ private:
 template <>
 class ArgParseConfigT<bool> : public ArgParseConfig<bool> {
 public:
-   ArgParseConfigT(std::string flag, bool* output_location)
-      : ArgParseConfig<bool>(flag), fOutput_location(output_location), fStored_default_value(false)
+   ArgParseConfigT(std::string flag, bool* output_location, bool firstPass)
+      : ArgParseConfig<bool>(flag, firstPass), fOutput_location(output_location), fStored_default_value(false)
    {
       *fOutput_location = fStored_default_value;
    }
@@ -236,8 +240,8 @@ private:
 template <typename T>
 class ArgParseConfigT<std::vector<T>> : public ArgParseConfig<std::vector<T>> {
 public:
-   ArgParseConfigT(std::string flag, std::vector<T>* output_location)
-      : ArgParseConfig<std::vector<T>>(flag), fOutput_location(output_location), fNum_arguments_expected(-1)
+   ArgParseConfigT(std::string flag, std::vector<T>* output_location, bool firstPass)
+      : ArgParseConfig<std::vector<T>>(flag, firstPass), fOutput_location(output_location), fNum_arguments_expected(-1)
    {
    }
 
@@ -275,251 +279,215 @@ public:
       }
    }
 
-   std::vector<std::string> parse(int argc, char** argv)
+   void parse(int argc, char** argv, bool firstPass)
    {
-		/// this version takes the original argc and argv, parses what it can,
-		/// and returns the rest as a vector of strings (w/o throwing any errors)
+		/// this version takes argc and argv, parses them, and sets only those
+		/// that have the matching firstPass flag set
+		/// this allows us to parse command line arguments in two stages, one
+		/// to get the normal options and file names (from which the run info
+		/// and analysis options are read), and a second stage where only the
+		/// run info and analysis option flags are parsed
       bool double_dash_encountered = false;
 
       int iarg = 1;
-		std::vector<std::string> unknownFlags;
       while(iarg < argc) {
+			std::string arg = argv[iarg++];
 
-         std::string arg = argv[iarg++];
-
-			try {
-				if(arg.at(0) != '-' || double_dash_encountered) {
-					handle_default_option(argc, argv, iarg);
-				} else if(arg.substr(0, 2) == "--") {
-					handle_long_flag(argc, argv, iarg);
-				} else {
-					handle_short_flag(argc, argv, iarg);
-				}
-			} catch(ParseError& err) {
-				std::cout<<"pushing back \""<<arg<<"\", "<<unknownFlags.size()<<std::endl;
-				unknownFlags.push_back(arg);
-				for(;iarg < argc && argv[iarg][0] != '-';++iarg) {
-					std::cout<<"pushing back \""<<argv[iarg]<<"\", "<<unknownFlags.size()<<std::endl;
-					unknownFlags.push_back(argv[iarg]);
-				}
-			}
-      }
-
-      for (auto& val : values) {
-         if(val->is_required() && !val->is_present()) {
-            std::stringstream ss;
-            ss << "Required argument \"" << val->flag_name() << "\" is not present";
-            throw ParseError(ss.str());
-         }
-      }
-		return unknownFlags;
-   }
-
-	void parse(std::vector<std::string> args)
-	{
-		/// this version takes the unknown flags of the version above and parses them.
-		/// any unknown flags create an exception.
-      bool double_dash_encountered = false;
-		int argc = static_cast<int>(args.size());
-		char** argv = new char*[argc];
-		for(int i = 0; i < argc; ++i) {
-			argv[i] = const_cast<char*>(args[i].c_str());
-		}
-		for(int i = 0; i < argc;) {
-			if(args[i].at(0) != '-' || double_dash_encountered) {
-				handle_default_option(argc, argv, ++i);
-			} else if(args[i].substr(0, 2) == "--") {
-				handle_long_flag(argc, argv, ++i);
+			if(arg.at(0) != '-' || double_dash_encountered) {
+				handle_default_option(argc, argv, iarg, firstPass);
+			} else if(arg.substr(0, 2) == "--") {
+				handle_long_flag(argc, argv, iarg, firstPass);
 			} else {
-				handle_short_flag(argc, argv, ++i);
+				handle_short_flag(argc, argv, iarg, firstPass);
 			}
 		}
 
-      for (auto& val : values) {
-         if(val->is_required() && !val->is_present()) {
-            std::stringstream ss;
-            ss << "Required argument \"" << val->flag_name() << "\" is not present";
-            throw ParseError(ss.str());
-         }
-      }
+		for (auto& val : values) {
+			if(val->is_required() && !val->is_present()) {
+				std::stringstream ss;
+				ss << "Required argument \"" << val->flag_name() << "\" is not present";
+				throw ParseError(ss.str());
+			}
+		}
 	}
 
-   void parse_file(std::string& filename)
-   {
-      std::ifstream infile(filename);
+	void parse_file(std::string& filename)
+	{
+		std::ifstream infile(filename);
 
-      std::string line;
-      while (std::getline(infile, line)) {
-         size_t colon     = line.find(":");
-         bool   has_colon = (colon != std::string::npos);
+		std::string line;
+		while (std::getline(infile, line)) {
+			size_t colon     = line.find(":");
+			bool   has_colon = (colon != std::string::npos);
 
-         std::string flag;
-         std::string remainder;
-         if(has_colon) {
-            flag = line.substr(0, colon);
-            std::stringstream(flag) >> flag; // Strip out whitespace
-            if(flag.length() == 1) {
-               flag = "-" + flag;
-            } else {
-               flag = "--" + flag;
-            }
-            remainder = line.substr(colon + 1, line.length());
-         } else {
-            flag      = "";
-            remainder = line;
-         }
+			std::string flag;
+			std::string remainder;
+			if(has_colon) {
+				flag = line.substr(0, colon);
+				std::stringstream(flag) >> flag; // Strip out whitespace
+				if(flag.length() == 1) {
+					flag = "-" + flag;
+				} else {
+					flag = "--" + flag;
+				}
+				remainder = line.substr(colon + 1, line.length());
+			} else {
+				flag      = "";
+				remainder = line;
+			}
 
-         std::vector<std::string> args;
-         std::stringstream        ss(remainder);
-         std::string              tmparg;
-         while (ss >> tmparg) {
-            args.push_back(tmparg);
-         }
+			std::vector<std::string> args;
+			std::stringstream        ss(remainder);
+			std::string              tmparg;
+			while (ss >> tmparg) {
+				args.push_back(tmparg);
+			}
 
-         if(has_colon) {
-            ArgParseItem& item = get_item(flag);
-            item.parse(flag, args, true);
-         } else {
-            for (auto& arg : args) {
-               ArgParseItem& item = get_item(arg);
-               item.parse(arg, std::vector<std::string>{arg});
-            }
-         }
-      }
-   }
+			if(has_colon) {
+				ArgParseItem& item = get_item(flag);
+				item.parse(flag, args, true, true); //parse "firstPass" items only
+				item.parse(flag, args, false, true); //parse "!firstPass" items only
+			} else {
+				for (auto& arg : args) {
+					ArgParseItem& item = get_item(arg);
+					item.parse(arg, std::vector<std::string>{arg}, true); //parse "firstPass" items only
+					item.parse(arg, std::vector<std::string>{arg}, false); //parse "!firstPass" items only
+				}
+			}
+		}
+	}
 
-   template <typename T>
-   ArgParseConfigT<T>& option(const std::string flag, T* output_location)
-   {
-      ArgParseConfigT<T>* output = new ArgParseConfigT<T>(flag, output_location);
-      values.push_back(output);
-      return *output;
-   }
+	template <typename T>
+		ArgParseConfigT<T>& option(const std::string flag, T* output_location, bool firstPass)
+		{
+			ArgParseConfigT<T>* output = new ArgParseConfigT<T>(flag, output_location, firstPass);
+			values.push_back(output);
+			return *output;
+		}
 
-   template <typename T>
-   ArgParseConfigT<std::vector<T>>& default_option(std::vector<T>* output_location)
-   {
-      return option("", output_location);
-   }
+	template <typename T>
+		ArgParseConfigT<std::vector<T>>& default_option(std::vector<T>* output_location, bool firstPass)
+		{
+			return option("", output_location, firstPass);
+		}
 
-   void print(std::ostream& out) const
-   {
-      out << "Options:\n";
+	void print(std::ostream& out) const
+	{
+		out << "Options:\n";
 
-      int max_length = -1;
-      for (auto item : values) {
-         int length;
-         item->printable(-1, &length);
-         max_length = std::max(length, max_length);
-      }
+		int max_length = -1;
+		for (auto item : values) {
+			int length;
+			item->printable(-1, &length);
+			max_length = std::max(length, max_length);
+		}
 
-      for (auto it = values.begin(); it != values.end(); it++) {
-         ArgParseItem* item = *it;
-         out << item->printable(max_length);
-         if(it != values.end() - 1) {
-            out << "\n";
-         }
-      }
-   }
+		for (auto it = values.begin(); it != values.end(); it++) {
+			ArgParseItem* item = *it;
+			out << item->printable(max_length);
+			if(it != values.end() - 1) {
+				out << "\n";
+			}
+		}
+	}
 
 private:
-   void handle_long_flag(int argc, char** argv, int& iarg)
-   {
-      std::string              arg = argv[iarg - 1];
-      std::vector<std::string> flag_args;
-      std::string              flag;
-      size_t                   equals_index = arg.find("=");
-      if(equals_index == std::string::npos) {
-         // flag followed by list of flag_args
-         flag = arg;
-      } else {
-         // = inside flag
-         flag = arg.substr(0, equals_index);
-      }
+	void handle_long_flag(int argc, char** argv, int& iarg, bool firstPass)
+	{
+		std::string              arg = argv[iarg - 1];
+		std::vector<std::string> flag_args;
+		std::string              flag;
+		size_t                   equals_index = arg.find("=");
+		if(equals_index == std::string::npos) {
+			// flag followed by list of flag_args
+			flag = arg;
+		} else {
+			// = inside flag
+			flag = arg.substr(0, equals_index);
+		}
 
-      ArgParseItem& item = get_item(flag);
+		ArgParseItem& item = get_item(flag);
 
-      if(equals_index == std::string::npos) {
-         flag_args = argument_list(argc, argv, iarg, item.num_arguments());
-      } else {
-         flag_args.push_back(arg.substr(equals_index + 1));
-      }
+		if(equals_index == std::string::npos) {
+			flag_args = argument_list(argc, argv, iarg, item.num_arguments());
+		} else {
+			flag_args.push_back(arg.substr(equals_index + 1));
+		}
+		item.parse(flag, flag_args, firstPass);
+	}
 
-      item.parse(flag, flag_args);
-   }
+	void handle_short_flag(int argc, char** argv, int& iarg, bool firstPass)
+	{
+		std::string   arg  = argv[iarg - 1];
+		std::string   flag = arg.substr(0, 2);
+		ArgParseItem& item = get_item(flag);
+		if(item.num_arguments() == 0) {
+			// Each character is a boolean flag
+			for (unsigned int ichar = 1; ichar < arg.length(); ichar++) {
+				std::string              tmpflag = "-" + arg.substr(ichar, 1);
+				std::vector<std::string> flag_args;
+				get_item(tmpflag).parse(tmpflag, flag_args, firstPass);
+			}
+		} else {
+			if(arg.length() == 2) {
+				// Next arguments passed to the program get passed to the flag.
+				std::vector<std::string> flag_args = argument_list(argc, argv, iarg, item.num_arguments());
+				item.parse(flag, flag_args, firstPass);
+			} else {
+				// Everything past the first character is argument to the flag.
+				std::vector<std::string> flag_args{arg.substr(2)};
+				item.parse(flag, flag_args, firstPass);
+			}
+		}
+	}
 
-   void handle_short_flag(int argc, char** argv, int& iarg)
-   {
-      std::string   arg  = argv[iarg - 1];
-      std::string   flag = arg.substr(0, 2);
-      ArgParseItem& item = get_item(flag);
-      if(item.num_arguments() == 0) {
-         // Each character is a boolean flag
-         for (unsigned int ichar = 1; ichar < arg.length(); ichar++) {
-            std::string              tmpflag = "-" + arg.substr(ichar, 1);
-            std::vector<std::string> flag_args;
-            get_item(tmpflag).parse(tmpflag, flag_args);
-         }
-      } else {
-         if(arg.length() == 2) {
-            // Next arguments passed to the program get passed to the flag.
-            std::vector<std::string> flag_args = argument_list(argc, argv, iarg, item.num_arguments());
-            item.parse(flag, flag_args);
-         } else {
-            // Everything past the first character is argument to the flag.
-            std::vector<std::string> flag_args{arg.substr(2)};
-            item.parse(flag, flag_args);
-         }
-      }
-   }
+	void handle_default_option(int /*argc*/, char** argv, int& iarg, bool firstPass)
+	{
+		std::string              arg = argv[iarg - 1];
+		std::vector<std::string> flag_args{arg};
 
-   void handle_default_option(int /*argc*/, char** argv, int& iarg)
-   {
-      std::string              arg = argv[iarg - 1];
-      std::vector<std::string> flag_args{arg};
+		ArgParseItem& item = get_item(arg);
+		item.parse(arg, flag_args, firstPass);
+	}
 
-      ArgParseItem& item = get_item(arg);
-      item.parse(arg, flag_args);
-   }
+	//! Reads arguments into a list until finding one that begins with '-'
+	std::vector<std::string> argument_list(int argc, char** argv, int& iarg, int max_args)
+	{
+		std::vector<std::string> output;
+		bool                     read_extra = false;
+		while (iarg < argc && (max_args == -1 || output.size() < size_t(max_args))) {
+			std::string next_arg = argv[iarg++];
+			if(next_arg.length() && next_arg.at(0) == '-') {
+				read_extra = true;
+				break;
+			} else {
+				output.push_back(next_arg);
+			}
+		}
+		if(read_extra) {
+			iarg--;
+		}
+		return output;
+	}
 
-   //! Reads arguments into a list until finding one that begins with '-'
-   std::vector<std::string> argument_list(int argc, char** argv, int& iarg, int max_args)
-   {
-      std::vector<std::string> output;
-      bool                     read_extra = false;
-      while (iarg < argc && (max_args == -1 || output.size() < size_t(max_args))) {
-         std::string next_arg = argv[iarg++];
-         if(next_arg.length() && next_arg.at(0) == '-') {
-            read_extra = true;
-            break;
-         } else {
-            output.push_back(next_arg);
-         }
-      }
-      if(read_extra) {
-         iarg--;
-      }
-      return output;
-   }
+	ArgParseItem& get_item(const std::string& flag)
+	{
+		for (auto val : values) {
+			if(val->matches(flag)) {
+				return *val;
+			}
+		}
 
-   ArgParseItem& get_item(const std::string& flag)
-   {
-      for (auto val : values) {
-         if(val->matches(flag)) {
-            return *val;
-         }
-      }
+		std::stringstream ss;
+		if(flag.at(0) == '-') {
+			ss << "Unknown option: \"" << flag << "\"";
+		} else {
+			ss << "Was passed \"" << flag << "\" as a non-option argument, when no non-option arguments are allowed";
+		}
+		throw ParseError(ss.str());
+	}
 
-      std::stringstream ss;
-      if(flag.at(0) == '-') {
-         ss << "Unknown option: \"" << flag << "\"";
-      } else {
-         ss << "Was passed \"" << flag << "\" as a non-option argument, when no non-option arguments are allowed";
-      }
-      throw ParseError(ss.str());
-   }
-
-   std::vector<ArgParseItem*> values;
+	std::vector<ArgParseItem*> values;
 };
 
 std::ostream& operator<<(std::ostream& out, const ArgParser& val);

--- a/include/GHSym.h
+++ b/include/GHSym.h
@@ -124,6 +124,7 @@ public:
       SetBinContent(GetBin(binx, biny), content);
    }
    virtual void SetBinsLength(Int_t n = -1);
+	virtual void UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = static_cast<Float_t>(content); }
    GHSymF& operator=(const GHSymF& h1);
    friend GHSymF operator*(Float_t c1, GHSymF& h1);
    friend GHSymF operator*(GHSymF& h1, Float_t c1) { return operator*(c1, h1); }
@@ -169,6 +170,7 @@ public:
       SetBinContent(GetBin(binx, biny), content);
    }
    virtual void SetBinsLength(Int_t n = -1);
+	virtual void UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
    GHSymD& operator=(const GHSymD& h1);
    friend GHSymD operator*(Float_t c1, GHSymD& h1);
    friend GHSymD operator*(GHSymD& h1, Float_t c1) { return operator*(c1, h1); }

--- a/include/TAnalysisOptions.h
+++ b/include/TAnalysisOptions.h
@@ -1,0 +1,68 @@
+#ifndef TANALYSISOPTIONS_H
+#define TANALYSISOPTIONS_H
+
+/** \addtogroup Sorting
+ *  @{
+ */
+
+#include "TObject.h"
+#include "TFile.h"
+
+#include "ArgParser.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TAnalysisOptions
+///
+/// This class stores those command line arguments passed to GRSISort, that
+/// are pertinent to the analysis. This includes such settings as the addback
+/// window width, whether to correct cross talk, etc.
+///
+/////////////////////////////////////////////////////////////////
+
+class TAnalysisOptions : public TObject {
+public:
+   TAnalysisOptions();
+
+   void Clear(Option_t* opt = "");
+   void Load(std::vector<std::string> args, ArgParser& prevParser);
+   void Print(Option_t* opt = "") const;
+
+   bool WriteToFile(TFile* file = nullptr);
+   void ReadFromFile(std::string file);
+
+	//sorting options
+   inline void SetBuildWindow(const long int t_bw) { fBuildWindow = t_bw; }
+   inline void SetAddbackWindow(const double t_abw) { fAddbackWindow = t_abw; }
+
+   inline void SetWaveformFitting(const bool flag) { fWaveformFitting = flag; }
+   inline bool IsWaveformFitting() { return fWaveformFitting; }
+
+   void SetCorrectCrossTalk(const bool flag, Option_t* opt = "");
+   inline bool IsCorrectingCrossTalk() { return fIsCorrectingCrossTalk; }
+
+   inline long int BuildWindow() { return fBuildWindow; }
+   inline double   AddbackWindow()
+   {
+      if (fAddbackWindow < 1) return 15.0;
+      return fAddbackWindow;
+   }
+
+   bool StaticWindow() const { return fStaticWindow; }
+
+private:
+	//sorting options
+   long int fBuildWindow;    ///< if building with a window(GRIFFIN) this is the size of the window. (default = 2us (200))
+   int      fAddbackWindow;  ///< Time used to build Addback-Ge-Events for TIGRESS/GRIFFIN.   (default = 150 ns (150))
+   bool     fIsCorrectingCrossTalk; ///< True if we are correcting for cross-talk in GRIFFIN at analysis-level
+   bool fWaveformFitting; ///< If true, waveform fitting with SFU algorithm will be performed
+   bool fStaticWindow;       ///< Flag to use static window (default moving)
+	bool fHelp; ///< help requested?
+
+   /// \cond CLASSIMP
+   ClassDef(TAnalysisOptions, 1); ///< Class for storing options in GRSISort
+	/// \endcond
+};
+/*! @} */
+#endif /* TANALYSISOPTIONS_H */
+

--- a/include/TAnalysisOptions.h
+++ b/include/TAnalysisOptions.h
@@ -21,6 +21,7 @@
 /////////////////////////////////////////////////////////////////
 
 class TAnalysisOptions : public TObject {
+	friend class TGRSIOptions;
 public:
    TAnalysisOptions();
 
@@ -57,7 +58,6 @@ private:
    bool     fIsCorrectingCrossTalk; ///< True if we are correcting for cross-talk in GRIFFIN at analysis-level
    bool fWaveformFitting; ///< If true, waveform fitting with SFU algorithm will be performed
    bool fStaticWindow;       ///< Flag to use static window (default moving)
-	bool fHelp; ///< help requested?
 
    /// \cond CLASSIMP
    ClassDef(TAnalysisOptions, 1); ///< Class for storing options in GRSISort

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -126,6 +126,8 @@ public:
    int  GetMaxWorkers() const { return fMaxWorkers; }
    bool SelectorOnly() const { return fSelectorOnly; }
 
+	void SuppressErrors(bool suppress) { fSuppressErrors = suppress; }
+
 private:
    TGRSIOptions(int argc, char** argv);
 	static TGRSIOptions* fGRSIOptions;

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -8,8 +8,10 @@
 #include <map>
 
 #include "TObject.h"
+#include "TFile.h"
 
 #include "TGRSITypes.h"
+#include "TAnalysisOptions.h"
 
 /////////////////////////////////////////////////////////////////
 ///
@@ -25,12 +27,16 @@
 
 class TGRSIOptions : public TObject {
 public:
+   TGRSIOptions() {}; /// Do not use!
    static TGRSIOptions* Get(int argc = 0, char** argv = nullptr);
 
    void Clear(Option_t* opt = "");
    void Load(int argc, char** argv);
    void Print(Option_t* opt = "") const;
-   void PrintSortingOptions() const;
+
+   static bool WriteToRoot(TFile* file = nullptr);
+   static void SetOptions(TGRSIOptions* temp);
+   static Bool_t ReadFromFile(TFile* tempf = nullptr);
 
    bool                            ShouldExit() { return fShouldExit; }
    const std::vector<std::string>& InputMidasFiles() { return fInputMidasFiles; }
@@ -59,9 +65,8 @@ public:
 
    std::string LogFile() { return fLogFile; }
 
-   int  BuildWindow() const { return fBuildWindow; }
-   int  AddbackWindow() const { return fAddbackWindow; }
-   bool StaticWindow() const { return fStaticWindow; }
+	static TAnalysisOptions* AnalysisOptions() { return fAnalysisOptions; }
+
    bool SeparateOutOfOrder() const { return fSeparateOutOfOrder; }
    bool RecordDialog() const { return fRecordDialog; }
    bool StartGui() const { return fStartGui; }
@@ -123,6 +128,7 @@ public:
 
 private:
    TGRSIOptions(int argc, char** argv);
+	static TGRSIOptions* fGRSIOptions;
 
    bool FileAutoDetect(const std::string& filename);
 
@@ -190,9 +196,8 @@ private:
    bool fTimeSortInput; ///< Flag to sort on time or triggers
    int  fSortDepth;     ///< Size of Q that stores fragments to be built into events
 
-   int  fBuildWindow;        ///< Size of the build window in us (2 us)
-   int  fAddbackWindow;      ///< Size of the addback window in us
-   bool fStaticWindow;       ///< Flag to use static window (default moving)
+	static TAnalysisOptions* fAnalysisOptions; ///< contains all options for analysis
+
    bool fSeparateOutOfOrder; ///< Flag to build out of order into seperate event tree
 
    bool fShouldExit; ///< Flag to exit sorting
@@ -207,8 +212,8 @@ private:
    bool fSelectorOnly; ///< Flag to turn PROOF off in grsiproof
 
    /// \cond CLASSIMP
-   ClassDef(TGRSIOptions, 1); ///< Class for storing options in GRSISort
-                              /// \endcond
+   ClassDef(TGRSIOptions, 2); ///< Class for storing options in GRSISort
+	/// \endcond
 };
 /*! @} */
 #endif /* _TGRSIOPTIONS_H_ */

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -91,7 +91,6 @@ public:
 
    bool Batch() const { return fBatch; }
 
-   bool ShowedHelp() const { return fHelp; }
    bool ShowedVersion() const { return fShowedVersion; }
    bool ShowLogo() const { return fShowLogo; }
    bool SortRaw() const { return fSortRaw; }
@@ -181,7 +180,6 @@ private:
    bool fBatch; ///< Flag to use batch mode (-b)
 
    bool fShowedVersion;
-   bool fHelp;         ///< Flag to show help (--help)
    bool fShowLogo;     ///< Flag to show logo (suppress with -l)
    bool fSortRaw;      ///< Flag to sort Midas file
    bool fSortRoot;     ///< Flag to sort root files
@@ -203,6 +201,8 @@ private:
    bool fSeparateOutOfOrder; ///< Flag to build out of order into seperate event tree
 
    bool fShouldExit; ///< Flag to exit sorting
+
+	bool fHelp; ///< help requested?
 
    size_t       fColumnWidth;    ///< Size of verbose columns
    size_t       fStatusWidth;    ///< Size of total verbose status

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -168,29 +168,6 @@ public:
    inline void SetRunInfoFileName(const char* fname) { fRunInfoFileName.assign(fname); }
    inline void SetRunInfoFile(const char* ffile) { fRunInfoFile.assign(ffile); }
 
-   inline void SetBuildWindow(const long int t_bw) { fBuildWindow = t_bw; }
-   inline void SetAddBackWindow(const double t_abw) { fAddBackWindow = t_abw; }
-   inline void SetBufferDuration(const long int t_bd) { fBufferDuration = t_bd; }
-   inline void SetBufferSize(const size_t t_bs) { fBufferSize = t_bs; }
-
-   inline void SetWaveformFitting(const bool flag) { fWaveformFitting = flag; }
-   static inline bool                        IsWaveformFitting() { return Get()->fWaveformFitting; }
-
-   inline void SetMovingWindow(const bool flag) { fIsMovingWindow = flag; }
-   static inline bool                     IsMovingWindow() { return Get()->fIsMovingWindow; }
-
-   void SetCorrectCrossTalk(const bool flag, Option_t* opt = "");
-   static inline bool IsCorrectingCrossTalk() { return Get()->fIsCorrectingCrossTalk; }
-
-   static inline long int BuildWindow() { return Get()->fBuildWindow / 10; }
-   static inline double   AddBackWindow()
-   {
-      if (Get()->fAddBackWindow < 1) return 15.0;
-      return Get()->fAddBackWindow;
-   }
-   static inline long int BufferDuration() { return Get()->fBufferDuration; }
-   static inline size_t   BufferSize() { return Get()->fBufferSize; }
-
    inline void SetHPGeArrayPosition(const double arr_pos) { fHPGeArrayPosition = arr_pos; }
    static inline double                          HPGeArrayPosition() { return Get()->fHPGeArrayPosition; }
 
@@ -278,16 +255,6 @@ private:
    std::string fRunInfoFile;     // The contents of the run info file
    static void trim(std::string*, const std::string& trimChars = " \f\n\r\t\v");
 
-   long int fBuildWindow;    // if building with a window(GRIFFIN) this is the size of the window. (default = 2us (200))
-   double   fAddBackWindow;  // Time used to build Addback-Ge-Events for TIGRESS/GRIFFIN.   (default =150 ns (15.0))
-   bool     fIsMovingWindow; // if set to true the event building window moves. Static otherwise.
-   bool     fIsCorrectingCrossTalk; // True if we are correcting for cross-talk in GRIFFIN at analysis-level
-
-   long int fBufferDuration; // GRIFFIN: the minimum length of the sorting buffer (default = 600s (60000000000))
-   size_t   fBufferSize;     // GRIFFIN: the minimum size of the sorting buffer (default = 1 000 000)
-
-   bool fWaveformFitting; // If true, waveform fitting with SFU algorithm will be performed
-
    double fHPGeArrayPosition; // Position of the HPGe Array (default = 110.0 mm );
    bool   fDescantAncillary;  // Descant is in the ancillary detector locations
 
@@ -303,7 +270,7 @@ public:
    std::string PrintToString(Option_t* opt = "");
 
    /// \cond CLASSIMP
-   ClassDef(TGRSIRunInfo, 11); // Contains the run-dependent information.
+   ClassDef(TGRSIRunInfo, 12); // Contains the run-dependent information.
    /// \endcond
 };
 /*! @} */

--- a/include/TGRSISelector.h
+++ b/include/TGRSISelector.h
@@ -16,6 +16,7 @@
 #include "TH2.h"
 #include "THnSparse.h"
 #include "GHSym.h"
+#include "TAnalysisOptions.h"
 
 #include <string>
 
@@ -58,6 +59,7 @@ protected:
 
 private:
    std::string fOutputPrefix;
+	TAnalysisOptions* fAnalysisOptions;
 
    ClassDef(TGRSISelector, 2);
 };

--- a/include/TGRSIint.h
+++ b/include/TGRSIint.h
@@ -103,8 +103,6 @@ private:
 
    std::vector<TRawFile*> fRawFiles; ///< List of Raw files opened
 
-  TStopwatch* fStopwatch;
-
    /// \cond CLASSIMP
    ClassDef(TGRSIint, 0); // Interpreter for GRSISort
    /// \endcond

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -70,8 +70,9 @@ int TDataParser::TigressDataToFragment(uint32_t* data, int size, unsigned int mi
 
    int      x     = 0;
    uint32_t dword = *(data + x);
-   uint32_t type  = (dword & 0xf0000000) >> 28;
-   uint32_t value = (dword & 0x0fffffff);
+
+   uint32_t type;
+   uint32_t value;
 
    if(!SetTIGTriggerID(dword, eventFrag)) {
       printf(RED "Setting TriggerId (0x%08x) failed on midas event: " DYELLOW "%i" RESET_COLOR "\n", dword,
@@ -245,7 +246,7 @@ void TDataParser::SetTIGCharge(uint32_t value, std::shared_ptr<TFragment> curren
    if(!chan) chan       = gChannel;
    std::string dig_type = chan->GetDigitizerTypeString();
 
-   int charge = currentFragment->GetCharge();
+   int charge;
    if((dig_type.compare(0, 5, "Tig10") == 0) || (dig_type.compare(0, 5, "TIG10") == 0)) {
       if(value & 0x02000000)
          charge = (-((~((int32_t)value & 0x01ffffff)) & 0x01ffffff) + 1);

--- a/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
@@ -9,7 +9,7 @@
 #include "TInterpreter.h"
 #include "TMnemonic.h"
 
-#include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 
 ////////////////////////////////////////////////////////////
 //
@@ -28,7 +28,7 @@ ClassImp(TFipps)
    bool DefaultAddback(TFippsHit& one, TFippsHit& two)
 {
    return ((one.GetDetector() == two.GetDetector()) &&
-           (std::fabs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()));
+           (std::fabs(one.GetTime() - two.GetTime()) < TGRSIOptions::AnalysisOptions()->AddbackWindow()));
 }
 
 std::function<bool(TFippsHit&, TFippsHit&)> TFipps::fAddbackCriterion = DefaultAddback;
@@ -383,7 +383,7 @@ Double_t TFipps::CTCorrectedEnergy(const TFippsHit* const hit_to_correct, const 
 
    if(time_constraint) {
       // Figure out if this passes the selected window
-      if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIRunInfo::AddBackWindow()) // placeholder
+      if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIOptions::AnalysisOptions()->AddbackWindow()) // placeholder
          return hit_to_correct->GetEnergy();
    }
 
@@ -404,7 +404,7 @@ void TFipps::FixCrossTalk()
    }
    for(size_t i = 0; i < hit_vec->size(); ++i) hit_vec->at(i).ClearEnergy();
 
-   if(TGRSIRunInfo::Get()->IsCorrectingCrossTalk()) {
+   if(TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) {
       size_t i, j;
       for(i = 0; i < hit_vec->size(); ++i) {
          for(j = i + 1; j < hit_vec->size(); ++j) {

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -9,7 +9,7 @@
 #include "TInterpreter.h"
 #include "TMnemonic.h"
 
-#include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 
 ////////////////////////////////////////////////////////////
 //
@@ -28,7 +28,7 @@ ClassImp(TGriffin)
    bool DefaultAddback(TGriffinHit& one, TGriffinHit& two)
 {
    return ((one.GetDetector() == two.GetDetector()) &&
-           (std::fabs(one.GetTime() - two.GetTime()) < TGRSIRunInfo::AddBackWindow()));
+           (std::fabs(one.GetTime() - two.GetTime()) < TGRSIOptions::AnalysisOptions()->AddbackWindow()));
 }
 
 std::function<bool(TGriffinHit&, TGriffinHit&)> TGriffin::fAddbackCriterion = DefaultAddback;
@@ -522,7 +522,7 @@ Double_t TGriffin::CTCorrectedEnergy(const TGriffinHit* const hit_to_correct, co
 
    if(time_constraint) {
       // Figure out if this passes the selected window
-      if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIRunInfo::AddBackWindow()) // placeholder
+      if(TMath::Abs(other_hit->GetTime() - hit_to_correct->GetTime()) > TGRSIOptions::AnalysisOptions()->AddbackWindow()) // placeholder
          return hit_to_correct->GetEnergy();
    }
 
@@ -570,7 +570,7 @@ void TGriffin::FixCrossTalk(const Int_t& gain_type)
    }
    for(size_t i = 0; i < hit_vec->size(); ++i) hit_vec->at(i).ClearEnergy();
 
-   if(TGRSIRunInfo::Get()->IsCorrectingCrossTalk()) {
+   if(TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) {
       size_t i, j;
       for(i = 0; i < hit_vec->size(); ++i) {
          for(j = i + 1; j < hit_vec->size(); ++j) {

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -4,7 +4,7 @@
 #include <cmath>
 #include "TMath.h"
 
-#include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 
 /// \cond CLASSIMP
 ClassImp(TS3)
@@ -67,14 +67,14 @@ void TS3::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan)
       dethit.SetRingNumber(frag->GetSegment());
       dethit.SetSectorNumber(0);
 
-      if(TGRSIRunInfo::IsWaveformFitting()) dethit.SetWavefit(*frag);
+      if(TGRSIOptions::AnalysisOptions()->IsWaveformFitting()) dethit.SetWavefit(*frag);
 
       fS3RingHits.push_back(std::move(dethit));
    } else {
       dethit.SetRingNumber(0);
       dethit.SetSectorNumber(frag->GetSegment());
 
-      if(TGRSIRunInfo::IsWaveformFitting()) dethit.SetWavefit(*frag);
+      if(TGRSIOptions::AnalysisOptions()->IsWaveformFitting()) dethit.SetWavefit(*frag);
 
       fS3SectorHits.push_back(std::move(dethit));
    }
@@ -199,19 +199,11 @@ void TS3::BuildPixels()
                               // Now we have accepted a good event, build it
                               TS3Hit dethit = fS3SectorHits[j]; // Sector now defines all data ring just gives position
                               dethit.SetRingNumber(fS3RingHits[i].GetRing());
-                              // 									if(TGRSIRunInfo::IsWaveformFitting()){
-                              // 										dethit.SetTimeFit(fS3SectorHits[j].GetFitTime());
-                              // 										dethit.SetSig2Noise(fS3SectorHits[j].GetSignalToNoise());
-                              // 									}
                               fS3Hits.push_back(dethit);
 
                               // Now we have accepted a good event, build it
                               TS3Hit dethitB = fS3SectorHits[k]; // Sector now defines all data ring just gives position
                               dethitB.SetRingNumber(fS3RingHits[i].GetRing());
-                              // 									if(TGRSIRunInfo::IsWaveformFitting()){
-                              // 										dethitB.SetTimeFit(fS3SectorHits[k].GetFitTime());
-                              // 										dethitB.SetSig2Noise(fS3SectorHits[k].GetSignalToNoise());
-                              // 									}
                               fS3Hits.push_back(dethitB);
                            }
 
@@ -269,19 +261,11 @@ void TS3::BuildPixels()
                               // Now we have accepted a good event, build it
                               TS3Hit dethit = fS3RingHits[j]; // Ring defines all data sector just gives position
                               dethit.SetSectorNumber(fS3SectorHits[i].GetSector());
-                              // 									if(TGRSIRunInfo::IsWaveformFitting()){
-                              // 										dethit.SetTimeFit(fS3RingHits[j].GetFitTime());
-                              // 										dethit.SetSig2Noise(fS3RingHits[j].GetSignalToNoise());
-                              // 									}
                               fS3Hits.push_back(dethit);
 
                               // Now we have accepted a good event, build it
                               TS3Hit dethitB = fS3RingHits[k]; // Ring defines all data sector just gives position
                               dethitB.SetSectorNumber(fS3SectorHits[i].GetSector());
-                              // 									if(TGRSIRunInfo::IsWaveformFitting()){
-                              // 										dethitB.SetTimeFit(fS3RingHits[k].GetFitTime());
-                              // 										dethitB.SetSig2Noise(fS3RingHits[k].GetSignalToNoise());
-                              // 									}
                               fS3Hits.push_back(dethitB);
                            }
 

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -1,6 +1,6 @@
 
 #include "TSiLi.h"
-#include <TGRSIRunInfo.h>
+#include "TGRSIOptions.h"
 
 /// \cond CLASSIMP
 ClassImp(TSiLi)
@@ -144,14 +144,14 @@ TSiLiHit* TSiLi::GetAddbackHit(const int& i)
 // If they are acceptable neighbours the second hit is also added to the cluster
 //
 // fAddbackCriterion checks if hits are flat surface contact (no corners) neighbours
-// and compares time to the global TGRSIRunInfo::AddBackWindow()
+// and compares time to the global TGRSIOptions::AddBackWindow()
 // some limited energy constraints are also added
 //
 // Clusters are then ordered by energy and summed
 // All base information is taken from the highest energy hit
 
 // Things to implement:
-// -maybe dont use global TGRSIRunInfo::AddBackWindow() time
+// -maybe dont use global TGRSIOptions::AddBackWindow() time
 // -better energy restrictions could be placed on what is a pair to suppress crosstalk issues
 // -instead of blindly summing entire clusters a decision could be made based on geometry of the pixels
 // eg if an event claims to go through a row of 3 the middle one must have sufficient energy for an electron to have
@@ -253,7 +253,7 @@ bool TSiLi::fAddbackCriterion(TSiLiHit* one, TSiLiHit* two)
 
    double e = one->GetEnergy() / two->GetEnergy();
    if(e > 0.1 && e < 10) { // very basic energy gate to suppress crosstalk noise issues
-      if(std::abs(T) < (TGRSIRunInfo::AddBackWindow() * 10.0)) {
+      if(std::abs(T) < (TGRSIOptions::AnalysisOptions()->AddbackWindow() * 10.0)) {
          int dring   = std::abs(one->GetRing() - two->GetRing());
          int dsector = std::abs(one->GetSector() - two->GetSector());
          if(dring == 1 && dsector == 0) return true;
@@ -263,7 +263,7 @@ bool TSiLi::fAddbackCriterion(TSiLiHit* one, TSiLiHit* two)
 
    // 	  TVector3 res = one.GetPosition() - two.GetPosition();
    //                         // GetTime is in ns;  AddbackWindow is in 10's of ns.
-   //   return ((std::abs(one.GetTime() - two.GetTime()) < (TGRSIRunInfo::AddBackWindow()*10.0)) &&
+   //   return ((std::abs(one.GetTime() - two.GetTime()) < (TGRSIOptions::AddBackWindow()*10.0)) &&
    //       ((((one.GetInitialHit() < 5 && two.GetInitialHit() < 5) || (one.GetInitialHit() > 4 && two.GetInitialHit() >
    //       4)) && res.Mag() < 54) ||  //not front to back
    //        (((one.GetInitialHit() < 5 && two.GetInitialHit() > 4) || (one.GetInitialHit() > 4 && two.GetInitialHit() <

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -7,7 +7,7 @@
 #include "TClass.h"
 #include "TInterpreter.h"
 
-#include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 
 /// \cond CLASSIMP
 ClassImp(TTigress)
@@ -27,7 +27,7 @@ bool DefaultAddback(TTigressHit& one, TTigressHit& two)
    // Checking for Scattering FROM "one" TO "two"
 
    // GetTime is in ns;  AddbackWindow is in 10's of ns.
-   if(std::abs(one.GetTime() - two.GetTime()) < (TGRSIRunInfo::AddBackWindow() * 10.0)) {
+   if(std::abs(one.GetTime() - two.GetTime()) < (TGRSIOptions::AnalysisOptions()->AddbackWindow() * 10.0)) {
 
       // segments of crystals have been sorted by descending energy during detector construction
       // LastPosition is the position of lowest energy segment and GetPosition the highest energy segment (assumed
@@ -205,7 +205,7 @@ void TTigress::BuildHits()
       // it->Print("all");
       if(it->GetNSegments() > 1) it->SortSegments();
 
-      if(it->HasWave() && TGRSIRunInfo::IsWaveformFitting()) it->SetWavefit();
+      if(it->HasWave() && TGRSIOptions::AnalysisOptions()->IsWaveformFitting()) it->SetWavefit();
       it++;
    }
    if(fTigressHits.size() > 1) std::sort(fTigressHits.begin(), fTigressHits.end());

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -1,6 +1,6 @@
 #include "TTip.h"
 #include "TTipHit.h"
-#include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 
 ////////////////////////////////////////////////////////////
 //
@@ -24,9 +24,9 @@ ClassImp(TTipHit)
 TTipHit::TTipHit(const TFragment& frag) : TGRSIDetectorHit(frag)
 {
    // SetVariables(frag);
-   if(TGRSIRunInfo::IsWaveformFitting() && !IsCsI())
+   if(TGRSIOptions::AnalysisOptions()->IsWaveformFitting() && !IsCsI())
       SetWavefit(frag);
-   else if(TGRSIRunInfo::IsWaveformFitting() && IsCsI())
+   else if(TGRSIOptions::AnalysisOptions()->IsWaveformFitting() && IsCsI())
       SetPID(frag);
 }
 

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -17,7 +17,7 @@
 
 #pragma link C++ class TEpicsFrag+;
 #pragma link C++ class TChannel-;
-#pragma link C++ class TGRSIRunInfo-;
+#pragma link C++ class TGRSIRunInfo+;
 #pragma link C++ class TGRSISortInfo+;
 #pragma link C++ class TGRSISortList+;
 

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -10,413 +10,11 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSIRunInfo)
-   /// \endcond
+/// \endcond
 
-   TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
+TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
 
 std::string TGRSIRunInfo::fGRSIVersion;
-
-// int  TGRSIRunInfo::fRunNumber    = 0;
-// int  TGRSIRunInfo::fSubRunNumber = -1;
-
-// bool TGRSIRunInfo:: fTigress     = false;
-// bool TGRSIRunInfo:: fSharc       = false;
-// bool TGRSIRunInfo:: fTriFoil     = false;
-// bool TGRSIRunInfo:: fRf          = false;
-// bool TGRSIRunInfo:: fCSM         = false;
-// bool TGRSIRunInfo:: fSpice       = false;
-// bool TGRSIRunInfo:: fTip         = false;
-// bool TGRSIRunInfo:: fS3          = false;
-
-// bool TGRSIRunInfo:: fGriffin     = false;
-// bool TGRSIRunInfo:: fSceptar     = false;
-// bool TGRSIRunInfo:: fPaces       = false;
-// bool TGRSIRunInfo:: fDante       = false;
-// bool TGRSIRunInfo:: fZeroDegree  = false;
-// bool TGRSIRunInfo:: fDescant     = false;
-
-// std::string TGRSIRunInfo::fMajorIndex;
-// std::string TGRSIRunInfo::fMinorIndex;
-
-// int TGRSIRunInfo::fNumberOfTrueSystems = 0;
-
-void TGRSIRunInfo::Streamer(TBuffer& b)
-{
-   // Streamer for TGRSIRunInfo. Allows us to write all of the run info
-   // to disk like a string. This way there isn't any compatibility issues
-   // between different TGRSIRunInfo classes written by different users.
-   UInt_t R__s, R__c;
-   if(b.IsReading()) {
-      Version_t R__v = b.ReadVersion(&R__s, &R__c);
-      if(R__v) {
-      }
-      TObject::Streamer(b);
-      {
-         Int_t R__int;
-         b >> R__int;
-         fRunNumber = R__int;
-      }
-      {
-         Int_t R__int;
-         b >> R__int;
-         fSubRunNumber = R__int;
-      }
-      if(R__v > 3) {
-         {
-            Double_t R__double;
-            b >> R__double;
-            fRunStart = R__double;
-         }
-         {
-            Double_t R__double;
-            b >> R__double;
-            fRunStop = R__double;
-         }
-      }
-      if(R__v > 4) {
-         {
-            Double_t R__double;
-            b >> R__double;
-            fRunLength = R__double;
-         }
-      }
-      if(R__v > 2) {
-         {
-            Double_t R__double;
-            b >> R__double;
-            fHPGeArrayPosition = R__double;
-         }
-         if(R__v > 5) {
-            {
-               Long_t R__int;
-               b >> R__int;
-               fBuildWindow = R__int;
-            }
-         } else {
-            {
-               Int_t R__int;
-               b >> R__int;
-               fBuildWindow = R__int;
-            }
-         }
-         {
-            Double_t R__double;
-            b >> R__double;
-            fAddBackWindow = R__double;
-         }
-      }
-      if(R__v > 4) {
-         {
-            Bool_t R__bool;
-            b >> R__bool;
-            fIsMovingWindow = R__bool;
-         }
-      }
-      if(R__v > 6) {
-         {
-            Bool_t R__bool;
-            b >> R__bool;
-            fWaveformFitting = R__bool;
-         }
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fTigress = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fSharc = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fTriFoil = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fRf = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fCSM = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fSpice = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fTip = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fS3 = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fBambino = R__bool;
-      }
-
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fGriffin = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fSceptar = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fPaces = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fDante = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fZeroDegree = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fDescant = R__bool;
-      }
-      {
-         Bool_t R__bool;
-         b >> R__bool;
-         fFipps = R__bool;
-      }
-      {
-         TString R__str;
-         R__str.Streamer(b);
-         fMajorIndex.assign(R__str.Data());
-      }
-      // printf("fMajorIndex = %s\n",fMajorIndex.c_str());
-      {
-         TString R__str;
-         R__str.Streamer(b);
-         fMinorIndex.assign(R__str.Data());
-      }
-      // printf("fMinorIndex = %s\n",fMinorIndex.c_str());
-      if(R__v > 2) {
-         {
-            TString R__str;
-            R__str.Streamer(b);
-            fRunInfoFileName.assign(R__str.Data());
-         }
-         // printf("fRunInfoFileNameMajor = %s\n",fRunInfoFileName.c_str());
-         {
-            TString R__str;
-            R__str.Streamer(b);
-            fRunInfoFile.assign(R__str.Data());
-         }
-         // printf("fMajorIndex = %s\n",fMajorIndex.c_str());
-      }
-      if(R__v > 8) {
-         {
-            Bool_t R__bool;
-            b >> R__bool;
-            fDescantAncillary = R__bool;
-         }
-      }
-      if(R__v > 9) {
-         {
-            Bool_t R__bool;
-            b >> R__bool;
-            fIsCorrectingCrossTalk = R__bool;
-         }
-         {
-            UInt_t R__uint;
-            b >> R__uint;
-            fBadCycleListSize = R__uint;
-         }
-         for(UInt_t i = 0; i < fBadCycleList.size(); ++i) {
-            Int_t R__int;
-            b >> R__int;
-            AddBadCycle(R__int);
-         }
-      }
-      if(R__v > 10) {
-         {
-            TString R__str;
-            b >> R__str;
-            fRunTitle = R__str;
-         }
-         {
-            TString R__str;
-            b >> R__str;
-            fRunComment = R__str;
-         }
-      }
-      fGRSIRunInfo = this;
-      b.CheckByteCount(R__s, R__c, TGRSIRunInfo::IsA());
-   } else {
-      R__c = b.WriteVersion(TGRSIRunInfo::IsA(), true);
-      TObject::Streamer(b);
-      {
-         Int_t R__int = fRunNumber;
-         b << R__int;
-      }
-      {
-         Int_t R__int = fSubRunNumber;
-         b << R__int;
-      }
-      {
-         Double_t R__double = fRunStart;
-         b << R__double;
-      }
-      {
-         Double_t R__double = fRunStop;
-         b << R__double;
-      }
-      {
-         Double_t R__double = fRunLength;
-         b << R__double;
-      }
-      {
-         Double_t R__double = fHPGeArrayPosition;
-         b << R__double;
-      }
-      {
-         Long_t R__long = fBuildWindow;
-         b << R__long;
-      }
-      {
-         Double_t R__double = fAddBackWindow;
-         b << R__double;
-      }
-      {
-         Bool_t R__bool = fIsMovingWindow;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fWaveformFitting;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fTigress;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fSharc;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fTriFoil;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fRf;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fCSM;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fSpice;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fTip;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fS3;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fBambino;
-         b << R__bool;
-      }
-
-      {
-         Bool_t R__bool = fGriffin;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fSceptar;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fPaces;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fDante;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fZeroDegree;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fDescant;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fFipps;
-         b << R__bool;
-      }
-      // printf("fMajorIndex = %s\n",fMajorIndex.c_str());
-      // printf("fMinorIndex = %s\n",fMinorIndex.c_str());
-      {
-         TString R__str(fMajorIndex.c_str());
-         R__str.Streamer(b);
-      } // printf("TString::data = %s\n",R__str.Data());  }//; R__str = fMajorIndex.c_str();      R__str.Streamer(b);}
-      {
-         TString R__str(fMinorIndex.c_str());
-         R__str.Streamer(b);
-      } // printf("TString::data = %s\n",R__str.Data()); }//; R__str = fMinorIndex.c_str();      R__str.Streamer(b);}
-      {
-         TString R__str(fRunInfoFileName.c_str());
-         R__str.Streamer(b);
-      } //; R__str = fRunInfoFileName.c_str(); R__str.Streamer(b);}
-      {
-         TString R__str(fRunInfoFile.c_str());
-         R__str.Streamer(b);
-      } //; R__str = fRunInfoFile.c_str();     R__str.Streamer(b);}
-      {
-         Bool_t R__bool = fDescantAncillary;
-         b << R__bool;
-      }
-      {
-         Bool_t R__bool = fIsCorrectingCrossTalk;
-         b << R__bool;
-      }
-      {
-         UInt_t R__uint = fBadCycleListSize;
-         b << R__uint;
-      }
-      for(UInt_t i = 0; i < fBadCycleList.size(); ++i) {
-         Int_t R__int = fBadCycleList.at(i);
-         b << R__int;
-      }
-      {
-         TString R__str(fRunTitle.c_str());
-         R__str.Streamer(b);
-      }
-      {
-         TString R__str(fRunComment.c_str());
-         R__str.Streamer(b);
-      }
-      b.SetByteCount(R__c, true);
-   }
-}
 
 TGRSIRunInfo* TGRSIRunInfo::Get()
 {
@@ -471,23 +69,10 @@ TGRSIRunInfo::TGRSIRunInfo() : fRunNumber(0), fSubRunNumber(-1)
    /// Default ctor for TGRSIRunInfo. The default values are:
    ///
    /// fHPGeArrayPosition = 110.0;
-   /// fBuildWindow       = 200;
-   /// fAddBackWindow     = 15.0;
-   /// fIsMovingWindow    = true;
-   /// fWaveformFitting	 = false;
-   /// fBufferSize        = 1000000;
-   /// fBufferDuration    = 60000000000;
 
    fHPGeArrayPosition = 110.0;
-   fBuildWindow       = 2000;
-   fAddBackWindow     = 150.0;
-   fIsMovingWindow    = true;
-   fWaveformFitting   = false;
-   fBufferSize        = 1000000;
-   fBufferDuration    = 60000000000;
 
    fDescantAncillary      = false;
-   fIsCorrectingCrossTalk = true;
    fBadCycleList.clear();
    fBadCycleListSize = 0;
 
@@ -530,16 +115,9 @@ void TGRSIRunInfo::Print(Option_t* opt) const
       printf("\t\tDANTE:        %s\n", Dante() ? "true" : "false");
       printf("\t\tFIPPS:        %s\n", Fipps() ? "true" : "false");
       printf("\n");
-      printf(DBLUE "\tBuild Window (10 ns) = " DRED "%lu" RESET_COLOR "\n", TGRSIRunInfo::BuildWindow());
-      printf(DBLUE "\tMoving Window = " DRED "%s" RESET_COLOR "\n", TGRSIRunInfo::IsMovingWindow() ? "TRUE" : "FALSE");
-      printf(DBLUE "\tAddBack Window (ns) = " DRED "%.01f" RESET_COLOR "\n", TGRSIRunInfo::AddBackWindow());
       printf(DBLUE "\tArray Position (mm) = " DRED "%.01f" RESET_COLOR "\n", TGRSIRunInfo::HPGeArrayPosition());
-      printf(DBLUE "\tWaveform fitting = " DRED "%s" RESET_COLOR "\n",
-             TGRSIRunInfo::IsWaveformFitting() ? "TRUE" : "FALSE");
       printf(DBLUE "\tDESCANT in ancillary positions = " DRED "%s" RESET_COLOR "\n",
              TGRSIRunInfo::DescantAncillary() ? "TRUE" : "FALSE");
-      printf(DBLUE "\tGRIFFIN Corrected for Cross-talk = " DRED "%s" RESET_COLOR "\n",
-             TGRSIRunInfo::IsCorrectingCrossTalk() ? "TRUE" : "FALSE");
       printf("\n");
       printf("\t==============================\n");
    } else {
@@ -575,17 +153,13 @@ void TGRSIRunInfo::Clear(Option_t*)
    fMinorIndex.assign("");
 
    fNumberOfTrueSystems   = 0;
-   fIsCorrectingCrossTalk = true;
    fBadCycleList.clear();
    fBadCycleListSize = 0;
-
-   // fRunTitle.assign("");
-   // fRunComment.assign("");
 }
 
 void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum)
 {
-   // Sets the run info. This figures out what systems are available.
+   /// Sets the run info. This figures out what systems are available.
 
    printf("In runinfo, found %i channels.\n", TChannel::GetNumberOfChannels());
    if(runnum != 0) {
@@ -782,8 +356,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
       if(!line.length()) continue;
 
       size_t ntype = line.find(":");
-      if(ntype == std::string::npos) // no seperator, not useful.
-         continue;
+      if(ntype == std::string::npos) continue; // no seperator, not useful.
 
       std::string type = line.substr(0, ntype);
       line             = line.substr(ntype + 1, line.length());
@@ -794,27 +367,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
          c         = toupper(c);
          type[j++] = c;
       }
-      if(type.compare("BW") == 0 || type.compare("BUILDWINDOW") == 0) {
-         std::istringstream ss(line);
-         long int           temp_bw;
-         ss >> temp_bw;
-         Get()->SetBuildWindow(temp_bw);
-      } else if(type.compare("WF") == 0 || type.compare("WAVEFORMFIT") == 0) {
-         std::istringstream ss(line);
-         bool               temp_wff;
-         ss >> temp_wff;
-         Get()->SetWaveformFitting(temp_wff);
-      } else if(type.compare("MW") == 0 || type.compare("MOVINGWINDOW") == 0) {
-         std::istringstream ss(line);
-         bool               temp_mw;
-         ss >> temp_mw;
-         Get()->SetMovingWindow(temp_mw);
-      } else if(type.compare("ABW") == 0 || type.compare("ADDBACKWINDOW") == 0 || type.compare("ADDBACK") == 0) {
-         std::istringstream ss(line);
-         double             temp_abw;
-         ss >> temp_abw;
-         Get()->SetAddBackWindow(temp_abw);
-      } else if(type.compare("CAL") == 0 || type.compare("CALFILE") == 0) {
+      if(type.compare("CAL") == 0 || type.compare("CALFILE") == 0) {
          // TODO Make this work again, using priorities
          // TGRSIOptions::AddInputCalFile(line);
       } else if(type.compare("MID") == 0 || type.compare("MIDAS") == 0 || type.compare("MIDASFILE") == 0) {
@@ -830,11 +383,6 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
          int                temp_int;
          ss >> temp_int;
          Get()->SetDescantAncillary(temp_int);
-      } else if(type.compare("CROSSTALK") == 0) {
-         std::istringstream ss(line);
-         bool               temp_ct;
-         ss >> temp_ct;
-         Get()->SetCorrectCrossTalk(temp_ct, "q");
       } else if(type.compare("BADCYCLE") == 0) {
          std::istringstream ss(line);
          int                tmp_int;
@@ -846,21 +394,14 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
 
    if(strcmp(opt, "q")) {
       printf("parsed %i lines.\n", linenumber);
-      printf(DBLUE "\tBuild Window (10 ns) = " DRED "%lu" RESET_COLOR "\n", TGRSIRunInfo::BuildWindow());
-      printf(DBLUE "\tMoving Window = " DRED "%s" RESET_COLOR "\n", TGRSIRunInfo::IsMovingWindow() ? "TRUE" : "FALSE");
-      printf(DBLUE "\tAddBack Window (ns) = " DRED "%.01f" RESET_COLOR "\n", TGRSIRunInfo::AddBackWindow());
       printf(DBLUE "\tArray Position (mm) = " DRED "%lf" RESET_COLOR "\n", TGRSIRunInfo::HPGeArrayPosition());
-      printf(DBLUE "\tWaveform Fitting  = " DRED "%s" RESET_COLOR "\n",
-             TGRSIRunInfo::IsWaveformFitting() ? "TRUE" : "FALSE");
-      printf(DBLUE "\tCorrecting Cross-talk  = " DRED "%s" RESET_COLOR "\n",
-             TGRSIRunInfo::IsCorrectingCrossTalk() ? "TRUE" : "FALSE");
    }
    return true;
 }
 
 void TGRSIRunInfo::trim(std::string* line, const std::string& trimChars)
 {
-   // Removes the the string "trimCars" from  the string 'line'
+   /// Removes the string "trimCars" from  the string 'line'
    if(line->length() == 0) return;
    std::size_t found                    = line->find_first_not_of(trimChars);
    if(found != std::string::npos) *line = line->substr(found, line->length());
@@ -882,18 +423,6 @@ Long64_t TGRSIRunInfo::Merge(TCollection* list)
       this->Add(runinfo);
    }
    return 0;
-}
-
-void TGRSIRunInfo::SetCorrectCrossTalk(const bool flag, Option_t* opt)
-{
-   fIsCorrectingCrossTalk = flag;
-   TString opt1           = opt;
-   opt1.ToUpper();
-   if(opt1.Contains("Q")) {
-      return;
-   }
-
-   printf("Please call TGriffin::ResetFlags() on current event to avoid bugs\n");
 }
 
 void TGRSIRunInfo::PrintBadCycles() const
@@ -987,33 +516,14 @@ bool TGRSIRunInfo::WriteInfoFile(std::string filename)
 std::string TGRSIRunInfo::PrintToString(Option_t*)
 {
    std::string buffer;
-   buffer.append("//The event building time, 10 ns units.\n");
-   buffer.append(Form("BuildWindow: %ld\n", Get()->BuildWindow()));
-   buffer.append("\n\n");
-   buffer.append("//The Addback event window, ns units.\n");
-   buffer.append(Form("AddBackWindow: %lf\n", Get()->AddBackWindow()));
-   buffer.append("\n\n");
    buffer.append("//The Array Position in mm.\n");
    buffer.append(Form("HPGePos: %lf\n", Get()->HPGeArrayPosition()));
    buffer.append("\n\n");
-   if(Get()->IsWaveformFitting()) {
-      buffer.append("//Waveforms being Fit.\n");
-      buffer.append(Form("WaveFormFit: %d\n", 1));
-      buffer.append("\n\n");
-   }
-   if(!(Get()->IsMovingWindow())) {
-      buffer.append("//Using a moving BuildWindow.\n");
-      buffer.append(Form("MovingWindow: %d\n", 0));
-      buffer.append("\n\n");
-   }
    if(Get()->DescantAncillary()) {
       buffer.append("//Is DESCANT in Ancillary positions?.\n");
       buffer.append(Form("DescantAncillary: %d\n", 1));
       buffer.append("\n\n");
    }
-   buffer.append("//Correcting for Cross Talk? (Only available in GRIFFIN).\n");
-   buffer.append(Form("CrossTalk: %d\n", Get()->IsCorrectingCrossTalk()));
-   buffer.append("\n\n");
    if(fBadCycleList.size()) {
       buffer.append("//A List of bad cycles.\n");
       buffer.append("BadCycle:");

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -150,11 +150,12 @@ void TGRSISelector::Terminate()
    Int_t runnumber    = TGRSIRunInfo::Get()->RunNumber();
    Int_t subrunnumber = TGRSIRunInfo::Get()->SubRunNumber();
 
-   std::cout << runnumber << " " << subrunnumber << std::endl;
-   TFile output_file(Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runnumber, subrunnumber), "RECREATE");
+   std::cout<<runnumber<<" "<<subrunnumber<<std::endl;
+   TFile outputFile(Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runnumber, subrunnumber), "RECREATE");
    fOutput->Write();
    TGRSIRunInfo::Get()->Write();
-   output_file.Close();
+	TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(&outputFile);
+   outputFile.Close();
 }
 
 void TGRSISelector::Init(TTree* tree)

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -32,21 +32,21 @@
 #include "TStyle.h"
 /// \cond CLASSIMP
 ClassImp(TGRSISelector)
-   /// \endcond
+/// \endcond
 
-   void TGRSISelector::Begin(TTree* /*tree*/)
+void TGRSISelector::Begin(TTree* /*tree*/)
 {
-   // The Begin() function is called at the start of the query.
-   // When running with PROOF Begin() is only called on the client.
-   // The tree argument is deprecated (on PROOF 0 is passed).
+   /// The Begin() function is called at the start of the query.
+   /// When running with PROOF Begin() is only called on the client.
+   /// The tree argument is deprecated (on PROOF 0 is passed).
    TString option = GetOption();
 }
 
 void TGRSISelector::SlaveBegin(TTree* /*tree*/)
 {
-   // The SlaveBegin() function is called after the Begin() function.
-   // When running with PROOF SlaveBegin() is called on each slave server.
-   // The tree argument is deprecated (on PROOF 0 is passed).
+   /// The SlaveBegin() function is called after the Begin() function.
+   /// When running with PROOF SlaveBegin() is called on each slave server.
+   /// The tree argument is deprecated (on PROOF 0 is passed).
    TString option = GetOption();
 
    std::cout << "input list size = " << fInput->GetEntries() << std::endl;
@@ -54,6 +54,11 @@ void TGRSISelector::SlaveBegin(TTree* /*tree*/)
       std::cout << fInput->At(i)->GetName() << ": ";
       fInput->At(i)->Print();
    }
+
+	// read the analysis options that were passed along and copy them to the local TGRSIOptions
+	fAnalysisOptions = static_cast<TAnalysisOptions*>(fInput->FindObject("TAnalysisOptions"));
+	*(TGRSIOptions::AnalysisOptions()) = *fAnalysisOptions;
+
    const char* workingDirectory = "";
    if(fInput->FindObject("pwd") != nullptr) {
       workingDirectory = fInput->FindObject("pwd")->GetTitle();
@@ -100,23 +105,23 @@ void TGRSISelector::SlaveBegin(TTree* /*tree*/)
 
 Bool_t TGRSISelector::Process(Long64_t entry)
 {
-   // The Process() function is called for each entry in the tree (or possibly
-   // keyed object in the case of PROOF) to be processed. The entry argument
-   // specifies which entry in the currently loaded tree is to be processed.
-   // It can be passed to either TGRSISelector::GetEntry() or TBranch::GetEntry()
-   // to read either all or the required parts of the data. When processing
-   // keyed objects with PROOF, the object is already loaded and is available
-   // via the fObject pointer.
-   //
-   // This function should contain the "body" of the analysis. It can contain
-   // simple or elaborate selection criteria, run algorithms on the data
-   // of the event and typically fill histograms.
-   //
-   // The processing can be stopped by calling Abort().
-   //
-   // Use fStatus to set the return value of TTree::Process().
-   //
-   // The return value is currently not used
+   /// The Process() function is called for each entry in the tree (or possibly
+   /// keyed object in the case of PROOF) to be processed. The entry argument
+   /// specifies which entry in the currently loaded tree is to be processed.
+   /// It can be passed to either TGRSISelector::GetEntry() or TBranch::GetEntry()
+   /// to read either all or the required parts of the data. When processing
+   /// keyed objects with PROOF, the object is already loaded and is available
+   /// via the fObject pointer.
+   ///
+   /// This function should contain the "body" of the analysis. It can contain
+   /// simple or elaborate selection criteria, run algorithms on the data
+   /// of the event and typically fill histograms.
+   ///
+   /// The processing can be stopped by calling Abort().
+   ///
+   /// Use fStatus to set the return value of TTree::Process().
+   ///
+   /// The return value is currently not used
 
    static TFile* current_file = nullptr;
    if(current_file != fChain->GetCurrentFile()) {
@@ -135,18 +140,18 @@ Bool_t TGRSISelector::Process(Long64_t entry)
 
 void TGRSISelector::SlaveTerminate()
 {
-   // The SlaveTerminate() function is called after all entries or objects
-   // have been processed. When running with PROOF SlaveTerminate() is called
-   // on each slave server.
+   /// The SlaveTerminate() function is called after all entries or objects
+   /// have been processed. When running with PROOF SlaveTerminate() is called
+   /// on each slave server.
 
    EndOfSort();
 }
 
 void TGRSISelector::Terminate()
 {
-   // The Terminate() function is the last function to be called during
-   // a query. It always runs on the client, it can be used to present
-   // the results graphically or save the results to file.
+   /// The Terminate() function is the last function to be called during
+   /// a query. It always runs on the client, it can be used to present
+   /// the results graphically or save the results to file.
    Int_t runnumber    = TGRSIRunInfo::Get()->RunNumber();
    Int_t subrunnumber = TGRSIRunInfo::Get()->SubRunNumber();
 
@@ -160,14 +165,14 @@ void TGRSISelector::Terminate()
 
 void TGRSISelector::Init(TTree* tree)
 {
-   // The Init() function is called when the selector needs to initialize
-   // a new tree or chain. Typically here the branch addresses and branch
-   // pointers of the tree will be set.
-   // It is normally not necessary to make changes to the generated
-   // code, but the routine can be extended by the user if needed.
-   // Init() will be called many times when running on PROOF
-   // (once per file to be processed).
-   // Set branch addresses and branch pointers
+   /// The Init() function is called when the selector needs to initialize
+   /// a new tree or chain. Typically here the branch addresses and branch
+   /// pointers of the tree will be set.
+   /// It is normally not necessary to make changes to the generated
+   /// code, but the routine can be extended by the user if needed.
+   /// Init() will be called many times when running on PROOF
+   /// (once per file to be processed).
+   /// Set branch addresses and branch pointers
    if(!tree) return;
    fChain = tree;
    InitializeBranches(tree);
@@ -175,11 +180,11 @@ void TGRSISelector::Init(TTree* tree)
 
 Bool_t TGRSISelector::Notify()
 {
-   // The Notify() function is called when a new file is opened. This
-   // can be either for a new TTree in a TChain or when when a new TTree
-   // is started when using PROOF. It is normally not necessary to make changes
-   // to the generated code, but the routine can be extended by the
-   // user if needed. The return value is currently not used.
+   /// The Notify() function is called when a new file is opened. This
+   /// can be either for a new TTree in a TChain or when when a new TTree
+   /// is started when using PROOF. It is normally not necessary to make changes
+   /// to the generated code, but the routine can be extended by the
+   /// user if needed. The return value is currently not used.
 
    return kTRUE;
 }

--- a/libraries/TGRSIint/ArgParser.cxx
+++ b/libraries/TGRSIint/ArgParser.cxx
@@ -1,0 +1,8 @@
+#include "ArgParser.h"
+
+std::ostream& operator<<(std::ostream& out, const ArgParser& val)
+{
+   val.print(out);
+   return out;
+}
+

--- a/libraries/TGRSIint/LinkDef.h
+++ b/libraries/TGRSIint/LinkDef.h
@@ -1,4 +1,4 @@
-//TGRSIOptions.h TGRSIint.h
+//TGRSIOptions.h TGRSIint.h TAnalysisOptions.h
 
 #ifdef __CINT__
 
@@ -8,6 +8,7 @@
 #pragma link C++ nestedclasses;
 
 #pragma link C++ class TGRSIOptions+;
+#pragma link C++ class TAnalysisOptions+;
 #pragma link C++ class TGRSIint+;
 
 #endif

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -25,34 +25,6 @@ void TAnalysisOptions::Clear(Option_t*)
    fStaticWindow          = false;
    fWaveformFitting       = false;
    fIsCorrectingCrossTalk = true;
-   fHelp          = false;
-}
-
-void TAnalysisOptions::Load(std::vector<std::string> args, ArgParser& prevParser)
-{
-   ArgParser parser;
-	// analysis options
-   parser.option("build-window", &fBuildWindow).description("Build window, timestamp units");
-   parser.option("addback-window", &fAddbackWindow).description("Addback window, time in ns");
-   parser.option("static-window", &fStaticWindow)
-      .description("use static window for event building");
-   parser.option("waveform-fitting", &fWaveformFitting)
-      .description("fit waveforms using SFU algorithms");
-   parser.option("is-correcting-cross-talk", &fIsCorrectingCrossTalk)
-      .description("correct cross-talk");
-
-   // Look at the command line.
-   try {
-      parser.parse(args);
-   } catch(ParseError& e) {
-      std::cerr<<"ERROR: "<<e.what()<<"\n"<<prevParser<<parser<<std::endl;
-   }
-
-   // Print help if requested.
-   if(fHelp) {
-      Version();
-      std::cout<<parser<<std::endl;
-   }
 }
 
 void TAnalysisOptions::Print(Option_t*) const

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -1,0 +1,134 @@
+#include "TAnalysisOptions.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+
+#include "TEnv.h"
+#include "TKey.h"
+
+#include "Globals.h"
+#include "DynamicLibrary.h"
+#include "TGRSIUtilities.h"
+#include "GRootCommands.h"
+
+TAnalysisOptions::TAnalysisOptions()
+{
+	Clear();
+}
+
+void TAnalysisOptions::Clear(Option_t*)
+{
+   /// Clears all of the variables in the TAnalysisOptions
+   fBuildWindow           = 200;
+   fAddbackWindow         = 300;
+   fStaticWindow          = false;
+   fWaveformFitting       = false;
+   fIsCorrectingCrossTalk = true;
+   fHelp          = false;
+}
+
+void TAnalysisOptions::Load(std::vector<std::string> args, ArgParser& prevParser)
+{
+   ArgParser parser;
+	// analysis options
+   parser.option("build-window", &fBuildWindow).description("Build window, timestamp units");
+   parser.option("addback-window", &fAddbackWindow).description("Addback window, time in ns");
+   parser.option("static-window", &fStaticWindow)
+      .description("use static window for event building");
+   parser.option("waveform-fitting", &fWaveformFitting)
+      .description("fit waveforms using SFU algorithms");
+   parser.option("is-correcting-cross-talk", &fIsCorrectingCrossTalk)
+      .description("correct cross-talk");
+
+   // Look at the command line.
+   try {
+      parser.parse(args);
+   } catch(ParseError& e) {
+      std::cerr<<"ERROR: "<<e.what()<<"\n"<<prevParser<<parser<<std::endl;
+   }
+
+   // Print help if requested.
+   if(fHelp) {
+      Version();
+      std::cout<<parser<<std::endl;
+   }
+}
+
+void TAnalysisOptions::Print(Option_t*) const
+{
+   /// Print the current status of TAnalysisOptions, includes all names, lists and flags
+   std::cout<<BLUE<<"fBuildWindow: "          <<DCYAN<<fBuildWindow<<std::endl
+            <<BLUE<<"fAddbackWindow: "        <<DCYAN<<fAddbackWindow<<std::endl
+            <<BLUE<<"fStaticWindow: "         <<DCYAN<<fStaticWindow<<std::endl
+				<<BLUE<<"fWaveformFitting: "      <<DCYAN<<fWaveformFitting<<std::endl
+   			<<BLUE<<"fIsCorrectingCrossTalk: "<<DCYAN<<fIsCorrectingCrossTalk<<std::endl
+            <<RESET_COLOR<<std::endl;
+}
+
+bool TAnalysisOptions::WriteToFile(TFile* file)
+{
+   /// Writes options information to the root file
+   // Maintain old gDirectory info
+   bool        success = true;
+   TDirectory* oldDir  = gDirectory;
+
+   if(file == nullptr) {
+		file = gDirectory->GetFile();
+	}
+   file->cd();
+   std::string oldoption = std::string(file->GetOption());
+   if(oldoption == "READ") {
+      file->ReOpen("UPDATE");
+   }
+   if(!gDirectory) {
+      printf("No file opened to write to.\n");
+      success = false;
+   } else {
+      Write();
+   }
+
+   printf("Writing Run Information to %s\n", gDirectory->GetFile()->GetName());
+   if(oldoption == "READ") {
+      printf("  Returning %s to \"%s\" mode.\n", gDirectory->GetFile()->GetName(), oldoption.c_str());
+      file->ReOpen("READ");
+   }
+   oldDir->cd(); // Go back to original gDirectory
+
+   return success;
+}
+
+void TAnalysisOptions::ReadFromFile(std::string file)
+{
+   TDirectory* oldDir = gDirectory;
+	auto f = new TFile(file.c_str());
+	if(f->IsOpen()) {
+		TList* list = f->GetListOfKeys();
+		TIter  iter(list);
+		std::cout<<"Reading Options from file:"<<CYAN<<f<<RESET_COLOR<<std::endl;
+		while(TKey* key = static_cast<TKey*>(iter.Next())) {
+			if(!key || strcmp(key->GetClassName(), "TAnalysisOptions")) continue;
+
+			*this = *static_cast<TAnalysisOptions*>(key->ReadObj());
+			f->Close();
+			oldDir->cd();
+			return;
+		}
+	} else {
+		std::cout<<"Failed to open file \""<<file<<"\""<<std::endl;
+	}
+   oldDir->cd();
+}
+
+void TAnalysisOptions::SetCorrectCrossTalk(const bool flag, Option_t* opt)
+{
+   fIsCorrectingCrossTalk = flag;
+   TString opt1           = opt;
+   opt1.ToUpper();
+   if(opt1.Contains("Q")) {
+      return;
+   }
+
+   printf("Please call TGriffin::ResetFlags() on current event to avoid bugs\n");
+}
+

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -79,7 +79,6 @@ void TGRSIOptions::Clear(Option_t*)
    fBatch = false;
 
    fShowedVersion = false;
-   fHelp          = false;
    fShowLogo      = false;
    fSortRaw       = true;
    fSortRoot      = false;
@@ -110,6 +109,8 @@ void TGRSIOptions::Clear(Option_t*)
    // Proof only
    fMaxWorkers   = -1;
    fSelectorOnly = false;
+
+   fHelp          = false;
 }
 
 void TGRSIOptions::Print(Option_t*) const
@@ -135,7 +136,6 @@ void TGRSIOptions::Print(Option_t*) const
             <<"fBatch: "<<fBatch<<std::endl
             <<std::endl
             <<"fShowedVersion: "<<fShowedVersion<<std::endl
-            <<"fHelp: "<<fHelp<<std::endl
             <<"fShowLogo: "<<fShowLogo<<std::endl
             <<"fSortRaw: "<<fSortRaw<<std::endl
             <<"fSortRoot: "<<fSortRoot<<std::endl
@@ -161,9 +161,11 @@ void TGRSIOptions::Print(Option_t*) const
             <<"fStatusWidth: "<<fStatusWidth<<std::endl
             <<"fStatusInterval: "<<fStatusInterval<<std::endl
             <<"fLongFileDescription: "<<fLongFileDescription<<std::endl
-
+				<<std::endl
             <<"fMaxWorkers: "<<fMaxWorkers<<std::endl
-            <<"fSelectorOnly "<<fSelectorOnly<<std::endl;
+            <<"fSelectorOnly: "<<fSelectorOnly<<std::endl
+				<<std::endl
+				<<"fHelp: "<<fHelp<<std::endl;
 
 				fAnalysisOptions->Print();
 }
@@ -199,70 +201,82 @@ void TGRSIOptions::Load(int argc, char** argv)
 
    // parser.option() will initialize boolean values to false.
 
-   parser.default_option(&input_files).description("Input file(s)");
-   parser.option("output-fragment-tree", &fOutputFragmentFile).description("Filename of output fragment tree");
-   parser.option("output-analysis-tree", &fOutputAnalysisFile).description("Filename of output analysis tree");
-   parser.option("output-fragment-hists", &fOutputFragmentHistogramFile)
+	// these options are all to be set directly on the first parsing pass, so we set the firstPass flag to true
+   parser.default_option(&input_files, true).description("Input file(s)");
+   parser.option("output-fragment-tree", &fOutputFragmentFile, true).description("Filename of output fragment tree");
+   parser.option("output-analysis-tree", &fOutputAnalysisFile, true).description("Filename of output analysis tree");
+   parser.option("output-fragment-hists", &fOutputFragmentHistogramFile, true)
       .description("Filename of output fragment hists");
-   parser.option("output-analysis-hists", &fOutputAnalysisHistogramFile)
+   parser.option("output-analysis-hists", &fOutputAnalysisHistogramFile, true)
       .description("Filename of output analysis hists");
 
-   parser.option("a", &fMakeAnalysisTree).description("Make the analysis tree");
-   parser.option("H histos", &fMakeHistos).description("attempt to run events through MakeHisto lib.");
-   parser.option("g start-gui", &fStartGui).description("Start the gui at program start");
-   parser.option("b batch", &fBatch).description("Run in batch mode");
+   parser.option("a", &fMakeAnalysisTree, true).description("Make the analysis tree");
+   parser.option("H histos", &fMakeHistos, true).description("attempt to run events through MakeHisto lib.");
+   parser.option("g start-gui", &fStartGui, true).description("Start the gui at program start");
+   parser.option("b batch", &fBatch, true).description("Run in batch mode");
 
-   parser.option("sort-depth", &fSortDepth)
+   parser.option("sort-depth", &fSortDepth, true)
       .description("Number of events to hold when sorting by time/trigger_id")
       .default_value(200000);
-   parser.option("s sort", &fSortRoot).description("Attempt to loop through root files.");
+   parser.option("s sort", &fSortRoot, true).description("Attempt to loop through root files.");
 
-   parser.option("q quit", &fCloseAfterSort).description("Run in batch mode");
-   parser.option("l no-logo", &fShowLogo).description("Inhibit the startup logo").default_value(true);
-   parser.option("h help ?", &fHelp).description("Show this help message");
-   parser.option("w extract-waves", &fExtractWaves)
+   parser.option("q quit", &fCloseAfterSort, true).description("Run in batch mode");
+   parser.option("l no-logo", &fShowLogo, true).description("Inhibit the startup logo").default_value(true);
+   parser.option("w extract-waves", &fExtractWaves, true)
       .description("Extract wave forms to data class when available.")
       .default_value(false);
-   parser.option("d debug", &fDebug)
+   parser.option("d debug", &fDebug, true)
       .description("Write debug information to output/file, e.g. enables writing of TDescantDebug at analysis stage.")
       .default_value(false);
-   parser.option("no-record-dialog", &fRecordDialog).description("Dump stuff to screen");
-   parser.option("write-diagnostics", &fWriteDiagnostics);
-   parser.option("log-errors", &fLogErrors);
-   parser.option("log-file", &fLogFile).description("File logs from grsiproof are written to.");
-   parser.option("reading-material", &fReadingMaterial);
-   parser.option("bad-frags write-bad-frags bad-fragments write-bad-fragments", &fWriteBadFrags);
-   parser.option("separate-out-of-order", &fSeparateOutOfOrder)
+   parser.option("no-record-dialog", &fRecordDialog, true).description("Dump stuff to screen");
+   parser.option("write-diagnostics", &fWriteDiagnostics, true);
+   parser.option("log-errors", &fLogErrors, true);
+   parser.option("log-file", &fLogFile, true).description("File logs from grsiproof are written to.");
+   parser.option("reading-material", &fReadingMaterial, true);
+   parser.option("bad-frags write-bad-frags bad-fragments write-bad-fragments", &fWriteBadFrags, true);
+   parser.option("separate-out-of-order", &fSeparateOutOfOrder, true)
       .description("Write out-of-order fragments to a separate tree at the sorting stage")
       .default_value(false);
-   parser.option("ignore-odb", &fIgnoreFileOdb);
-   parser.option("ignore-epics", &fIgnoreEpics);
-   parser.option("ignore-scaler", &fIgnoreScaler);
-   parser.option("suppress-error suppress-errors suppress_error suppress_errors", &fSuppressErrors);
-   parser.option("reconstruct-timestamp reconstruct-time-stamp", &fReconstructTimeStamp);
+   parser.option("ignore-odb", &fIgnoreFileOdb, true);
+   parser.option("ignore-epics", &fIgnoreEpics, true);
+   parser.option("ignore-scaler", &fIgnoreScaler, true);
+   parser.option("suppress-error suppress-errors suppress_error suppress_errors", &fSuppressErrors, true);
+   parser.option("reconstruct-timestamp reconstruct-time-stamp", &fReconstructTimeStamp, true);
 
-   parser.option("fragment-size", &fFragmentWriteQueueSize)
+   parser.option("fragment-size", &fFragmentWriteQueueSize, true)
       .description("size of fragment write queue")
       .default_value(10000000);
-   parser.option("analysis-size", &fAnalysisWriteQueueSize)
+   parser.option("analysis-size", &fAnalysisWriteQueueSize, true)
       .description("size of analysis write queue")
       .default_value(1000000);
 
-   parser.option("column-width", &fColumnWidth).description("width of one column of status").default_value(20);
-   parser.option("status-width", &fStatusWidth)
+   parser.option("column-width", &fColumnWidth, true).description("width of one column of status").default_value(20);
+   parser.option("status-width", &fStatusWidth, true)
       .description("number of characters to be used for status output")
       .default_value(80);
-   parser.option("status-interval", &fStatusInterval)
+   parser.option("status-interval", &fStatusInterval, true)
       .description(
          "seconds between each detailed status output (each a new line), non-positive numbers mean no detailed status")
       .default_value(10);
 
    // Proof only parser options
-   parser.option("max-workers", &fMaxWorkers)
+   parser.option("max-workers", &fMaxWorkers, true)
       .description("Max number of nodes to use when running a grsiproof session")
       .default_value(-1);
 
-   parser.option("selector-only", &fSelectorOnly).description("Turns off PROOF to run a selector on the main thread");
+   parser.option("selector-only", &fSelectorOnly, true).description("Turns off PROOF to run a selector on the main thread");
+
+   parser.option("h help ?", &fHelp, true).description("Show this help message");
+
+	// analysis options, these options are to be parsed on the second pass, so firstPass is set to false
+   parser.option("build-window", &fAnalysisOptions->fBuildWindow, false).description("Build window, timestamp units");
+   parser.option("addback-window", &fAnalysisOptions->fAddbackWindow, false).description("Addback window, time in ns");
+   parser.option("static-window", &fAnalysisOptions->fStaticWindow, false)
+      .description("use static window for event building");
+   parser.option("waveform-fitting", &fAnalysisOptions->fWaveformFitting, false)
+      .description("fit waveforms using SFU algorithms");
+   parser.option("is-correcting-cross-talk", &fAnalysisOptions->fIsCorrectingCrossTalk, false)
+      .description("Correct cross-talk");
 
    // look for any arguments ending with .info, pass to parser.
    for(int i = 0; i < argc; i++) {
@@ -278,18 +292,10 @@ void TGRSIOptions::Load(int argc, char** argv)
    }
 
    // Look at the command line.
-	std::vector<std::string> unknownFlags;
    try {
-      unknownFlags = parser.parse(argc, argv);
+      parser.parse(argc, argv, true);
    } catch(ParseError& e) {
       std::cerr<<"ERROR: "<<e.what()<<"\n"<<parser<<std::endl;
-      fShouldExit = true;
-   }
-
-   // Print help if requested.
-   if(fHelp) {
-      Version();
-      std::cout<<parser<<std::endl;
       fShouldExit = true;
    }
 
@@ -298,6 +304,12 @@ void TGRSIOptions::Load(int argc, char** argv)
       Version();
       fShouldExit = true;
    }
+
+	// print help if required
+	if(fHelp) {
+		std::cout<<parser<<std::endl;
+		fShouldExit = true;
+	}
 
    if(fOutputFragmentHistogramFile.length() > 0 && fOutputFragmentHistogramFile != "none") {
       fMakeHistos = true;
@@ -317,7 +329,12 @@ void TGRSIOptions::Load(int argc, char** argv)
 		fAnalysisOptions->Print();
 	}
 	// parse analysis options from command line options 
-	fAnalysisOptions->Load(unknownFlags, parser);
+   try {
+      parser.parse(argc, argv, false);
+   } catch(ParseError& e) {
+      std::cerr<<"ERROR: "<<e.what()<<"\n"<<parser<<std::endl;
+      fShouldExit = true;
+   }
 }
 
 kFileType TGRSIOptions::DetermineFileType(const std::string& filename) const

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include "TEnv.h"
+#include "TKey.h"
 
 #include "Globals.h"
 #include "ArgParser.h"
@@ -12,14 +13,17 @@
 #include "TGRSIUtilities.h"
 #include "GRootCommands.h"
 
+TGRSIOptions* TGRSIOptions::fGRSIOptions = nullptr;
+TAnalysisOptions* TGRSIOptions::fAnalysisOptions = new TAnalysisOptions;
+
 TGRSIOptions* TGRSIOptions::Get(int argc, char** argv)
 {
-   /// Gets the global instance of TGRSIOptions
-   static TGRSIOptions* item = nullptr;
-   if(!item) {
-      item = new TGRSIOptions(argc, argv);
-   }
-   return item;
+   // The Getter for the singleton TGRSIOptions. This makes it
+   // so there is only ever one instance of the options during
+   // a session and it can be accessed from anywhere during that
+   // session.
+   if(fGRSIOptions == nullptr) fGRSIOptions = new TGRSIOptions(argc, argv);
+   return fGRSIOptions;
 }
 
 TGRSIOptions::TGRSIOptions(int argc, char** argv) : fShouldExit(false)
@@ -91,10 +95,8 @@ void TGRSIOptions::Clear(Option_t*)
 
    fTimeSortInput = false;
 
-   fBuildWindow        = 200;
-   fAddbackWindow      = 300;
-   fStaticWindow       = false;
-   fSeparateOutOfOrder = false;
+
+   fSeparateOutOfOrder    = false;
 
    fShouldExit = false;
 
@@ -102,6 +104,8 @@ void TGRSIOptions::Clear(Option_t*)
    fStatusWidth         = 80;
    fStatusInterval      = 10;
    fLongFileDescription = false;
+
+	fAnalysisOptions->Clear();
 
    // Proof only
    fMaxWorkers   = -1;
@@ -111,70 +115,57 @@ void TGRSIOptions::Clear(Option_t*)
 void TGRSIOptions::Print(Option_t*) const
 {
    /// Print the current status of TGRSIOptions, includes all names, lists and flags
-   std::cout << "fCloseAfterSort: " << fCloseAfterSort << std::endl
-             << "fLogErrors: " << fLogErrors << std::endl
-             << "fUseMidFileOdb: " << fUseMidFileOdb << std::endl
-             << "fSuppressErrors: " << fSuppressErrors << std::endl
-             << "fReconstructTimeStamp: " << fReconstructTimeStamp << std::endl
-             << std::endl
-             << "fMakeAnalysisTree: " << fMakeAnalysisTree << std::endl
-             << "fProgressDialog: " << fProgressDialog << std::endl
-             << "fReadingMaterial;: " << fReadingMaterial << std::endl
-             << "fIgnoreFileOdb: " << fIgnoreFileOdb << std::endl
-             << "fRecordDialog: " << fRecordDialog << std::endl
-             << std::endl
-             << "fIgnoreScaler: " << fIgnoreScaler << std::endl
-             << "fIgnoreEpics: " << fIgnoreEpics << std::endl
-             << "fWriteBadFrags: " << fWriteBadFrags << std::endl
-             << "fWriteDiagnostics: " << fWriteDiagnostics << std::endl
-             << std::endl
-             << "fBatch: " << fBatch << std::endl
-             << std::endl
-             << "fShowedVersion: " << fShowedVersion << std::endl
-             << "fHelp: " << fHelp << std::endl
-             << "fShowLogo: " << fShowLogo << std::endl
-             << "fSortRaw: " << fSortRaw << std::endl
-             << "fSortRoot: " << fSortRoot << std::endl
-             << "fExtractWaves;: " << fExtractWaves << std::endl
-             << "fIsOnline: " << fIsOnline << std::endl
-             << "fStartGui: " << fStartGui << std::endl
-             << "fMakeHistos: " << fMakeHistos << std::endl
-             << "fSortMultiple: " << fSortMultiple << std::endl
-             << "fDebug: " << fDebug << std::endl
-             << "fLogFile: " << fLogFile << std::endl
-             << std::endl
-             << "fFragmentWriteQueueSize: " << fFragmentWriteQueueSize << std::endl
-             << "fAnalysisWriteQueueSize: " << fAnalysisWriteQueueSize << std::endl
-             << std::endl
-             << "fTimeSortInput: " << fTimeSortInput << std::endl
-             << "fSortDepth: " << fSortDepth << std::endl
-             << std::endl
-             << "fBuildWindow: " << fBuildWindow << std::endl
-             << "fAddbackWindow: " << fAddbackWindow << std::endl
-             << "fStaticWindow: " << fStaticWindow << std::endl
-             << "fSeparateOutOfOrder: " << fSeparateOutOfOrder << std::endl
-             << std::endl
-             << "fShouldExit: " << fShouldExit << std::endl
-             << std::endl
-             << "fColumnWidth: " << fColumnWidth << std::endl
-             << "fStatusWidth: " << fStatusWidth << std::endl
-             << "fStatusInterval: " << fStatusInterval << std::endl
-             << "fLongFileDescription: " << fLongFileDescription << std::endl
+   std::cout<<"fCloseAfterSort: "<<fCloseAfterSort<<std::endl
+            <<"fLogErrors: "<<fLogErrors<<std::endl
+            <<"fUseMidFileOdb: "<<fUseMidFileOdb<<std::endl
+            <<"fSuppressErrors: "<<fSuppressErrors<<std::endl
+            <<"fReconstructTimeStamp: "<<fReconstructTimeStamp<<std::endl
+            <<std::endl
+            <<"fMakeAnalysisTree: "<<fMakeAnalysisTree<<std::endl
+            <<"fProgressDialog: "<<fProgressDialog<<std::endl
+            <<"fReadingMaterial;: "<<fReadingMaterial<<std::endl
+            <<"fIgnoreFileOdb: "<<fIgnoreFileOdb<<std::endl
+            <<"fRecordDialog: "<<fRecordDialog<<std::endl
+            <<std::endl
+            <<"fIgnoreScaler: "<<fIgnoreScaler<<std::endl
+            <<"fIgnoreEpics: "<<fIgnoreEpics<<std::endl
+            <<"fWriteBadFrags: "<<fWriteBadFrags<<std::endl
+            <<"fWriteDiagnostics: "<<fWriteDiagnostics<<std::endl
+            <<std::endl
+            <<"fBatch: "<<fBatch<<std::endl
+            <<std::endl
+            <<"fShowedVersion: "<<fShowedVersion<<std::endl
+            <<"fHelp: "<<fHelp<<std::endl
+            <<"fShowLogo: "<<fShowLogo<<std::endl
+            <<"fSortRaw: "<<fSortRaw<<std::endl
+            <<"fSortRoot: "<<fSortRoot<<std::endl
+            <<"fExtractWaves;: "<<fExtractWaves<<std::endl
+            <<"fIsOnline: "<<fIsOnline<<std::endl
+            <<"fStartGui: "<<fStartGui<<std::endl
+            <<"fMakeHistos: "<<fMakeHistos<<std::endl
+            <<"fSortMultiple: "<<fSortMultiple<<std::endl
+            <<"fDebug: "<<fDebug<<std::endl
+            <<"fLogFile: "<<fLogFile<<std::endl
+            <<std::endl
+            <<"fFragmentWriteQueueSize: "<<fFragmentWriteQueueSize<<std::endl
+            <<"fAnalysisWriteQueueSize: "<<fAnalysisWriteQueueSize<<std::endl
+            <<std::endl
+            <<"fTimeSortInput: "<<fTimeSortInput<<std::endl
+            <<"fSortDepth: "<<fSortDepth<<std::endl
+            <<std::endl
+            <<"fSeparateOutOfOrder: "<<fSeparateOutOfOrder<<std::endl
+            <<std::endl
+            <<"fShouldExit: "<<fShouldExit<<std::endl
+            <<std::endl
+            <<"fColumnWidth: "<<fColumnWidth<<std::endl
+            <<"fStatusWidth: "<<fStatusWidth<<std::endl
+            <<"fStatusInterval: "<<fStatusInterval<<std::endl
+            <<"fLongFileDescription: "<<fLongFileDescription<<std::endl
 
-             << "fMaxWorkers: " << fMaxWorkers << std::endl
-             << "fSelectorOnly " << fSelectorOnly << std::endl;
-}
+            <<"fMaxWorkers: "<<fMaxWorkers<<std::endl
+            <<"fSelectorOnly "<<fSelectorOnly<<std::endl;
 
-void TGRSIOptions::PrintSortingOptions() const
-{
-   /// Print just the sorting options in TGRSIOptions. This includes sort depth, build window, etc.
-   std::cout << DBLUE << "fTimeSortInput: " << DCYAN << fTimeSortInput << std::endl
-             << DBLUE << "fSortDepth:     " << DCYAN << fSortDepth << std::endl
-             << DBLUE << "fBuildWindow:   " << DCYAN << fBuildWindow << std::endl
-             << DBLUE << "fAddbackWindow: " << DCYAN << fAddbackWindow << std::endl
-             << DBLUE << "fStaticWindow:  " << DCYAN << fStaticWindow << std::endl
-             << DBLUE << "fSeparateOutOfOrder:  " << DCYAN << fSeparateOutOfOrder << std::endl
-             << RESET_COLOR << std::endl;
+				fAnalysisOptions->Print();
 }
 
 void TGRSIOptions::Load(int argc, char** argv)
@@ -257,32 +248,6 @@ void TGRSIOptions::Load(int argc, char** argv)
       .description("size of analysis write queue")
       .default_value(1000000);
 
-   // parser.option("o output", &output_file)
-   //   .description("Root output file");
-   // parser.option("f filter-output",&fOutputFilteredFile)
-   //   .description("Output file for raw filtered data");
-   // parser.option("hist-output",&fOutputHistogramFile)
-   //   .description("Output file for histograms");
-   // parser.option("r ring",&fInputRing)
-   //   .description("Input ring source (host/ringname).  Requires --format to be specified.");
-   //   .default_value(false);
-   // parser.option("n no-sort", &fSortRaw)
-   //   .description("Load raw data files without sorting")
-   //   .default_value(true);
-   // parser.option("m sort-multiple", &fSortMultiple)
-   //   .description("If passed multiple raw data files, treat them as one file.")
-   //   .default_value(false);
-   //   .default_value(false);
-   // parser.option("t time-sort", &fTimeSortInput)
-   //   .description("Reorder raw events by time");
-   // parser.option("time-sort-depth",&fTimeSortDepth)
-   //   .description("Number of events to hold when time sorting")
-   //   .default_value(100000);
-   parser.option("build-window", &fBuildWindow).description("Build window, timestamp units").default_value(200);
-   parser.option("addback-window", &fAddbackWindow).description("Addback window, time in ns").default_value(300);
-   parser.option("static-window", &fStaticWindow)
-      .description("use static window for event building")
-      .default_value(false);
    parser.option("column-width", &fColumnWidth).description("width of one column of status").default_value(20);
    parser.option("status-width", &fStatusWidth)
       .description("number of characters to be used for status output")
@@ -291,18 +256,6 @@ void TGRSIOptions::Load(int argc, char** argv)
       .description(
          "seconds between each detailed status output (each a new line), non-positive numbers mean no detailed status")
       .default_value(10);
-
-   // parser.option("long-file-description", &fLongFileDescription)
-   //   .description("Show full path to file in status messages")
-   //   .default_value(false);
-   // parser.option("format",&default_file_format)
-   //   .description("File format of raw data.  Allowed options are \"EVT\" and \"GEB\"."
-   //                "If unspecified, will be guessed from the filename.");
-   // parser.option("g start-gui",&fStartGui)
-   //   .description("Start the GUI")
-   //   .default_value(false);
-   // parser.option("v version", &fShowedVersion)
-   //   .description("Show version information");
 
    // Proof only parser options
    parser.option("max-workers", &fMaxWorkers)
@@ -318,24 +271,25 @@ void TGRSIOptions::Load(int argc, char** argv)
          try {
             parser.parse_file(filename);
          } catch(ParseError& e) {
-            std::cerr << "ERROR: " << e.what() << "\n" << parser << std::endl;
+            std::cerr<<"ERROR: "<<e.what()<<"\n"<<parser<<std::endl;
             fShouldExit = true;
          }
       }
    }
 
    // Look at the command line.
+	std::vector<std::string> unknownFlags;
    try {
-      parser.parse(argc, argv);
+      unknownFlags = parser.parse(argc, argv);
    } catch(ParseError& e) {
-      std::cerr << "ERROR: " << e.what() << "\n" << parser << std::endl;
+      std::cerr<<"ERROR: "<<e.what()<<"\n"<<parser<<std::endl;
       fShouldExit = true;
    }
 
    // Print help if requested.
    if(fHelp) {
       Version();
-      std::cout << parser << std::endl;
+      std::cout<<parser<<std::endl;
       fShouldExit = true;
    }
 
@@ -355,6 +309,15 @@ void TGRSIOptions::Load(int argc, char** argv)
    for(auto& file : input_files) {
       FileAutoDetect(file);
    }
+
+	// read analysis options from input file(s)
+	for(std::string file : fInputRootFiles) {
+		std::cout<<"Reading options from \""<<file<<"\":"<<std::endl;
+		fAnalysisOptions->ReadFromFile(file);
+		fAnalysisOptions->Print();
+	}
+	// parse analysis options from command line options 
+	fAnalysisOptions->Load(unknownFlags, parser);
 }
 
 kFileType TGRSIOptions::DetermineFileType(const std::string& filename) const
@@ -434,7 +397,7 @@ bool TGRSIOptions::FileAutoDetect(const std::string& filename)
          used                  = true;
       }
       if(!used) {
-         std::cerr << filename << " did not contain MakeFragmentHistograms() or MakeAnalysisHistograms()" << std::endl;
+         std::cerr<<filename<<" did not contain MakeFragmentHistograms() or MakeAnalysisHistograms()"<<std::endl;
       }
       return true;
    }
@@ -465,3 +428,73 @@ std::string TGRSIOptions::GenerateOutputFilename(const std::vector<std::string>&
    /// Currently does nothing
    return "temp_from_multi.root";
 }
+
+bool TGRSIOptions::WriteToRoot(TFile* file)
+{
+   /// Writes options information to the tree
+   // Maintain old gDirectory info
+   bool        success = true;
+   TDirectory* oldDir  = gDirectory;
+
+   if(file == nullptr) {
+		file = gDirectory->GetFile();
+	}
+   file->cd();
+   std::string oldoption = std::string(file->GetOption());
+   if(oldoption == "READ") {
+      file->ReOpen("UPDATE");
+   }
+   if(!gDirectory) {
+      printf("No file opened to write to.\n");
+      success = false;
+   } else {
+      Get()->Write();
+   }
+
+   printf("Writing Run Information to %s\n", gDirectory->GetFile()->GetName());
+   if(oldoption == "READ") {
+      printf("  Returning %s to \"%s\" mode.\n", gDirectory->GetFile()->GetName(), oldoption.c_str());
+      file->ReOpen("READ");
+   }
+   oldDir->cd(); // Go back to original gDirectory
+
+   return success;
+}
+
+void TGRSIOptions::SetOptions(TGRSIOptions* tmp)
+{
+   // Sets the TGRSIOptions to the info passes as tmp.
+   if(fGRSIOptions && (tmp != fGRSIOptions)) delete fGRSIOptions;
+   fGRSIOptions = tmp;
+}
+
+Bool_t TGRSIOptions::ReadFromFile(TFile* file)
+{
+   TDirectory* oldDir = gDirectory;
+   if(file != nullptr) {
+      file->cd();
+   }
+
+   if(gDirectory->GetFile() == nullptr) {
+      printf("File does not exist\n");
+      oldDir->cd();
+      return false;
+   }
+
+   file = gDirectory->GetFile();
+
+   TList* list = file->GetListOfKeys();
+   TIter  iter(list);
+   printf("Reading Options from file:" CYAN " %s" RESET_COLOR "\n", file->GetName());
+   while(TKey* key = static_cast<TKey*>(iter.Next())) {
+      if(!key || strcmp(key->GetClassName(), "TGRSIOptions")) continue;
+
+      TGRSIOptions::SetOptions(static_cast<TGRSIOptions*>(key->ReadObj()));
+      oldDir->cd();
+      return true;
+   }
+   oldDir->cd();
+
+   return false;
+}
+

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -280,6 +280,8 @@ void TGRSIint::PrintLogo(bool print)
 
       std::thread drawlogo(&TGRSIint::DrawLogo, this);
       drawlogo.detach();
+	} else {
+		std::cout<<"\tgrsisort version "<<GRSI_RELEASE<<std::endl;
    }
 }
 

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -71,7 +71,6 @@ TGRSIint::TGRSIint(int argc, char** argv, void* options, Int_t numOptions, Bool_
 {
    /// Singleton constructor
    fGRSIEnv   = gEnv;
-   fStopwatch = new TStopwatch;
 
    GetSignalHandler()->Remove();
    TGRSIInterruptHandler* ih = new TGRSIInterruptHandler();
@@ -195,15 +194,6 @@ void TGRSIint::Terminate(Int_t status)
    if(TGRSIOptions::Get()->MakeAnalysisTree()) {
       TSortingDiagnostics::Get()->Print("error");
    }
-
-   // Be polite when you leave.
-   double realTime = fStopwatch->RealTime();
-   int    hour     = static_cast<int>(realTime / 3600);
-   realTime -= hour * 3600;
-   int min = static_cast<int>(realTime / 60);
-   realTime -= min * 60;
-   printf(DMAGENTA "\nbye,bye\t" DCYAN "%s" RESET_COLOR " after %d:%02d:%.3f h:m:s\n", getpwuid(getuid())->pw_name,
-          hour, min, realTime);
 
    if((clock() % 60) == 0) {
       printf("DING!");
@@ -627,10 +617,10 @@ void TGRSIint::SetupPipeline()
 
    // If needed, generate the individual detectors from the TFragments
    if(generate_analysis_data) {
-      TGRSIOptions::Get()->PrintSortingOptions();
+      TGRSIOptions::AnalysisOptions()->Print();
       eventBuildingLoop = TEventBuildingLoop::Get("5_event_build_loop", event_build_mode);
       eventBuildingLoop->SetSortDepth(opt->SortDepth());
-      eventBuildingLoop->SetBuildWindow(opt->BuildWindow());
+      eventBuildingLoop->SetBuildWindow(opt->AnalysisOptions()->BuildWindow());
       if(unpackLoop) eventBuildingLoop->InputQueue()        = unpackLoop->AddGoodOutputQueue();
       if(fragmentChainLoop) eventBuildingLoop->InputQueue() = fragmentChainLoop->AddOutputQueue();
       fragmentQueues.push_back(eventBuildingLoop->InputQueue());

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -9,8 +9,9 @@
 #include "GValue.h"
 #include "TChannel.h"
 #include "TGRSIRunInfo.h"
-#include "TTreeFillMutex.h"
 #include "TGRSIOptions.h"
+#include "TTreeFillMutex.h"
+#include "TAnalysisOptions.h"
 #include "TSortingDiagnostics.h"
 #include "TDescant.h"
 
@@ -127,6 +128,7 @@ void TAnalysisWriteLoop::Write()
          TChannel::WriteToRoot();
       }
       TGRSIRunInfo::Get()->WriteToRoot(fOutputFile);
+      TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
       TPPG::Get()->Write();
 
       if(TGRSIOptions::Get()->WriteDiagnostics()) {

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -117,8 +117,8 @@ bool TEventBuildingLoop::CheckBuildCondition(std::shared_ptr<const TFragment> fr
 bool TEventBuildingLoop::CheckTimestampCondition(std::shared_ptr<const TFragment> frag)
 {
    long timestamp   = frag->GetTimeStamp();
-   long event_start = (fNextEvent.size() ? (TGRSIOptions::Get()->StaticWindow() ? fNextEvent[0]->GetTimeStamp()
-                                                                                : fNextEvent.back()->GetTimeStamp())
+   long event_start = (fNextEvent.size() ? (TGRSIOptions::Get()->AnalysisOptions()->StaticWindow() ? fNextEvent[0]->GetTimeStamp()
+                                                                                                   : fNextEvent.back()->GetTimeStamp())
                                          : timestamp);
 
    // save timestamp every <BuildWindow> fragments

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -11,9 +11,10 @@
 #include "GValue.h"
 #include "TChannel.h"
 #include "TGRSIRunInfo.h"
+#include "TGRSIOptions.h"
 #include "TThread.h"
 #include "TTreeFillMutex.h"
-#include "TGRSIOptions.h"
+#include "TAnalysisOptions.h"
 #include "TParsingDiagnostics.h"
 
 #include "TBadFragment.h"
@@ -145,6 +146,7 @@ void TFragWriteLoop::Write()
       }
 
       TGRSIRunInfo::Get()->WriteToRoot(fOutputFile);
+      TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
       TPPG::Get()->Write();
 
       if(TGRSIOptions::Get()->WriteDiagnostics()) {

--- a/util/offsetfix.cxx
+++ b/util/offsetfix.cxx
@@ -1,11 +1,12 @@
 //g++ offsetfind.cxx `root-config --cflags --libs` -I${GRSISYS}/include -L${GRSISYS}/libraries -lMidasFormat -lXMLParser -lSpectrum  -ooffsetfind
 
-
+#include "TGRSIOptions.h"
 #include "TMidasFile.h"
 #include "TMidasEvent.h"
 #include "TFile.h"
 #include "TFragment.h"
 #include "TDataParser.h"
+#include "TDataParserException.h"
 #include "TTree.h"
 #include "TSpectrum.h"
 #include "TChannel.h"
@@ -223,7 +224,7 @@ void PrintError(std::shared_ptr<TMidasEvent> event, int frags,bool verb){
    }
 }
 
-int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
+int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ) {
    int events_read = 0;
    const int total_events = 1E6;
    //const int event_start = 1E5;
@@ -268,640 +269,645 @@ int QueueEvents(TMidasFile *infile, std::vector<TEventTime*> *eventQ){
                banksize = event->LocateBank(nullptr,"GRF1",&ptr);
 
             if(banksize>0) {
-               int frags = parser.GriffinDataToFragment((uint32_t*)(ptr),banksize,TDataParser::kGRF2,mserial,mtime);
-               if(frags > -1){
-                  events_read++;
-                  if((subrun > 0) || (events_read > event_start))
-                     eventQ->push_back(new TEventTime(event));//I'll keep 4G data in here for now in case we need to use it for time stamping 
-               }
-               else{
-                  PrintError(event,frags,0);
-               }
-            }
-            break;
-       };
-      if(events_read % 250000 == 0){
-         printf(DYELLOW "\tQUEUEING EVENT %d/%d  \r" RESET_COLOR,events_read,total_events); fflush(stdout);
-      }
-   }
-   TEventTime::OrderDigitizerMap();
-   printf("\n");
-   return 0;
+               int frags;
+					try {
+						frags = parser.GriffinDataToFragment((uint32_t*)(ptr),banksize,TDataParser::kGRF2,mserial,mtime);
+					} catch(TDataParserException& e) {
+						frags = -e.GetFailedWord();
+					}
+					if(frags > -1) {
+						events_read++;
+						if((subrun > 0) || (events_read > event_start))
+							eventQ->push_back(new TEventTime(event));//I'll keep 4G data in here for now in case we need to use it for time stamping 
+					}
+					else{
+						PrintError(event,frags,0);
+					}
+				}
+				break;
+		};
+		if(events_read % 250000 == 0){
+			printf(DYELLOW "\tQUEUEING EVENT %d/%d  \r" RESET_COLOR,events_read,total_events); fflush(stdout);
+		}
+	}
+	TEventTime::OrderDigitizerMap();
+	printf("\n");
+	return 0;
 }
 
 void CheckHighTimeStamp(std::vector<TEventTime*> *eventQ){
-//This function should return an array of corrections
+	//This function should return an array of corrections
 
-   TList *midvshigh = new TList;
-   printf(DBLUE "Correcting High time stamps...\n" RESET_COLOR);
-   //These first four are for looking to see if high time-stamp reset
-   std::map<uint32_t,int>::iterator mapit; //This is an iterator over the digitizer map 
-   for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
-      TH2D *midvshighhist = new TH2D(Form("midvshigh_0x%04x",mapit->first),Form("midvshigh_0x%04x",mapit->first), 5000,0,5000,5000,0,5000); 
-      midvshigh->Add(midvshighhist);
-   }
-  
-   unsigned int lowmidtime = TEventTime::GetLowestMidasTime();
+	TList *midvshigh = new TList;
+	printf(DBLUE "Correcting High time stamps...\n" RESET_COLOR);
+	//These first four are for looking to see if high time-stamp reset
+	std::map<uint32_t,int>::iterator mapit; //This is an iterator over the digitizer map 
+	for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
+		TH2D *midvshighhist = new TH2D(Form("midvshigh_0x%04x",mapit->first),Form("midvshigh_0x%04x",mapit->first), 5000,0,5000,5000,0,5000); 
+		midvshigh->Add(midvshighhist);
+	}
 
-   //MidasTimeStamp is the only time we can trust at this level. 
+	unsigned int lowmidtime = TEventTime::GetLowestMidasTime();
 
-   //int fEntries = eventQ->size();
+	//MidasTimeStamp is the only time we can trust at this level. 
 
-   int FragsIn = 0;
+	//int fEntries = eventQ->size();
 
-   FragsIn++;
-   //Clear lowest hightime
-   std::map<uint32_t,int> lowest_hightime;
-   std::vector<TEventTime*>::iterator it;
-   
-   for(it = eventQ->begin(); it != eventQ->end(); it++) {
-      //This makes the plot, might not be required
-      int hightime = (*it)->TimeStampHigh();
-      unsigned long midtime = (*it)->MidasTime() - lowmidtime;
-      if(midtime>20) break;//20 seconds seems like plenty enough time
-      if( ((*it)->Digitizer() == 0) && ((*it)->DetectorType()>1)) continue; 
-      //The next few lines are probably unnecessary
-      ((TH2D*)(midvshigh->FindObject(Form("midvshigh_0x%04x",(*it)->Digitizer()))))->Fill(midtime, hightime);
-      if(lowest_hightime.find((*it)->Digitizer()) == lowest_hightime.end()){
-         lowest_hightime[(*it)->Digitizer()] = hightime; //initialize this as the first time that is seen.
-      }
-      else if(hightime < lowest_hightime.find((*it)->Digitizer())->second)
-         lowest_hightime.find((*it)->Digitizer())->second = hightime;
-   }
+	int FragsIn = 0;
 
-//find lowest digitizer 
-   uint32_t lowest_dig = 0;
-   int lowtime = 999999;
- /*  for(mapit = lowest_hightime.begin(); mapit != lowest_hightime.end(); mapit++){
-      if(mapit->second < lowtime){
-         lowest_dig = mapit->first;
-         lowtime = mapit->second;
-      }
-   }*/
+	FragsIn++;
+	//Clear lowest hightime
+	std::map<uint32_t,int> lowest_hightime;
+	std::vector<TEventTime*>::iterator it;
 
-   lowest_dig = TEventTime::GetBestDigitizer();
-   lowtime = lowest_hightime.find(lowest_dig)->second;
+	for(it = eventQ->begin(); it != eventQ->end(); it++) {
+		//This makes the plot, might not be required
+		int hightime = (*it)->TimeStampHigh();
+		unsigned long midtime = (*it)->MidasTime() - lowmidtime;
+		if(midtime>20) break;//20 seconds seems like plenty enough time
+		if( ((*it)->Digitizer() == 0) && ((*it)->DetectorType()>1)) continue; 
+		//The next few lines are probably unnecessary
+		((TH2D*)(midvshigh->FindObject(Form("midvshigh_0x%04x",(*it)->Digitizer()))))->Fill(midtime, hightime);
+		if(lowest_hightime.find((*it)->Digitizer()) == lowest_hightime.end()){
+			lowest_hightime[(*it)->Digitizer()] = hightime; //initialize this as the first time that is seen.
+		}
+		else if(hightime < lowest_hightime.find((*it)->Digitizer())->second)
+			lowest_hightime.find((*it)->Digitizer())->second = hightime;
+	}
 
-   midvshigh->Print();  
-   printf("The lowest digitizer is 0x%04x\n",lowest_dig);
-   printf("*****  High time shifts *******\n");
-   for(mapit = lowest_hightime.begin(); mapit != lowest_hightime.end(); mapit++){
-      if(mapit->first == lowest_dig){
-         continue;
-      }
-      printf("0x%04x:\t %d \t %lf sec\n",mapit->first,mapit->second -lowtime, static_cast<double>((static_cast<int64_t>(mapit->second-lowtime))*(1<<28))/1.0E8);
-      //Calculate the shift to the first event in all digitizers
-      TEventTime::correctionmap.find(mapit->first)->second = ((static_cast<uint64_t>(mapit->second-lowtime))*(1<<28));
-   }
-   printf("********************\n");
+	//find lowest digitizer 
+	uint32_t lowest_dig = 0;
+	int lowtime = 999999;
+	/*  for(mapit = lowest_hightime.begin(); mapit != lowest_hightime.end(); mapit++){
+		 if(mapit->second < lowtime){
+		 lowest_dig = mapit->first;
+		 lowtime = mapit->second;
+		 }
+		 }*/
 
-   midvshigh->Write();
-   midvshigh->Delete();
+	lowest_dig = TEventTime::GetBestDigitizer();
+	lowtime = lowest_hightime.find(lowest_dig)->second;
+
+	midvshigh->Print();  
+	printf("The lowest digitizer is 0x%04x\n",lowest_dig);
+	printf("*****  High time shifts *******\n");
+	for(mapit = lowest_hightime.begin(); mapit != lowest_hightime.end(); mapit++){
+		if(mapit->first == lowest_dig){
+			continue;
+		}
+		printf("0x%04x:\t %d \t %lf sec\n",mapit->first,mapit->second -lowtime, static_cast<double>((static_cast<int64_t>(mapit->second-lowtime))*(1<<28))/1.0E8);
+		//Calculate the shift to the first event in all digitizers
+		TEventTime::correctionmap.find(mapit->first)->second = ((static_cast<uint64_t>(mapit->second-lowtime))*(1<<28));
+	}
+	printf("********************\n");
+
+	midvshigh->Write();
+	midvshigh->Delete();
 
 }
 
 
 void GetRoughTimeDiff(std::vector<TEventTime*> *eventQ){
-   //We want the MIDAS time stamps to still be the way we index these events, but we want to index on low time stamps next
-   printf(DBLUE "Looking for rough time differences...\n" RESET_COLOR);
+	//We want the MIDAS time stamps to still be the way we index these events, but we want to index on low time stamps next
+	printf(DBLUE "Looking for rough time differences...\n" RESET_COLOR);
 
-   TList *roughlist = new TList;
-   //These first four are for looking to see if high time-stamp reset
+	TList *roughlist = new TList;
+	//These first four are for looking to see if high time-stamp reset
 
-   std::map<uint32_t,bool> keep_filling;
-   std::map<uint32_t,int>::iterator mapit;
-   for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
-     // TH1F *roughhist = new TH1F(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 6E7,-3E8,3E8); 
-      TH1D *roughhist = new TH1D(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 3E7,-3E8,3E8); 
-      roughhist->SetTitle(Form("rough_0x%04x against 0x%04x",mapit->first,TEventTime::GetBestDigitizer()));
-      roughlist->Add(roughhist);
-      keep_filling[mapit->first] = true;
-   }
-   
-   //The "best digitizer" is set when we fill the event Q
-   printf(DYELLOW "Using the best digitizer 0x%04x\n" RESET_COLOR, TEventTime::GetBestDigitizer());
+	std::map<uint32_t,bool> keep_filling;
+	std::map<uint32_t,int>::iterator mapit;
+	for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
+		// TH1F *roughhist = new TH1F(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 6E7,-3E8,3E8); 
+		TH1D *roughhist = new TH1D(Form("rough_0x%04x",mapit->first),Form("rough_0x%04x",mapit->first), 3E7,-3E8,3E8); 
+		roughhist->SetTitle(Form("rough_0x%04x against 0x%04x",mapit->first,TEventTime::GetBestDigitizer()));
+		roughlist->Add(roughhist);
+		keep_filling[mapit->first] = true;
+	}
 
-   TH1D* fillhist; //This pointer is useful later to clean up a lot of messiness
+	//The "best digitizer" is set when we fill the event Q
+	printf(DYELLOW "Using the best digitizer 0x%04x\n" RESET_COLOR, TEventTime::GetBestDigitizer());
 
-   std::vector<TEventTime*>::iterator hit1;
-   std::vector<TEventTime*>::iterator hit2;
-   const int range = 5000;
-   int event1count = 0;
- //  for(hit1 = (eventQ->begin()+8000); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
-   for(hit1 = (eventQ->begin()); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
-      //We want to have the first hit be in the "good digitizer"
-      if(event1count%75000 == 0)
-         printf("Processing Event %d /%lu      \r",event1count,eventQ->size()); fflush(stdout);
-      event1count++;
+	TH1D* fillhist; //This pointer is useful later to clean up a lot of messiness
 
-      if(((*hit1)->Digitizer() == 0) && ((*hit1)->DetectorType()>1)) continue; 
+	std::vector<TEventTime*>::iterator hit1;
+	std::vector<TEventTime*>::iterator hit2;
+	const int range = 5000;
+	int event1count = 0;
+	//  for(hit1 = (eventQ->begin()+8000); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
+	for(hit1 = (eventQ->begin()); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
+		//We want to have the first hit be in the "good digitizer"
+		if(event1count%75000 == 0)
+			printf("Processing Event %d /%lu      \r",event1count,eventQ->size()); fflush(stdout);
+		event1count++;
 
-      if((*hit1)->Digitizer() != TEventTime::GetBestDigitizer())  continue;
+		if(((*hit1)->Digitizer() == 0) && ((*hit1)->DetectorType()>1)) continue; 
 
-      int64_t time1 = static_cast<int64_t>((*hit1)->GetTimeStamp());
-  
-      if(event1count > range){
-         hit2 = hit1 - range;
-      }
-      else{
-         hit2 = eventQ->begin();
-      }
-      //Now that we have the best digitizer, we can start looping through the events 
-      int event2count = 0;
-      while((hit2 != eventQ->end()) && (event2count < 2*range)){
+		if((*hit1)->Digitizer() != TEventTime::GetBestDigitizer())  continue;
 
-         if( ((*hit2)->Digitizer() == 0) && ((*hit2)->DetectorType()>1)){
-            ++hit2;
-            continue; 
-         }
-         if(hit1 == hit2){
-            ++hit2;
-            continue;
-         }
-         event2count++;
-         uint32_t digitizer = (*hit2)->Digitizer();
-         if(keep_filling[digitizer]){
-            fillhist = (TH1D*)(roughlist->At((*hit2)->DigIndex())); //This is where that pointer comes in handy
-            int64_t time2 = static_cast<int64_t>((*hit2)->GetTimeStamp()) - TEventTime::correctionmap.find((*hit2)->Digitizer())->second;
-            Int_t bin = static_cast<Int_t>(time2 - time1);
-               
-            if((fillhist->FindBin(bin) > 0) && (fillhist->FindBin(bin) < fillhist->GetNbinsX())){
-               fillhist->Fill(bin);
-            //   if(fillhist->GetBinContent(fillhist->Fill(bin))>126){
-              //    keep_filling[digitizer] = false;
-              //    printf("\nDigitizer 0x%04x is done filling\n",digitizer);
-              // }
-            }
-            
-         }
-         ++hit2;
-     }
-   }
+		int64_t time1 = static_cast<int64_t>((*hit1)->GetTimeStamp());
 
-   for(mapit = TEventTime::digmap.begin(); mapit != TEventTime::digmap.end(); mapit++){
-      if(mapit->first == TEventTime::GetBestDigitizer())
-         continue;
-      fillhist = (TH1D*)(roughlist->At(mapit->second));
-      std::cout << static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin())) << std::endl;
-      TEventTime::correctionmap.find(mapit->first)->second +=  static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin()));
-   }
+		if(event1count > range){
+			hit2 = hit1 - range;
+		}
+		else{
+			hit2 = eventQ->begin();
+		}
+		//Now that we have the best digitizer, we can start looping through the events 
+		int event2count = 0;
+		while((hit2 != eventQ->end()) && (event2count < 2*range)){
 
-   printf("*****  Rough time shifts *******\n");
-   std::map<uint32_t,int64_t>::iterator cit;
-   for(cit = TEventTime::correctionmap.begin(); cit != TEventTime::correctionmap.end(); cit++){
-      if(cit->first == TEventTime::GetBestDigitizer())
-         printf("0x%04x:\t BEST\n",cit->first);
-      else
+			if( ((*hit2)->Digitizer() == 0) && ((*hit2)->DetectorType()>1)){
+				++hit2;
+				continue; 
+			}
+			if(hit1 == hit2){
+				++hit2;
+				continue;
+			}
+			event2count++;
+			uint32_t digitizer = (*hit2)->Digitizer();
+			if(keep_filling[digitizer]){
+				fillhist = (TH1D*)(roughlist->At((*hit2)->DigIndex())); //This is where that pointer comes in handy
+				int64_t time2 = static_cast<int64_t>((*hit2)->GetTimeStamp()) - TEventTime::correctionmap.find((*hit2)->Digitizer())->second;
+				Int_t bin = static_cast<Int_t>(time2 - time1);
+
+				if((fillhist->FindBin(bin) > 0) && (fillhist->FindBin(bin) < fillhist->GetNbinsX())){
+					fillhist->Fill(bin);
+					//   if(fillhist->GetBinContent(fillhist->Fill(bin))>126){
+					//    keep_filling[digitizer] = false;
+					//    printf("\nDigitizer 0x%04x is done filling\n",digitizer);
+					// }
+				}
+
+			}
+			++hit2;
+		}
+	}
+
+	for(mapit = TEventTime::digmap.begin(); mapit != TEventTime::digmap.end(); mapit++){
+		if(mapit->first == TEventTime::GetBestDigitizer())
+			continue;
+		fillhist = (TH1D*)(roughlist->At(mapit->second));
+		std::cout << static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin())) << std::endl;
+		TEventTime::correctionmap.find(mapit->first)->second +=  static_cast<int64_t>(fillhist->GetBinCenter(fillhist->GetMaximumBin()));
+	}
+
+	printf("*****  Rough time shifts *******\n");
+	std::map<uint32_t,int64_t>::iterator cit;
+	for(cit = TEventTime::correctionmap.begin(); cit != TEventTime::correctionmap.end(); cit++){
+		if(cit->first == TEventTime::GetBestDigitizer())
+			printf("0x%04x:\t BEST\n",cit->first);
+		else
 #ifdef OS_DARWIN
 			printf("0x%04x:\t %lld\n",cit->first,cit->second);
 #else
-		   printf("0x%04x:\t %ld\n",cit->first,cit->second);
+		printf("0x%04x:\t %ld\n",cit->first,cit->second);
 #endif
-   }
-   printf("********************\n");
+	}
+	printf("********************\n");
 
-   roughlist->Print();
-   roughlist->Write();
-   roughlist->Delete();
+	roughlist->Print();
+	roughlist->Write();
+	roughlist->Delete();
 
 }
 
 void GetTimeDiff(std::vector<TEventTime*> *eventQ){
-   //We want the MIDAS time stamps to still be the way we index these events, but we want to index on low time stamps next
-   printf(DBLUE "Looking for final time differences...\n" RESET_COLOR);
+	//We want the MIDAS time stamps to still be the way we index these events, but we want to index on low time stamps next
+	printf(DBLUE "Looking for final time differences...\n" RESET_COLOR);
 
-   TList *list = new TList;
-   //These first four are for looking to see if high time-stamp reset
+	TList *list = new TList;
+	//These first four are for looking to see if high time-stamp reset
 
-   std::map<uint32_t,int>::iterator mapit;
-   for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
-      TH1D *hist = new TH1D(Form("timediff_0x%04x",mapit->first),Form("timediff_0x%04x",mapit->first), 1000,-500,500); 
-      hist->SetTitle(Form("timediff_0x%04x Against 0x%04x",mapit->first,TEventTime::GetBestDigitizer()));
-      list->Add(hist);
-   }
-   
-   //The "best digitizer" is set when we fill the event Q
-   printf(DYELLOW "Using the best digitizer 0x%04x\n" RESET_COLOR, TEventTime::GetBestDigitizer());
+	std::map<uint32_t,int>::iterator mapit;
+	for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
+		TH1D *hist = new TH1D(Form("timediff_0x%04x",mapit->first),Form("timediff_0x%04x",mapit->first), 1000,-500,500); 
+		hist->SetTitle(Form("timediff_0x%04x Against 0x%04x",mapit->first,TEventTime::GetBestDigitizer()));
+		list->Add(hist);
+	}
 
-   TH1D* fillhist; //This pointer is useful later to clean up a lot of messiness
+	//The "best digitizer" is set when we fill the event Q
+	printf(DYELLOW "Using the best digitizer 0x%04x\n" RESET_COLOR, TEventTime::GetBestDigitizer());
 
-   std::vector<TEventTime*>::iterator hit1;
-   std::vector<TEventTime*>::iterator hit2;
-   int event1count = 0;
-   const int range = 2000;
-   for(hit1 = eventQ->begin(); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
-      //We want to have the first hit be in the "good digitizer"
-      if(event1count%75000 == 0)
-         printf("Processing Event %d / %lu       \r",event1count,eventQ->size()); fflush(stdout);
-      
-      event1count++;
-      //We need to make sure that that if we have a digitizer of 0, we have a detector type of 1
-      if( (*hit1)->Digitizer() == 0 && (*hit1)->DetectorType()>1) continue; 
-         
-      if((*hit1)->Digitizer() != TEventTime::GetBestDigitizer()) continue;
+	TH1D* fillhist; //This pointer is useful later to clean up a lot of messiness
 
-      int64_t time1 = static_cast<int64_t>((*hit1)->GetTimeStamp());
-  
-      if(event1count > range){
-         hit2 = hit1 - range;
-      }
-      else{
-         hit2 = eventQ->begin();
-      }
-      //Now that we have the best digitizer, we can start looping through the events 
-      int event2count = 0;
-      while((hit2 != eventQ->end()) && (event2count < range*2)){
-         event2count++;
-         //We need to make sure that that if we have a digitizer of 0, we have a detector type of 1
-         if( ((*hit2)->Digitizer() == 0) && ((*hit2)->DetectorType()>1)){
-            hit2++;
-            continue; 
-         }
- 
-         if(hit1 != hit2 ){
-            //uint32_t digitizer = (*hit2)->Digitizer();
-            fillhist = (TH1D*)(list->At((*hit2)->DigIndex())); //This is where that pointer comes in handy
-            int64_t time2 = static_cast<int64_t>((*hit2)->GetTimeStamp()) - TEventTime::correctionmap.find((*hit2)->Digitizer())->second;
-            if((time2-time1 < 2147483647) && (time2-time1 > -2147483647)){//Make sure we are casting this to 32 bit properly
-               Int_t bin = static_cast<Int_t>(time2 - time1);
-               fillhist->Fill(bin);
-            }
-         }
-         hit2++;
-      }
-   }
-   for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
-      if(mapit->first == TEventTime::GetBestDigitizer())
-         continue;
-      fillhist = (TH1D*)(list->At(mapit->second));
-      TSpectrum* spec = new TSpectrum();
-      spec->Search(fillhist);
-      double peak = spec->GetPositionX()[0];
-      std::cout << static_cast<int64_t>(floor(peak+0.5)) << std::endl;
-      TEventTime::correctionmap.find(mapit->first)->second +=  static_cast<int64_t>(floor(peak+0.5));
- //     fillhist->Draw();
+	std::vector<TEventTime*>::iterator hit1;
+	std::vector<TEventTime*>::iterator hit2;
+	int event1count = 0;
+	const int range = 2000;
+	for(hit1 = eventQ->begin(); hit1 != eventQ->end(); hit1++) { //This steps hit1 through the eventQ
+		//We want to have the first hit be in the "good digitizer"
+		if(event1count%75000 == 0)
+			printf("Processing Event %d / %lu       \r",event1count,eventQ->size()); fflush(stdout);
 
-   }
-      
-   printf("*****  Rough time shifts *******\n");
-   std::map<uint32_t,int64_t>::iterator cit;
-   for(cit = TEventTime::correctionmap.begin(); cit != TEventTime::correctionmap.end(); cit++){
-      if(cit->first == TEventTime::GetBestDigitizer())
-         printf("0x%04x:\t BEST\n",cit->first);
-      else
+		event1count++;
+		//We need to make sure that that if we have a digitizer of 0, we have a detector type of 1
+		if( (*hit1)->Digitizer() == 0 && (*hit1)->DetectorType()>1) continue; 
+
+		if((*hit1)->Digitizer() != TEventTime::GetBestDigitizer()) continue;
+
+		int64_t time1 = static_cast<int64_t>((*hit1)->GetTimeStamp());
+
+		if(event1count > range){
+			hit2 = hit1 - range;
+		}
+		else{
+			hit2 = eventQ->begin();
+		}
+		//Now that we have the best digitizer, we can start looping through the events 
+		int event2count = 0;
+		while((hit2 != eventQ->end()) && (event2count < range*2)){
+			event2count++;
+			//We need to make sure that that if we have a digitizer of 0, we have a detector type of 1
+			if( ((*hit2)->Digitizer() == 0) && ((*hit2)->DetectorType()>1)){
+				hit2++;
+				continue; 
+			}
+
+			if(hit1 != hit2 ){
+				//uint32_t digitizer = (*hit2)->Digitizer();
+				fillhist = (TH1D*)(list->At((*hit2)->DigIndex())); //This is where that pointer comes in handy
+				int64_t time2 = static_cast<int64_t>((*hit2)->GetTimeStamp()) - TEventTime::correctionmap.find((*hit2)->Digitizer())->second;
+				if((time2-time1 < 2147483647) && (time2-time1 > -2147483647)){//Make sure we are casting this to 32 bit properly
+					Int_t bin = static_cast<Int_t>(time2 - time1);
+					fillhist->Fill(bin);
+				}
+			}
+			hit2++;
+		}
+	}
+	for(mapit = TEventTime::digmap.begin(); mapit!=TEventTime::digmap.end();mapit++){
+		if(mapit->first == TEventTime::GetBestDigitizer())
+			continue;
+		fillhist = (TH1D*)(list->At(mapit->second));
+		TSpectrum* spec = new TSpectrum();
+		spec->Search(fillhist);
+		double peak = spec->GetPositionX()[0];
+		std::cout << static_cast<int64_t>(floor(peak+0.5)) << std::endl;
+		TEventTime::correctionmap.find(mapit->first)->second +=  static_cast<int64_t>(floor(peak+0.5));
+		//     fillhist->Draw();
+
+	}
+
+	printf("*****  Rough time shifts *******\n");
+	std::map<uint32_t,int64_t>::iterator cit;
+	for(cit = TEventTime::correctionmap.begin(); cit != TEventTime::correctionmap.end(); cit++){
+		if(cit->first == TEventTime::GetBestDigitizer())
+			printf("0x%04x:\t BEST\n",cit->first);
+		else
 #ifdef OS_DARWIN
 			printf("0x%04x:\t %lld\n",cit->first,cit->second);
 #else
-		   printf("0x%04x:\t %ld\n",cit->first,cit->second);
+		printf("0x%04x:\t %ld\n",cit->first,cit->second);
 #endif
-        // printf("0x%04x:\t %lld\n",mapit->first,correction[mapit->second]);
-   }
-   printf("********************\n");
+		// printf("0x%04x:\t %lld\n",mapit->first,correction[mapit->second]);
+	}
+	printf("********************\n");
 
-   list->Print();
-   list->Write();
-   list->Delete();
+	list->Print();
+	list->Write();
+	list->Delete();
 
 }
 
 bool ProcessEvent(std::shared_ptr<TMidasEvent> event,TMidasFile *outfile) {
-   if(event->GetEventId() !=1 ) {
-      outfile->FillBuffer(event);
-      return false;
-   }
-   event->SetBankList();
-   //int size;
-   //int data[1024];
-  
-   void *ptr;
-   
-   int banksize = event->LocateBank(nullptr,"GRF2",&ptr);
-   int bank = 2;
-   if(!banksize){
-      banksize = event->LocateBank(nullptr,"GRF1",&ptr);
-      bank =1;
-   }
-   uint32_t type  = 0xffffffff;
-   uint32_t value = 0xffffffff;
+	if(event->GetEventId() !=1 ) {
+		outfile->FillBuffer(event);
+		return false;
+	}
+	event->SetBankList();
+	//int size;
+	//int data[1024];
 
-   uint32_t dettype = 0;
-   uint32_t chanadd = 0;
+	void *ptr;
 
-   unsigned int timelow  = 0;
-   unsigned int timehigh = 0;
+	int banksize = event->LocateBank(nullptr,"GRF2",&ptr);
+	int bank = 2;
+	if(!banksize){
+		banksize = event->LocateBank(nullptr,"GRF1",&ptr);
+		bank =1;
+	}
+	uint32_t type  = 0xffffffff;
+	uint32_t value = 0xffffffff;
 
-   uint64_t time = 0;
+	uint32_t dettype = 0;
+	uint32_t chanadd = 0;
 
-   for(int x=0;x<banksize;x++) {
-      value = *((int*)ptr+x);
-      type  = value & 0xf0000000; 
+	unsigned int timelow  = 0;
+	unsigned int timehigh = 0;
 
-      switch(type) {
-          case 0x80000000:
-            switch(bank){
-                case 1: // header format from before May 2015 experiments
-                   //Sets: 
-                    //     The number of filters
-                  //     The Data Type
-                  //     Number of Pileups
-                 //     Channel Address
-                 //     Detector Type
-                  if( (value&0xf0000000) != 0x80000000) {
-                     return false;
-                   }
-                  chanadd  =  (value &0x0003fff0)>> 4;
-                  dettype    =  (value &0x0000000f);
-                       
-                   // if(frag-DetectorType==2)
-                  //    frag->ChannelAddress += 0x8000;
-                  break;
-               case 2:
-                  //Sets: 
-                  //     The number of filters
-                  //     The Data Type
-                  //     Number of Pileups
-                  //     Channel Address
-                  //     Detector Type
-                  if( (value&0xf0000000) != 0x80000000) {
-                     return false;
-                  }
-                  chanadd  =  (value &0x000ffff0)>> 4;
-                  dettype    =  (value &0x0000000f);
-                       
-                  // if(frag-DetectorType==2)
-                  //    frag->ChannelAddress += 0x8000;
-                  break;
-               default:
-                  printf("This bank not yet defined.\n");
-                  break;
-             };
-             case 0xa0000000:
-                timelow = value & 0x0fffffff;
-                break;
-             case 0xb0000000:
-                timehigh = value & 0x00003fff;
-                break;
+	uint64_t time = 0;
 
-           };
-   }
+	for(int x=0;x<banksize;x++) {
+		value = *((int*)ptr+x);
+		type  = value & 0xf0000000; 
 
-   time = timehigh;
-   time = time << 28;
-   time |= timelow &0x0fffffff;
+		switch(type) {
+			case 0x80000000:
+				switch(bank){
+					case 1: // header format from before May 2015 experiments
+						//Sets: 
+						//     The number of filters
+						//     The Data Type
+						//     Number of Pileups
+						//     Channel Address
+						//     Detector Type
+						if( (value&0xf0000000) != 0x80000000) {
+							return false;
+						}
+						chanadd  =  (value &0x0003fff0)>> 4;
+						dettype    =  (value &0x0000000f);
 
-//   if((chanadd&0x0000ff00) != TEventTime::GetBestDigitizer()){
- //  if((dettype<2) || ((chanadd&0xf) < 2) ){   
-   if(dettype > 1 && ((chanadd&0xF) > 1) && ((chanadd&0xF00)>1) && SplitMezz) {
-      time -= TEventTime::correctionmap.find((chanadd&0x0000ff00)+2)->second;    
-   }
-   else{
-      time -= TEventTime::correctionmap.find(chanadd&0x0000ff00)->second;    
-    }
+						// if(frag-DetectorType==2)
+						//    frag->ChannelAddress += 0x8000;
+						break;
+					case 2:
+						//Sets: 
+						//     The number of filters
+						//     The Data Type
+						//     Number of Pileups
+						//     Channel Address
+						//     Detector Type
+						if( (value&0xf0000000) != 0x80000000) {
+							return false;
+						}
+						chanadd  =  (value &0x000ffff0)>> 4;
+						dettype    =  (value &0x0000000f);
 
-//  }
+						// if(frag-DetectorType==2)
+						//    frag->ChannelAddress += 0x8000;
+						break;
+					default:
+						printf("This bank not yet defined.\n");
+						break;
+				};
+			case 0xa0000000:
+				timelow = value & 0x0fffffff;
+				break;
+			case 0xb0000000:
+				timehigh = value & 0x00003fff;
+				break;
 
-   if(time>0x3ffffffffff)
-      time -= 0x3ffffffffff;
+		};
+	}
 
-   // moving these inside the next switch, to account for doubly printed words.
-   // (hey, it happens.)
-   // -JKS, 14 January 2015
-   //timelow = time&0x0fffffff;
-   //timehigh = (time&0x3fff0000000) >> 28;
+	time = timehigh;
+	time = time << 28;
+	time |= timelow &0x0fffffff;
 
-//   printf(DRED);
-//   event->Print("a");
-//   printf(RESET_COLOR);
+	//   if((chanadd&0x0000ff00) != TEventTime::GetBestDigitizer()){
+	//  if((dettype<2) || ((chanadd&0xf) < 2) ){   
+	if(dettype > 1 && ((chanadd&0xF) > 1) && ((chanadd&0xF00)>1) && SplitMezz) {
+		time -= TEventTime::correctionmap.find((chanadd&0x0000ff00)+2)->second;    
+	}
+	else{
+		time -= TEventTime::correctionmap.find(chanadd&0x0000ff00)->second;    
+	}
+
+	//  }
+
+	if(time>0x3ffffffffff)
+		time -= 0x3ffffffffff;
+
+	// moving these inside the next switch, to account for doubly printed words.
+	// (hey, it happens.)
+	// -JKS, 14 January 2015
+	//timelow = time&0x0fffffff;
+	//timehigh = (time&0x3fff0000000) >> 28;
+
+	//   printf(DRED);
+	//   event->Print("a");
+	//   printf(RESET_COLOR);
 
 	std::shared_ptr<TMidasEvent> copyevent = std::make_shared<TMidasEvent>(*event);
-   copyevent->SetBankList();
+	copyevent->SetBankList();
 
-   banksize = copyevent->LocateBank(nullptr,"GRF2",&ptr);
-   if(!banksize) banksize = copyevent->LocateBank(nullptr,"GRF1",&ptr);
+	banksize = copyevent->LocateBank(nullptr,"GRF2",&ptr);
+	if(!banksize) banksize = copyevent->LocateBank(nullptr,"GRF1",&ptr);
 
-   for(int x=0;x<banksize;x++) {
-      value = *((int*)ptr+x);
-      type  = value & 0xf0000000; 
+	for(int x=0;x<banksize;x++) {
+		value = *((int*)ptr+x);
+		type  = value & 0xf0000000; 
 
-      switch(type) {
-         case 0xa0000000:
-            timelow = time&0x0fffffff;
-            timelow += 0xa0000000;
-            *((int*)ptr+x) = timelow;
-            break;
-         case 0xb0000000: {
-            timehigh = (time&0x3fff0000000) >> 28;
-            int tempdead = value & 0xffffc000;
-            timehigh +=tempdead;
-            *((int*)ptr+x) = timehigh;
-            break;
-         }
-      };
+		switch(type) {
+			case 0xa0000000:
+				timelow = time&0x0fffffff;
+				timelow += 0xa0000000;
+				*((int*)ptr+x) = timelow;
+				break;
+			case 0xb0000000: {
+									  timehigh = (time&0x3fff0000000) >> 28;
+									  int tempdead = value & 0xffffc000;
+									  timehigh +=tempdead;
+									  *((int*)ptr+x) = timehigh;
+									  break;
+								  }
+		};
 
 
 
-       //printf( "0x%08x ",*((int*)ptr+x));
-       //if(x!=0 && (x%7)==0)
-       //   printf("\n");
-   }
-   //printf("===================\n");
+		//printf( "0x%08x ",*((int*)ptr+x));
+		//if(x!=0 && (x%7)==0)
+		//   printf("\n");
+	}
+	//printf("===================\n");
 
-   outfile->FillBuffer(copyevent);
+	outfile->FillBuffer(copyevent);
 
-//   printf(DBLUE);
-//   copyevent.Print("a");
-//   printf(RESET_COLOR);
-   return true;
+	//   printf(DBLUE);
+	//   copyevent.Print("a");
+	//   printf(RESET_COLOR);
+	return true;
 }
 
 void WriteEvents(TMidasFile* file) {
 
-   std::ifstream in(file->GetFilename(), std::ifstream::in | std::ifstream::binary);
-   in.seekg(0, std::ifstream::end);
-   long long filesize = in.tellg();
-   in.close();
+	std::ifstream in(file->GetFilename(), std::ifstream::in | std::ifstream::binary);
+	in.seekg(0, std::ifstream::end);
+	long long filesize = in.tellg();
+	in.close();
 
-   int bytes = 0;
-   long long bytesread = 0;
+	int bytes = 0;
+	long long bytesread = 0;
 
-   UInt_t num_evt = 0;
+	UInt_t num_evt = 0;
 
-   TStopwatch w;
-   w.Start();
+	TStopwatch w;
+	w.Start();
 
 	std::shared_ptr<TMidasEvent> event = std::make_shared<TMidasEvent>();
 
-   while(true) {
-      bytes = file->Read(event);
-      if(bytes == 0){
-         printf(DMAGENTA "\tfile: %s ended on %s" RESET_COLOR "\n",file->GetFilename(),file->GetLastError());
-      if(file->GetLastErrno()==-1)  //try to read some more...
-         continue;
-      break;
-      }
-      bytesread += bytes;
-                                          
-      switch(event->GetEventId()) {
-         case 0x8000:
-            printf("start of run\n");
-            file->FillBuffer(event);
-            printf(DGREEN);
-            event->Print();
-            printf(RESET_COLOR);
-            break;
-         case 0x8001:
-            printf("end of run\n");
-            printf(DRED);
-            event->Print();
-            printf(RESET_COLOR);
-            file->FillBuffer(event);
-            break;
-         default: 
-            num_evt++;
-            ProcessEvent(event,file);
-            break;
-       };
-       if(num_evt %5000 == 0){
-         gSystem->ProcessEvents();
-         printf(HIDE_CURSOR " Events %d have processed %.2fMB/%.2f MB => %.1f MB/s              " SHOW_CURSOR "\r",num_evt,(bytesread/1000000.0),(filesize/1000000.0),(bytesread/1000000.0)/w.RealTime());
-         w.Continue();
-       }
-   }
-   printf("\n");
-   
-   file->WriteBuffer();
+	while(true) {
+		bytes = file->Read(event);
+		if(bytes == 0){
+			printf(DMAGENTA "\tfile: %s ended on %s" RESET_COLOR "\n",file->GetFilename(),file->GetLastError());
+			if(file->GetLastErrno()==-1)  //try to read some more...
+				continue;
+			break;
+		}
+		bytesread += bytes;
+
+		switch(event->GetEventId()) {
+			case 0x8000:
+				printf("start of run\n");
+				file->FillBuffer(event);
+				printf(DGREEN);
+				event->Print();
+				printf(RESET_COLOR);
+				break;
+			case 0x8001:
+				printf("end of run\n");
+				printf(DRED);
+				event->Print();
+				printf(RESET_COLOR);
+				file->FillBuffer(event);
+				break;
+			default: 
+				num_evt++;
+				ProcessEvent(event,file);
+				break;
+		};
+		if(num_evt %5000 == 0){
+			gSystem->ProcessEvents();
+			printf(HIDE_CURSOR " Events %d have processed %.2fMB/%.2f MB => %.1f MB/s              " SHOW_CURSOR "\r",num_evt,(bytesread/1000000.0),(filesize/1000000.0),(bytesread/1000000.0)/w.RealTime());
+			w.Continue();
+		}
+	}
+	printf("\n");
+
+	file->WriteBuffer();
 
 }
 
 void WriteCorrectionFile(int runnumber){
-//I think I can directly write the map, but I was having a bit of trouble, so I'm using this Tree hack
-   char filename[64];
-   sprintf(filename,"corrections%05i.root",runnumber); 
-   TFile *corrfile = new TFile(filename,"RECREATE");
+	//I think I can directly write the map, but I was having a bit of trouble, so I'm using this Tree hack
+	char filename[64];
+	sprintf(filename,"corrections%05i.root",runnumber); 
+	TFile *corrfile = new TFile(filename,"RECREATE");
 
-   //Just going to make a corrections map for now...it should be a map throughout....
+	//Just going to make a corrections map for now...it should be a map throughout....
 
-   uint32_t address;
-   Long64_t correction;
-   TTree *t = new TTree("correctiontree","Tree with map");
-   t->Branch("address",&address);
-   t->Branch("correction",&correction);
+	uint32_t address;
+	Long64_t correction;
+	TTree *t = new TTree("correctiontree","Tree with map");
+	t->Branch("address",&address);
+	t->Branch("correction",&correction);
 
-   std::map<uint32_t,int64_t>::iterator it;
-   for(it = TEventTime::correctionmap.begin();it != TEventTime::correctionmap.end();it++){
-      address = it->first;
-      correction = it->second;
-      t->Fill();
-   }
-   corrfile->Write();
-   
-   corrfile->Close();
-   delete corrfile;
+	std::map<uint32_t,int64_t>::iterator it;
+	for(it = TEventTime::correctionmap.begin();it != TEventTime::correctionmap.end();it++){
+		address = it->first;
+		correction = it->second;
+		t->Fill();
+	}
+	corrfile->Write();
+
+	corrfile->Close();
+	delete corrfile;
 }
 
 int CorrectionFile(int runnumber){
-//I think I can directly write the map, but I was having a bit of trouble, so I'm using this Tree hack
-   char filename[64];
-   sprintf(filename,"corrections%05i.root",runnumber); 
-   TFile *corrfile = new TFile(filename,"READ");
-   if(!(corrfile->IsOpen())){
-      delete corrfile;
-      return 0;
-   }
-   
-   printf(DGREEN "Found Correction File %s\n" RESET_COLOR,filename);
+	//I think I can directly write the map, but I was having a bit of trouble, so I'm using this Tree hack
+	char filename[64];
+	sprintf(filename,"corrections%05i.root",runnumber); 
+	TFile *corrfile = new TFile(filename,"READ");
+	if(!(corrfile->IsOpen())){
+		delete corrfile;
+		return 0;
+	}
 
-   TTree* t; corrfile->GetObject("correctiontree",t);
-   TBranch *baddress = 0;
-   TBranch *bcorrection = 0;
-   uint32_t address;
-   Long64_t correction;
-   t->SetBranchAddress("address",&address,&baddress);
-   t->SetBranchAddress("correction",&correction,&bcorrection);
+	printf(DGREEN "Found Correction File %s\n" RESET_COLOR,filename);
 
-   int i =0;
-   printf("Digitizer \t Correction\n");
-   while(true){
-      Long64_t tentry = t->LoadTree(i++);
-      if(tentry<0) break;
-      baddress->GetEntry(tentry);
-      bcorrection->GetEntry(tentry);
-      printf("0x%04x: \t\t %lld\n",address,correction);
-      TEventTime::correctionmap.insert(std::pair<uint32_t,int64_t>(address,correction));
-   }
+	TTree* t; corrfile->GetObject("correctiontree",t);
+	TBranch *baddress = 0;
+	TBranch *bcorrection = 0;
+	uint32_t address;
+	Long64_t correction;
+	t->SetBranchAddress("address",&address,&baddress);
+	t->SetBranchAddress("correction",&correction,&bcorrection);
 
-   t->ResetBranchAddresses();
-   printf(DGREEN "Found %lu digitizers\n" RESET_COLOR,TEventTime::correctionmap.size());
-   corrfile->Close();
-   delete corrfile;
+	int i =0;
+	printf("Digitizer \t Correction\n");
+	while(true){
+		Long64_t tentry = t->LoadTree(i++);
+		if(tentry<0) break;
+		baddress->GetEntry(tentry);
+		bcorrection->GetEntry(tentry);
+		printf("0x%04x: \t\t %lld\n",address,correction);
+		TEventTime::correctionmap.insert(std::pair<uint32_t,int64_t>(address,correction));
+	}
 
-   return TEventTime::correctionmap.size();
+	t->ResetBranchAddresses();
+	printf(DGREEN "Found %lu digitizers\n" RESET_COLOR,TEventTime::correctionmap.size());
+	corrfile->Close();
+	delete corrfile;
+
+	return TEventTime::correctionmap.size();
 
 }
 
 int main(int argc, char **argv) {
 
-   if(argc<2) {
-      printf("Usage: ./offsetfix <input.mid> <output.mid> <y/n>(read correction file)\n");
-      return 1;
-   }
-   if(argv[1] == argv[2]){
-      printf("ERROR: Cannot overwrite midas file %s\n",argv[1]);
-   }
+	if(argc<2) {
+		printf("Usage: ./offsetfix <input.mid> <output.mid> <y/n>(read correction file)\n");
+		return 1;
+	}
+	if(argv[1] == argv[2]){
+		printf("ERROR: Cannot overwrite midas file %s\n",argv[1]);
+	}
 
-   TMidasFile *midfile  = new TMidasFile;
-   midfile->Open(argv[1]);
-   int runnumber = midfile->GetRunNumber();
-   int subrunnumber = midfile->GetSubRunNumber();
-   if(argc < 3){
-      midfile->OutOpen(Form("fixrun%05d_%03d.mid",runnumber,subrunnumber));
-   }
-   else{
-      midfile->OutOpen(argv[2]);
-   }
-   char filename[64];
-   if(subrunnumber>-1)
-      sprintf(filename,"time_diffs%05i_%03i.root",runnumber,subrunnumber); 
-   else
-      sprintf(filename,"time_diffs%05i.root",runnumber);
+	TMidasFile *midfile  = new TMidasFile;
+	midfile->Open(argv[1]);
+	int runnumber = midfile->GetRunNumber();
+	int subrunnumber = midfile->GetSubRunNumber();
+	if(argc < 3){
+		midfile->OutOpen(Form("fixrun%05d_%03d.mid",runnumber,subrunnumber));
+	}
+	else{
+		midfile->OutOpen(argv[2]);
+	}
+	char filename[64];
+	if(subrunnumber>-1)
+		sprintf(filename,"time_diffs%05i_%03i.root",runnumber,subrunnumber); 
+	else
+		sprintf(filename,"time_diffs%05i.root",runnumber);
 	printf("Creating root outfile: %s\n",filename);
-   
-   int nDigitizers = 0;
-   if(argc == 4){
-      if(strcmp(argv[3],"n")==0){
-         nDigitizers = 0;
-      }
-      else{
-         nDigitizers = CorrectionFile(runnumber);
-      }
-   }
-   else{
-      nDigitizers = CorrectionFile(runnumber);
-   }
 
-   if(!nDigitizers){
-      TFile *outfile = new TFile(filename,"RECREATE");
-      std::vector<TEventTime*> *eventQ = new std::vector<TEventTime*>;
-      QueueEvents(midfile,eventQ);
-      std::cout << "Number of Digitizers Found: " << TEventTime::digmap.size() << std::endl;
+	int nDigitizers = 0;
+	if(argc > 3) {
+		if(strcmp(argv[3],"n")==0){
+			nDigitizers = 0;
+		} else {
+			nDigitizers = CorrectionFile(runnumber);
+		}
+	} else {
+		nDigitizers = CorrectionFile(runnumber);
+	}
 
-      CheckHighTimeStamp(eventQ);
-      GetRoughTimeDiff(eventQ);
-      GetTimeDiff(eventQ);
-      WriteCorrectionFile(runnumber);
-      midfile->Close();
-      midfile->Open(argv[1]);//This seems like the easiest way to reset the file....
-      outfile->Close();
-      delete outfile;
-   }
+	TGRSIOptions::Get()->SuppressErrors(true);
 
-   WriteEvents(midfile);
+	if(!nDigitizers) {
+		TFile *outfile = new TFile(filename,"RECREATE");
+		std::vector<TEventTime*> *eventQ = new std::vector<TEventTime*>;
+		QueueEvents(midfile,eventQ);
+		std::cout << "Number of Digitizers Found: " << TEventTime::digmap.size() << std::endl;
+
+		CheckHighTimeStamp(eventQ);
+		GetRoughTimeDiff(eventQ);
+		GetTimeDiff(eventQ);
+		WriteCorrectionFile(runnumber);
+		midfile->Close();
+		midfile->Open(argv[1]);//This seems like the easiest way to reset the file....
+		outfile->Close();
+		delete outfile;
+	}
+
+	WriteEvents(midfile);
 
 
-   //Have to do deleting on Q if we move to a next step of fixing the MIDAS File
-   midfile->Close();
-   midfile->OutClose();
-   delete midfile;
+	//Have to do deleting on Q if we move to a next step of fixing the MIDAS File
+	midfile->Close();
+	midfile->OutClose();
+	delete midfile;
 
 }
 


### PR DESCRIPTION
- The analysis options are now written to the root files, and read at the start of grsisort. Commandline options overwrite anything in the analysis options that were read from file.
- This also required some changes to the argument parser:
  - Moved the definition of the output streamer into a (new) source file.
  - Created two different versions of the member function parse, one takes the original int argc, char** argv as arguments, and puts  any unknown flags (and their arguments) into a vector of strings. The second one takes that vector of strings as argument and does throw exceptions if unknown flags are encountered.
- Still need to make sure this works for the PROOF selectors.
- Moved the stopwatch to grsisort.cxx itself, this eliminated the double "bye.bye" message and guarantees printing the message after the last command prompt.