### PR TITLE
Fixes TChannel Parsing issue, TMultiPeak upgrade

### DIFF
--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -40,6 +40,10 @@ protected:
    {
       this->Clear();
    }
+   template <class PtrObj, typename MemFn>
+   TGRSIFit(const char *name, const  PtrObj &p, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar, const char *class_name, const char *fcn_name) : TF1(name,p,memFn, xmin, xmax, npar, class_name, fcn_name){
+      this->Clear();
+   }
 
    TGRSIFit(const TGRSIFit& copy);
 

--- a/include/TMultiPeak.h
+++ b/include/TMultiPeak.h
@@ -27,6 +27,7 @@
 /// Gaussian like in nature (ie centroid and area).
 ///
 /////////////////////////////////////////////////////////////////
+class TPeak;
 
 class TMultiPeak : public TGRSIFit {
 public:
@@ -48,7 +49,7 @@ public:
    void   SortPeaks(Bool_t (*SortFunction)(const TPeak*, const TPeak*) = TPeak::CompareEnergy);
    TPeak* GetPeak(UInt_t idx);
    TPeak* GetPeakClosestTo(Double_t energy);
-   void DrawPeaks() const;
+   void DrawPeaks();
    TF1* Background() const { return fBackground; }
 
    static void SetLogLikelihoodFlag(bool flag) { fLogLikelihoodFlag = flag; }
@@ -63,10 +64,11 @@ private:
    static bool         fLogLikelihoodFlag; //!<!
    std::vector<TPeak*> fPeakVec;
    TF1*                fBackground;
+   bool                fConstrainWidths;
 
-   static Double_t MultiPhotoPeakBG(Double_t* dim, Double_t* par);
-   static Double_t MultiStepBG(Double_t* dim, Double_t* par);
-   static Double_t SinglePeakBG(Double_t* dim, Double_t* par);
+   Double_t MultiPhotoPeakBG(Double_t* dim, Double_t* par);
+   Double_t MultiStepBG(Double_t* dim, Double_t* par);
+   Double_t SinglePeakBG(Double_t* dim, Double_t* par);
 
    /// \cond CLASSIMP
    ClassDef(TMultiPeak, 2);

--- a/libraries/GROOT/GPeak.cxx
+++ b/libraries/GROOT/GPeak.cxx
@@ -260,7 +260,7 @@ Bool_t GPeak::Fit(TH1* fithist, Option_t* opt)
 
    if(fithist->GetSumw2()->fN != fithist->GetNbinsX() + 2) fithist->Sumw2();
 
-   TFitResultPtr fitres = fithist->Fit(this, Form("%sLRSME", options.Data()));
+   TFitResultPtr fitres = fithist->Fit(this, Form("%sLRSM", options.Data()));
 
    // fitres.Get()->Print();
    printf("chi^2/NDF = %.02f\n", this->GetChisquare() / (double)this->GetNDF());

--- a/libraries/GROOT/GValue.cxx
+++ b/libraries/GROOT/GValue.cxx
@@ -228,8 +228,8 @@ int GValue::ParseInputData(const std::string& input, EPriority priority, Option_
 
    bool        brace_open = false;
    std::string name;
-
-   while(std::getline(infile, line) != nullptr) {
+   
+   while(std::getline(infile, line)) { //This line was giving me a comilation problem (RD)
       linenumber++;
       trim(&line);
       size_t comment = line.find("//");

--- a/libraries/GROOT/GValue.cxx
+++ b/libraries/GROOT/GValue.cxx
@@ -229,7 +229,7 @@ int GValue::ParseInputData(const std::string& input, EPriority priority, Option_
    bool        brace_open = false;
    std::string name;
 
-   while( std::getline(infile, line).good() ) {
+   while( !std::getline(infile, line).fail() ) {
       linenumber++;
       trim(&line);
       size_t comment = line.find("//");

--- a/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -4,6 +4,8 @@
 #include "Math/Factory.h"
 #include "Math/Functor.h"
 
+#include <algorithm>
+
 /// \cond CLASSIMP
 ClassImp(TMultiPeak)
    /// \endcond
@@ -11,12 +13,12 @@ ClassImp(TMultiPeak)
    Bool_t TMultiPeak::fLogLikelihoodFlag = false;
 
 TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t>& centroids, Option_t*)
-   : TGRSIFit("multipeakbg", MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5)
+   : TGRSIFit("multipeakbg",this, &TMultiPeak::MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5,"TMultiPeak","MultiPhotoPeakBG")
 {
    this->Clear();
    // We make the background first so we can send it to the TPeaks.
-   fBackground = new TF1(Form("MPbackground_%d_to_%d", (Int_t)(xlow), (Int_t)(xhigh)), MultiStepBG, xlow, xhigh,
-                         centroids.size() * 6 + 5);
+   fBackground = new TF1(Form("MPbackground_%d_to_%d", (Int_t)(xlow), (Int_t)(xhigh)),this,&TMultiPeak::MultiStepBG, xlow, xhigh,
+                         centroids.size() * 6 + 5,"TMuliPeak","MultiStepBG");
    fBackground->SetNpx(1000);
    fBackground->SetLineStyle(2);
    fBackground->SetLineColor(kBlack);
@@ -47,11 +49,11 @@ TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t
    this->InitNames();
 }
 
-TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg", MultiPhotoPeakBG, 0, 1000, 10)
+TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, 0, 1000, 10, "TMultiPeak","MultiPhotoPeakBG")
 {
    // I don't think this constructor should be used, RD.
    this->InitNames();
-   fBackground = new TF1("background", MultiStepBG, 1000, 10); // This is a weird nonsense line.
+   fBackground = new TF1("background",this, &TMultiPeak::MultiStepBG, 1000, 10,10,"TMultiPeak","MultiStepBG"); // This is a weird nonsense line.
    fBackground->SetNpx(1000);
    fBackground->SetLineStyle(2);
    fBackground->SetLineColor(kBlack);
@@ -152,7 +154,7 @@ Bool_t TMultiPeak::InitParams(TH1* fithist)
       this->SetParLimits(6 * i + 5, 0, fithist->GetBinContent(bin) * 5.);
       this->SetParLimits(6 * i + 6, centroid - 4, centroid + 4);
       // this->SetParLimits(6*i+7,0.1,xhigh-xlow);//This will be linked to other peaks eventually.
-      this->SetParLimits(6 * i + 7, 0.1, 1.5); // This will be linked to other peaks eventually.
+      this->SetParLimits(6 * i + 7, 0.1, 2.5); // This will be linked to other peaks eventually.
       this->SetParLimits(6 * i + 8, 0.000001, 10);
       this->SetParLimits(6 * i + 9, 0.000001, 100);
       this->SetParLimits(6 * i + 10, 0.0, 1.0E2);
@@ -202,6 +204,29 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
 
    TFitResultPtr fitres;
    // Log likelihood is the proper fitting technique UNLESS the data is a result of an addition or subtraction.
+   if(GetLogLikelihoodFlag()) {
+      fitres = fithist->Fit(this, Form("%sLRSQ", opt)); // The RS needs to always be there
+   } else {
+      fitres = fithist->Fit(this, Form("%sRSQ", opt)); // The RS needs to always be there
+   }
+
+   std::vector<Double_t> sigma_list;
+   for(int i = 0; i<static_cast<int>(GetParameter(0)+0.5); ++i){
+      //Get Median sigma
+      sigma_list.push_back(GetParameter(6*i + 7));
+   }
+   std::sort(sigma_list.begin(), sigma_list.end(), std::greater<Double_t>() );
+   Double_t median = sigma_list.at(static_cast<int>(sigma_list.size()/2.));
+   
+   Double_t range_low,range_high;
+   for(int i = 0; i<static_cast<int>(GetParameter(0)+0.5); ++i){
+      GetParLimits(6*i+7,range_low,range_high);
+      if(range_low != range_high){
+         SetParLimits(6 *i + 7,median*.95,median*1.05);
+      }
+   }
+
+   //Refit
    if(GetLogLikelihoodFlag()) {
       fitres = fithist->Fit(this, Form("%sLRS", opt)); // The RS needs to always be there
    } else {
@@ -373,11 +398,14 @@ Double_t TMultiPeak::MultiPhotoPeakBG(Double_t* dim, Double_t* par)
    // General background.
    int    npeaks = (int)(par[0] + 0.5);
    double result = TGRSIFunctions::PolyBg(dim, &par[1], 2); // polynomial background. uses par[1->4]
-   for(int i = 0; i < npeaks; i++) {                        // par[0] is number of peaks
+   for(int i = 0; i < npeaks; ++i) {                        // par[0] is number of peaks
       Double_t tmp_par[6];
       tmp_par[0] = par[6 * i + 5];  // height of photopeak
       tmp_par[1] = par[6 * i + 6];  // Peak Centroid of non skew gaus
       tmp_par[2] = par[6 * i + 7];  // standard deviation  of gaussian
+      //This is where I link up the widths of the gaussians if they are within 5 keV. 
+   //  for(int j = 0; j < npeaks; ++j){
+      //}
       tmp_par[3] = par[6 * i + 8];  //"skewedness" of the skewed gaussian
       tmp_par[4] = par[6 * i + 9];  // relative height of skewed gaussian
       tmp_par[5] = par[6 * i + 10]; // Size of step in background
@@ -452,7 +480,7 @@ TPeak* TMultiPeak::GetPeakClosestTo(Double_t energy)
    return GetPeak(closest_idx);
 }
 
-void TMultiPeak::DrawPeaks() const
+void TMultiPeak::DrawPeaks()
 {
    // Draws the individual TPeaks that make up the TMultiPeak. ROOT makes this a complicated process. The result on the
    // histogram might have memory issues.
@@ -465,8 +493,8 @@ void TMultiPeak::DrawPeaks() const
       Double_t centroid = peak->GetCentroid();
       Double_t range    = 2. * peak->GetFWHM();
 
-      TF1* sum = new TF1(Form("tmp%s", peak->GetName()), SinglePeakBG, centroid - range, centroid + range,
-                         fPeakVec.size() * 6 + 11);
+      TF1* sum = new TF1(Form("tmp%s", peak->GetName()), this, &TMultiPeak::SinglePeakBG, centroid - range, centroid + range,
+                         fPeakVec.size() * 6 + 11, "TMultiPeak","SinglePeakBG");
 
       for(int j = 0; j < GetNpar(); ++j) {
          sum->SetParameter(j, GetParameter(j));

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -80,7 +80,8 @@ TNucleus::TNucleus(const char* name)
 		// MassFile.append(massfile);
 		infile.open(MassFile.c_str());
 		// printf("MassFile.c_str()
-		while(getline(infile, line) != nullptr) {
+		//while(getline(infile, line) != nullptr) { 
+		while(getline(infile, line)) {  //This line was causing compile problems RD
 			if(line.length() < 1) {
 				continue;
 			}
@@ -480,7 +481,8 @@ bool TNucleus::LoadTransitionFile()
 
 	std::string line;
 
-	while(getline(transfile, line) != nullptr) {
+	//while(getline(transfile, line) != nullptr) { This line was causing compile problems RD
+	while(getline(transfile, line)) {
 		// printf("%i\t%s\n",counter++,line.c_str());
 		if(line.compare(0, 2, "//") == 0) {
 			continue;
@@ -492,7 +494,8 @@ bool TNucleus::LoadTransitionFile()
 		auto*             tran = new TTransition;
 		std::stringstream ss(line);
 		int               counter = 0;
-		while((ss >> temp) != nullptr) {
+		//while((ss >> temp) != nullptr) { //This line was causing compile problems RD
+		while((ss >> temp)) {
 			counter++;
 			if(counter == 1) {
 				tran->SetEnergy(temp);

--- a/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TGRSIAnalysis/TNucleus/TNucleus.cxx
@@ -80,7 +80,7 @@ TNucleus::TNucleus(const char* name)
 		// MassFile.append(massfile);
 		infile.open(MassFile.c_str());
 		// printf("MassFile.c_str()
-		while(getline(infile, line).good()) {
+		while(!getline(infile, line).fail()) {
 			if(line.length() < 1) {
 				continue;
 			}
@@ -480,7 +480,7 @@ bool TNucleus::LoadTransitionFile()
 
 	std::string line;
 
-	while(getline(transfile, line).good()) {
+	while(!getline(transfile, line).fail()) {
 		// printf("%i\t%s\n",counter++,line.c_str());
 		if(line.compare(0, 2, "//") == 0) {
 			continue;
@@ -492,7 +492,7 @@ bool TNucleus::LoadTransitionFile()
 		auto*             tran = new TTransition;
 		std::stringstream ss(line);
 		int               counter = 0;
-		while((ss >> temp).good()) {
+		while(!(ss >> temp).fail()) {
 			counter++;
 			if(counter == 1) {
 				tran->SetEnergy(temp);

--- a/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
+++ b/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
@@ -60,16 +60,16 @@ void TSRIM::ReadEnergyLossFile(const char* filename, double emax, double emin, b
    std::vector<double>      number_input, dEdX_temp;
    std::vector<std::string> string_input;
 
-   while(std::getline(infile, line).good() ) {
+   while(!std::getline(infile, line).fail() ) {
       if(line.length() == 0u) {
          continue;
       }
       std::stringstream linestream(line);
       number_input.clear();
       string_input.clear();
-      while((linestream >> word).good()) {
+      while(!(linestream >> word).fail()) {
          std::stringstream ss(word);
-         if( (ss >> temp).good() ) { // if it's a number
+         if( !(ss >> temp).fail() ) { // if it's a number
             number_input.push_back(temp);
          } else {
             string_input.push_back(ss.str());

--- a/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
+++ b/libraries/TGRSIAnalysis/TSRIM/TSRIM.cxx
@@ -60,16 +60,18 @@ void TSRIM::ReadEnergyLossFile(const char* filename, double emax, double emin, b
    std::vector<double>      number_input, dEdX_temp;
    std::vector<std::string> string_input;
 
-   while(std::getline(infile, line) != nullptr) {
+   //while(std::getline(infile, line) != nullptr) { //This line was giving me compile problems RD
+   while(std::getline(infile, line)) {
       if(line.length() == 0u) {
          continue;
       }
       std::stringstream linestream(line);
       number_input.clear();
       string_input.clear();
-      while((linestream >> word) != nullptr) {
+      //while((linestream >> word) != nullptr) { This line was giving me compile problems RD
+      while((linestream >> word)) {
          std::stringstream ss(word);
-         if((ss >> temp) != nullptr) { // if it's a number
+         if((ss >> temp)) { // if it's a number (compile probs RD)
             number_input.push_back(temp);
          } else {
             string_input.push_back(ss.str());

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -1197,43 +1197,43 @@ Int_t TChannel::ParseInputData(const char* inputdata, Option_t* opt)
             } else if(type.compare("ENGCOEFF") == 0) {
                channel->DestroyENGCal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddENGCoefficient(value);
                }
             } else if(type.compare("LEDCOEFF") == 0) {
                channel->DestroyLEDCal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddLEDCoefficient(value);
                }
             } else if(type.compare("CFDCOEFF") == 0) {
                channel->DestroyCFDCal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddCFDCoefficient(value);
                }
             } else if(type.compare("TIMECOEFF") == 0) {
                channel->DestroyTIMECal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddTIMECoefficient(value);
                }
             } else if(type.compare("CTCOEFF") == 0) {
                channel->DestroyCTCal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddCTCoefficient(value);
                }
             } else if(type.compare("WALK") == 0) {
                channel->DestroyTIMECal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddTIMECoefficient(value);
                }
             } else if(type.compare("EFFCOEFF") == 0) {
                channel->DestroyEFFCal();
                double value;
-               while((ss >> value) != nullptr) {
+               while((ss >> value)) {
                   channel->AddEFFCoefficient(value);
                }
             } else if(type.compare("FILEINT") == 0) {

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -1074,7 +1074,7 @@ Int_t TChannel::ParseInputData(const char* inputdata, Option_t* opt)
 
    // Parse the cal file. This is useful because if the cal file contains something that
    // the parser does not recognize, it just skips it!
-   while(std::getline(infile, line).good()) {
+   while(std::getline(infile, line)) {
       linenumber++;
       trim(&line);
       size_t comment = line.find("//");
@@ -1197,43 +1197,43 @@ Int_t TChannel::ParseInputData(const char* inputdata, Option_t* opt)
             } else if(type.compare("ENGCOEFF") == 0) {
                channel->DestroyENGCal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddENGCoefficient(value);
                }
             } else if(type.compare("LEDCOEFF") == 0) {
                channel->DestroyLEDCal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddLEDCoefficient(value);
                }
             } else if(type.compare("CFDCOEFF") == 0) {
                channel->DestroyCFDCal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddCFDCoefficient(value);
                }
             } else if(type.compare("TIMECOEFF") == 0) {
                channel->DestroyTIMECal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddTIMECoefficient(value);
                }
             } else if(type.compare("CTCOEFF") == 0) {
                channel->DestroyCTCal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddCTCoefficient(value);
                }
             } else if(type.compare("WALK") == 0) {
                channel->DestroyTIMECal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddTIMECoefficient(value);
                }
             } else if(type.compare("EFFCOEFF") == 0) {
                channel->DestroyEFFCal();
                double value;
-               while((ss >> value).good()) {
+               while(!(ss >> value).fail()) {
                   channel->AddEFFCoefficient(value);
                }
             } else if(type.compare("FILEINT") == 0) {

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -348,7 +348,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
    int                linenumber = 0;
 
    // Parse the info file.
-   while(std::getline(infile, line).good() ) {
+   while(!std::getline(infile, line).fail() ) {
       linenumber++;
       trim(&line);
       size_t comment = line.find("//");
@@ -392,7 +392,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
       } else if(type.compare("BADCYCLE") == 0) {
          std::istringstream ss(line);
          int                tmp_int;
-         while((ss >> tmp_int).good() ) {
+         while(!(ss >> tmp_int).fail() ) {
             Get()->AddBadCycle(tmp_int);
          }
       }

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -348,7 +348,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
    int                linenumber = 0;
 
    // Parse the info file.
-   while(std::getline(infile, line) != nullptr) {
+   while(std::getline(infile, line)) {
       linenumber++;
       trim(&line);
       size_t comment = line.find("//");
@@ -392,7 +392,7 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
       } else if(type.compare("BADCYCLE") == 0) {
          std::istringstream ss(line);
          int                tmp_int;
-         while((ss >> tmp_int) != nullptr) {
+         while((ss >> tmp_int)) {
             Get()->AddBadCycle(tmp_int);
          }
       }

--- a/util/gadd.cxx
+++ b/util/gadd.cxx
@@ -221,7 +221,7 @@ int main(int argc, char** argv)
          }
          while(indirect_file.good()) {
             std::string line;
-            if((std::getline(indirect_file, line).good()) && (line.length() != 0u) &&
+            if(!(std::getline(indirect_file, line).fail()) && (line.length() != 0u) &&
                !merger.AddFile(line.c_str())) {
                return 1;
             }

--- a/util/gadd.cxx
+++ b/util/gadd.cxx
@@ -219,9 +219,9 @@ int main(int argc, char** argv)
             std::cerr<<"gadd could not open indirect file "<<(argv[i] + 1)<<std::endl;
             return 1;
          }
-         while(indirect_file != nullptr) {
+         while(indirect_file) {
             std::string line;
-            if((std::getline(indirect_file, line) != nullptr) && (line.length() != 0u) &&
+            if((std::getline(indirect_file, line)) && (line.length() != 0u) &&
                !merger.AddFile(line.c_str())) {
                return 1;
             }


### PR DESCRIPTION
Changed the `good()` calls to `!fail()` calls.

Got TMultiPeak into a nicer form using functors. It does, however, make some initial guesses on sigma right now which can work really well, or take some manual manipulation. Will fix this soon, needed to get this PR in so that TChannel regained basic functionality.