### PR TITLE
Fixed GetEnergy for use with defined cal file integrations

### DIFF
--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -105,15 +105,15 @@ double TGRSIDetectorHit::GetEnergy(Option_t*) const
       // Error("GetEnergy","No TChannel exists for address 0x%08x",GetAddress());
       return SetEnergy(static_cast<Double_t>(Charge()));
    }
+   if(channel->UseCalFileIntegration()) {
+      double energy = channel->CalibrateENG(Charge(), 0);
+      return SetEnergy(energy +
+                       GetEnergyNonlinearity(energy)); // this will use the integration value
+                                                       // in the TChannel if it exists.
+   }
    if(fKValue > 0) {
       double energy = channel->CalibrateENG(Charge(), static_cast<int>(fKValue));
       return SetEnergy(energy + GetEnergyNonlinearity(energy));
-   }
-   if(channel->UseCalFileIntegration()) {
-      double energy = channel->CalibrateENG(Charge(), 0);
-      return SetEnergy(channel->CalibrateENG(energy) +
-                       GetEnergyNonlinearity(energy)); // this will use the integration value
-                                                       // in the TChannel if it exists.
    }
    double energy = channel->CalibrateENG(Charge());
    return SetEnergy(energy + GetEnergyNonlinearity(energy));


### PR DESCRIPTION
- Fixes order in which energy calibration occurs. One needs to check if we are forcing the kvalue before we decide to use the one we have in the data.
- We also don't want to calibrate the energy twice if this is the case 😜 