### PR TITLE
Fixed weird copy ctor issue in GPeak.

### DIFF
--- a/libraries/GROOT/GPeak.cxx
+++ b/libraries/GROOT/GPeak.cxx
@@ -347,7 +347,8 @@ Bool_t GPeak::Fit(TH1* fithist, Option_t* opt)
    Double_t range_low, range_high;
    GetRange(range_low,range_high);
 
-   GPeak* tmppeak = new GPeak(*this);
+   GPeak* tmppeak = new GPeak;
+   Copy(*tmppeak);
    tmppeak->SetParameter("step", 0.0);
    tmppeak->SetParameter("A", 0.0);
    tmppeak->SetParameter("B", 0.0);


### PR DESCRIPTION
- will investigate this at a later time
This reverts back to the old way of making a copy of GPeak for uncertainty calculations. Still not sure why using the copy ctor would cause this to seg fault. Likely something to do in TF1 constructor calls, and TF1's being drawn/deleted from the pad.