### PR TITLE
Small bug fixes, reading run stop

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -34,6 +34,7 @@ void Analyze(const char* tree_type, TProof* proof)
             static bool info_set = false;
             if(!info_set) {
                TGRSIRunInfo::Get()->ReadInfoFromFile(in_file);
+					TGRSIRunInfo::Get()->Print();
                info_set = true;
             }
          }

--- a/include/TBetaDecay.h
+++ b/include/TBetaDecay.h
@@ -12,6 +12,15 @@
 #include "TNamed.h"
 #include "TNucleus.h"
 
+//////////////////////////////////////////////////////////////////
+///
+/// \class TBetaDecay
+///
+/// This class contains information about beta decays to be used
+/// in analyses.
+///
+///////////////////////////////////////////////////////////////////
+
 class TBetaDecay : public TNamed {
 public:
    TBetaDecay();

--- a/include/TEnergyCal.h
+++ b/include/TEnergyCal.h
@@ -9,37 +9,47 @@
 #include "TPeak.h"
 #include "TSpectrum.h"
 
+////////////////////////////////////////////////////////////////
+///
+/// \class TEnergyCal
+///
+/// Class for performing energy calibrations using a single
+/// nucleus.
+///
+////////////////////////////////////////////////////////////////
+
+
 class TEnergyCal : public TCal {
 public:
-   TEnergyCal();
-   TEnergyCal(const char* name, const char* title) : TCal(name, title) {}
-   ~TEnergyCal() override;
+	TEnergyCal();
+	TEnergyCal(const char* name, const char* title) : TCal(name, title) {}
+	~TEnergyCal() override;
 
 public:
-   std::vector<Double_t> GetParameters() const override;
-   Double_t GetParameter(size_t parameter) const override;
-   void WriteToChannel() const override;
+	std::vector<Double_t> GetParameters() const override;
+	Double_t GetParameter(size_t parameter) const override;
+	void WriteToChannel() const override;
 
-   void AddPoint(Double_t measured, Double_t accepted, Double_t measuredUncertainty = 0.0,
-                 Double_t acceptedUncertainty = 0.0);
-   using TGraphErrors::SetPoint;
-   using TGraphErrors::SetPointError;
-   Bool_t SetPoint(Int_t idx, Double_t measured);
-   Bool_t SetPoint(Int_t idx, TPeak* peak);
-   Bool_t SetPointError(Int_t idx, Double_t measuredUncertainty);
+	void AddPoint(Double_t measured, Double_t accepted, Double_t measuredUncertainty = 0.0,
+			Double_t acceptedUncertainty = 0.0);
+	using TGraphErrors::SetPoint;
+	using TGraphErrors::SetPointError;
+	Bool_t SetPoint(Int_t idx, Double_t measured);
+	Bool_t SetPoint(Int_t idx, TPeak* peak);
+	Bool_t SetPointError(Int_t idx, Double_t measuredUncertainty);
 
-   void SetNucleus(TNucleus* nuc, Option_t* opt = "") override;
+	void SetNucleus(TNucleus* nuc, Option_t* opt = "") override;
 
-   void Clear(Option_t* opt = "") override;
-   void Print(Option_t* opt = "") const override;
-   void SetDefaultTitles();
+	void Clear(Option_t* opt = "") override;
+	void Print(Option_t* opt = "") const override;
+	void SetDefaultTitles();
 
-   Bool_t IsGroupable() const override { return true; }
+	Bool_t IsGroupable() const override { return true; }
 
 private:
-   /// \cond CLASSIMP
-   ClassDefOverride(TEnergyCal, 1); // Class used for Energy Calibrations
-   /// \endcond
+	/// \cond CLASSIMP
+	ClassDefOverride(TEnergyCal, 1); // Class used for Energy Calibrations
+	/// \endcond
 };
 /*! @} */
 #endif

--- a/include/TFipps.h
+++ b/include/TFipps.h
@@ -20,6 +20,16 @@
 #include "TGRSIRunInfo.h"
 #include "TTransientBits.h"
 
+////////////////////////////////////////////////////////////
+///
+/// \class TFipps
+///
+/// The TFipps class defines the observables and algorithms used
+/// when analyzing FIPPS data. It includes detector positions,
+/// add-back methods, etc.
+///
+////////////////////////////////////////////////////////////
+
 class TFipps : public TGRSIDetector {
 public:
    enum EFippsBits {

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -99,6 +99,7 @@ public:
    static inline void SetRunStart(double tmp) { fGRSIRunInfo->fRunStart = tmp; }
    static inline void SetRunStop(double tmp) { fGRSIRunInfo->fRunStop = tmp; }
    static inline void SetRunLength(double tmp) { fGRSIRunInfo->fRunLength = tmp; }
+   static inline void SetRunLength() { fGRSIRunInfo->fRunLength = fGRSIRunInfo->fRunStop - fGRSIRunInfo->fRunStart; }
 
    static inline double RunStart() { return fGRSIRunInfo->fRunStart; }
    static inline double RunStop() { return fGRSIRunInfo->fRunStop; }
@@ -180,7 +181,13 @@ public:
    {
       fRunStart = 0.;
       fRunStop  = 0.;
-      fRunLength += runinfo->RunLength();
+      if(runinfo->RunLength() > 0) {
+			if(fRunLength > 0) {
+				fRunLength += runinfo->RunLength();
+			} else {
+				fRunLength = runinfo->RunLength();
+			}
+		}
    }
 
    void PrintBadCycles() const;

--- a/include/TKinematics.h
+++ b/include/TKinematics.h
@@ -21,6 +21,15 @@
 #define PI (TMath::Pi())
 #endif
 
+/////////////////////////////////////////////////////////////////
+///
+/// \class TKinematics
+///
+/// This class calculates 2 body kinematics from a beam, target,
+/// recoil, ejectile, and beam energy.
+///
+/////////////////////////////////////////////////////////////////
+
 class TKinematics : public TNamed {
 public:
    TKinematics(double beame, const char* beam, const char* targ, const char* ejec = nullptr, const char* reco = nullptr,

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -15,82 +15,91 @@
 #include "TNamed.h"
 #include "TList.h"
 
+/////////////////////////////////////////////////////////////////
+///
+/// \class TNucleus
+///
+/// This class builds a nucleus and sets all the basic information
+/// (mass, Z, symbol, radius, etc.)
+///
+/////////////////////////////////////////////////////////////////
+
 class TNucleus : public TNamed {
 
 private:
-   static const char*  grsipath;
-   static std::string& massfile(); // The massfile to be used, which includes Z, N, atomic symbol, and mass excess
-   // static const char *massfile; //The massfile to be used, which includes Z, N, atomic symbol, and mass excess
-   // static std::string masspath;
+	static const char*  grsipath;
+	static std::string& massfile(); // The massfile to be used, which includes Z, N, atomic symbol, and mass excess
+	// static const char *massfile; //The massfile to be used, which includes Z, N, atomic symbol, and mass excess
+	// static std::string masspath;
 
 public:
-   TNucleus() {};               // Should not be use, here so we can write things to a root file.
-   TNucleus(const char* name); // Creates a nucleus based on symbol and sets all parameters from mass.dat
-   TNucleus(int charge, int neutrons, double mass, const char* symbol); // Creates a nucleus with Z, N, mass, and symbol
-   TNucleus(
-      int charge, int neutrons,
-      const char* MassFile = nullptr); // Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
+	TNucleus() {};               // Should not be use, here so we can write things to a root file.
+	TNucleus(const char* name); // Creates a nucleus based on symbol and sets all parameters from mass.dat
+	TNucleus(int charge, int neutrons, double mass, const char* symbol); // Creates a nucleus with Z, N, mass, and symbol
+	TNucleus(
+			int charge, int neutrons,
+			const char* MassFile = nullptr); // Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
 
-   ~TNucleus() override;
+	~TNucleus() override;
 
-   // static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
+	// static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
 
-   static const char* SortName(const char* name);
-   // void SetName(const char *name) { fName = name; }
-   void SetZ(int);              // Sets the Z (# of protons) of the nucleus
-   void SetN(int);              // Sets the N (# of neutrons) of the nucleus
-   void SetMassExcess(double);  // Sets the mass excess of the nucleus (in MeV)
-   void SetMass(double);        // Sets the mass manually (in MeV)
-   void SetMass();              // Sets the mass based on the A and mass excess of nucleus (in MeV)
-   void SetSymbol(const char*); // Sets the atomic symbol for the nucleus
+	static const char* SortName(const char* name);
+	// void SetName(const char *name) { fName = name; }
+	void SetZ(int);              // Sets the Z (# of protons) of the nucleus
+	void SetN(int);              // Sets the N (# of neutrons) of the nucleus
+	void SetMassExcess(double);  // Sets the mass excess of the nucleus (in MeV)
+	void SetMass(double);        // Sets the mass manually (in MeV)
+	void SetMass();              // Sets the mass based on the A and mass excess of nucleus (in MeV)
+	void SetSymbol(const char*); // Sets the atomic symbol for the nucleus
 
-   void AddTransition(Double_t energy, Double_t intensity, Double_t energy_uncertainty = 0.0,
-                      Double_t intensity_uncertainty = 0.0);
-   void AddTransition(TTransition* tran);
-   // Bool_t RemoveTransition(Int_t idx);
-   // TGRSITransition *GetTransition(Int_t idx);
+	void AddTransition(Double_t energy, Double_t intensity, Double_t energy_uncertainty = 0.0,
+			Double_t intensity_uncertainty = 0.0);
+	void AddTransition(TTransition* tran);
+	// Bool_t RemoveTransition(Int_t idx);
+	// TGRSITransition *GetTransition(Int_t idx);
 
-   // const char* GetName()        { return fName.c_str(); }
-   int         GetZ() const { return fZ; }                   // Gets the Z (# of protons) of the nucleus
-   int         GetN() const { return fN; }                   // Gets the N (# of neutrons) of the nucleus
-   int         GetA() const { return fN + fZ; }              // Gets the A (Z + N) of the nucleus
-   double      GetMassExcess() const { return fMassExcess; } // Gets the mass excess of the nucleus (in MeV)
-   double      GetMass() const { return fMass; }             // Gets the mass of the nucleus (in MeV)
-   const char* GetSymbol() const { return fSymbol.c_str(); } // Gets the atomic symbol of the nucleus
+	// const char* GetName()        { return fName.c_str(); }
+	int         GetZ() const { return fZ; }                   // Gets the Z (# of protons) of the nucleus
+	int         GetN() const { return fN; }                   // Gets the N (# of neutrons) of the nucleus
+	int         GetA() const { return fN + fZ; }              // Gets the A (Z + N) of the nucleus
+	double      GetMassExcess() const { return fMassExcess; } // Gets the mass excess of the nucleus (in MeV)
+	double      GetMass() const { return fMass; }             // Gets the mass of the nucleus (in MeV)
+	const char* GetSymbol() const { return fSymbol.c_str(); } // Gets the atomic symbol of the nucleus
 
-   // Returns total kinetic energy in MeV
-   double GetEnergyFromBeta(double beta);
-   double GetBetaFromEnergy(double energy_MeV);
+	// Returns total kinetic energy in MeV
+	double GetEnergyFromBeta(double beta);
+	double GetBetaFromEnergy(double energy_MeV);
 
-   // Bool_t RemoveTransition(Int_t idx);
-   TTransition* GetTransition(Int_t idx);
+	// Bool_t RemoveTransition(Int_t idx);
+	TTransition* GetTransition(Int_t idx);
 
-   Int_t  NTransitions() const { return TransitionList.GetSize(); };
-   Int_t  GetNTransitions() const { return TransitionList.GetSize(); };
-   double GetRadius() const;
-   int    GetZfromSymbol(char*);
+	Int_t  NTransitions() const { return TransitionList.GetSize(); };
+	Int_t  GetNTransitions() const { return TransitionList.GetSize(); };
+	double GetRadius() const;
+	int    GetZfromSymbol(char*);
 
-   // bool SetSourceData();
+	// bool SetSourceData();
 
-   void Print(Option_t* opt = "") const override;
-   void WriteSourceFile(const std::string& outfilename = "");
+	void Print(Option_t* opt = "") const override;
+	void WriteSourceFile(const std::string& outfilename = "");
 
-   const TList* GetTransitionList() const { return &TransitionList; }
+	const TList* GetTransitionList() const { return &TransitionList; }
 
 private:
-   void SetName(const char* c = "") override;
+	void SetName(const char* c = "") override;
 
-   int         fA{0};          // Number of nucleons (Z + N)
-   int         fN{0};          // Number of neutrons (N)
-   int         fZ{0};          // Number of protons (Z)
-   double      fMass{0.};      // Mass (in MeV)
-   double      fMassExcess{0.};// Mass excess (in MeV)
-   std::string fSymbol;        // Atomic symbol (ex. Ba, C, O, N)
+	int         fA{0};          // Number of nucleons (Z + N)
+	int         fN{0};          // Number of neutrons (N)
+	int         fZ{0};          // Number of protons (Z)
+	double      fMass{0.};      // Mass (in MeV)
+	double      fMassExcess{0.};// Mass excess (in MeV)
+	std::string fSymbol;        // Atomic symbol (ex. Ba, C, O, N)
 
-   TList TransitionList;
-   bool  LoadTransitionFile();
+	TList TransitionList;
+	bool  LoadTransitionFile();
 
-   ClassDefOverride(TNucleus, 1); // Creates a nucleus with corresponding nuclear information
+	ClassDefOverride(TNucleus, 1); // Creates a nucleus with corresponding nuclear information
 };
 
 #endif

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -1,46 +1,42 @@
 #include "Globals.h"
 #include "GCanvas.h"
 
-#include <TClass.h>
-#include <TPaveStats.h>
-#include <TList.h>
-#include <TText.h>
-#include <TLatex.h>
-#include <TH1.h>
-#include <TH2.h>
-#include <TGraphErrors.h>
-#include <Buttons.h>
-#include <KeySymbols.h>
-#include <TVirtualX.h>
-#include <TROOT.h>
-#include <TFrame.h>
-#include <TF1.h>
-#include <TGraph.h>
-#include <TPolyMarker.h>
-#include <TSpectrum.h>
-#include <TPython.h>
-#include <TCutG.h>
+#include "TClass.h"
+#include "TPaveStats.h"
+#include "TList.h"
+#include "TText.h"
+#include "TLatex.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TGraphErrors.h"
+#include "Buttons.h"
+#include "KeySymbols.h"
+#include "TVirtualX.h"
+#include "TROOT.h"
+#include "TFrame.h"
+#include "TF1.h"
+#include "TGraph.h"
+#include "TPolyMarker.h"
+#include "TSpectrum.h"
+#include "TPython.h"
+#include "TCutG.h"
 
-#include <TApplication.h>
-#include <TContextMenu.h>
-#include <TGButton.h>
+#include "TApplication.h"
+#include "TContextMenu.h"
+#include "TGButton.h"
 
-//#include <TGFileDialog.h>
-#include <GPopup.h>
+#include "GPopup.h"
 
-//#include "GROOTGuiFactory.h"
 #include "GRootCommands.h"
 #include "GH2I.h"
 #include "GH2D.h"
 #include "GH1D.h"
 
-//#include "TRuntimeObjects.h"
-
 #include <iostream>
 #include <fstream>
 #include <string>
 
-#include <TMath.h>
+#include "TMath.h"
 
 #include "TGRSIint.h"
 

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -47,7 +47,9 @@
 
 enum MyArrowPress { kMyArrowLeft = 0x1012, kMyArrowUp = 0x1013, kMyArrowRight = 0x1014, kMyArrowDown = 0x1015 };
 
+/// \cond CLASSIMP
 ClassImp(GMarker)
+/// \endcond
 
 void GMarker::Copy(TObject& object) const
 {

--- a/libraries/GROOT/GH2Base.cxx
+++ b/libraries/GROOT/GH2Base.cxx
@@ -8,7 +8,7 @@
 #include "SuppressTH1GDirectory.h"
 
 /// \cond CLASSIMP
-ClassImp(GHSym)
+ClassImp(GH2Base)
 /// \endcond
 
 GH2Base::~GH2Base()

--- a/libraries/GROOT/GH2Base.cxx
+++ b/libraries/GROOT/GH2Base.cxx
@@ -7,9 +7,11 @@
 #include "GH1D.h"
 #include "SuppressTH1GDirectory.h"
 
-ClassImp(GH2Base)
+/// \cond CLASSIMP
+ClassImp(GHSym)
+/// \endcond
 
-   GH2Base::~GH2Base()
+GH2Base::~GH2Base()
 {
    fProjections->Delete();
    fSummaryProjections->Delete();

--- a/libraries/GROOT/GH2I.cxx
+++ b/libraries/GROOT/GH2I.cxx
@@ -8,8 +8,8 @@
 
 ClassImp(GH2I)
 
-   GH2I::GH2I(const char* name, const char* title, Int_t nbinsx, const Double_t* xbins, Int_t nbinsy,
-              const Double_t* ybins)
+GH2I::GH2I(const char* name, const char* title, Int_t nbinsx, const Double_t* xbins, Int_t nbinsy,
+			  const Double_t* ybins)
    : TH2I(name, title, nbinsx, xbins, nbinsy, ybins), GH2Base()
 {
 }

--- a/libraries/GROOT/GHSym.cxx
+++ b/libraries/GROOT/GHSym.cxx
@@ -27,9 +27,11 @@ class DifferentBinLimits : public std::exception {
 class DifferentLabels : public std::exception {
 };
 
+/// \cond CLASSIMP
 ClassImp(GHSym)
+/// \endcond
 
-   GHSym::GHSym()
+GHSym::GHSym()
 {
    fDimension = 2;
    fTsumwy    = 0;

--- a/libraries/GROOT/GRootGuiFactory.cxx
+++ b/libraries/GROOT/GRootGuiFactory.cxx
@@ -33,9 +33,11 @@
 
 #include "GCanvas.h"
 
+/// \cond CLASSIMP
 ClassImp(GRootGuiFactory)
+/// \endcond
 
-   void GRootGuiFactory::Init()
+void GRootGuiFactory::Init()
 {
    if(gROOT->IsBatch()) {
       return;

--- a/libraries/GROOT/TCalibrator.cxx
+++ b/libraries/GROOT/TCalibrator.cxx
@@ -26,9 +26,11 @@
 
 #include "combinations.h"
 
+/// \cond CLASSIMP
 ClassImp(TCalibrator)
+/// \endcond
 
-   TCalibrator::TCalibrator()
+TCalibrator::TCalibrator()
 {
    linfit = nullptr;
    efffit = nullptr;

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -14,10 +14,6 @@
 #include "TFragment.h"
 #include "TBadFragment.h"
 
-/// \cond CLASSIMP
-// ClassImp(TDataParser)
-/// \endcond
-
 TGRSIOptions* TDataParser::fOptions = nullptr;
 
 TDataParser::TDataParser()

--- a/libraries/TGRSIAnalysis/TAngularCorrelation/TAngularCorrelation.cxx
+++ b/libraries/TGRSIAnalysis/TAngularCorrelation/TAngularCorrelation.cxx
@@ -12,12 +12,12 @@
 
 /// \cond CLASSIMP
 ClassImp(TAngularCorrelation)
-   /// \endcond
+/// \endcond
 
-   ////////////////////////////////////////////////////////////////////////////////
-   /// Angular correlation default constructor
-   ///
-   TAngularCorrelation::TAngularCorrelation()
+////////////////////////////////////////////////////////////////////////////////
+/// Angular correlation default constructor
+///
+TAngularCorrelation::TAngularCorrelation()
 {
    fIndexCorrelation = nullptr; // used the 1D histograms for a specific energy ranged used for FitSlices
    fIndexMapSize     = 0;       // number of indexes, never called in making the histograms

--- a/libraries/TGRSIAnalysis/TBetaDecay/TBetaDecay.cxx
+++ b/libraries/TGRSIAnalysis/TBetaDecay/TBetaDecay.cxx
@@ -4,15 +4,6 @@
 ClassImp(TBetaDecay)
 /// \endcond
 
-//////////////////////////////////////////////////////////////////
-///
-/// \class TBetaDecay
-///
-/// This class contains information about beta decays to be used
-/// in analyses.
-///
-///////////////////////////////////////////////////////////////////
-
 TBetaDecay::TBetaDecay()
 {
 	fParentAllocated = false;

--- a/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
+++ b/libraries/TGRSIAnalysis/TCSM/TCSM.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCSM)
-   /// \endcond
+/// \endcond
 
-   int TCSM::fCfdBuildDiff = 5;
+int TCSM::fCfdBuildDiff = 5;
 
 TCSM::TCSM()
 {

--- a/libraries/TGRSIAnalysis/TCSM/TCSMHit.cxx
+++ b/libraries/TGRSIAnalysis/TCSM/TCSMHit.cxx
@@ -2,9 +2,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCSMHit)
-   /// \endcond
+/// \endcond
 
-   TCSMHit::TCSMHit()
+TCSMHit::TCSMHit()
 {
 #if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);

--- a/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCFDCal.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCFDCal)
-   /// \endcond
+/// \endcond
 
-   void TCFDCal::Clear(Option_t* opt)
+void TCFDCal::Clear(Option_t* opt)
 {
    fParameters.clear();
    TCal::Clear(opt);

--- a/libraries/TGRSIAnalysis/TCal/TCalGraph.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalGraph.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCalGraph)
-   /// \endcond
+/// \endcond
 
-   TCalGraph::TCalGraph()
+TCalGraph::TCalGraph()
    : TGraphErrors()
 {
    Clear();

--- a/libraries/TGRSIAnalysis/TCal/TCalList.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalList.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCalList)
-   /// \endcond
+/// \endcond
 
-   TCalList::TCalList()
+TCalList::TCalList()
    : TNamed()
 {
    Clear();

--- a/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalManager.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCalManager)
-   /// \endcond
+/// \endcond
 
-   TCalManager::TCalManager()
+TCalManager::TCalManager()
 {
    fClass = nullptr; // fClass will point to a TClass which is made persistant through a root session within gROOT.
    // So we don't need to worry about allocating it.

--- a/libraries/TGRSIAnalysis/TCal/TCalPoint.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TCalPoint.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TCalPoint)
-   /// \endcond
+/// \endcond
 
-   TCalPoint::TCalPoint()
+TCalPoint::TCalPoint()
 {
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TCal/TEfficiencyGraph.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TEfficiencyGraph.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TEfficiencyGraph)
-   /// \endcond
+/// \endcond
 
-   TEfficiencyGraph::TEfficiencyGraph()
+TEfficiencyGraph::TEfficiencyGraph()
    : TCalGraph(), fIsAbsolute(false)
 {
    Clear();

--- a/libraries/TGRSIAnalysis/TCal/TEnergyCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TEnergyCal.cxx
@@ -2,17 +2,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TEnergyCal)
-   /// \endcond
-   ////////////////////////////////////////////////////////////////
-   //                                                            //
-   // TEnergyCal                                                 //
-   //
-   // Class for performing energy calibrations using a single
-   // nucleus.
-   //                                                            //
-   ////////////////////////////////////////////////////////////////
+/// \endcond
 
-   TEnergyCal::TEnergyCal()
+TEnergyCal::TEnergyCal()
 {
    // Default Constructor
    SetDefaultTitles();

--- a/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TGainMatch.cxx
@@ -11,9 +11,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGainMatch)
-   /// \endcond
+/// \endcond
 
-   Double_t TGainMatch::gDefaultCoarseRange = 40.;
+Double_t TGainMatch::gDefaultCoarseRange = 40.;
 
 TGainMatch::TGainMatch(const TGainMatch& copy) : TCal(copy), fCoarseRange(gDefaultCoarseRange)
 {

--- a/libraries/TGRSIAnalysis/TCal/TSourceList.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TSourceList.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TSourceList)
-   /// \endcond
+/// \endcond
 
-   TSourceList::TSourceList()
+TSourceList::TSourceList()
    : TCalList()
 {
    Clear();

--- a/libraries/TGRSIAnalysis/TCal/TTimeCal.cxx
+++ b/libraries/TGRSIAnalysis/TCal/TTimeCal.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TTimeCal)
-   /// \endcond
+/// \endcond
 
-   void TTimeCal::Clear(Option_t* opt)
+void TTimeCal::Clear(Option_t* opt)
 {
    fParameters.clear();
    TCal::Clear(opt);

--- a/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
@@ -11,13 +11,17 @@ ClassImp(TDetector)
    : TObject()
 {
    /// Default constructor.
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
 }
 
 TDetector::TDetector(const TDetector& rhs) : TObject()
 {
    /// Default Copy constructor.
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    rhs.Copy(*this);
 }
 

--- a/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetector.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TDetector)
-   /// \endcond
+/// \endcond
 
-   TDetector::TDetector()
+TDetector::TDetector()
    : TObject()
 {
    /// Default constructor.

--- a/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
+++ b/libraries/TGRSIAnalysis/TFipps/TFipps.cxx
@@ -11,21 +11,11 @@
 
 #include "TGRSIOptions.h"
 
-////////////////////////////////////////////////////////////
-//
-// TFipps
-//
-// The TFipps class defines the observables and algorithms used
-// when analyzing FIPPS data. It includes detector positions,
-// add-back methods, etc.
-//
-////////////////////////////////////////////////////////////
-
 /// \cond CLASSIMP
 ClassImp(TFipps)
-   /// \endcond
+/// \endcond
 
-   bool DefaultAddback(TFippsHit& one, TFippsHit& two)
+bool DefaultAddback(TFippsHit& one, TFippsHit& two)
 {
    return ((one.GetDetector() == two.GetDetector()) &&
            (std::fabs(one.GetTime() - two.GetTime()) < TGRSIOptions::AnalysisOptions()->AddbackWindow()));

--- a/libraries/TGRSIAnalysis/TFipps/TFippsHit.cxx
+++ b/libraries/TGRSIAnalysis/TFipps/TFippsHit.cxx
@@ -7,23 +7,23 @@
 
 /// \cond CLASSIMP
 ClassImp(TFippsHit)
-   /// \endcond
+/// \endcond
 
-   TFippsHit::TFippsHit()
-   : TGRSIDetectorHit()
+TFippsHit::TFippsHit()
+	: TGRSIDetectorHit()
 {
-// Default Ctor. Ignores TObject Streamer in ROOT < 6.
+	// Default Ctor. Ignores TObject Streamer in ROOT < 6.
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TFippsHit::TFippsHit(const TFippsHit& rhs) : TGRSIDetectorHit()
 {
-   // Copy Ctor. Ignores TObject Streamer in ROOT < 6.
-   Clear();
-   rhs.Copy(*this);
+	// Copy Ctor. Ignores TObject Streamer in ROOT < 6.
+	Clear();
+	rhs.Copy(*this);
 }
 
 TFippsHit::TFippsHit(const TFragment& frag) : TGRSIDetectorHit(frag)
@@ -34,71 +34,71 @@ TFippsHit::~TFippsHit() = default;
 
 void TFippsHit::Copy(TObject& rhs) const
 {
-   TGRSIDetectorHit::Copy(rhs);
+	TGRSIDetectorHit::Copy(rhs);
 }
 
 void TFippsHit::Copy(TObject& obj, bool) const
 {
-   Copy(obj);
+	Copy(obj);
 }
 
 void TFippsHit::Clear(Option_t* opt)
 {
-   // Clears the information stored in the TFippsHit.
-   TGRSIDetectorHit::Clear(opt); // clears the base (address, position and waveform)
+	// Clears the information stored in the TFippsHit.
+	TGRSIDetectorHit::Clear(opt); // clears the base (address, position and waveform)
 }
 
 void TFippsHit::Print(Option_t*) const
 {
-   // Prints the Detector Number, Crystal Number, Energy, Time and Angle.
-   printf("Fipps Detector: %i\n", GetDetector());
-   printf("Fipps Crystal:  %i\n", GetCrystal());
-   printf("Fipps Energy:   %lf\n", GetEnergy());
-   printf("Fipps hit time:   %lf\n", GetTime());
-   printf("Fipps hit TV3 theta: %.2f\tphi%.2f\n", GetPosition().Theta() * 180 / (3.141597),
-          GetPosition().Phi() * 180 / (3.141597));
+	// Prints the Detector Number, Crystal Number, Energy, Time and Angle.
+	printf("Fipps Detector: %i\n", GetDetector());
+	printf("Fipps Crystal:  %i\n", GetCrystal());
+	printf("Fipps Energy:   %lf\n", GetEnergy());
+	printf("Fipps hit time:   %lf\n", GetTime());
+	printf("Fipps hit TV3 theta: %.2f\tphi%.2f\n", GetPosition().Theta() * 180 / (3.141597),
+			GetPosition().Phi() * 180 / (3.141597));
 }
 
 TVector3 TFippsHit::GetPosition(double dist) const
 {
-   return TFipps::GetPosition(GetDetector(), GetCrystal(), dist);
+	return TFipps::GetPosition(GetDetector(), GetCrystal(), dist);
 }
 
 TVector3 TFippsHit::GetPosition() const
 {
-   return GetPosition(GetDefaultDistance());
+	return GetPosition(GetDefaultDistance());
 }
 
 bool TFippsHit::CompareEnergy(const TFippsHit* lhs, const TFippsHit* rhs)
 {
-   return (lhs->GetEnergy() > rhs->GetEnergy());
+	return (lhs->GetEnergy() > rhs->GetEnergy());
 }
 
 void TFippsHit::Add(const TFippsHit* hit)
 {
-   // add another griffin hit to this one (for addback),
-   // using the time and position information of the one with the higher energy
-   if(!CompareEnergy(this, hit)) {
-      SetCfd(hit->GetCfd());
-      SetTime(hit->GetTime());
-      // SetPosition(hit->GetPosition());
-      SetAddress(hit->GetAddress());
-   }
-   SetEnergy(GetEnergy() + hit->GetEnergy());
-   // this has to be done at the very end, otherwise GetEnergy() might not work
-   SetCharge(0);
-   // KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
-   if(GetKValue() > hit->GetKValue()) {
-      SetKValue(hit->GetKValue());
-   }
+	// add another griffin hit to this one (for addback),
+	// using the time and position information of the one with the higher energy
+	if(!CompareEnergy(this, hit)) {
+		SetCfd(hit->GetCfd());
+		SetTime(hit->GetTime());
+		// SetPosition(hit->GetPosition());
+		SetAddress(hit->GetAddress());
+	}
+	SetEnergy(GetEnergy() + hit->GetEnergy());
+	// this has to be done at the very end, otherwise GetEnergy() might not work
+	SetCharge(0);
+	// KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
+	if(GetKValue() > hit->GetKValue()) {
+		SetKValue(hit->GetKValue());
+	}
 }
 
 Double_t TFippsHit::GetNoCTEnergy(Option_t*) const
 {
-   TChannel* chan = GetChannel();
-   if(chan == nullptr) {
-      Error("GetEnergy", "No TChannel exists for address 0x%08x", GetAddress());
-      return 0.;
-   }
-   return chan->CalibrateENG(Charge(), GetKValue());
+	TChannel* chan = GetChannel();
+	if(chan == nullptr) {
+		Error("GetEnergy", "No TChannel exists for address 0x%08x", GetAddress());
+		return 0.;
+	}
+	return chan->CalibrateENG(Charge(), GetKValue());
 }

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetector.cxx
@@ -4,19 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSIDetector)
-   /// \endcond
+/// \endcond
 
-   ////////////////////////////////////////////////////////////////
-   //                                                            //
-   // TGRSIDetector                                              //
-   //                                                            //
-   // This is an abstract class that contains the basic info     //
-   // about a detector. This is where the hits are built and
-   // the data is filled.
-   //                                                            //
-   ////////////////////////////////////////////////////////////////
-
-   TGRSIDetector::TGRSIDetector()
+TGRSIDetector::TGRSIDetector()
    : TDetector()
 {
 // Default constructor.

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -18,7 +18,9 @@ TGRSIDetectorHit::TGRSIDetectorHit(const int& Address) : TObject()
    Clear();
    fAddress = Address;
 
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
 }
 
 TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) : TObject(rhs)
@@ -30,7 +32,9 @@ TGRSIDetectorHit::TGRSIDetectorHit(const TGRSIDetectorHit& rhs, bool copywave) :
    }
    ClearTransients();
 
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
 }
 
 TGRSIDetectorHit::~TGRSIDetectorHit()

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -6,9 +6,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSIDetectorHit)
-   /// \endcond
+/// \endcond
 
-   TPPG* TGRSIDetectorHit::fPPG = nullptr;
+TPPG* TGRSIDetectorHit::fPPG = nullptr;
 
 TVector3 TGRSIDetectorHit::fBeamDirection(0, 0, 1);
 

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFit.cxx
@@ -2,9 +2,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSIFit)
-   /// \endcond
+/// \endcond
 
-   TString TGRSIFit::fDefaultFitType("");
+TString TGRSIFit::fDefaultFitType("");
 
 TGRSIFit::TGRSIFit()
 {

--- a/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TLMFitter.cxx
@@ -2,27 +2,29 @@
 #include <iomanip>
 #include <iostream>
 
+/// \cond CLASSIMP
 ClassImp(TLMFitter)
+/// \endcond
 
-   /* DEFINITIONS */
-   /*******************************************************************/
-   /* alamda = parameter switches between curve and gradient method   */
-   /*          must begin negative to initialize fit routine          */
-   /* x[DIM] = x values of the data                                   */
-   /* y[DIM] = y values of the data (Number of counts)                */
-   /* sig[i] = sigma in the y value                                   */
-   /* chisq  = chi-squared definitions defined in mrqcof subroutine   */
-   /* sig2i  = 1 over sigma squared (Used in computing the chisq)     */
-   /* a[i]   = fit parameters of the fitting function                 */
-   /* ia[i]  = set to '1' to free a[i] or '0' for fixed               */
-   /* beta[j]= extremum vector                                        */
-   /* alpha[k][k] = curvature matrix                                  */
-   /* dy     = yfit - ydata                                           */
-   /* ma     = number of fit parameters in fit function               */
-   /*******************************************************************/
+/* DEFINITIONS */
+/*******************************************************************/
+/* alamda = parameter switches between curve and gradient method   */
+/*          must begin negative to initialize fit routine          */
+/* x[DIM] = x values of the data                                   */
+/* y[DIM] = y values of the data (Number of counts)                */
+/* sig[i] = sigma in the y value                                   */
+/* chisq  = chi-squared definitions defined in mrqcof subroutine   */
+/* sig2i  = 1 over sigma squared (Used in computing the chisq)     */
+/* a[i]   = fit parameters of the fitting function                 */
+/* ia[i]  = set to '1' to free a[i] or '0' for fixed               */
+/* beta[j]= extremum vector                                        */
+/* alpha[k][k] = curvature matrix                                  */
+/* dy     = yfit - ydata                                           */
+/* ma     = number of fit parameters in fit function               */
+/*******************************************************************/
 
-   /* Function Subroutine-***Put fitting function here***-------------*/
-   void TLMFitter::funcs(const double& x, Vec_IO_double& a, double& y, Vec_O_double& dyda)
+/* Function Subroutine-***Put fitting function here***-------------*/
+void TLMFitter::funcs(const double& x, Vec_IO_double& a, double& y, Vec_O_double& dyda)
 {
    for(int i = 0; i < a.size(); ++i) {
       fFunction->SetParameter(i, a[i]);

--- a/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -6,9 +6,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TMultiPeak)
-   /// \endcond
+/// \endcond
 
-   Bool_t TMultiPeak::fLogLikelihoodFlag = false;
+Bool_t TMultiPeak::fLogLikelihoodFlag = false;
 
 TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t>& centroids, Option_t*)
    : TGRSIFit("multipeakbg", MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5)

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -5,9 +5,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TPeak)
-   /// \endcond
+/// \endcond
 
-   Bool_t TPeak::fLogLikelihoodFlag = true;
+Bool_t TPeak::fLogLikelihoodFlag = true;
 TPeak* TPeak::fLastFit              = nullptr;
 
 // We need c++ 11 for constructor delegation....

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -7,9 +7,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGriffinHit)
-   /// \endcond
+/// \endcond
 
-   TGriffinHit::TGriffinHit()
+TGriffinHit::TGriffinHit()
    : TGRSIDetectorHit()
 {
 // Default Ctor. Ignores TObject Streamer in ROOT < 6.

--- a/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
+++ b/libraries/TGRSIAnalysis/TKinematics/TKinematics.cxx
@@ -5,19 +5,10 @@
 
 /// \cond CLASSIMP
 ClassImp(TKinematics)
-   /// \endcond
+/// \endcond
 
-   //////////////////////////////////////////////////////////////////
-   //
-   // TKinematics
-   //
-   // This class calculates 2 body kinematics from a beam, target,
-   // recoil, ejectile, and beam energy
-   //
-   //////////////////////////////////////////////////////////////////
-
-   TKinematics::TKinematics(double beame, const char* beam, const char* targ, const char* ejec, const char* reco,
-                            const char* name)
+TKinematics::TKinematics(double beame, const char* beam, const char* targ, const char* ejec, const char* reco,
+								 const char* name)
 {
    InitKin();
 

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBr.cxx
@@ -5,93 +5,93 @@
 
 /// \cond CLASSIMP
 ClassImp(TLaBr)
-   /// \endcond
+/// \endcond
 
-   TVector3 TLaBr::gPosition[9] = {
-      // These positions should be updated (they are currently SCEPTAR-ish)
-      TVector3(0, 0, 1),
-      TVector3(14.3025, 4.6472, 22.8096),
-      TVector3(0, 15.0386, 22.8096),
-      TVector3(-14.3025, 4.6472, 22.8096),
-      TVector3(-8.8395, -12.1665, 22.8096),
-      TVector3(8.8395, -12.1665, 22.8096),
-      TVector3(19.7051, 6.4026, 6.2123),
-      TVector3(0, 20.7192, 6.2123),
-      TVector3(-19.7051, 6.4026, 6.2123),
+TVector3 TLaBr::gPosition[9] = {
+	// These positions should be updated (they are currently SCEPTAR-ish)
+	TVector3(0, 0, 1),
+	TVector3(14.3025, 4.6472, 22.8096),
+	TVector3(0, 15.0386, 22.8096),
+	TVector3(-14.3025, 4.6472, 22.8096),
+	TVector3(-8.8395, -12.1665, 22.8096),
+	TVector3(8.8395, -12.1665, 22.8096),
+	TVector3(19.7051, 6.4026, 6.2123),
+	TVector3(0, 20.7192, 6.2123),
+	TVector3(-19.7051, 6.4026, 6.2123),
 };
 
 TLaBr::TLaBr()
 {
-// Default Constructor
+	// Default Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TLaBr::~TLaBr()
 {
-   // Default Destructor
+	// Default Destructor
 }
 
 TLaBr::TLaBr(const TLaBr& rhs) : TGRSIDetector()
 {
-// Copy Contructor
+	// Copy Contructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TLaBr::Clear(Option_t* opt)
 {
-   // Clears all of the hits
-   // The Option "all" clears the base class.
-   if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
-      TGRSIDetector::Clear(opt);
-   }
-   fLaBrHits.clear();
+	// Clears all of the hits
+	// The Option "all" clears the base class.
+	if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
+		TGRSIDetector::Clear(opt);
+	}
+	fLaBrHits.clear();
 }
 
 void TLaBr::Copy(TObject& rhs) const
 {
-   // Copies a TLaBr
-   TGRSIDetector::Copy(rhs);
+	// Copies a TLaBr
+	TGRSIDetector::Copy(rhs);
 
-   static_cast<TLaBr&>(rhs).fLaBrHits = fLaBrHits;
+	static_cast<TLaBr&>(rhs).fLaBrHits = fLaBrHits;
 }
 
 TLaBr& TLaBr::operator=(const TLaBr& rhs)
 {
-   rhs.Copy(*this);
-   return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
 void TLaBr::Print(Option_t*) const
 {
-   // Prints out TLaBr Multiplicity, currently does little.
-   printf("%lu fLaBrHits\n", fLaBrHits.size());
+	// Prints out TLaBr Multiplicity, currently does little.
+	printf("%lu fLaBrHits\n", fLaBrHits.size());
 }
 
 TGRSIDetectorHit* TLaBr::GetHit(const Int_t& idx)
 {
-   // Gets the TLaBrHit at index idx.
-   return GetLaBrHit(idx);
+	// Gets the TLaBrHit at index idx.
+	return GetLaBrHit(idx);
 }
 
 TLaBrHit* TLaBr::GetLaBrHit(const int& i)
 {
-   try {
-      return &fLaBrHits.at(i);
-   } catch(const std::out_of_range& oor) {
-      std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
-      throw grsi::exit_exception(1);
-   }
-   return nullptr;
+	try {
+		return &fLaBrHits.at(i);
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+		throw grsi::exit_exception(1);
+	}
+	return nullptr;
 }
 
 void TLaBr::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-   TLaBrHit laHit(*frag);                 // Building is controlled in the constructor of the hit
-   fLaBrHits.push_back(std::move(laHit)); // use std::move for efficienciy since laHit loses scope here anyway
+	TLaBrHit laHit(*frag);                 // Building is controlled in the constructor of the hit
+	fLaBrHits.push_back(std::move(laHit)); // use std::move for efficienciy since laHit loses scope here anyway
 }

--- a/libraries/TGRSIAnalysis/TLaBr/TLaBrHit.cxx
+++ b/libraries/TGRSIAnalysis/TLaBr/TLaBrHit.cxx
@@ -9,9 +9,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TLaBrHit)
-   /// \endcond
+/// \endcond
 
-   TLaBrHit::TLaBrHit()
+TLaBrHit::TLaBrHit()
 {
 // Default Constructor
 #if MAJOR_ROOT_VERSION < 6

--- a/libraries/TGRSIAnalysis/TNucleus/TGRSITransition.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TGRSITransition.cxx
@@ -2,77 +2,67 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSITransition)
-   /// \endcond
+/// \endcond
 
-   ////////////////////////////////////////////////////////////////
-   //                                                            //
-   // TGRSITransition                                            //
-   //                                                            //
-   // This Class contains the information about a nuclear
-   // transition. These transitions are a part of a TNucleus
-   // and are typically set within the TNucleus framework
-   //                                                            //
-   ////////////////////////////////////////////////////////////////
-
-   TGRSITransition::TGRSITransition()
+TGRSITransition::TGRSITransition()
 {
-// Default constructor for TGRSITransition
+	// Default constructor for TGRSITransition
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TGRSITransition::~TGRSITransition()
 {
-   // Default Destructor
+	// Default Destructor
 }
 
 void TGRSITransition::Print(Option_t*) const
 {
-   // Prints information about the TGRSITransition
-   printf("**************************\n");
-   printf("TGRSITransition:\n");
-   printf("Energy:    %lf\t+/-%lf\n", fEnergy, fEnergyUncertainty);
-   printf("Intensity: %lf\t+/-%lf\n", fIntensity, fIntensityUncertainty);
-   printf("**************************\n");
+	// Prints information about the TGRSITransition
+	printf("**************************\n");
+	printf("TGRSITransition:\n");
+	printf("Energy:    %lf\t+/-%lf\n", fEnergy, fEnergyUncertainty);
+	printf("Intensity: %lf\t+/-%lf\n", fIntensity, fIntensityUncertainty);
+	printf("**************************\n");
 }
 
 std::string TGRSITransition::PrintToString()
 {
-   // Writes transitions in a way that is nicer to ourput.
-   std::string buffer;
-   buffer.append(Form("%lf\t", fEnergy));
-   buffer.append(Form("%lf\t", fEnergyUncertainty));
-   buffer.append(Form("%lf\t", fIntensity));
-   buffer.append(Form("%lf\t", fIntensityUncertainty));
-   return buffer;
+	// Writes transitions in a way that is nicer to ourput.
+	std::string buffer;
+	buffer.append(Form("%lf\t", fEnergy));
+	buffer.append(Form("%lf\t", fEnergyUncertainty));
+	buffer.append(Form("%lf\t", fIntensity));
+	buffer.append(Form("%lf\t", fIntensityUncertainty));
+	return buffer;
 }
 
 void TGRSITransition::Clear(Option_t*)
 {
-   // Clears TGRSITransition
-   fEnergy               = 0.;
-   fEnergyUncertainty    = 0.;
-   fIntensity            = 0.;
-   fIntensityUncertainty = 0.;
+	// Clears TGRSITransition
+	fEnergy               = 0.;
+	fEnergyUncertainty    = 0.;
+	fIntensity            = 0.;
+	fIntensityUncertainty = 0.;
 }
 
 int TGRSITransition::Compare(const TObject* obj) const
 {
-   // Compares the intensities of the TGRSITransitions and returns
-   //-1 if this >  obj
-   // 0 if  this == obj
-   // 1 if  this <  obj
-   if(fIntensity > static_cast<const TGRSITransition*>(obj)->fIntensity) {
-      return -1;
-   }
-   if(fIntensity == static_cast<const TGRSITransition*>(obj)->fIntensity) {
-      return 0;
-   } //(fIntensity < static_cast<const TGRSITransition*>(obj)->fIntensity)
-   return 1;
+	// Compares the intensities of the TGRSITransitions and returns
+	//-1 if this >  obj
+	// 0 if  this == obj
+	// 1 if  this <  obj
+	if(fIntensity > static_cast<const TGRSITransition*>(obj)->fIntensity) {
+		return -1;
+	}
+	if(fIntensity == static_cast<const TGRSITransition*>(obj)->fIntensity) {
+		return 0;
+	} //(fIntensity < static_cast<const TGRSITransition*>(obj)->fIntensity)
+	return 1;
 
-   printf("%s: Error, intensity neither greater, nor equal, nor smaller than provided intensity!\n",
-          __PRETTY_FUNCTION__);
-   return -9;
+	printf("%s: Error, intensity neither greater, nor equal, nor smaller than provided intensity!\n",
+			__PRETTY_FUNCTION__);
+	return -9;
 }

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -10,186 +10,172 @@
 #include <TClass.h>
 #include <TGraph.h>
 
-//#include "ProgramPath.h"
-
-//#define debug
-
+/// \cond CLASSIMP
 ClassImp(TNucleus)
+/// \endcond
 
-   /////////////////////////////////////////////////////////////////
-   //
-   // TNucleus
-   //
-   // This class builds a nucleus and sets all the basic information
-   // (mass, Z, symbol, radius, etc.)
-   //
-   /////////////////////////////////////////////////////////////////
-
-   // const char *TNucleus::massfile = "/home/tiguser/packages/GRSISort/libraries/TGRSIAnalysis/SourceData/mass.dat";
-
-   static double amu = 931.494043;
-// static double MeV2Kg = 1.77777778e-30;
+static double amu = 931.494043;
 
 std::string& TNucleus::massfile()
 {
-   static std::string output = std::string(getenv("GRSISYS")) + "/libraries/TGRSIAnalysis/SourceData/mass.dat";
-   return output;
+	static std::string output = std::string(getenv("GRSISYS")) + "/libraries/TGRSIAnalysis/SourceData/mass.dat";
+	return output;
 }
 // const char *TNucleus::massfile = mfile.c_str();
 
 TNucleus::TNucleus(const char* name)
 {
-   // Creates a nucleus based on symbol (ex. 26Na OR Na26) and sets all parameters from mass.dat
-   std::string Name = name;
-   // fName=name;
-   // SetMassFile();
-   int           Number = 0;
-   std::string   symbol;
-   std::string   element;
-   int           first_digit, first_letter;
-   int           z, n;
-   std::string   sym_name;
-   double        mass;
-   bool          found = false;
-   std::string   line;
-   std::ifstream infile;
-   std::string   MassFile;
-   Name.erase(std::remove_if(Name.begin(), Name.end(), (int (*)(int))std::isspace), Name.end());
+	// Creates a nucleus based on symbol (ex. 26Na OR Na26) and sets all parameters from mass.dat
+	std::string Name = name;
+	// fName=name;
+	// SetMassFile();
+	int           Number = 0;
+	std::string   symbol;
+	std::string   element;
+	int           first_digit, first_letter;
+	int           z, n;
+	std::string   sym_name;
+	double        mass;
+	bool          found = false;
+	std::string   line;
+	std::ifstream infile;
+	std::string   MassFile;
+	Name.erase(std::remove_if(Name.begin(), Name.end(), (int (*)(int))std::isspace), Name.end());
 
-   if(Name.length() < 2) {
-      switch(Name[0]) {
-      case 'p':
-         Name.clear();
-         Name.assign("h1");
-         break;
-      case 'd':
-         Name.clear();
-         Name.assign("h2");
-         break;
-      case 't':
-         Name.clear();
-         Name.assign("h3");
-         break;
-      case 'a':
-         Name.clear();
-         Name.assign("he4");
-         break;
-      default: printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n"); return;
-      };
-   }
-   try {
-      first_digit  = Name.find_first_of("0123456789 \t\n\r");
-      first_letter = Name.find_first_not_of("0123456789 \t\n\r");
+	if(Name.length() < 2) {
+		switch(Name[0]) {
+			case 'p':
+				Name.clear();
+				Name.assign("h1");
+				break;
+			case 'd':
+				Name.clear();
+				Name.assign("h2");
+				break;
+			case 't':
+				Name.clear();
+				Name.assign("h3");
+				break;
+			case 'a':
+				Name.clear();
+				Name.assign("he4");
+				break;
+			default: printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n"); return;
+		};
+	}
+	try {
+		first_digit  = Name.find_first_of("0123456789 \t\n\r");
+		first_letter = Name.find_first_not_of("0123456789 \t\n\r");
 
-      if(first_digit > first_letter) {
-         Number = atoi(Name.substr(first_digit).c_str());
-         symbol.append(Name.substr(first_letter, first_digit - first_letter));
-      } else {
-         Number = atoi(Name.substr(first_digit, first_letter - first_digit).c_str());
-         symbol.append(Name.substr(first_letter));
-      }
-      element.append(std::to_string(static_cast<long long>(Number)));
-      element.append(symbol);
-      MassFile = massfile();
-      // MassFile.append(massfile);
-      infile.open(MassFile.c_str());
-      // printf("MassFile.c_str()
-      while(getline(infile, line) != nullptr) {
-         if(line.length() < 1) {
-            continue;
-         }
-         //              printf("%s\n",line.c_str());
-         std::stringstream ss(line);
-         ss >> n;
-         ss >> z;
-         ss >> sym_name;
-         ss >> mass;
-         if(strcasecmp(element.c_str(), sym_name.c_str()) == 0) {
-            found = true;
-            break;
-         }
-      }
-   } catch(std::out_of_range) {
-      std::cout<<"Could not parse element "<<name<<std::endl<<"Nucleus not Set!"<<std::endl;
-      return;
-   }
-   if(!found) {
-      printf("Warning: Element %s not found in the mass table %s.\n Nucleus not Set!\n", element.c_str(),
-             MassFile.c_str());
-      return;
-   }
-   infile.close();
-   SetZ(z);
-   SetN(n);
-   SetMassExcess(mass / 1000.0);
-   SetMass();
-   SetSymbol(symbol.c_str());
-   SetName();
-   // SetName(element.c_str());
-   // SetSourceData();
-   LoadTransitionFile();
+		if(first_digit > first_letter) {
+			Number = atoi(Name.substr(first_digit).c_str());
+			symbol.append(Name.substr(first_letter, first_digit - first_letter));
+		} else {
+			Number = atoi(Name.substr(first_digit, first_letter - first_digit).c_str());
+			symbol.append(Name.substr(first_letter));
+		}
+		element.append(std::to_string(static_cast<long long>(Number)));
+		element.append(symbol);
+		MassFile = massfile();
+		// MassFile.append(massfile);
+		infile.open(MassFile.c_str());
+		// printf("MassFile.c_str()
+		while(getline(infile, line) != nullptr) {
+			if(line.length() < 1) {
+				continue;
+			}
+			//              printf("%s\n",line.c_str());
+			std::stringstream ss(line);
+			ss >> n;
+			ss >> z;
+			ss >> sym_name;
+			ss >> mass;
+			if(strcasecmp(element.c_str(), sym_name.c_str()) == 0) {
+				found = true;
+				break;
+			}
+		}
+	} catch(std::out_of_range) {
+		std::cout<<"Could not parse element "<<name<<std::endl<<"Nucleus not Set!"<<std::endl;
+		return;
+	}
+	if(!found) {
+		printf("Warning: Element %s not found in the mass table %s.\n Nucleus not Set!\n", element.c_str(),
+				MassFile.c_str());
+		return;
+	}
+	infile.close();
+	SetZ(z);
+	SetN(n);
+	SetMassExcess(mass / 1000.0);
+	SetMass();
+	SetSymbol(symbol.c_str());
+	SetName();
+	// SetName(element.c_str());
+	// SetSourceData();
+	LoadTransitionFile();
 }
 /*
- */
+*/
 TNucleus::TNucleus(int charge, int neutrons, double mass, const char* symbol)
 {
-   // Creates a nucleus with Z, N, mass, and symbol
-   // SetMassFile();
-   fZ      = charge;
-   fN      = neutrons;
-   fSymbol = symbol;
-   fMass   = mass;
-   // SetName(symbol);
-   SetName();
-   LoadTransitionFile();
-   // SetSourceData();
+	// Creates a nucleus with Z, N, mass, and symbol
+	// SetMassFile();
+	fZ      = charge;
+	fN      = neutrons;
+	fSymbol = symbol;
+	fMass   = mass;
+	// SetName(symbol);
+	SetName();
+	LoadTransitionFile();
+	// SetSourceData();
 }
 
 TNucleus::TNucleus(int charge, int neutrons, const char* MassFile)
 {
-   // Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
-   // SetMassFile();
-   if(MassFile == nullptr) {
-      MassFile = massfile().c_str();
-   }
-   fZ              = charge;
-   fN              = neutrons;
-   int           i = 0, n, z;
-   double        emass;
-   char          tmp[256];
-   std::ifstream mass_file;
-   mass_file.open(MassFile, std::ios::in);
-   while(!mass_file.bad() && !mass_file.eof() && i < 3008) {
-      mass_file >> n;
-      mass_file >> z;
-      mass_file >> tmp;
-      mass_file >> emass;
-      if(n == fN && z == fZ) {
-         fMassExcess = emass / 1000.;
-         fSymbol     = tmp;
+	// Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
+	// SetMassFile();
+	if(MassFile == nullptr) {
+		MassFile = massfile().c_str();
+	}
+	fZ              = charge;
+	fN              = neutrons;
+	int           i = 0, n, z;
+	double        emass;
+	char          tmp[256];
+	std::ifstream mass_file;
+	mass_file.open(MassFile, std::ios::in);
+	while(!mass_file.bad() && !mass_file.eof() && i < 3008) {
+		mass_file >> n;
+		mass_file >> z;
+		mass_file >> tmp;
+		mass_file >> emass;
+		if(n == fN && z == fZ) {
+			fMassExcess = emass / 1000.;
+			fSymbol     = tmp;
 #ifdef debug
-         cout<<"Symbol "<<fSymbol<<" tmp "<<tmp<<endl;
+			cout<<"Symbol "<<fSymbol<<" tmp "<<tmp<<endl;
 #endif
-         SetMass();
-         SetSymbol(fSymbol.c_str());
-         break;
-      }
-      i++;
-      mass_file.ignore(256, '\n');
-   }
-   // max_elements=i;
+			SetMass();
+			SetSymbol(fSymbol.c_str());
+			break;
+		}
+		i++;
+		mass_file.ignore(256, '\n');
+	}
+	// max_elements=i;
 
-   mass_file.close();
-   std::string name   = fSymbol;
-   std::string number = name.substr(0, name.find_first_not_of("0123456789 "));
+	mass_file.close();
+	std::string name   = fSymbol;
+	std::string number = name.substr(0, name.find_first_not_of("0123456789 "));
 
-   name = name.substr(name.find_first_not_of("0123456789 "));
-   name.append(number);
-   // SetName(name.c_str());
+	name = name.substr(name.find_first_not_of("0123456789 "));
+	name.append(number);
+	// SetName(name.c_str());
 
-   SetName();
-   LoadTransitionFile();
-   // SetSourceData();
+	SetName();
+	LoadTransitionFile();
+	// SetSourceData();
 }
 
 // void TNucleus::SetA(int aval){
@@ -198,168 +184,168 @@ TNucleus::TNucleus(int charge, int neutrons, const char* MassFile)
 
 void TNucleus::SetName(const char*)
 {
-   std::string name = GetSymbol();
-   name.append(std::to_string(GetA()));
-   TNamed::SetName(name.c_str());
+	std::string name = GetSymbol();
+	name.append(std::to_string(GetA()));
+	TNamed::SetName(name.c_str());
 }
 
 TNucleus::~TNucleus()
 {
-   TransitionList.Delete();
+	TransitionList.Delete();
 }
 
 const char* TNucleus::SortName(const char* name)
 {
-   // Names a nucleus based on symbol (ex. 26Na OR Na26). This is to get a nice naming convention.
-   std::string Name = name;
-   // SetMassFile();
-   int         Number = 0;
-   std::string symbol;
-   std::string element;
-   Name.erase(std::remove_if(Name.begin(), Name.end(), (int (*)(int))std::isspace), Name.end());
+	// Names a nucleus based on symbol (ex. 26Na OR Na26). This is to get a nice naming convention.
+	std::string Name = name;
+	// SetMassFile();
+	int         Number = 0;
+	std::string symbol;
+	std::string element;
+	Name.erase(std::remove_if(Name.begin(), Name.end(), (int (*)(int))std::isspace), Name.end());
 
-   if(Name.length() < 2) {
-      switch(Name[0]) {
-      case 'p':
-         Name.clear();
-         Name.assign("h1");
-         break;
-      case 'd':
-         Name.clear();
-         Name.assign("h2");
-         break;
-      case 't':
-         Name.clear();
-         Name.assign("h3");
-         break;
-      case 'a':
-         Name.clear();
-         Name.assign("he4");
-         break;
-      default: printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n"); return nullptr;
-      };
-   }
-   int first_digit  = Name.find_first_of("0123456789 \t\n\r");
-   int first_letter = Name.find_first_not_of("0123456789 \t\n\r");
-   if(first_digit > first_letter) {
-      Number = atoi(Name.substr(first_digit).c_str());
-      symbol.append(Name.substr(first_letter, first_digit - first_letter));
-   } else {
-      Number = atoi(Name.substr(first_digit, first_letter - first_digit).c_str());
-      symbol.append(Name.substr(first_letter));
-   }
-   std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::tolower);
-   symbol[0] = toupper(symbol[0]);
-   element.append(std::to_string(static_cast<long long>(Number)));
-   element.append(symbol);
+	if(Name.length() < 2) {
+		switch(Name[0]) {
+			case 'p':
+				Name.clear();
+				Name.assign("h1");
+				break;
+			case 'd':
+				Name.clear();
+				Name.assign("h2");
+				break;
+			case 't':
+				Name.clear();
+				Name.assign("h3");
+				break;
+			case 'a':
+				Name.clear();
+				Name.assign("he4");
+				break;
+			default: printf("error, type numbersymbol, or symbolnumber, i.e. 30Mg oder Mg30\n"); return nullptr;
+		};
+	}
+	int first_digit  = Name.find_first_of("0123456789 \t\n\r");
+	int first_letter = Name.find_first_not_of("0123456789 \t\n\r");
+	if(first_digit > first_letter) {
+		Number = atoi(Name.substr(first_digit).c_str());
+		symbol.append(Name.substr(first_letter, first_digit - first_letter));
+	} else {
+		Number = atoi(Name.substr(first_digit, first_letter - first_digit).c_str());
+		symbol.append(Name.substr(first_letter));
+	}
+	std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::tolower);
+	symbol[0] = toupper(symbol[0]);
+	element.append(std::to_string(static_cast<long long>(Number)));
+	element.append(symbol);
 
-   return element.c_str();
+	return element.c_str();
 }
 
 void TNucleus::SetZ(int charge)
 {
-   // Sets the Z (# of protons) of the nucleus
-   fZ = charge;
+	// Sets the Z (# of protons) of the nucleus
+	fZ = charge;
 }
 void TNucleus::SetN(int neutrons)
 {
-   // Sets the N (# of neutrons) of the nucleus
-   fN = neutrons;
+	// Sets the N (# of neutrons) of the nucleus
+	fN = neutrons;
 }
 void TNucleus::SetMassExcess(double mass_ex)
 {
-   // Sets the mass excess of the nucleus (in MeV)
-   fMassExcess = mass_ex;
+	// Sets the mass excess of the nucleus (in MeV)
+	fMassExcess = mass_ex;
 }
 
 void TNucleus::SetMass(double mass)
 {
-   // Sets the mass manually (in MeV)
-   fMass = mass;
+	// Sets the mass manually (in MeV)
+	fMass = mass;
 }
 
 void TNucleus::SetMass()
 {
-   // Sets the mass based on the A and mass excess of nucleus (in MeV)
-   fMass = amu * GetA() + GetMassExcess();
+	// Sets the mass based on the A and mass excess of nucleus (in MeV)
+	fMass = amu * GetA() + GetMassExcess();
 }
 
 void TNucleus::SetSymbol(const char* symbol)
 {
-   // Sets the atomic symbol for the nucleus
-   fSymbol = symbol;
+	// Sets the atomic symbol for the nucleus
+	fSymbol = symbol;
 }
 
 int TNucleus::GetZfromSymbol(char* symbol)
 {
-   // Figures out the Z of the nucleus based on the atomic symbol
-   char symbols[105][3] = {"H",  "HE", "LI", "BE", "B",  "C",  "N",  "O",  "F",  "NE", "NA", "MG", "AL", "SI", "P",
-                           "S",  "CL", "AR", "K",  "CA", "SC", "TI", "V",  "CR", "MN", "FE", "CO", "NI", "CU", "ZN",
-                           "GA", "GE", "AS", "SE", "BR", "KR", "RB", "SR", "Y",  "ZR", "NB", "MO", "TC", "RU", "RH",
-                           "PD", "AG", "CD", "IN", "SN", "SB", "TE", "F",  "XE", "CS", "BA", "LA", "CE", "PR", "ND",
-                           "PM", "SM", "EU", "GD", "TB", "DY", "HO", "ER", "TM", "YB", "LU", "HF", "TA", "W",  "RE",
-                           "OS", "IR", "PT", "AU", "HG", "TI", "PB", "BI", "PO", "AT", "RN", "FR", "RA", "AC", "TH",
-                           "PA", "U",  "NP", "PU", "AM", "CM", "BK", "CF", "ES", "FM", "MD", "NO", "LR", "RF", "HA"};
-   int length = strlen(symbol);
-   // cout<<symbol<<"   "<<length<<endl;
-   auto* search = new char[length + 1];
-   for(int i = 0; i < length; i++) {
-      search[i] = toupper(symbol[i]); // make sure symbol is in uppercase
-   }
-   search[length] = '\0';
-   for(int i = 0; i < 105; i++) {
-      if(strcmp(search, symbols[i]) == 0) {
-         delete[] search;
-         SetZ(i + 1);
-         return i + 1;
-      }
-   }
+	// Figures out the Z of the nucleus based on the atomic symbol
+	char symbols[105][3] = {"H",  "HE", "LI", "BE", "B",  "C",  "N",  "O",  "F",  "NE", "NA", "MG", "AL", "SI", "P",
+		"S",  "CL", "AR", "K",  "CA", "SC", "TI", "V",  "CR", "MN", "FE", "CO", "NI", "CU", "ZN",
+		"GA", "GE", "AS", "SE", "BR", "KR", "RB", "SR", "Y",  "ZR", "NB", "MO", "TC", "RU", "RH",
+		"PD", "AG", "CD", "IN", "SN", "SB", "TE", "F",  "XE", "CS", "BA", "LA", "CE", "PR", "ND",
+		"PM", "SM", "EU", "GD", "TB", "DY", "HO", "ER", "TM", "YB", "LU", "HF", "TA", "W",  "RE",
+		"OS", "IR", "PT", "AU", "HG", "TI", "PB", "BI", "PO", "AT", "RN", "FR", "RA", "AC", "TH",
+		"PA", "U",  "NP", "PU", "AM", "CM", "BK", "CF", "ES", "FM", "MD", "NO", "LR", "RF", "HA"};
+	int length = strlen(symbol);
+	// cout<<symbol<<"   "<<length<<endl;
+	auto* search = new char[length + 1];
+	for(int i = 0; i < length; i++) {
+		search[i] = toupper(symbol[i]); // make sure symbol is in uppercase
+	}
+	search[length] = '\0';
+	for(int i = 0; i < 105; i++) {
+		if(strcmp(search, symbols[i]) == 0) {
+			delete[] search;
+			SetZ(i + 1);
+			return i + 1;
+		}
+	}
 
-   delete[] search;
-   SetZ(0);
-   return 0;
+	delete[] search;
+	SetZ(0);
+	return 0;
 }
 
 double TNucleus::GetRadius() const
 {
-   // Gets the radius of the nucleus (in fm).
-   // The radius is calculated using 1.12*A^1/3 - 0.94*A^-1/3
-   return 1.12 * pow(GetA(), 1. / 3.) - 0.94 * pow(GetA(), -1. / 3.);
+	// Gets the radius of the nucleus (in fm).
+	// The radius is calculated using 1.12*A^1/3 - 0.94*A^-1/3
+	return 1.12 * pow(GetA(), 1. / 3.) - 0.94 * pow(GetA(), -1. / 3.);
 }
 
 /*
-   bool TNucleus::SetSourceData() {
+	bool TNucleus::SetSourceData() {
 
-   std::string name = GetSymbol();
-   if(name.length()==0)
-   return false;
+	std::string name = GetSymbol();
+	if(name.length()==0)
+	return false;
 
-   if(name[0]<='Z' && name[0]>='A')
-   name[0] = name[0]-'A'+'a';
-   name = name + Form("%i",GetA()) + ".sou";
-   std::string path = getenv("GRSISYS");
-   path +=  "/libraries/TGRSIAnalysis/SourceData/";
-   path +=  name;
+	if(name[0]<='Z' && name[0]>='A')
+	name[0] = name[0]-'A'+'a';
+	name = name + Form("%i",GetA()) + ".sou";
+	std::string path = getenv("GRSISYS");
+	path +=  "/libraries/TGRSIAnalysis/SourceData/";
+	path +=  name;
 
-   printf("path = %s\n",path.c_str());
-   std::ifstream sourcefile;
-   sourcefile.open(path.c_str());
-   if(!sourcefile.is_open()) {
-   printf("unable to set source data for %s.\n",GetName());
-   return false;
-   }
+	printf("path = %s\n",path.c_str());
+	std::ifstream sourcefile;
+	sourcefile.open(path.c_str());
+	if(!sourcefile.is_open()) {
+	printf("unable to set source data for %s.\n",GetName());
+	return false;
+	}
 
-   TransitionList.Clear();
+	TransitionList.Clear();
 
-   std::string line;
-   int linenumber = 0;
-   while(getline(sourcefile,line)) {
-   linenumber++;
-   int comment = line.find("//");
-   if (comment != std::string::npos)
-   line = line.substr(0, comment);
-   if(line.length()==0)
-   continue;
+	std::string line;
+	int linenumber = 0;
+	while(getline(sourcefile,line)) {
+	linenumber++;
+	int comment = line.find("//");
+	if (comment != std::string::npos)
+	line = line.substr(0, comment);
+	if(line.length()==0)
+	continue;
 //TGRSITransition *tran = new TGRSITransition;
 //std::stringstream ss(line);
 //ss >> tran->fenergy;
@@ -374,167 +360,167 @@ double TNucleus::GetRadius() const
 printf("Found %d Transitions for %s\n",TransitionList.GetSize(),GetName());
 return true;
 
-  TransitionList.Clear();
+TransitionList.Clear();
 
-  std::string line;
-  int linenumber = 0;
-  while(getline(sourcefile,line)) {
-  linenumber++;
-  int comment = line.find("//");
-  if (comment != std::string::npos)
-  line = line.substr(0, comment);
-  if(line.length()==0)
-  continue;
-  //TGRSITransition *tran = new TGRSITransition;
-  //std::stringstream ss(line);
-  //ss >> tran->fenergy;
-  //ss >> tran->fenergy_uncertainty;
-  //ss >> tran->fintensity;
-  //ss >> tran->fintensity_uncertainty;
-  //TransitionList.Add(tran);
-  //  printf("eng: %.02f\tinten:
+std::string line;
+int linenumber = 0;
+while(getline(sourcefile,line)) {
+linenumber++;
+int comment = line.find("//");
+if (comment != std::string::npos)
+line = line.substr(0, comment);
+if(line.length()==0)
+continue;
+//TGRSITransition *tran = new TGRSITransition;
+//std::stringstream ss(line);
+//ss >> tran->fenergy;
+//ss >> tran->fenergy_uncertainty;
+//ss >> tran->fintensity;
+//ss >> tran->fintensity_uncertainty;
+//TransitionList.Add(tran);
+//  printf("eng: %.02f\tinten:
 %.02f\n",((TGRSITransition*)TransitionList.Last())->fenergy,((TGRSITransition*)TransitionList.Last())->fintensity);
-  }
+}
 
-  printf("Found %d Transitions for %s\n",TransitionList.GetSize(),GetName());
-  return true;
+printf("Found %d Transitions for %s\n",TransitionList.GetSize(),GetName());
+return true;
 
-  }
+}
 */
 
 void TNucleus::AddTransition(Double_t energy, Double_t intensity, Double_t energy_uncertainty,
-                             Double_t intensity_uncertainty)
+		Double_t intensity_uncertainty)
 {
-   auto* tran = new TTransition();
-   tran->SetEnergy(energy);
-   tran->SetEnergyUncertainty(energy_uncertainty);
-   tran->SetIntensity(intensity);
-   tran->SetIntensityUncertainty(intensity_uncertainty);
+	auto* tran = new TTransition();
+	tran->SetEnergy(energy);
+	tran->SetEnergyUncertainty(energy_uncertainty);
+	tran->SetIntensity(intensity);
+	tran->SetIntensityUncertainty(intensity_uncertainty);
 
-   AddTransition(tran);
+	AddTransition(tran);
 }
 
 void TNucleus::AddTransition(TTransition* tran)
 {
-   TransitionList.Add(tran);
+	TransitionList.Add(tran);
 }
 /*
-   Bool_t TNucleus::RemoveTransition(Int_t idx){
-   TGRSITransition *tran;
-   tran = (TGRSITransition*)TransitionList.RemoveAt(idx);
-   if(tran){
-   printf("Removed transition: ");
-   printf("%d\t eng: %.02f\tinten: %.02f\n",idx,tran->fenergy,tran->fintensity);
-   delete tran;
-   return true;
-   }
-   else{
-   printf("Out of range\n");
-   return false;
-   }
-   }
-*/
+	Bool_t TNucleus::RemoveTransition(Int_t idx){
+	TGRSITransition *tran;
+	tran = (TGRSITransition*)TransitionList.RemoveAt(idx);
+	if(tran){
+	printf("Removed transition: ");
+	printf("%d\t eng: %.02f\tinten: %.02f\n",idx,tran->fenergy,tran->fintensity);
+	delete tran;
+	return true;
+	}
+	else{
+	printf("Out of range\n");
+	return false;
+	}
+	}
+	*/
 
 TTransition* TNucleus::GetTransition(Int_t idx)
 {
-   TTransition* tran = static_cast<TTransition*>(TransitionList.At(idx));
-   if(tran == nullptr) {
-      printf("Out of Range\n");
-   }
+	TTransition* tran = static_cast<TTransition*>(TransitionList.At(idx));
+	if(tran == nullptr) {
+		printf("Out of Range\n");
+	}
 
-   return tran;
+	return tran;
 }
 
 void TNucleus::Print(Option_t*) const
 {
-   // Prints out the Name of the nucleus, as well as the numerated transition list
-   printf("Nucleus: %s\n", GetName());
-   TIter next(&TransitionList);
-   int   counter = 0;
-   while(TTransition* tran = static_cast<TTransition*>(next())) {
-      printf("\t%i\t", counter++);
-      tran->Print();
-   }
+	// Prints out the Name of the nucleus, as well as the numerated transition list
+	printf("Nucleus: %s\n", GetName());
+	TIter next(&TransitionList);
+	int   counter = 0;
+	while(TTransition* tran = static_cast<TTransition*>(next())) {
+		printf("\t%i\t", counter++);
+		tran->Print();
+	}
 }
 
 void TNucleus::WriteSourceFile(const std::string& outfilename)
 {
-   if(outfilename.length() > 0) {
-      std::ofstream sourceout;
-      sourceout.open(outfilename.c_str());
-      for(int i = 0; i < TransitionList.GetSize(); i++) {
-         std::string transtr = (static_cast<TTransition*>(TransitionList.At(i)))->PrintToString();
-         sourceout<<transtr.c_str();
-         sourceout<<std::endl;
-      }
-      sourceout<<std::endl;
-      sourceout.close();
-   }
+	if(outfilename.length() > 0) {
+		std::ofstream sourceout;
+		sourceout.open(outfilename.c_str());
+		for(int i = 0; i < TransitionList.GetSize(); i++) {
+			std::string transtr = (static_cast<TTransition*>(TransitionList.At(i)))->PrintToString();
+			sourceout<<transtr.c_str();
+			sourceout<<std::endl;
+		}
+		sourceout<<std::endl;
+		sourceout.close();
+	}
 }
 
 bool TNucleus::LoadTransitionFile()
 {
-   if(TransitionList.GetSize() != 0) {
-      return false;
-   }
-   std::string filename;
-   filename           = std::string(getenv("GRSISYS")) + "/libraries/TGRSIAnalysis/SourceData/";
-   std::string symbol = GetSymbol();
-   std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::tolower);
-   filename.append(symbol);
-   filename.append(std::to_string(GetA()));
-   filename.append(".sou");
-   std::ifstream transfile;
-   transfile.open(filename.c_str());
-   if(!transfile.is_open()) {
-      printf("failed to open source file: %s\n", filename.c_str());
-      return false;
-   }
-   // printf("found %s\n",filename.c_str());
+	if(TransitionList.GetSize() != 0) {
+		return false;
+	}
+	std::string filename;
+	filename           = std::string(getenv("GRSISYS")) + "/libraries/TGRSIAnalysis/SourceData/";
+	std::string symbol = GetSymbol();
+	std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::tolower);
+	filename.append(symbol);
+	filename.append(std::to_string(GetA()));
+	filename.append(".sou");
+	std::ifstream transfile;
+	transfile.open(filename.c_str());
+	if(!transfile.is_open()) {
+		printf("failed to open source file: %s\n", filename.c_str());
+		return false;
+	}
+	// printf("found %s\n",filename.c_str());
 
-   std::string line;
+	std::string line;
 
-   while(getline(transfile, line) != nullptr) {
-      // printf("%i\t%s\n",counter++,line.c_str());
-      if(line.compare(0, 2, "//") == 0) {
-         continue;
-      }
-      if(line.compare(0, 1, "#") == 0) {
-         continue;
-      }
-      double            temp;
-      auto*             tran = new TTransition;
-      std::stringstream ss(line);
-      int               counter = 0;
-      while((ss >> temp) != nullptr) {
-         counter++;
-         if(counter == 1) {
-            tran->SetEnergy(temp);
-         } else if(counter == 2) {
-            tran->SetEnergyUncertainty(temp);
-         } else if(counter == 3) {
-            tran->SetIntensity(temp);
-         } else if(counter == 4) {
-            tran->SetIntensityUncertainty(temp);
-         } else {
-            break;
-         }
-      }
-      AddTransition(tran);
-   }
+	while(getline(transfile, line) != nullptr) {
+		// printf("%i\t%s\n",counter++,line.c_str());
+		if(line.compare(0, 2, "//") == 0) {
+			continue;
+		}
+		if(line.compare(0, 1, "#") == 0) {
+			continue;
+		}
+		double            temp;
+		auto*             tran = new TTransition;
+		std::stringstream ss(line);
+		int               counter = 0;
+		while((ss >> temp) != nullptr) {
+			counter++;
+			if(counter == 1) {
+				tran->SetEnergy(temp);
+			} else if(counter == 2) {
+				tran->SetEnergyUncertainty(temp);
+			} else if(counter == 3) {
+				tran->SetIntensity(temp);
+			} else if(counter == 4) {
+				tran->SetIntensityUncertainty(temp);
+			} else {
+				break;
+			}
+		}
+		AddTransition(tran);
+	}
 
-   return true;
+	return true;
 }
 
 double TNucleus::GetEnergyFromBeta(double beta)
 {
-   double gamma = 1 / std::sqrt(1 - beta * beta);
-   return fMass * (gamma - 1);
+	double gamma = 1 / std::sqrt(1 - beta * beta);
+	return fMass * (gamma - 1);
 }
 
 double TNucleus::GetBetaFromEnergy(double energy_MeV)
 {
-   double gamma = energy_MeV / fMass + 1;
-   double beta  = std::sqrt(1 - 1 / (gamma * gamma));
-   return beta;
+	double gamma = energy_MeV / fMass + 1;
+	double beta  = std::sqrt(1 - 1 / (gamma * gamma));
+	return beta;
 }

--- a/libraries/TGRSIAnalysis/TNucleus/TTransition.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TTransition.cxx
@@ -1,83 +1,85 @@
 #include "TTransition.h"
 
+/// \cond CLASSIMP
 ClassImp(TTransition)
+/// \endcond
 
-   TTransition::TTransition()
+TTransition::TTransition()
 {
-   Clear();
+	Clear();
 }
 
 TTransition::~TTransition()
 {
-   // empty
+	// empty
 }
 
 void TTransition::Clear(Option_t*)
 {
-   fEnergy         = 0;
-   fEngUncertainty = 0;
-   fIntensity      = 0;
-   fIntUncertainty = 0;
+	fEnergy         = 0;
+	fEngUncertainty = 0;
+	fIntensity      = 0;
+	fIntUncertainty = 0;
 }
 
 void TTransition::Print(Option_t*) const
 {
 
-   if(!std::isnan(fEngUncertainty)) {
-      printf("Energy:    %.02f +/- %.02f", fEnergy, fEngUncertainty);
-   } else {
-      printf("Energy:    %.02f ", fEnergy);
-   }
-   if(!std::isnan(fIntensity)) {
-      if(!std::isnan(fIntUncertainty)) {
-         printf("\tIntensity: %.02f +/- %.02f\n", fIntensity, fIntUncertainty);
-      } else {
-         printf("\tIntensity: %.02f \n", fEnergy);
-      }
-   } else {
-      printf("\n");
-   }
+	if(!std::isnan(fEngUncertainty)) {
+		printf("Energy:    %.02f +/- %.02f", fEnergy, fEngUncertainty);
+	} else {
+		printf("Energy:    %.02f ", fEnergy);
+	}
+	if(!std::isnan(fIntensity)) {
+		if(!std::isnan(fIntUncertainty)) {
+			printf("\tIntensity: %.02f +/- %.02f\n", fIntensity, fIntUncertainty);
+		} else {
+			printf("\tIntensity: %.02f \n", fEnergy);
+		}
+	} else {
+		printf("\n");
+	}
 
-   // printf("**************************\n");
+	// printf("**************************\n");
 }
 
 std::string TTransition::PrintToString()
 {
-   std::string toString;
-   toString.append(Form("%f\t", fEnergy));
-   toString.append(Form("%f\t", fEngUncertainty));
-   toString.append(Form("%f\t", fIntensity));
-   toString.append(Form("%f\t", fIntUncertainty));
+	std::string toString;
+	toString.append(Form("%f\t", fEnergy));
+	toString.append(Form("%f\t", fEngUncertainty));
+	toString.append(Form("%f\t", fIntensity));
+	toString.append(Form("%f\t", fIntUncertainty));
 
-   return toString;
+	return toString;
 }
 
 int TTransition::CompareIntensity(const TObject* obj) const
 {
-   if(fIntensity > static_cast<const TTransition*>(obj)->fIntensity) {
-      return -1;
-   }
-   if(fIntensity == static_cast<const TTransition*>(obj)->fIntensity) {
-      return 0;
-   }
-   return 1;
+	if(fIntensity > static_cast<const TTransition*>(obj)->fIntensity) {
+		return -1;
+	}
+	if(fIntensity == static_cast<const TTransition*>(obj)->fIntensity) {
+		return 0;
+	}
+	return 1;
 
-   return -9;
+	return -9;
 }
 
 int TTransition::Compare(const TObject* obj) const
 {
 
-   return CompareIntensity(obj);
+	return CompareIntensity(obj);
 
-   // Compares the intensities of the TTransitions and returns
-   if(fEnergy > static_cast<const TTransition*>(obj)->fEnergy) {
-      return -1;
-   }
-   if(fEnergy == static_cast<const TTransition*>(obj)->fEnergy) {
-      return 0;
-   }
-   return 1;
+	// Compares the intensities of the TTransitions and returns
+	if(fEnergy > static_cast<const TTransition*>(obj)->fEnergy) {
+		return -1;
+	}
+	if(fEnergy == static_cast<const TTransition*>(obj)->fEnergy) {
+		return 0;
+	}
+	return 1;
 
-   return -9;
+	return -9;
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -14,85 +14,85 @@
 
 /// \cond CLASSIMP
 ClassImp(TPaces)
-   /// \endcond
+/// \endcond
 
-   bool TPaces::fSetCoreWave = false;
+bool TPaces::fSetCoreWave = false;
 
 TPaces::TPaces() : TGRSIDetector()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TPaces::TPaces(const TPaces& rhs) : TGRSIDetector()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TPaces::Copy(TObject& rhs) const
 {
-   TGRSIDetector::Copy(rhs);
+	TGRSIDetector::Copy(rhs);
 
-   static_cast<TPaces&>(rhs).fPacesHits   = fPacesHits;
-   static_cast<TPaces&>(rhs).fSetCoreWave = fSetCoreWave;
+	static_cast<TPaces&>(rhs).fPacesHits   = fPacesHits;
+	static_cast<TPaces&>(rhs).fSetCoreWave = fSetCoreWave;
 }
 
 TPaces::~TPaces()
 {
-   // Default Destructor
+	// Default Destructor
 }
 
 void TPaces::Clear(Option_t* opt)
 {
-   // Clears the mother, all of the hits
-   if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
-      TGRSIDetector::Clear(opt);
-   }
-   fPacesHits.clear();
+	// Clears the mother, all of the hits
+	if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
+		TGRSIDetector::Clear(opt);
+	}
+	fPacesHits.clear();
 }
 
 void TPaces::Print(Option_t*) const
 {
-   // Prints out TPaces members, currently does nothing.
-   printf("%lu fPacesHits\n", fPacesHits.size());
+	// Prints out TPaces members, currently does nothing.
+	printf("%lu fPacesHits\n", fPacesHits.size());
 }
 
 TPaces& TPaces::operator=(const TPaces& rhs)
 {
-   rhs.Copy(*this);
-   return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
 void TPaces::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-   TPacesHit hit(*frag);
-   fPacesHits.push_back(std::move(hit));
+	TPacesHit hit(*frag);
+	fPacesHits.push_back(std::move(hit));
 }
 
 TGRSIDetectorHit* TPaces::GetHit(const Int_t& idx)
 {
-   return GetPacesHit(idx);
+	return GetPacesHit(idx);
 }
 
 TPacesHit* TPaces::GetPacesHit(const int& i)
 {
-   try {
-      return &fPacesHits.at(i);
-   } catch(const std::out_of_range& oor) {
-      std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
-      throw grsi::exit_exception(1);
-   }
-   return nullptr;
+	try {
+		return &fPacesHits.at(i);
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+		throw grsi::exit_exception(1);
+	}
+	return nullptr;
 }
 
 TVector3 TPaces::GetPosition(int)
 {
-   // Gets the position vector for a crystal specified by DetNbr
-   // Does not currently contain any positons.
-   return TVector3(0, 0, 1);
+	// Gets the position vector for a crystal specified by DetNbr
+	// Does not currently contain any positons.
+	return TVector3(0, 0, 1);
 }

--- a/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPacesHit.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TPacesHit)
-   /// \endcond
+/// \endcond
 
-   TPacesHit::TPacesHit()
+TPacesHit::TPacesHit()
    : TGRSIDetectorHit()
 {
 #if MAJOR_ROOT_VERSION < 6

--- a/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TGRSIAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -4,9 +4,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TPulseAnalyzer)
-   /// \endcond
+/// \endcond
 
-   TPulseAnalyzer::TPulseAnalyzer()
+TPulseAnalyzer::TPulseAnalyzer()
    : cWpar(nullptr), spar(nullptr), shpar(nullptr)
 {
    Clear();

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -8,9 +8,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TS3)
-   /// \endcond
+/// \endcond
 
-   int TS3::fRingNumber = 24;
+int TS3::fRingNumber = 24;
 int TS3::fSectorNumber  = 32;
 
 double TS3::fOffsetPhiCon = 0.5 * TMath::Pi(); // Offset between connector and sector 0 (viewed from sector side)

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -3,9 +3,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TS3Hit)
-   /// \endcond
+/// \endcond
 
-   TS3Hit::TS3Hit()
+TS3Hit::TS3Hit()
 {
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
+++ b/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
@@ -14,9 +14,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TSRIM)
-   /// \endcond
+/// \endcond
 
-   const double TSRIM::dx = 1.0; // um [sets accuracy of energy loss E vs X functions]
+const double TSRIM::dx = 1.0; // um [sets accuracy of energy loss E vs X functions]
 
 TSRIM::TSRIM()
 {

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptar.cxx
@@ -5,108 +5,108 @@
 
 /// \cond CLASSIMP
 ClassImp(TSceptar)
-   /// \endcond
+/// \endcond
 
-   bool TSceptar::fSetWave = false;
+bool TSceptar::fSetWave = false;
 
 TVector3 TSceptar::gPaddlePosition[21] = {
-   // Sceptar positions from Evan; Thanks Evan.
-   TVector3(0, 0, 1),
-   TVector3(14.3025, 4.6472, 22.8096),
-   TVector3(0, 15.0386, 22.8096),
-   TVector3(-14.3025, 4.6472, 22.8096),
-   TVector3(-8.8395, -12.1665, 22.8096),
-   TVector3(8.8395, -12.1665, 22.8096),
-   TVector3(19.7051, 6.4026, 6.2123),
-   TVector3(0, 20.7192, 6.2123),
-   TVector3(-19.7051, 6.4026, 6.2123),
-   TVector3(-12.1784, -16.7622, 6.2123),
-   TVector3(12.1784, -16.7622, 6.2123),
-   TVector3(19.7051, 6.4026, -6.2123),
-   TVector3(0, 20.7192, -6.2123),
-   TVector3(-19.7051, 6.4026, -6.2123),
-   TVector3(-12.1784, -16.7622, -6.2123),
-   TVector3(12.1784, -16.7622, -6.2123),
-   TVector3(14.3025, 4.6472, -22.8096),
-   TVector3(0, 15.0386, -22.8096),
-   TVector3(-14.3025, 4.6472, -22.8096),
-   TVector3(-8.8395, -12.1665, -22.8096),
-   TVector3(8.8395, -12.1665, -22.8096)};
+	// Sceptar positions from Evan; Thanks Evan.
+	TVector3(0, 0, 1),
+	TVector3(14.3025, 4.6472, 22.8096),
+	TVector3(0, 15.0386, 22.8096),
+	TVector3(-14.3025, 4.6472, 22.8096),
+	TVector3(-8.8395, -12.1665, 22.8096),
+	TVector3(8.8395, -12.1665, 22.8096),
+	TVector3(19.7051, 6.4026, 6.2123),
+	TVector3(0, 20.7192, 6.2123),
+	TVector3(-19.7051, 6.4026, 6.2123),
+	TVector3(-12.1784, -16.7622, 6.2123),
+	TVector3(12.1784, -16.7622, 6.2123),
+	TVector3(19.7051, 6.4026, -6.2123),
+	TVector3(0, 20.7192, -6.2123),
+	TVector3(-19.7051, 6.4026, -6.2123),
+	TVector3(-12.1784, -16.7622, -6.2123),
+	TVector3(12.1784, -16.7622, -6.2123),
+	TVector3(14.3025, 4.6472, -22.8096),
+	TVector3(0, 15.0386, -22.8096),
+	TVector3(-14.3025, 4.6472, -22.8096),
+	TVector3(-8.8395, -12.1665, -22.8096),
+	TVector3(8.8395, -12.1665, -22.8096)};
 
 TSceptar::TSceptar()
 {
-// Default Constructor
+	// Default Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   // Class()->AddRule("TSceptar sceptar_hits attributes=NotOwner");
-   // Class()->AddRule("TSceptar sceptardata attributes=NotOwner");
-   Clear();
+	// Class()->AddRule("TSceptar sceptar_hits attributes=NotOwner");
+	// Class()->AddRule("TSceptar sceptardata attributes=NotOwner");
+	Clear();
 }
 
 TSceptar::~TSceptar()
 {
-   // Default Destructor
+	// Default Destructor
 }
 
 TSceptar::TSceptar(const TSceptar& rhs) : TGRSIDetector()
 {
-// Copy Contructor
+	// Copy Contructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TSceptar::Clear(Option_t* opt)
 {
-   // Clears all of the hits
-   // The Option "all" clears the base class.
-   // if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
-   TGRSIDetector::Clear(opt);
-   //}
-   fSceptarHits.clear();
+	// Clears all of the hits
+	// The Option "all" clears the base class.
+	// if(TString(opt).Contains("all",TString::ECaseCompare::kIgnoreCase)) {
+	TGRSIDetector::Clear(opt);
+	//}
+	fSceptarHits.clear();
 }
 
 void TSceptar::Copy(TObject& rhs) const
 {
-   // Copies a TSceptar
-   TGRSIDetector::Copy(rhs);
+	// Copies a TSceptar
+	TGRSIDetector::Copy(rhs);
 
-   static_cast<TSceptar&>(rhs).fSceptarHits = fSceptarHits;
+	static_cast<TSceptar&>(rhs).fSceptarHits = fSceptarHits;
 }
 
 TSceptar& TSceptar::operator=(const TSceptar& rhs)
 {
-   rhs.Copy(*this);
-   return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
 void TSceptar::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-   TSceptarHit scHit(*frag);                 // Construction of TSceptarHit is handled in the constructor
-   fSceptarHits.push_back(std::move(scHit)); // Can't use scHit outside of vector after using std::move
+	TSceptarHit scHit(*frag);                 // Construction of TSceptarHit is handled in the constructor
+	fSceptarHits.push_back(std::move(scHit)); // Can't use scHit outside of vector after using std::move
 }
 
 void TSceptar::Print(Option_t*) const
 {
-   // Prints out TSceptar Multiplicity, currently does little.
-   printf("%lu fSceptarHits\n", fSceptarHits.size());
+	// Prints out TSceptar Multiplicity, currently does little.
+	printf("%lu fSceptarHits\n", fSceptarHits.size());
 }
 
 TGRSIDetectorHit* TSceptar::GetHit(const Int_t& idx)
 {
-   // Gets the TSceptarHit at index idx.
-   return GetSceptarHit(idx);
+	// Gets the TSceptarHit at index idx.
+	return GetSceptarHit(idx);
 }
 
 TSceptarHit* TSceptar::GetSceptarHit(const int& i)
 {
-   try {
-      return &fSceptarHits.at(i);
-   } catch(const std::out_of_range& oor) {
-      std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
-      throw grsi::exit_exception(1);
-   }
-   return nullptr;
+	try {
+		return &fSceptarHits.at(i);
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+		throw grsi::exit_exception(1);
+	}
+	return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
+++ b/libraries/TGRSIAnalysis/TSceptar/TSceptarHit.cxx
@@ -10,270 +10,270 @@
 
 /// \cond CLASSIMP
 ClassImp(TSceptarHit)
-   /// \endcond
+/// \endcond
 
-   TSceptarHit::TSceptarHit()
+TSceptarHit::TSceptarHit()
 {
-// Default Constructor
+	// Default Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TSceptarHit::~TSceptarHit() = default;
 
 TSceptarHit::TSceptarHit(const TSceptarHit& rhs) : TGRSIDetectorHit()
 {
-// Copy Constructor
+	// Copy Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
-   rhs.Copy(*this);
+	Clear();
+	rhs.Copy(*this);
 }
 
 TSceptarHit::TSceptarHit(const TFragment& frag) : TGRSIDetectorHit(frag)
 {
-   if(TSceptar::SetWave()) {
-      if(frag.GetWaveform()->empty()) {
-         printf("Warning, TSceptar::SetWave() set, but data waveform size is zero!\n");
-      }
-      if(false) {
-         std::vector<Short_t> x;
-         // Need to reorder waveform data for S1507 data from December 2014
-         // All pairs of samples are swapped.
-         // The first two samples are also delayed by 8.
-         // We choose to throw out the first 2 samples (junk) and the last 6 samples (convience)
-         x              = *(frag.GetWaveform());
-         size_t  length = x.size() - (x.size() % 8);
-         Short_t temp;
+	if(TSceptar::SetWave()) {
+		if(frag.GetWaveform()->empty()) {
+			printf("Warning, TSceptar::SetWave() set, but data waveform size is zero!\n");
+		}
+		if(false) {
+			std::vector<Short_t> x;
+			// Need to reorder waveform data for S1507 data from December 2014
+			// All pairs of samples are swapped.
+			// The first two samples are also delayed by 8.
+			// We choose to throw out the first 2 samples (junk) and the last 6 samples (convience)
+			x              = *(frag.GetWaveform());
+			size_t  length = x.size() - (x.size() % 8);
+			Short_t temp;
 
-         if(length > 8) {
-            for(size_t i = 0; i < length - 8; i += 8) {
-               x[i]     = x[i + 9];
-               x[i + 1] = x[i + 8];
-               temp     = x[i + 2];
-               x[i + 2] = x[i + 3];
-               x[i + 3] = temp;
-               temp     = x[i + 4];
-               x[i + 4] = x[i + 5];
-               x[i + 5] = temp;
-               temp     = x[i + 6];
-               x[i + 6] = x[i + 7];
-               x[i + 7] = temp;
-            }
-            x.resize(length - 8);
-         }
-         SetWaveform(x);
-      } else {
-         frag.CopyWave(*this);
-      }
-      if(!GetWaveform()->empty()) {
-         //            printf("Analyzing waveform, current cfd = %d\n",dethit.GetCfd());
-         AnalyzeWaveform();
-         //            printf("%s analyzed waveform, cfd = %d\n",analyzed ?
-         //            "successfully":"unsuccessfully",dethit.GetCfd());
-      }
-   }
+			if(length > 8) {
+				for(size_t i = 0; i < length - 8; i += 8) {
+					x[i]     = x[i + 9];
+					x[i + 1] = x[i + 8];
+					temp     = x[i + 2];
+					x[i + 2] = x[i + 3];
+					x[i + 3] = temp;
+					temp     = x[i + 4];
+					x[i + 4] = x[i + 5];
+					x[i + 5] = temp;
+					temp     = x[i + 6];
+					x[i + 6] = x[i + 7];
+					x[i + 7] = temp;
+				}
+				x.resize(length - 8);
+			}
+			SetWaveform(x);
+		} else {
+			frag.CopyWave(*this);
+		}
+		if(!GetWaveform()->empty()) {
+			//            printf("Analyzing waveform, current cfd = %d\n",dethit.GetCfd());
+			AnalyzeWaveform();
+			//            printf("%s analyzed waveform, cfd = %d\n",analyzed ?
+			//            "successfully":"unsuccessfully",dethit.GetCfd());
+		}
+	}
 }
 
 void TSceptarHit::Copy(TObject& rhs) const
 {
-   // Copies a TSceptarHit
-   TGRSIDetectorHit::Copy(rhs);
-   static_cast<TSceptarHit&>(rhs).fFilter = fFilter;
+	// Copies a TSceptarHit
+	TGRSIDetectorHit::Copy(rhs);
+	static_cast<TSceptarHit&>(rhs).fFilter = fFilter;
 }
 
 void TSceptarHit::Copy(TObject& obj, bool waveform) const
 {
-   Copy(obj);
-   if(waveform) {
-      CopyWave(obj);
-   }
+	Copy(obj);
+	if(waveform) {
+		CopyWave(obj);
+	}
 }
 
 TVector3 TSceptarHit::GetPosition(Double_t) const
 {
-   // Gets the position of the current TSceptarHit
-   return TSceptar::GetPosition(GetDetector());
+	// Gets the position of the current TSceptarHit
+	return TSceptar::GetPosition(GetDetector());
 }
 
 TVector3 TSceptarHit::GetPosition() const
 {
-   // Gets the position of the current TSceptarHit
-   return GetPosition(GetDefaultDistance());
+	// Gets the position of the current TSceptarHit
+	return GetPosition(GetDefaultDistance());
 }
 
 bool TSceptarHit::InFilter(Int_t)
 {
-   // check if the desired filter is in wanted filter;
-   // return the answer;
-   return true;
+	// check if the desired filter is in wanted filter;
+	// return the answer;
+	return true;
 }
 
 void TSceptarHit::Clear(Option_t*)
 {
-   // Clears the SceptarHit
-   fFilter = 0;
-   TGRSIDetectorHit::Clear();
+	// Clears the SceptarHit
+	fFilter = 0;
+	TGRSIDetectorHit::Clear();
 }
 
 void TSceptarHit::Print(Option_t*) const
 {
-   // Prints the SceptarHit. Returns:
-   // Detector
-   // Energy
-   // Time
-   printf("Sceptar Detector: %i\n", GetDetector());
-   printf("Sceptar hit energy: %.2f\n", GetEnergy());
-   printf("Sceptar hit time:   %.lf\n", GetTime());
+	// Prints the SceptarHit. Returns:
+	// Detector
+	// Energy
+	// Time
+	printf("Sceptar Detector: %i\n", GetDetector());
+	printf("Sceptar hit energy: %.2f\n", GetEnergy());
+	printf("Sceptar hit time:   %.lf\n", GetTime());
 }
 
 bool TSceptarHit::AnalyzeWaveform()
 {
-   // Calculates the cfd time from the waveform
-   bool error = false;
-   if(fWaveform.empty()) {
-      return false; // Error!
-   }
+	// Calculates the cfd time from the waveform
+	bool error = false;
+	if(fWaveform.empty()) {
+		return false; // Error!
+	}
 
-   std::vector<Int_t>   baselineCorrections(8, 0);
-   std::vector<Short_t> smoothedWaveform;
+	std::vector<Int_t>   baselineCorrections(8, 0);
+	std::vector<Short_t> smoothedWaveform;
 
-   // all timing algorithms use interpolation with this many steps between two samples (all times are stored as
-   // integers)
-   unsigned int interpolationSteps  = 256;
-   int          delay               = 8;
-   double       attenuation         = 24. / 64.;
-   int          halfsmoothingwindow = 0; // 2*halfsmoothingwindow + 1 = number of samples in moving window.
+	// all timing algorithms use interpolation with this many steps between two samples (all times are stored as
+	// integers)
+	unsigned int interpolationSteps  = 256;
+	int          delay               = 8;
+	double       attenuation         = 24. / 64.;
+	int          halfsmoothingwindow = 0; // 2*halfsmoothingwindow + 1 = number of samples in moving window.
 
-   // baseline algorithm: correct each adc with average of first two samples in that adc
-   for(size_t i = 0; i < 8 && i < fWaveform.size(); ++i) {
-      baselineCorrections[i] = fWaveform[i];
-   }
-   for(size_t i = 8; i < 16 && i < fWaveform.size(); ++i) {
-      baselineCorrections[i - 8] =
-         ((baselineCorrections[i - 8] + fWaveform[i]) + ((baselineCorrections[i - 8] + fWaveform[i]) > 0 ? 1 : -1)) >>
-         1;
-   }
-   for(size_t i = 0; i < fWaveform.size(); ++i) {
-      fWaveform[i] -= baselineCorrections[i % 8];
-   }
+	// baseline algorithm: correct each adc with average of first two samples in that adc
+	for(size_t i = 0; i < 8 && i < fWaveform.size(); ++i) {
+		baselineCorrections[i] = fWaveform[i];
+	}
+	for(size_t i = 8; i < 16 && i < fWaveform.size(); ++i) {
+		baselineCorrections[i - 8] =
+			((baselineCorrections[i - 8] + fWaveform[i]) + ((baselineCorrections[i - 8] + fWaveform[i]) > 0 ? 1 : -1)) >>
+			1;
+	}
+	for(size_t i = 0; i < fWaveform.size(); ++i) {
+		fWaveform[i] -= baselineCorrections[i % 8];
+	}
 
-   SetCfd(CalculateCfd(attenuation, delay, halfsmoothingwindow, interpolationSteps));
+	SetCfd(CalculateCfd(attenuation, delay, halfsmoothingwindow, interpolationSteps));
 
-   return !error;
+	return !error;
 }
 
 Int_t TSceptarHit::CalculateCfd(double attenuation, unsigned int delay, int halfsmoothingwindow,
-                                unsigned int interpolationSteps)
+		unsigned int interpolationSteps)
 {
-   // Used when calculating the CFD from the waveform
-   std::vector<Short_t> monitor;
+	// Used when calculating the CFD from the waveform
+	std::vector<Short_t> monitor;
 
-   return CalculateCfdAndMonitor(attenuation, delay, halfsmoothingwindow, interpolationSteps, monitor);
+	return CalculateCfdAndMonitor(attenuation, delay, halfsmoothingwindow, interpolationSteps, monitor);
 }
 
 Int_t TSceptarHit::CalculateCfdAndMonitor(double attenuation, unsigned int delay, int halfsmoothingwindow,
-                                          unsigned int interpolationSteps, std::vector<Short_t>& monitor)
+		unsigned int interpolationSteps, std::vector<Short_t>& monitor)
 {
-   // Used when calculating the CFD from the waveform
+	// Used when calculating the CFD from the waveform
 
-   Short_t monitormax = 0;
+	Short_t monitormax = 0;
 
-   bool armed = false;
+	bool armed = false;
 
-   Int_t cfd = 0;
+	Int_t cfd = 0;
 
-   std::vector<Short_t> smoothedWaveform;
+	std::vector<Short_t> smoothedWaveform;
 
-   if(fWaveform.empty()) {
-      return INT_MAX; // Error!
-   }
+	if(fWaveform.empty()) {
+		return INT_MAX; // Error!
+	}
 
-   if(static_cast<unsigned int>(fWaveform.size()) > delay + 1) {
+	if(static_cast<unsigned int>(fWaveform.size()) > delay + 1) {
 
-      if(halfsmoothingwindow > 0) {
-         smoothedWaveform = TSceptarHit::CalculateSmoothedWaveform(halfsmoothingwindow);
-      } else {
-         smoothedWaveform = fWaveform;
-      }
+		if(halfsmoothingwindow > 0) {
+			smoothedWaveform = TSceptarHit::CalculateSmoothedWaveform(halfsmoothingwindow);
+		} else {
+			smoothedWaveform = fWaveform;
+		}
 
-      monitor.resize(smoothedWaveform.size() - delay);
-      monitor[0] = attenuation * smoothedWaveform[delay] - smoothedWaveform[0];
-      if(monitor[0] > monitormax) {
-         armed      = true;
-         monitormax = monitor[0];
-      }
+		monitor.resize(smoothedWaveform.size() - delay);
+		monitor[0] = attenuation * smoothedWaveform[delay] - smoothedWaveform[0];
+		if(monitor[0] > monitormax) {
+			armed      = true;
+			monitormax = monitor[0];
+		}
 
-      for(unsigned int i = delay + 1; i < smoothedWaveform.size(); ++i) {
-         monitor[i - delay] = attenuation * smoothedWaveform[i] - smoothedWaveform[i - delay];
-         if(monitor[i - delay] > monitormax) {
-            armed      = true;
-            monitormax = monitor[i - delay];
-         } else {
-            if(armed && monitor[i - delay] < 0) {
-               armed = false;
-               if(monitor[i - delay - 1] - monitor[i - delay] != 0) {
-                  // Linear interpolation.
-                  cfd = (i - delay - 1) * interpolationSteps +
-                        (monitor[i - delay - 1] * interpolationSteps) / (monitor[i - delay - 1] - monitor[i - delay]);
-               } else {
-                  // Should be impossible, since monitor[i-delay-1] => 0 and monitor[i-delay] > 0
-                  cfd = 0;
-               }
-            }
-         }
-      }
-   } else {
-      monitor.resize(0);
-   }
+		for(unsigned int i = delay + 1; i < smoothedWaveform.size(); ++i) {
+			monitor[i - delay] = attenuation * smoothedWaveform[i] - smoothedWaveform[i - delay];
+			if(monitor[i - delay] > monitormax) {
+				armed      = true;
+				monitormax = monitor[i - delay];
+			} else {
+				if(armed && monitor[i - delay] < 0) {
+					armed = false;
+					if(monitor[i - delay - 1] - monitor[i - delay] != 0) {
+						// Linear interpolation.
+						cfd = (i - delay - 1) * interpolationSteps +
+							(monitor[i - delay - 1] * interpolationSteps) / (monitor[i - delay - 1] - monitor[i - delay]);
+					} else {
+						// Should be impossible, since monitor[i-delay-1] => 0 and monitor[i-delay] > 0
+						cfd = 0;
+					}
+				}
+			}
+		}
+	} else {
+		monitor.resize(0);
+	}
 
-   return cfd;
+	return cfd;
 }
 
 std::vector<Short_t> TSceptarHit::CalculateSmoothedWaveform(unsigned int halfsmoothingwindow)
 {
-   // Used when calculating the CFD from the waveform
+	// Used when calculating the CFD from the waveform
 
-   if(fWaveform.empty()) {
-      return std::vector<Short_t>(); // Error!
-   }
+	if(fWaveform.empty()) {
+		return std::vector<Short_t>(); // Error!
+	}
 
-   std::vector<Short_t> smoothedWaveform(std::max(static_cast<size_t>(0), fWaveform.size() - 2 * halfsmoothingwindow),
-                                         0);
+	std::vector<Short_t> smoothedWaveform(std::max(static_cast<size_t>(0), fWaveform.size() - 2 * halfsmoothingwindow),
+			0);
 
-   for(size_t i = halfsmoothingwindow; i < fWaveform.size() - halfsmoothingwindow; ++i) {
-      for(int j = -static_cast<int>(halfsmoothingwindow); j <= static_cast<int>(halfsmoothingwindow); ++j) {
-         smoothedWaveform[i - halfsmoothingwindow] += fWaveform[i + j];
-      }
-   }
+	for(size_t i = halfsmoothingwindow; i < fWaveform.size() - halfsmoothingwindow; ++i) {
+		for(int j = -static_cast<int>(halfsmoothingwindow); j <= static_cast<int>(halfsmoothingwindow); ++j) {
+			smoothedWaveform[i - halfsmoothingwindow] += fWaveform[i + j];
+		}
+	}
 
-   return smoothedWaveform;
+	return smoothedWaveform;
 }
 
 std::vector<Short_t> TSceptarHit::CalculateCfdMonitor(double attenuation, int delay, int halfsmoothingwindow)
 {
-   // Used when calculating the CFD from the waveform
+	// Used when calculating the CFD from the waveform
 
-   if(fWaveform.empty()) {
-      return std::vector<Short_t>(); // Error!
-   }
+	if(fWaveform.empty()) {
+		return std::vector<Short_t>(); // Error!
+	}
 
-   std::vector<Short_t> smoothedWaveform;
+	std::vector<Short_t> smoothedWaveform;
 
-   if(halfsmoothingwindow > 0) {
-      smoothedWaveform = TSceptarHit::CalculateSmoothedWaveform(halfsmoothingwindow);
-   } else {
-      smoothedWaveform = fWaveform;
-   }
+	if(halfsmoothingwindow > 0) {
+		smoothedWaveform = TSceptarHit::CalculateSmoothedWaveform(halfsmoothingwindow);
+	} else {
+		smoothedWaveform = fWaveform;
+	}
 
-   std::vector<Short_t> monitor(std::max(static_cast<size_t>(0), smoothedWaveform.size() - delay), 0);
+	std::vector<Short_t> monitor(std::max(static_cast<size_t>(0), smoothedWaveform.size() - delay), 0);
 
-   for(size_t i = delay; i < smoothedWaveform.size(); ++i) {
-      monitor[i - delay] = attenuation * smoothedWaveform[i] - smoothedWaveform[i - delay];
-   }
+	for(size_t i = delay; i < smoothedWaveform.size(); ++i) {
+		monitor[i - delay] = attenuation * smoothedWaveform[i] - smoothedWaveform[i - delay];
+	}
 
-   return monitor;
+	return monitor;
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharc.cxx
@@ -10,299 +10,299 @@
 
 /// \cond CLASSIMP
 ClassImp(TSharc)
-   /// \endcond
+/// \endcond
 
-   // various sharc dimensions in mm
-
-   // const int TSharc::frontstripslist[16]     = {16,16,16,16,  24,24,24,24,  24,24,24,24,  16,16,16,16};
-   // const int TSharc::backstripslist[16]      = {24,24,24,24,  48,48,48,48,  48,48,48,48,  24,24,24,24};
-
-   // const double TSharc::frontpitchlist[16]   = {2.0,2.0,2.0,2.0,  3.0,3.0,3.0,3.0,  3.0,3.0,3.0,3.0,
-   // 2.0,2.0,2.0,2.0};
-   // const double TSharc::backpitchlist[16]    = {TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,
-   // 1.0,1.0,1.0,1.0,  1.0,1.0,1.0,1.0,  TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48};    // QQQ back
-   // pitches are angles
-   // const double TSharc::stripFpitch          = TSharc::Ydim / TSharc::frontstripslist[5]; // 72.0/24 = 3.0 mm
-   // const double TSharc::ringpitch            = TSharc::Rdim / TSharc::frontstripslist[1]; // 32.0/16 = 2.0 mm
-   // const double TSharc::stripBpitch          = TSharc::Zdim / TSharc::backstripslist[5] ; // 48.0/48 = 1.0 mm
-   // const double TSharc::segmentpitch         = TSharc::Pdim / TSharc::backstripslist[1] ; // 81.6/24 = 3.4 degrees
-   // (angular pitch)
-
-   //==========================================================================//
-   //==========================================================================//
-   //==========================================================================//
-   //==========================================================================//
-   //==========================================================================//
-
-   double TSharc::fXoffset = +0.00; //
-double TSharc::fYoffset    = +0.00; //
-double TSharc::fZoffset    = +0.00; //
-
-double TSharc::fXdim   = +72.0; // total X dimension of all boxes
-double TSharc::fYdim   = +72.0; // total Y dimension of all boxes
-double TSharc::fZdim   = +48.0; // total Z dimension of all boxes
-double TSharc::fRdim   = +32.0; // Rmax-Rmin for all QQQs
-double TSharc::fPdim   = +81.6; // QQQ quadrant angular range (degrees)
-double TSharc::fXposUB = +42.5;
-double TSharc::fYminUB = -36.0;
-double TSharc::fZminUB = -5.00;
-double TSharc::fXposDB = +40.5;
-double TSharc::fYminDB = -36.0;
-double TSharc::fZminDB = +9.00;
-double TSharc::fZposUQ = -66.5;
-double TSharc::fRmaxUQ = +41.00;
-double TSharc::fRminUQ = +9.00;
-double TSharc::fPminUQ = +2.00; // degrees
-double TSharc::fZposDQ = +74.5;
-double TSharc::fRmaxDQ = +41.00;
-double TSharc::fRminDQ = +9.00;
-double TSharc::fPminDQ = +6.40; // degrees
+// various sharc dimensions in mm
 
 // const int TSharc::frontstripslist[16]     = {16,16,16,16,  24,24,24,24,  24,24,24,24,  16,16,16,16};
 // const int TSharc::backstripslist[16]      = {24,24,24,24,  48,48,48,48,  48,48,48,48,  24,24,24,24};
 
-// const double TSharc::frontpitchlist[16]   = {2.0,2.0,2.0,2.0,  3.0,3.0,3.0,3.0,  3.0,3.0,3.0,3.0,  2.0,2.0,2.0,2.0};
+// const double TSharc::frontpitchlist[16]   = {2.0,2.0,2.0,2.0,  3.0,3.0,3.0,3.0,  3.0,3.0,3.0,3.0,
+// 2.0,2.0,2.0,2.0};
 // const double TSharc::backpitchlist[16]    = {TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,
-// 1.0,1.0,1.0,1.0,  1.0,1.0,1.0,1.0,  TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48};
-// QQQ back pitches are angles
-//
-double TSharc::fStripFPitch = TSharc::fYdim / 24.0; // TSharc::frontstripslist[5]; // 72.0/24 = 3.0 mm
-double TSharc::fRingPitch   = TSharc::fRdim / 16.0; // TSharc::frontstripslist[1]; // 32.0/16 = 2.0 mm
-double TSharc::fStripBPitch = TSharc::fZdim / 48.0; // TSharc::backstripslist[5] ; // 48.0/48 = 1.0 mm
-double TSharc::fSegmentPitch =
-   TSharc::fPdim / 24.0; // TSharc::backstripslist[1] ; // 81.6/24 = 3.4 degrees (angular pitch)
+// 1.0,1.0,1.0,1.0,  1.0,1.0,1.0,1.0,  TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48};    // QQQ back
+// pitches are angles
+// const double TSharc::stripFpitch          = TSharc::Ydim / TSharc::frontstripslist[5]; // 72.0/24 = 3.0 mm
+// const double TSharc::ringpitch            = TSharc::Rdim / TSharc::frontstripslist[1]; // 32.0/16 = 2.0 mm
+// const double TSharc::stripBpitch          = TSharc::Zdim / TSharc::backstripslist[5] ; // 48.0/48 = 1.0 mm
+// const double TSharc::segmentpitch         = TSharc::Pdim / TSharc::backstripslist[1] ; // 81.6/24 = 3.4 degrees
+// (angular pitch)
 
-// The dimensions are described for a single detector of each type UQ,UB,DB,DQ, and all other detectors can be
-// calculated by rotating this
+//==========================================================================//
+//==========================================================================//
+//==========================================================================//
+//==========================================================================//
+//==========================================================================//
+
+	double TSharc::fXoffset = +0.00; //
+	double TSharc::fYoffset    = +0.00; //
+	double TSharc::fZoffset    = +0.00; //
+
+	double TSharc::fXdim   = +72.0; // total X dimension of all boxes
+	double TSharc::fYdim   = +72.0; // total Y dimension of all boxes
+	double TSharc::fZdim   = +48.0; // total Z dimension of all boxes
+	double TSharc::fRdim   = +32.0; // Rmax-Rmin for all QQQs
+	double TSharc::fPdim   = +81.6; // QQQ quadrant angular range (degrees)
+	double TSharc::fXposUB = +42.5;
+	double TSharc::fYminUB = -36.0;
+	double TSharc::fZminUB = -5.00;
+	double TSharc::fXposDB = +40.5;
+	double TSharc::fYminDB = -36.0;
+	double TSharc::fZminDB = +9.00;
+	double TSharc::fZposUQ = -66.5;
+	double TSharc::fRmaxUQ = +41.00;
+	double TSharc::fRminUQ = +9.00;
+	double TSharc::fPminUQ = +2.00; // degrees
+	double TSharc::fZposDQ = +74.5;
+	double TSharc::fRmaxDQ = +41.00;
+	double TSharc::fRminDQ = +9.00;
+	double TSharc::fPminDQ = +6.40; // degrees
+
+	// const int TSharc::frontstripslist[16]     = {16,16,16,16,  24,24,24,24,  24,24,24,24,  16,16,16,16};
+	// const int TSharc::backstripslist[16]      = {24,24,24,24,  48,48,48,48,  48,48,48,48,  24,24,24,24};
+
+	// const double TSharc::frontpitchlist[16]   = {2.0,2.0,2.0,2.0,  3.0,3.0,3.0,3.0,  3.0,3.0,3.0,3.0,  2.0,2.0,2.0,2.0};
+	// const double TSharc::backpitchlist[16]    = {TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,
+	// 1.0,1.0,1.0,1.0,  1.0,1.0,1.0,1.0,  TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48,TMath::Pi()/48};
+	// QQQ back pitches are angles
+	//
+	double TSharc::fStripFPitch = TSharc::fYdim / 24.0; // TSharc::frontstripslist[5]; // 72.0/24 = 3.0 mm
+	double TSharc::fRingPitch   = TSharc::fRdim / 16.0; // TSharc::frontstripslist[1]; // 32.0/16 = 2.0 mm
+	double TSharc::fStripBPitch = TSharc::fZdim / 48.0; // TSharc::backstripslist[5] ; // 48.0/48 = 1.0 mm
+	double TSharc::fSegmentPitch =
+	TSharc::fPdim / 24.0; // TSharc::backstripslist[1] ; // 81.6/24 = 3.4 degrees (angular pitch)
+
+	// The dimensions are described for a single detector of each type UQ,UB,DB,DQ, and all other detectors can be
+	// calculated by rotating this
 
 TSharc::TSharc()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TSharc::~TSharc() = default;
 
 TSharc::TSharc(const TSharc& rhs) : TGRSIDetector()
 {
-   Class()->IgnoreTObjectStreamer(kTRUE);
-   Clear("ALL");
-   rhs.Copy(*this);
+	Class()->IgnoreTObjectStreamer(kTRUE);
+	Clear("ALL");
+	rhs.Copy(*this);
 }
 
 void TSharc::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
 {
-   if(frag == nullptr || chan == nullptr) {
-      return;
-   }
-   /*  if(GetMidasTimestamp() == -1) {
-       SetMidasTimestamp(frag->GetMidasTimeStamp());
-     }
-   */
-   switch(chan->GetMnemonic()->ArraySubPosition()) {
-   case TMnemonic::kD:
-      if(chan->GetMnemonic()->CollectedCharge() == TMnemonic::kP) {
-         fFrontFragments.push_back(*frag);
-      } else {
-         fBackFragments.push_back(*frag);
-      }
-      break;
-   case TMnemonic::kE: fPadFragments.push_back(*frag); break;
-   };
+	if(frag == nullptr || chan == nullptr) {
+		return;
+	}
+	/*  if(GetMidasTimestamp() == -1) {
+		 SetMidasTimestamp(frag->GetMidasTimeStamp());
+		 }
+		 */
+	switch(chan->GetMnemonic()->ArraySubPosition()) {
+		case TMnemonic::kD:
+			if(chan->GetMnemonic()->CollectedCharge() == TMnemonic::kP) {
+				fFrontFragments.push_back(*frag);
+			} else {
+				fBackFragments.push_back(*frag);
+			}
+			break;
+		case TMnemonic::kE: fPadFragments.push_back(*frag); break;
+	};
 
-   // if(frag->GetDetector()==11 && frag->GetSegment()==16)
-   //   return;
-   // printf("FRONT:  %s\n",frag->GetName());
+	// if(frag->GetDetector()==11 && frag->GetSegment()==16)
+	//   return;
+	// printf("FRONT:  %s\n",frag->GetName());
 }
 
 void TSharc::BuildHits()
 {
-   std::vector<TFragment>::iterator front;
-   std::vector<TFragment>::iterator back;
-   std::vector<TFragment>::iterator pad;
-   // static int total;
-   // printf("\t%i:  front = %i; back = %i\n",total++,fFrontFragments.size(),fBackFragments.size()); fflush(stdout);
+	std::vector<TFragment>::iterator front;
+	std::vector<TFragment>::iterator back;
+	std::vector<TFragment>::iterator pad;
+	// static int total;
+	// printf("\t%i:  front = %i; back = %i\n",total++,fFrontFragments.size(),fBackFragments.size()); fflush(stdout);
 
-   for(front = fFrontFragments.begin(); front != fFrontFragments.end();) {
-      bool front_used = false;
-      bool back_used  = false;
-      for(back = fBackFragments.begin(); back != fBackFragments.end(); back++) {
-         if(front->GetDetector() == back->GetDetector()) {
-            // if((TMath::Abs(front->GetCharge() - back->GetCharge()) <  6000) ){ // ||
-            //(front->GetDetector()==5 && (front->GetSegment()%2)!=0))  {
-            // time gate ?
-            front_used = true;
-            back_used  = true;
-            break;
-            //}
-         }
-      }
-      if(front_used && back_used) {
-         TSharcHit hit;
-         hit.SetFront(*front);
-         hit.SetBack(*back);
-         fSharcHits.push_back(hit); // TODO: consider using std::move here
-         front = fFrontFragments.erase(front);
-         back  = fBackFragments.erase(back);
-      } else {
-         front++;
-      }
-   }
+	for(front = fFrontFragments.begin(); front != fFrontFragments.end();) {
+		bool front_used = false;
+		bool back_used  = false;
+		for(back = fBackFragments.begin(); back != fBackFragments.end(); back++) {
+			if(front->GetDetector() == back->GetDetector()) {
+				// if((TMath::Abs(front->GetCharge() - back->GetCharge()) <  6000) ){ // ||
+				//(front->GetDetector()==5 && (front->GetSegment()%2)!=0))  {
+				// time gate ?
+				front_used = true;
+				back_used  = true;
+				break;
+				//}
+			}
+			}
+			if(front_used && back_used) {
+				TSharcHit hit;
+				hit.SetFront(*front);
+				hit.SetBack(*back);
+				fSharcHits.push_back(hit); // TODO: consider using std::move here
+				front = fFrontFragments.erase(front);
+				back  = fBackFragments.erase(back);
+			} else {
+				front++;
+			}
+		}
 
-   for(auto& fSharcHit : fSharcHits) {
-      for(pad = fPadFragments.begin(); pad != fPadFragments.end(); pad++) {
-         if(fSharcHit.GetDetector() == pad->GetDetector()) {
-            fSharcHit.SetPad(*pad);
-            pad = fPadFragments.erase(pad);
-            break;
-         }
-      }
-   }
-   // printf(DRED "built %i sharc hits!" RESET_COLOR "\n",fSharcHits.size()); fflush(stdout);
-}
+		for(auto& fSharcHit : fSharcHits) {
+			for(pad = fPadFragments.begin(); pad != fPadFragments.end(); pad++) {
+				if(fSharcHit.GetDetector() == pad->GetDetector()) {
+					fSharcHit.SetPad(*pad);
+					pad = fPadFragments.erase(pad);
+					break;
+				}
+			}
+		}
+		// printf(DRED "built %i sharc hits!" RESET_COLOR "\n",fSharcHits.size()); fflush(stdout);
+	}
 
-void TSharc::RemoveHits(std::vector<TSharcHit>* hits, std::set<int>* to_remove)
-{
-   for(auto iter = to_remove->rbegin(); iter != to_remove->rend(); ++iter) {
-      if(*iter == -1) {
-         continue;
-      }
-      hits->erase(hits->begin() + *iter);
-   }
-}
+	void TSharc::RemoveHits(std::vector<TSharcHit>* hits, std::set<int>* to_remove)
+	{
+		for(auto iter = to_remove->rbegin(); iter != to_remove->rend(); ++iter) {
+			if(*iter == -1) {
+				continue;
+			}
+			hits->erase(hits->begin() + *iter);
+		}
+	}
 
-void TSharc::Clear(Option_t* option)
-{
-   TGRSIDetector::Clear(option);
-   fSharcHits.clear();
+	void TSharc::Clear(Option_t* option)
+	{
+		TGRSIDetector::Clear(option);
+		fSharcHits.clear();
 
-   fFrontFragments.clear(); //!
-   fBackFragments.clear();  //!
-   fPadFragments.clear();   //!
+		fFrontFragments.clear(); //!
+		fBackFragments.clear();  //!
+		fPadFragments.clear();   //!
 
-   if(strcmp(option, "ALL") == 0) {
-      fXoffset = 0.00;
-      fYoffset = 0.00;
-      fZoffset = 0.00;
-   }
-   return;
-}
+		if(strcmp(option, "ALL") == 0) {
+			fXoffset = 0.00;
+			fYoffset = 0.00;
+			fZoffset = 0.00;
+		}
+		return;
+	}
 
-void TSharc::Print(Option_t*) const
-{
-   printf("not yet written...\n");
-}
+	void TSharc::Print(Option_t*) const
+	{
+		printf("not yet written...\n");
+	}
 
-void TSharc::Copy(TObject& rhs) const
-{
-   // if(!rhs.InheritsFrom("TSharc"))
-   //  return;
-   TGRSIDetector::Copy(rhs);
+	void TSharc::Copy(TObject& rhs) const
+	{
+		// if(!rhs.InheritsFrom("TSharc"))
+		//  return;
+		TGRSIDetector::Copy(rhs);
 
-   static_cast<TSharc&>(rhs).fSharcHits = fSharcHits;
-   static_cast<TSharc&>(rhs).fXoffset   = fXoffset;
-   static_cast<TSharc&>(rhs).fYoffset   = fYoffset;
-   static_cast<TSharc&>(rhs).fZoffset   = fZoffset;
-}
+		static_cast<TSharc&>(rhs).fSharcHits = fSharcHits;
+		static_cast<TSharc&>(rhs).fXoffset   = fXoffset;
+		static_cast<TSharc&>(rhs).fYoffset   = fYoffset;
+		static_cast<TSharc&>(rhs).fZoffset   = fZoffset;
+	}
 
-TVector3 TSharc::GetPosition(int detector, int frontstrip, int backstrip, double X, double Y, double Z)
-{
-   int FrontDet = detector;
-   int FrontStr = frontstrip;
-   // int BackDet  = detector;
-   int BackStr = backstrip;
-   int nrots   = 0; // allows us to rotate into correct position
+	TVector3 TSharc::GetPosition(int detector, int frontstrip, int backstrip, double X, double Y, double Z)
+	{
+		int FrontDet = detector;
+		int FrontStr = frontstrip;
+		// int BackDet  = detector;
+		int BackStr = backstrip;
+		int nrots   = 0; // allows us to rotate into correct position
 
-   TVector3 position;
-   TVector3 position_offset;
-   position_offset.SetXYZ(X, Y, Z);
+		TVector3 position;
+		TVector3 position_offset;
+		position_offset.SetXYZ(X, Y, Z);
 
-   if(FrontDet >= 5 && FrontDet <= 8) { // forward box
-      nrots    = FrontDet - 4; // edited to make box 5 on the ceiling.  assuming rotaing ccw around the +z axis!!
-      double x = fXposDB;      // ?? x stays the same. first detector is aways defined in the y-z plane.
-      double y = -(fYminDB + (FrontStr + 0.5) * fStripFPitch); // [(-36.0) - (+36.0)]        // ?? add minus sign,
-                                                               // reversve the order of the strips on the ds section.
-      double z = fZminDB + (BackStr + 0.5) * fStripBPitch;     // [(+9.0) - (+57.0)]
-      position.SetXYZ(x, y, z);
-   } else if(FrontDet >= 9 && FrontDet <= 12) { // backward box
-      nrots    = FrontDet - 8; // edited to make box 5 on the ceiling.  assuming rotaing ccw around the +z axis!!
-      double x = fXposUB;
-      double y = fYminUB + (FrontStr + 0.5) * fStripFPitch; // [(-36.0) - (+36.0)]
-      double z = fZminUB - (BackStr + 0.5) * fStripBPitch;  // [(-5.0) - (-53.0)]
-      position.SetXYZ(x, y, z);
-   } else if(FrontDet >= 13) { // backward (upstream) QQQ
-      nrots      = FrontDet - 13;
-      double z   = fZposUQ;
-      double rho = fRmaxUQ - (FrontStr + 0.5) * fRingPitch;                           // [(+9.0) - (+41.0)]
-      double phi = (fPminUQ + (BackStr + 0.5) * fSegmentPitch) * TMath::Pi() / 180.0; // [(+2.0) - (+83.6)]
-      position.SetXYZ(rho * TMath::Sin(phi), rho * TMath::Cos(phi), z);
-   } else if(FrontDet <= 4) { // forward (downstream) QQQ
-      nrots      = FrontDet - 1;
-      double z   = fZposDQ;
-      double rho = fRmaxDQ - (FrontStr + 0.5) * fRingPitch;                           // [(+9.0) - (+41.0)]
-      double phi = (fPminDQ + (BackStr + 0.5) * fSegmentPitch) * TMath::Pi() / 180.0; // [(+6.4) - (+88.0)]
-      position.SetXYZ(rho * TMath::Sin(phi), rho * TMath::Cos(phi), z);
-   }
+		if(FrontDet >= 5 && FrontDet <= 8) { // forward box
+			nrots    = FrontDet - 4; // edited to make box 5 on the ceiling.  assuming rotaing ccw around the +z axis!!
+			double x = fXposDB;      // ?? x stays the same. first detector is aways defined in the y-z plane.
+			double y = -(fYminDB + (FrontStr + 0.5) * fStripFPitch); // [(-36.0) - (+36.0)]        // ?? add minus sign,
+			// reversve the order of the strips on the ds section.
+			double z = fZminDB + (BackStr + 0.5) * fStripBPitch;     // [(+9.0) - (+57.0)]
+			position.SetXYZ(x, y, z);
+		} else if(FrontDet >= 9 && FrontDet <= 12) { // backward box
+			nrots    = FrontDet - 8; // edited to make box 5 on the ceiling.  assuming rotaing ccw around the +z axis!!
+			double x = fXposUB;
+			double y = fYminUB + (FrontStr + 0.5) * fStripFPitch; // [(-36.0) - (+36.0)]
+			double z = fZminUB - (BackStr + 0.5) * fStripBPitch;  // [(-5.0) - (-53.0)]
+			position.SetXYZ(x, y, z);
+		} else if(FrontDet >= 13) { // backward (upstream) QQQ
+			nrots      = FrontDet - 13;
+			double z   = fZposUQ;
+			double rho = fRmaxUQ - (FrontStr + 0.5) * fRingPitch;                           // [(+9.0) - (+41.0)]
+			double phi = (fPminUQ + (BackStr + 0.5) * fSegmentPitch) * TMath::Pi() / 180.0; // [(+2.0) - (+83.6)]
+			position.SetXYZ(rho * TMath::Sin(phi), rho * TMath::Cos(phi), z);
+		} else if(FrontDet <= 4) { // forward (downstream) QQQ
+			nrots      = FrontDet - 1;
+			double z   = fZposDQ;
+			double rho = fRmaxDQ - (FrontStr + 0.5) * fRingPitch;                           // [(+9.0) - (+41.0)]
+			double phi = (fPminDQ + (BackStr + 0.5) * fSegmentPitch) * TMath::Pi() / 180.0; // [(+6.4) - (+88.0)]
+			position.SetXYZ(rho * TMath::Sin(phi), rho * TMath::Cos(phi), z);
+		}
 
-   position.RotateZ(TMath::Pi() * nrots / 2);
-   return (position + position_offset);
-}
+		position.RotateZ(TMath::Pi() * nrots / 2);
+		return (position + position_offset);
+	}
 
-TGRSIDetectorHit* TSharc::GetHit(const Int_t& idx)
-{
-   return GetSharcHit(idx);
-}
+	TGRSIDetectorHit* TSharc::GetHit(const Int_t& idx)
+	{
+		return GetSharcHit(idx);
+	}
 
-TSharcHit* TSharc::GetSharcHit(const int& i)
-{
-   try {
-      return &fSharcHits.at(i);
-   } catch(const std::out_of_range& oor) {
-      std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
-      throw grsi::exit_exception(1);
-   }
-   return nullptr;
-}
+	TSharcHit* TSharc::GetSharcHit(const int& i)
+	{
+		try {
+			return &fSharcHits.at(i);
+		} catch(const std::out_of_range& oor) {
+			std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+			throw grsi::exit_exception(1);
+		}
+		return nullptr;
+	}
 
-double TSharc::GetDetectorThickness(TSharcHit& hit, double dist)
-{
-   static double fDetectorThickness[16] = {998., 998.,  998.,  1001., 141., 142., 133., 143.,
-                                           999., 1001., 1001., 1002., 390., 390., 383., 385.};
-   if(dist < 0.0) {
-      dist = fDetectorThickness[hit.GetDetector()];
-   }
+	double TSharc::GetDetectorThickness(TSharcHit& hit, double dist)
+	{
+		static double fDetectorThickness[16] = {998., 998.,  998.,  1001., 141., 142., 133., 143.,
+			999., 1001., 1001., 1002., 390., 390., 383., 385.};
+		if(dist < 0.0) {
+			dist = fDetectorThickness[hit.GetDetector()];
+		}
 
-   double phi_90 = fmod(std::fabs(hit.GetPosition().Phi()), TMath::Pi() / 2);
-   double phi_45 = phi_90;
-   if(phi_90 > (TMath::Pi() / 4.)) {
-      phi_45 = TMath::Pi() / 2 - phi_90;
-   }
+		double phi_90 = fmod(std::fabs(hit.GetPosition().Phi()), TMath::Pi() / 2);
+		double phi_45 = phi_90;
+		if(phi_90 > (TMath::Pi() / 4.)) {
+			phi_45 = TMath::Pi() / 2 - phi_90;
+		}
 
-   if(hit.GetDetector() >= 5 && hit.GetDetector() <= 12) {
-      return dist / (TMath::Sin(hit.GetPosition().Theta()) * TMath::Cos(phi_45));
-   }
-   return std::fabs(dist / (TMath::Cos(hit.GetPosition().Theta())));
-}
+		if(hit.GetDetector() >= 5 && hit.GetDetector() <= 12) {
+			return dist / (TMath::Sin(hit.GetPosition().Theta()) * TMath::Cos(phi_45));
+		}
+		return std::fabs(dist / (TMath::Cos(hit.GetPosition().Theta())));
+	}
 
-double TSharc::GetDeadLayerThickness(TSharcHit& hit)
-{
-   static double fDeadLayerThickness[16] = {0.7, 0.7, 0.7, 0.7, 0.1, 0.1, 0.1, 0.1,
-                                            0.1, 0.1, 0.1, 0.1, 0.7, 0.7, 0.7, 0.7};
-   return GetDetectorThickness(hit, fDeadLayerThickness[hit.GetDetector()]);
-}
+	double TSharc::GetDeadLayerThickness(TSharcHit& hit)
+	{
+		static double fDeadLayerThickness[16] = {0.7, 0.7, 0.7, 0.7, 0.1, 0.1, 0.1, 0.1,
+			0.1, 0.1, 0.1, 0.1, 0.7, 0.7, 0.7, 0.7};
+		return GetDetectorThickness(hit, fDeadLayerThickness[hit.GetDetector()]);
+	}
 
-double TSharc::GetPadThickness(TSharcHit& hit)
-{
-   static double fPadThickness[16] = {0.0, 0.0, 0.0, 0.0, 1534, 1535, 1535, 1539,
-                                      0.0, 0.0, 0.0, 0.0, 0.0,  0.0,  0.0,  0.0};
-   return GetDetectorThickness(hit, fPadThickness[hit.GetDetector()]);
-}
+	double TSharc::GetPadThickness(TSharcHit& hit)
+	{
+		static double fPadThickness[16] = {0.0, 0.0, 0.0, 0.0, 1534, 1535, 1535, 1539,
+			0.0, 0.0, 0.0, 0.0, 0.0,  0.0,  0.0,  0.0};
+		return GetDetectorThickness(hit, fPadThickness[hit.GetDetector()]);
+	}
 
-double TSharc::GetPadDeadLayerThickness(TSharcHit& hit)
-{
-   static double fPadDeadLayerThickness[16] = {0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0,
-                                               0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-   return GetDetectorThickness(hit, fPadDeadLayerThickness[hit.GetDetector()]);
-}
+	double TSharc::GetPadDeadLayerThickness(TSharcHit& hit)
+	{
+		static double fPadDeadLayerThickness[16] = {0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0,
+			0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+		return GetDetectorThickness(hit, fPadDeadLayerThickness[hit.GetDetector()]);
+	}

--- a/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
@@ -21,7 +21,9 @@ TSharcHit::~TSharcHit() = default;
 
 TSharcHit::TSharcHit(const TSharcHit& rhs) : TGRSIDetectorHit()
 {
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    Clear();
    rhs.Copy(*this);
 }

--- a/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
+++ b/libraries/TGRSIAnalysis/TSharc/TSharcHit.cxx
@@ -7,14 +7,14 @@
 
 /// \cond CLASSIMP
 ClassImp(TSharcHit)
-   /// \endcond
+/// \endcond
 
-   TSharcHit::TSharcHit()
+TSharcHit::TSharcHit()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear("ALL");
+	Clear("ALL");
 }
 
 TSharcHit::~TSharcHit() = default;
@@ -22,98 +22,98 @@ TSharcHit::~TSharcHit() = default;
 TSharcHit::TSharcHit(const TSharcHit& rhs) : TGRSIDetectorHit()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
-   rhs.Copy(*this);
+	Clear();
+	rhs.Copy(*this);
 }
 
 void TSharcHit::Copy(TObject& rhs) const
 {
-   TGRSIDetectorHit::Copy(rhs);
-   static_cast<const TGRSIDetectorHit&>(fBackHit).Copy(static_cast<TObject&>(static_cast<TSharcHit&>(rhs).fBackHit));
-   static_cast<const TGRSIDetectorHit&>(fPadHit).Copy(static_cast<TObject&>(static_cast<TSharcHit&>(rhs).fPadHit));
+	TGRSIDetectorHit::Copy(rhs);
+	static_cast<const TGRSIDetectorHit&>(fBackHit).Copy(static_cast<TObject&>(static_cast<TSharcHit&>(rhs).fBackHit));
+	static_cast<const TGRSIDetectorHit&>(fPadHit).Copy(static_cast<TObject&>(static_cast<TSharcHit&>(rhs).fPadHit));
 
-   // static_cast<TSharcHit&>(rhs).fDetectorNumber = fDetectorNumber;
-   // static_cast<TSharcHit&>(rhs).fFrontStrip     = fFrontStrip;
-   // static_cast<TSharcHit&>(rhs).fBackStrip      = fBackStrip;
+	// static_cast<TSharcHit&>(rhs).fDetectorNumber = fDetectorNumber;
+	// static_cast<TSharcHit&>(rhs).fFrontStrip     = fFrontStrip;
+	// static_cast<TSharcHit&>(rhs).fBackStrip      = fBackStrip;
 }
 
 void TSharcHit::Clear(Option_t* options)
 {
-   TGRSIDetectorHit::Clear(options); //
-   fBackHit.Clear(options);          //
-   fPadHit.Clear(options);           //
+	TGRSIDetectorHit::Clear(options); //
+	fBackHit.Clear(options);          //
+	fPadHit.Clear(options);           //
 
-   // fDetectorNumber = -1;    //
-   // fFrontStrip    = -1;    //
-   // fBackStrip     = -1;    //
+	// fDetectorNumber = -1;    //
+	// fFrontStrip    = -1;    //
+	// fBackStrip     = -1;    //
 }
 
 void TSharcHit::Print(Option_t*) const
 {
-   printf(DGREEN "[D/F/B] = %02i\t/%02i\t/%02i " RESET_COLOR "\n", GetDetector(), GetFrontStrip(), GetBackStrip());
-   // printf("Sharc hit charge: %02f\n",GetFrontCharge());
-   // printf("Sharc hit energy: %f\n",GetDeltaE());
-   // printf("Sharc hit time:   %f\n",GetDeltaT());
-   // printf( DGREEN "=	=	=	=	=	=	=	" RESET_COLOR "\n");
+	printf(DGREEN "[D/F/B] = %02i\t/%02i\t/%02i " RESET_COLOR "\n", GetDetector(), GetFrontStrip(), GetBackStrip());
+	// printf("Sharc hit charge: %02f\n",GetFrontCharge());
+	// printf("Sharc hit energy: %f\n",GetDeltaE());
+	// printf("Sharc hit time:   %f\n",GetDeltaT());
+	// printf( DGREEN "=	=	=	=	=	=	=	" RESET_COLOR "\n");
 }
 
 TVector3 TSharcHit::GetPosition(Double_t) const
 {
-   // return  fposition; // returned from this -> i.e front...
-   // PC BENDER PLEASE LOOK AT THIS.
-   //
-   // this is fine, in all reality this function should not be used in sharc analysis,
-   // the buildhits function now properly sets fPosition in the base class, for finer
-   // position tweaks of the target, one should just use the static function in the
-   // sharc mother class.   pcb.
+	// return  fposition; // returned from this -> i.e front...
+	// PC BENDER PLEASE LOOK AT THIS.
+	//
+	// this is fine, in all reality this function should not be used in sharc analysis,
+	// the buildhits function now properly sets fPosition in the base class, for finer
+	// position tweaks of the target, one should just use the static function in the
+	// sharc mother class.   pcb.
 
-   return TSharc::GetPosition(TGRSIDetectorHit::GetDetector(), TGRSIDetectorHit::GetSegment(), GetBack().GetSegment(),
-                              TSharc::GetXOffset(), TSharc::GetYOffset(), TSharc::GetZOffset());
-   // return
-   // TSharc::GetPosition(fDetectorNumber,fFrontStrip,fBackStrip,TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());
+	return TSharc::GetPosition(TGRSIDetectorHit::GetDetector(), TGRSIDetectorHit::GetSegment(), GetBack().GetSegment(),
+			TSharc::GetXOffset(), TSharc::GetYOffset(), TSharc::GetZOffset());
+	// return
+	// TSharc::GetPosition(fDetectorNumber,fFrontStrip,fBackStrip,TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());
 }
 
 TVector3 TSharcHit::GetPosition() const
 {
-   return GetPosition(GetDefaultDistance());
+	return GetPosition(GetDefaultDistance());
 }
 
 Double_t TSharcHit::GetTheta(double Xoff, double Yoff, double Zoff)
 {
-   TVector3 posOff;
-   posOff.SetXYZ(Xoff, Yoff, Zoff);
-   return (GetPosition() + posOff).Theta();
+	TVector3 posOff;
+	posOff.SetXYZ(Xoff, Yoff, Zoff);
+	return (GetPosition() + posOff).Theta();
 }
 
 void TSharcHit::SetFront(const TFragment& frag)
 {
-   // frag.CopyHit(*this);
-   // printf("frag->GetCfd() = %i\n",frag.GetCfd());
-   // frag.Print("a");
-   frag.Copy(*this);
-   // printf("shit->GetCfd() = %i\n",GetCfd());
-   // printf("============================================\n");
-   // printf("============================================\n");
-   // printf("============================================\n");
-   // printf("============================================\n"); fflush(stdout);
-   // SetPosition(TSharc::GetPosition(TGRSIDetector::GetDetector(),
-   //                           TGRSIDetector::GetSegment(),
-   //                           GetBack()->GetSegment(),
-   //                           TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());
+	// frag.CopyHit(*this);
+	// printf("frag->GetCfd() = %i\n",frag.GetCfd());
+	// frag.Print("a");
+	frag.Copy(*this);
+	// printf("shit->GetCfd() = %i\n",GetCfd());
+	// printf("============================================\n");
+	// printf("============================================\n");
+	// printf("============================================\n");
+	// printf("============================================\n"); fflush(stdout);
+	// SetPosition(TSharc::GetPosition(TGRSIDetector::GetDetector(),
+	//                           TGRSIDetector::GetSegment(),
+	//                           GetBack()->GetSegment(),
+	//                           TSharc::GetXOffset(),TSharc::GetYOffset(),TSharc::GetZOffset());
 }
 
 void TSharcHit::SetBack(const TFragment& frag)
 {
-   // frag.CopyHit(fBackHit);
-   //  fBackHit.Copy(frag);
-   frag.Copy(fBackHit);
+	// frag.CopyHit(fBackHit);
+	//  fBackHit.Copy(frag);
+	frag.Copy(fBackHit);
 }
 
 void TSharcHit::SetPad(const TFragment& frag)
 {
-   //  frag.CopyHit(fPadHit);
-   //  fPadHit.Copy(frag);
-   frag.Copy(fPadHit);
+	//  frag.CopyHit(fPadHit);
+	//  fPadHit.Copy(frag);
+	frag.Copy(fPadHit);
 }

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLi.cxx
@@ -4,10 +4,10 @@
 
 /// \cond CLASSIMP
 ClassImp(TSiLi)
-   /// \endcond
+/// \endcond
 
-   // Having these in Clear() caused issues as functions can be called abstract with out initialising a TSiLi
-   int TSiLi::fRingNumber     = 10;
+// Having these in Clear() caused issues as functions can be called abstract with out initialising a TSiLi
+int TSiLi::fRingNumber     = 10;
 int    TSiLi::fSectorNumber   = 12;
 double TSiLi::fOffsetPhi      = -165. * TMath::Pi() / 180.; // For SPICE. Sectors upstream.
 double TSiLi::fOuterDiameter  = 94.;

--- a/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
+++ b/libraries/TGRSIAnalysis/TSiLi/TSiLiHit.cxx
@@ -3,9 +3,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TSiLiHit)
-   /// \endcond
+/// \endcond
 
-   TSiLiHit::TSiLiHit()
+TSiLiHit::TSiLiHit()
 {
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTAC.cxx
@@ -5,80 +5,80 @@
 
 /// \cond CLASSIMP
 ClassImp(TTAC)
-   /// \endcond
+/// \endcond
 
-   TTAC::TTAC()
+TTAC::TTAC()
 {
-// Default Constructor
+	// Default Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TTAC::~TTAC()
 {
-   // Default Destructor
+	// Default Destructor
 }
 
 TTAC::TTAC(const TTAC& rhs) : TGRSIDetector()
 {
-// Copy Contructor
+	// Copy Contructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TTAC::Clear(Option_t* opt)
 {
-   // Clears all of the hits
-   // The Option "all" clears the base class.
-   if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
-      TGRSIDetector::Clear(opt);
-   }
-   fTACHits.clear();
+	// Clears all of the hits
+	// The Option "all" clears the base class.
+	if(TString(opt).Contains("all", TString::ECaseCompare::kIgnoreCase)) {
+		TGRSIDetector::Clear(opt);
+	}
+	fTACHits.clear();
 }
 
 void TTAC::Copy(TObject& rhs) const
 {
-   // Copies a TTAC
-   TGRSIDetector::Copy(rhs);
+	// Copies a TTAC
+	TGRSIDetector::Copy(rhs);
 
-   static_cast<TTAC&>(rhs).fTACHits = fTACHits;
+	static_cast<TTAC&>(rhs).fTACHits = fTACHits;
 }
 
 TTAC& TTAC::operator=(const TTAC& rhs)
 {
-   rhs.Copy(*this);
-   return *this;
+	rhs.Copy(*this);
+	return *this;
 }
 
 void TTAC::Print(Option_t*) const
 {
-   // Prints out TTAC Multiplicity, currently does little.
-   printf("%lu fTACHits\n", fTACHits.size());
+	// Prints out TTAC Multiplicity, currently does little.
+	printf("%lu fTACHits\n", fTACHits.size());
 }
 
 void TTAC::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel*)
 {
-   TTACHit hit(*frag);
-   fTACHits.push_back(std::move(hit));
+	TTACHit hit(*frag);
+	fTACHits.push_back(std::move(hit));
 }
 
 TGRSIDetectorHit* TTAC::GetHit(const Int_t& idx)
 {
-   // Gets the TTACHit at index idx.
-   return GetTACHit(idx);
+	// Gets the TTACHit at index idx.
+	return GetTACHit(idx);
 }
 
 TTACHit* TTAC::GetTACHit(const int& i)
 {
-   try {
-      return &fTACHits.at(i);
-   } catch(const std::out_of_range& oor) {
-      std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
-      throw grsi::exit_exception(1);
-   }
-   return nullptr;
+	try {
+		return &fTACHits.at(i);
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" is out of range: "<<oor.what()<<std::endl;
+		throw grsi::exit_exception(1);
+	}
+	return nullptr;
 }

--- a/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
+++ b/libraries/TGRSIAnalysis/TTAC/TTACHit.cxx
@@ -9,94 +9,94 @@
 
 /// \cond CLASSIMP
 ClassImp(TTACHit)
-   /// \endcond
+/// \endcond
 
-   TTACHit::TTACHit()
+TTACHit::TTACHit()
 {
-// Default Constructor
+	// Default Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
+	Clear();
 }
 
 TTACHit::~TTACHit() = default;
 
 TTACHit::TTACHit(const TTACHit& rhs) : TGRSIDetectorHit()
 {
-// Copy Constructor
+	// Copy Constructor
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   Clear();
-   rhs.Copy(*this);
+	Clear();
+	rhs.Copy(*this);
 }
 
 void TTACHit::Copy(TObject& rhs) const
 {
-   // Copies a TTACHit
-   TGRSIDetectorHit::Copy(rhs);
-   static_cast<TTACHit&>(rhs).fFilter = fFilter;
+	// Copies a TTACHit
+	TGRSIDetectorHit::Copy(rhs);
+	static_cast<TTACHit&>(rhs).fFilter = fFilter;
 }
 
 Double_t TTACHit::GetTempCorrectedCharge(TGraph* correction_graph) const {
-   //Applies the kValue ot the charge
-   if(!correction_graph){
-      std::cout << "Graph for temperture corrections is null" << std::endl;
-   }
+	//Applies the kValue ot the charge
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
 
-   return GetCharge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
+	return GetCharge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
 }
 
 Double_t TTACHit::TempCorrectedCharge(TGraph* correction_graph) const {
-   //Returns the raw charge with no kValue applied
-   if(!correction_graph){
-      std::cout << "Graph for temperture corrections is null" << std::endl;
-   }
+	//Returns the raw charge with no kValue applied
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
 
-   return Charge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
+	return Charge()*correction_graph->Eval(GetTime()/1e9);//The graph should be defined in seconds
 }
 
 Double_t TTACHit::GetTempCorrectedEnergy(TGraph* correction_graph) const {
-   //This will not overwrite the normal energy, nor will it get stored as the energy.
-   if(!correction_graph){
-      std::cout << "Graph for temperture corrections is null" << std::endl;
-   }
+	//This will not overwrite the normal energy, nor will it get stored as the energy.
+	if(!correction_graph){
+		std::cout << "Graph for temperture corrections is null" << std::endl;
+	}
 
-   TChannel* channel = GetChannel();
-   if(channel == nullptr) {
-      return 0.0;
-   }
-   if(fKValue > 0) {
-      return channel->CalibrateENG(TempCorrectedCharge(correction_graph), (int)fKValue);
-   } else if(channel->UseCalFileIntegration()) {
-      return channel->CalibrateENG(TempCorrectedCharge(correction_graph), 0);
-   }
-   return channel->CalibrateENG(TempCorrectedCharge(correction_graph));
+	TChannel* channel = GetChannel();
+	if(channel == nullptr) {
+		return 0.0;
+	}
+	if(fKValue > 0) {
+		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), (int)fKValue);
+	} else if(channel->UseCalFileIntegration()) {
+		return channel->CalibrateENG(TempCorrectedCharge(correction_graph), 0);
+	}
+	return channel->CalibrateENG(TempCorrectedCharge(correction_graph));
 }
 
 bool TTACHit::InFilter(Int_t)
 {
-   // check if the desired filter is in wanted filter;
-   // return the answer;
-   // currently does nothing
-   return true;
+	// check if the desired filter is in wanted filter;
+	// return the answer;
+	// currently does nothing
+	return true;
 }
 
 void TTACHit::Clear(Option_t*)
 {
-   // Clears the TACHit
-   fFilter = 0;
-   TGRSIDetectorHit::Clear();
+	// Clears the TACHit
+	fFilter = 0;
+	TGRSIDetectorHit::Clear();
 }
 
 void TTACHit::Print(Option_t*) const
 {
-   // Prints the TACHit. Returns:
-   // Detector
-   // Energy
-   // Time
-   printf("TAC Detector: %i\n", GetDetector());
-   printf("TAC hit energy: %.2f\n", GetEnergy());
-   printf("TAC hit time:   %.lf\n", GetTime());
+	// Prints the TACHit. Returns:
+	// Detector
+	// Energy
+	// Time
+	printf("TAC Detector: %i\n", GetDetector());
+	printf("TAC hit energy: %.2f\n", GetEnergy());
+	printf("TAC hit time:   %.lf\n", GetTime());
 }

--- a/libraries/TGRSIAnalysis/TTigress/TBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TBgoHit.cxx
@@ -6,9 +6,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TBgoHit)
-   /// \endcond
+/// \endcond
 
-   TBgoHit::TBgoHit()
+TBgoHit::TBgoHit()
 {
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigressHit.cxx
@@ -6,9 +6,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TTigressHit)
-   /// \endcond
+/// \endcond
 
-   TTigressHit::TTigressHit()
+TTigressHit::TTigressHit()
 {
    Clear();
 }

--- a/libraries/TGRSIAnalysis/TTip/TTip.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTip.cxx
@@ -10,9 +10,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TTip)
-   /// \endcond
+/// \endcond
 
-   TTip::TTip()
+TTip::TTip()
 {
 }
 
@@ -23,7 +23,9 @@ TTip::~TTip()
 
 TTip::TTip(const TTip& rhs) : TGRSIDetector()
 {
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    rhs.Copy(*this);
 }
 

--- a/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
+++ b/libraries/TGRSIAnalysis/TTip/TTipHit.cxx
@@ -13,11 +13,13 @@
 
 /// \cond CLASSIMP
 ClassImp(TTipHit)
-   /// \endcond
+/// \endcond
 
-   TTipHit::TTipHit()
+TTipHit::TTipHit()
 {
-   Class()->IgnoreTObjectStreamer(true);
+#if MAJOR_ROOT_VERSION < 6
+   Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    Clear();
 }
 
@@ -35,7 +37,9 @@ TTipHit::~TTipHit() = default;
 
 TTipHit::TTipHit(const TTipHit& rhs) : TGRSIDetectorHit()
 {
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    Clear();
    rhs.Copy(*this);
 }

--- a/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
+++ b/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
@@ -32,7 +32,9 @@ void TTriFoil::Copy(TObject& rhs) const
 
 TTriFoil::TTriFoil(const TTriFoil& rhs) : TDetector()
 {
+#if MAJOR_ROOT_VERSION < 6
    Class()->IgnoreTObjectStreamer(kTRUE);
+#endif
    rhs.Copy(*this);
 }
 

--- a/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
+++ b/libraries/TGRSIAnalysis/TTriFoil/TTriFoil.cxx
@@ -2,78 +2,78 @@
 
 /// \cond CLASSIMP
 ClassImp(TTriFoil)
-   /// \endcond
+/// \endcond
 
-   TTriFoil::TTriFoil()
+TTriFoil::TTriFoil()
 {
-   Clear();
+	Clear();
 }
 
 TTriFoil::~TTriFoil() = default;
 
 void TTriFoil::Clear(Option_t* opt)
 {
-   // Clears all of the hits and data
-   TDetector::Clear(opt);
-   fTfWave.clear();
-   fTimestamp = 0;
-   fBeam      = false;
-   fTBeam.clear();
+	// Clears all of the hits and data
+	TDetector::Clear(opt);
+	fTfWave.clear();
+	fTimestamp = 0;
+	fBeam      = false;
+	fTBeam.clear();
 }
 
 void TTriFoil::Copy(TObject& rhs) const
 {
-   TDetector::Copy(rhs);
-   static_cast<TTriFoil&>(rhs).fTfWave    = fTfWave;
-   static_cast<TTriFoil&>(rhs).fTimestamp = fTimestamp;
-   static_cast<TTriFoil&>(rhs).fBeam      = fBeam;
-   static_cast<TTriFoil&>(rhs).fTBeam     = fTBeam;
+	TDetector::Copy(rhs);
+	static_cast<TTriFoil&>(rhs).fTfWave    = fTfWave;
+	static_cast<TTriFoil&>(rhs).fTimestamp = fTimestamp;
+	static_cast<TTriFoil&>(rhs).fBeam      = fBeam;
+	static_cast<TTriFoil&>(rhs).fTBeam     = fTBeam;
 }
 
 TTriFoil::TTriFoil(const TTriFoil& rhs) : TDetector()
 {
 #if MAJOR_ROOT_VERSION < 6
-   Class()->IgnoreTObjectStreamer(kTRUE);
+	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
-   rhs.Copy(*this);
+	rhs.Copy(*this);
 }
 
 void TTriFoil::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
 {
-   if(frag == nullptr || chan == nullptr) {
-      return;
-   }
+	if(frag == nullptr || chan == nullptr) {
+		return;
+	}
 
-   if(!(frag->GetWaveform()->empty())) {
-      fTfWave = *(frag->GetWaveform());
-   }
-   fTimestamp = frag->GetTimeStamp();
-   int max    = 0;
-   int imax   = 0;
-   /*for(size_t i=0;i<fTfWave.size();i++){
-     if(fTfWave[i]>max){
-       max = fTfWave[i];
-       imax = i;
-     }
-   }
-   if(max>1500) {
-     fBeam = true;
-     fTBeam = imax;
-   }*/
+	if(!(frag->GetWaveform()->empty())) {
+		fTfWave = *(frag->GetWaveform());
+	}
+	fTimestamp = frag->GetTimeStamp();
+	int max    = 0;
+	int imax   = 0;
+	/*for(size_t i=0;i<fTfWave.size();i++){
+	  if(fTfWave[i]>max){
+	  max = fTfWave[i];
+	  imax = i;
+	  }
+	  }
+	  if(max>1500) {
+	  fBeam = true;
+	  fTBeam = imax;
+	  }*/
 
-   fTBeam.clear();
+	fTBeam.clear();
 
-   for(size_t i = 0; i < fTfWave.size(); i++) {
-      if(fTfWave[i] > 1500 && fTfWave[i] > max) {
-         max  = fTfWave[i];
-         imax = i;
-      }
-      if(max != 0 && imax != 0 && (i - imax) > 15) {
-         fTBeam.push_back(imax);
-         max  = 0;
-         imax = 0;
-      }
-   }
+	for(size_t i = 0; i < fTfWave.size(); i++) {
+		if(fTfWave[i] > 1500 && fTfWave[i] > max) {
+			max  = fTfWave[i];
+			imax = i;
+		}
+		if(max != 0 && imax != 0 && (i - imax) > 15) {
+			fTBeam.push_back(imax);
+			max  = 0;
+			imax = 0;
+		}
+	}
 }
 
 void TTriFoil::Print(Option_t*) const

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegree.cxx
@@ -8,9 +8,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TZeroDegree)
-   /// \endcond
+/// \endcond
 
-   bool TZeroDegree::fSetWave = false;
+bool TZeroDegree::fSetWave = false;
 
 TZeroDegree::TZeroDegree()
 {

--- a/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
+++ b/libraries/TGRSIAnalysis/TZeroDegree/TZeroDegreeHit.cxx
@@ -12,9 +12,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TZeroDegreeHit)
-   /// \endcond
+/// \endcond
 
-   TZeroDegreeHit::TZeroDegreeHit()
+TZeroDegreeHit::TZeroDegreeHit()
 {
 // Default Constructor
 #if MAJOR_ROOT_VERSION < 6

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -10,9 +10,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TGRSIRunInfo)
-   /// \endcond
+/// \endcond
 
-   TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
+TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
 
 std::string TGRSIRunInfo::fGRSIVersion;
 
@@ -55,7 +55,7 @@ Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
 
    TList* list = tempf->GetListOfKeys();
    TIter  iter(list);
-   printf("Reading Info from file:" CYAN " %s" RESET_COLOR "\n", tempf->GetName());
+	std::cout<<R"(Reading run info from file ")"<<CYAN<<tempf->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
    while(TKey* key = static_cast<TKey*>(iter.Next())) {
       if((key == nullptr) || (strcmp(key->GetClassName(), "TGRSIRunInfo") != 0)) {
          continue;
@@ -75,14 +75,6 @@ TGRSIRunInfo::TGRSIRunInfo() : fRunNumber(0), fSubRunNumber(-1)
    /// Default ctor for TGRSIRunInfo. The default values are:
    ///
    /// fHPGeArrayPosition = 110.0;
-
-   fHPGeArrayPosition = 110.0;
-
-   fDescantAncillary = false;
-   fBadCycleList.clear();
-   fBadCycleListSize = 0;
-
-   // printf("run info created.\n");
 
    Clear();
 }
@@ -135,6 +127,8 @@ void TGRSIRunInfo::Clear(Option_t*)
    // Clears the TGRSIRunInfo. Currently, there are no available
    // options.
 
+   fHPGeArrayPosition = 110.0;
+
    fTigress = false;
    fSharc   = false;
    fTriFoil = false;
@@ -152,6 +146,8 @@ void TGRSIRunInfo::Clear(Option_t*)
    fZeroDegree = false;
    fDescant    = false;
    fFipps      = false;
+
+   fDescantAncillary = false;
 
    fMajorIndex.assign("");
    fMinorIndex.assign("");

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -424,10 +424,10 @@ void TGRSIRunInfo::trim(std::string* line, const std::string& trimChars)
 
 Long64_t TGRSIRunInfo::Merge(TCollection* list)
 {
-   // Loop through the TCollection of TGRSISortLists, and add each entry to the original TGRSISort List
+   // Loop through the TCollection of TGRSIRunInfos, and add each entry to the original TGRSIRunInfo List
    TIter it(list);
-   // The TCollection will be filled by something like hadd. Each element in the list will be a TGRSISortList from
-   // An individual file that was submitted to hadd.
+   // The TCollection will be filled by something like hadd. Each element in the list will be a TGRSIRunInfo from
+   // an individual file that was submitted to hadd.
    TGRSIRunInfo* runinfo = nullptr;
 
    while((runinfo = static_cast<TGRSIRunInfo*>(it.Next())) != nullptr) {

--- a/libraries/TGRSIFormat/TParsingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TParsingDiagnostics.cxx
@@ -8,11 +8,13 @@ TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = nullptr;
 
 TParsingDiagnostics::TParsingDiagnostics() : TObject()
 {
+   fIdHist         = nullptr;
    Clear();
 }
 
 TParsingDiagnostics::TParsingDiagnostics(const TParsingDiagnostics&) : TObject()
 {
+   fIdHist         = nullptr;
    Clear();
 }
 

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -77,7 +77,7 @@ void TAnalysisOptions::ReadFromFile(const std::string& file)
    if(f->IsOpen()) {
       TList* list = f->GetListOfKeys();
       TIter  iter(list);
-      std::cout<<"Reading Options from file:"<<CYAN<<f<<RESET_COLOR<<std::endl;
+      std::cout<<R"(Reading analysis options from file: ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
       while(TKey* key = static_cast<TKey*>(iter.Next())) {
          if((key == nullptr) || (strcmp(key->GetClassName(), "TAnalysisOptions") != 0)) {
             continue;

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -77,7 +77,7 @@ void TAnalysisOptions::ReadFromFile(const std::string& file)
    if(f->IsOpen()) {
       TList* list = f->GetListOfKeys();
       TIter  iter(list);
-      std::cout<<R"(Reading analysis options from file: ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
+      std::cout<<R"(Reading analysis options from file ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
       while(TKey* key = static_cast<TKey*>(iter.Next())) {
          if((key == nullptr) || (strcmp(key->GetClassName(), "TAnalysisOptions") != 0)) {
             continue;

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -332,7 +332,6 @@ void TGRSIOptions::Load(int argc, char** argv)
 
 	// read analysis options from input file(s)
 	for(const std::string& file : fInputRootFiles) {
-		std::cout<<R"(Reading options from ")"<<file<<R"(":)"<<std::endl;
 		fAnalysisOptions->ReadFromFile(file);
 		fAnalysisOptions->Print();
 	}
@@ -526,7 +525,7 @@ Bool_t TGRSIOptions::ReadFromFile(TFile* file)
 
    TList* list = file->GetListOfKeys();
    TIter  iter(list);
-   printf("Reading Options from file:" CYAN " %s" RESET_COLOR "\n", file->GetName());
+	std::cout<<"Reading options from file: "<<CYAN<<file->GetName()<<RESET_COLOR<<std::endl;
    while(TKey* key = static_cast<TKey*>(iter.Next())) {
       if((key == nullptr) || (strcmp(key->GetClassName(), "TGRSIOptions") != 0)) {
 			continue;

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -259,9 +259,9 @@ void ReadTheNews()
 {
 /// Opens a random wikipedia page for your enjoyment
 #ifdef __APPLE__
-   gROOT->ProcessLine(".! open http://en.wikipedia.org/wiki/Special:Random > /dev/null 2>&1");
+   gROOT->ProcessLine(".! open http://en.wikipedia.org/wiki/Special:Random > /dev/null 2>&1;");
 #else
-   gROOT->ProcessLine(".! xdg-open http://en.wikipedia.org/wiki/Special:Random > /dev/null 2>&1");
+   gROOT->ProcessLine(".! xdg-open http://en.wikipedia.org/wiki/Special:Random > /dev/null 2>&1;");
 #endif
 }
 
@@ -308,7 +308,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
       file = new TFile(filename.c_str(), "RECREATE");
       if(file != nullptr) {
          // Give access to the file inside the interpreter.
-         const char* command = Form("TFile* _file%i = (TFile*)%luL", fRootFilesOpened, (unsigned long)file);
+         const char* command = Form("TFile* _file%i = (TFile*)%luL;", fRootFilesOpened, (unsigned long)file);
          TRint::ProcessLine(command);
          fRootFilesOpened++;
       } else {
@@ -319,7 +319,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
       file = new TFile(filename.c_str(), opt);
       if(file != nullptr) {
          // Give access to the file inside the interpreter.
-         const char* command = Form("TFile* _file%i = (TFile*)%luL", fRootFilesOpened, (unsigned long)file);
+         const char* command = Form("TFile* _file%i = (TFile*)%luL;", fRootFilesOpened, (unsigned long)file);
          TRint::ProcessLine(command);
          std::cout<<"\tfile "<<BLUE<<file->GetName()<<RESET_COLOR<<" opened as "<<BLUE<<"_file"
                   <<fRootFilesOpened<<RESET_COLOR<<std::endl;
@@ -388,7 +388,7 @@ TMidasFile* TGRSIint::OpenMidasFile(const std::string& filename)
    auto* file = new TMidasFile(filename.c_str());
    fRawFiles.push_back(file);
 
-   const char* command = Form("TMidasFile* _midas%i = (TMidasFile*)%luL", fMidasFilesOpened, (unsigned long)file);
+   const char* command = Form("TMidasFile* _midas%i = (TMidasFile*)%luL;", fMidasFilesOpened, (unsigned long)file);
    ProcessLine(command);
 
    if(file != nullptr) {
@@ -679,7 +679,7 @@ void TGRSIint::RunMacroFile(const std::string& filename)
 {
    /// Runs a macro file. This happens when --work-harder is used with a .C file
    if(file_exists(filename.c_str())) {
-      const char* command = Form(".x %s", filename.c_str());
+      const char* command = Form(".x %s;", filename.c_str());
       ProcessLine(command);
    } else {
       std::cerr<<R"(File ")"<<filename<<R"(" does not exist)"<<std::endl;

--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -16,8 +16,7 @@ TDataLoop::TDataLoop(std::string name, TRawFile* source)
    : StoppableThread(name), fSource(source), fSelfStopping(true),
      fOutputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TRawEvent>>>("midas_queue"))
 #ifdef HAS_XML
-     ,
-     fOdb(nullptr)
+     , fOdb(nullptr)
 #endif
 {
    TMidasFile* midasFile = dynamic_cast<TMidasFile*>(source);
@@ -51,10 +50,8 @@ void TDataLoop::SetFileOdb(char* data, int size)
 #ifdef HAS_XML
    // check if we have already set the TChannels....
    //
-   if(fOdb != nullptr) {
-      delete fOdb;
-      fOdb = nullptr;
-   }
+	delete fOdb;
+	fOdb = nullptr;
 
    if(TGRSIOptions::Get()->IgnoreFileOdb()) {
       printf(DYELLOW "\tskipping odb information stored in file.\n" RESET_COLOR);
@@ -374,19 +371,19 @@ void TDataLoop::OnEnd()
 bool TDataLoop::Iteration()
 {
    std::shared_ptr<TRawEvent> evt = fSource->NewEvent();
-   int                        bytes_read;
+   int                        bytesRead;
    {
       std::lock_guard<std::mutex> lock(fSourceMutex);
-      bytes_read   = fSource->Read(evt);
+      bytesRead   = fSource->Read(evt);
       fItemsPopped = fSource->GetBytesRead() / 1000;
       fInputSize = fSource->GetFileSize() / 1000 - fItemsPopped; // this way fInputSize+fItemsPopped give the file size
    }
 
-   if(bytes_read <= 0 && fSelfStopping) {
+   if(bytesRead <= 0 && fSelfStopping) {
       // Error, and no point in trying again.
       return false;
    }
-   if(bytes_read > 0) {
+   if(bytesRead > 0) {
       // A good event was returned
       fOutputQueue->Push(evt);
       return true;
@@ -396,6 +393,3 @@ bool TDataLoop::Iteration()
    return true;
 }
 
-// std::string TDataLoop::Status() {
-//  //return fSource->Status(TGRSIOptions::Get()->LongFileDescription());
-//}

--- a/libraries/TLoops/TDetBuildingLoop.cxx
+++ b/libraries/TLoops/TDetBuildingLoop.cxx
@@ -5,11 +5,9 @@
 
 #include "TUnpackedEvent.h"
 
-//#include "TMode3.h"
-
 ClassImp(TDetBuildingLoop)
 
-   TDetBuildingLoop* TDetBuildingLoop::Get(std::string name)
+TDetBuildingLoop* TDetBuildingLoop::Get(std::string name)
 {
    if(name.length() == 0) {
       name = "unpack_loop";

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -8,7 +8,7 @@
 
 ClassImp(TEventBuildingLoop)
 
-   TEventBuildingLoop* TEventBuildingLoop::Get(std::string name, EBuildMode mode)
+TEventBuildingLoop* TEventBuildingLoop::Get(std::string name, EBuildMode mode)
 {
    if(name.length() == 0) {
       name = "build_loop";

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -9,8 +9,6 @@
 #include "TLstEvent.h"
 #include "TMidasEvent.h"
 
-// ClassImp(TUnpackingLoop)
-
 TUnpackingLoop* TUnpackingLoop::Get(std::string name)
 {
    if(name.length() == 0) {
@@ -40,10 +38,6 @@ void TUnpackingLoop::ClearQueue()
    }
 
    fParser.ClearQueue();
-   // while(fParser.GoodOutputQueue()->Size()){
-   //	fParser.GoodOutputQueue()->Pop(frag);
-   //	delete frag;
-   //}
 }
 
 bool TUnpackingLoop::Iteration()

--- a/libraries/TMidas/TLstEvent.cxx
+++ b/libraries/TMidas/TLstEvent.cxx
@@ -14,9 +14,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TLstEvent)
-   /// \endcond
+/// \endcond
 
-   TLstEvent::TLstEvent()
+TLstEvent::TLstEvent()
 {
    // Default constructor
    fData.resize(0);

--- a/libraries/TMidas/TLstFile.cxx
+++ b/libraries/TMidas/TLstFile.cxx
@@ -22,9 +22,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TLstFile)
-   /// \endcond
+/// \endcond
 
-   TLstFile::TLstFile()
+TLstFile::TLstFile()
 {
    // Default Constructor
    fBytesRead = 0;

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -13,6 +13,8 @@
 #include "TMidasEvent.h"
 #include "TGRSIOptions.h"
 #include "TDataParserException.h"
+#include "TGRSIRunInfo.h"
+#include "TXMLOdb.h"
 
 /// \cond CLASSIMP
 ClassImp(TMidasEvent)
@@ -702,6 +704,19 @@ int TMidasEvent::Process(TDataParser& parser)
             frags = ProcessEPICS(reinterpret_cast<float*>(ptr), banksize, parser);
          }
          break;
+		case 0x8001:
+			// end of file ODB
+#ifdef HAS_XML
+			TXMLOdb* odb = new TXMLOdb(GetData(), GetDataSize());
+			TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
+			TXMLNode*     node     = odb->FindPath("/Runinfo/Stop time binary");
+			if(node != nullptr) {
+				runInfo->SetRunStop(atof(node->GetText()));
+			}
+			runInfo->SetRunLength();
+			delete odb;
+#endif
+			break;
       };
    } catch(const std::bad_alloc&) {
    }

--- a/libraries/TMidas/TMidasFile.cxx
+++ b/libraries/TMidas/TMidasFile.cxx
@@ -22,9 +22,9 @@
 
 /// \cond CLASSIMP
 ClassImp(TMidasFile)
-   /// \endcond
+/// \endcond
 
-   TMidasFile::TMidasFile()
+TMidasFile::TMidasFile()
 {
    // Default Constructor
    uint32_t endian = 0x12345678;

--- a/libraries/TMidas/TXMLOdb.cxx
+++ b/libraries/TMidas/TXMLOdb.cxx
@@ -7,9 +7,11 @@
 #include "TList.h"
 #include "TXMLAttr.h"
 
+/// \cond CLASSIMP
 ClassImp(TXMLOdb)
+/// \endcond
 
-   char TXMLOdb::fTextBuffer[256];
+char TXMLOdb::fTextBuffer[256];
 
 TXMLOdb::TXMLOdb(char* buffer, int size)
 {

--- a/util/ErrorReport.sh
+++ b/util/ErrorReport.sh
@@ -5,18 +5,18 @@ echo GRSISYS      = $GRSISYS
 echo ROOTSYS      = $ROOTSYS
 
 echo ROOT Version = `root-config --version`
-echo '\nComputer and Path to File that failed: \n'
+printf "\nComputer and Path to File that failed: \n"
 
 LASTDIR=$PWD
 cd $GRSISYS
 echo GRSISort Branch = `git rev-parse --abbrev-ref HEAD`
-echo '\nLast Commit: ' 
+printf "\nLast Commit: " 
 
 git log -1
 
-echo '\nPut Error Here:\n\n\n\n'
+printf "\nPut Error Here:\n\n\n\n"
 
-echo 'Last Working Commit: Put commit here\n\n'
+printf "Last Working Commit: Put commit here\n\n"
 
-echo 'What I have tried so far\n\n\n'
+printf "What I have tried so far\n\n\n"
 cd $LASTDIR


### PR DESCRIPTION
- Fixed bug in TParsingDiagnostics
- ODB from event ID 0x8001 is parsed to get run start and stop and set the run length based on those.
  If the file is the last from the run this will read the correct stop time, otherwise the stop time will be zero!
- Restricted all calls to TClass::IgnoreTObjectStreamer to ROOT 5 (will be removed soon).
- Switched ErrorReport.sh from echo to printf so that "\n" creates actual newlines.