### PR TITLE
Fixed issues with merging TGRSIRunInfo

### DIFF
--- a/include/GCube.h
+++ b/include/GCube.h
@@ -17,11 +17,6 @@ public:
    GCube(const char* name, const char* title, Int_t nbins, const Float_t* bins);
    ~GCube() override;
 
-#if MAJOR_ROOT_VERSION < 6
-   Bool_t Add(TF1* h1, Double_t c1 = 1., Option_t* option = "") override;
-   Bool_t Add(const TH1* h1, Double_t c1 = 1.) override;
-   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1., Double_t c2 = 1.) override;
-#endif
    Int_t BufferEmpty(Int_t action = 0) override;
    Int_t         BufferFill(Double_t, Double_t) override { return -2; } // MayNotUse
    virtual Int_t BufferFill(Double_t x, Double_t y, Double_t z, Double_t w);
@@ -106,21 +101,17 @@ public:
    void AddBinContent(Int_t bin, Double_t w) override { fArray[bin] += Float_t(w); }
    void Copy(TObject& rh) const override;
    void Draw(Option_t* option = "") override { GetMatrix()->Draw(option); }
-#if MAJOR_ROOT_VERSION < 6
-   virtual TH1* DrawCopy(Option_t* option = "") const;
-#else
    TH1* DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const override;
-#endif
    Double_t GetBinContent(Int_t bin) const override;
+   Double_t GetBinContent(Int_t bin, Int_t) const override { return GetBinContent(bin); }
    Double_t GetBinContent(Int_t binx, Int_t biny, Int_t binz) const override
    {
       return GetBinContent(GetBin(binx, biny, binz));
    }
    void Reset(Option_t* option = "") override;
-#if MAJOR_ROOT_VERSION >= 6
    Double_t RetrieveBinContent(Int_t bin) const override { return Double_t(fArray[bin]); }
-#endif
    void SetBinContent(Int_t bin, Double_t content) override;
+   void SetBinContent(Int_t bin, Int_t, Double_t content) override { SetBinContent(bin, content); }
    void SetBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t content) override
    {
       SetBinContent(GetBin(binx, biny, binz), content);
@@ -152,22 +143,18 @@ public:
    void AddBinContent(Int_t bin) override { ++fArray[bin]; }
    void AddBinContent(Int_t bin, Double_t w) override { fArray[bin] += w; }
    void Copy(TObject& rh) const override;
-#if MAJOR_ROOT_VERSION < 6
-   virtual TH1* DrawCopy(Option_t* option = "") const;
-#else
    TH1* DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const override;
-#endif
    void Draw(Option_t* option = "") override { GetMatrix()->Draw(option); }
    Double_t GetBinContent(Int_t bin) const override;
+   Double_t GetBinContent(Int_t bin, Int_t) const override { return GetBinContent(bin); }
    Double_t GetBinContent(Int_t binx, Int_t biny, Int_t binz) const override
    {
       return GetBinContent(GetBin(binx, biny, binz));
    }
    void Reset(Option_t* option = "") override;
-#if MAJOR_ROOT_VERSION >= 6
    Double_t RetrieveBinContent(Int_t bin) const override { return Double_t(fArray[bin]); }
-#endif
    void SetBinContent(Int_t bin, Double_t content) override;
+   void SetBinContent(Int_t bin, Int_t, Double_t content) override { SetBinContent(bin, content); }
    void SetBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t content) override
    {
       SetBinContent(GetBin(binx, biny, binz), content);

--- a/include/GHSym.h
+++ b/include/GHSym.h
@@ -16,11 +16,6 @@ public:
    GHSym(const char* name, const char* title, Int_t nbins, const Float_t* bins);
    ~GHSym() override;
 
-#if MAJOR_ROOT_VERSION < 6
-   Bool_t Add(TF1* h1, Double_t c1 = 1., Option_t* option = "") override;
-   Bool_t Add(const TH1* h1, Double_t c1 = 1.) override;
-   Bool_t Add(const TH1* h1, const TH1* h2, Double_t c1 = 1., Double_t c2 = 1.) override;
-#endif
    Int_t BufferEmpty(Int_t action = 0) override;
    Int_t         BufferFill(Double_t, Double_t) override { return -2; } // MayNotUse
    virtual Int_t BufferFill(Double_t x, Double_t y, Double_t w);
@@ -106,18 +101,12 @@ public:
    void AddBinContent(Int_t bin, Double_t w) override { fArray[bin] += Float_t(w); }
    void Copy(TObject& rh) const override;
    void Draw(Option_t* option = "") override { GetMatrix()->Draw(option); }
-#if MAJOR_ROOT_VERSION < 6
-   virtual TH1* DrawCopy(Option_t* option = "") const;
-#else
    TH1* DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const override;
-#endif
    Double_t GetBinContent(Int_t bin) const override;
    Double_t GetBinContent(Int_t binx, Int_t biny) const override { return GetBinContent(GetBin(binx, biny)); }
    Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const override { return GetBinContent(GetBin(binx, biny)); }
    void Reset(Option_t* option = "") override;
-#if MAJOR_ROOT_VERSION >= 6
    Double_t RetrieveBinContent(Int_t bin) const override { return Double_t(fArray[bin]); }
-#endif
    void SetBinContent(Int_t bin, Double_t content) override;
    void SetBinContent(Int_t binx, Int_t biny, Double_t content) override { SetBinContent(GetBin(binx, biny), content); }
    void SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) override
@@ -151,19 +140,13 @@ public:
    void AddBinContent(Int_t bin) override { ++fArray[bin]; }
    void AddBinContent(Int_t bin, Double_t w) override { fArray[bin] += w; }
    void Copy(TObject& rh) const override;
-#if MAJOR_ROOT_VERSION < 6
-   virtual TH1* DrawCopy(Option_t* option = "") const;
-#else
    TH1* DrawCopy(Option_t* option = "", const char* name_postfix = "_copy") const override;
-#endif
    void Draw(Option_t* option = "") override { GetMatrix()->Draw(option); }
    Double_t GetBinContent(Int_t bin) const override;
    Double_t GetBinContent(Int_t binx, Int_t biny) const override { return GetBinContent(GetBin(binx, biny)); }
    Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const override { return GetBinContent(GetBin(binx, biny)); }
    void Reset(Option_t* option = "") override;
-#if MAJOR_ROOT_VERSION >= 6
    Double_t RetrieveBinContent(Int_t bin) const override { return Double_t(fArray[bin]); }
-#endif
    void SetBinContent(Int_t bin, Double_t content) override;
    void SetBinContent(Int_t binx, Int_t biny, Double_t content) override { SetBinContent(GetBin(binx, biny), content); }
    void SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) override

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -175,11 +175,11 @@ public:
    {
       fRunStart = 0.;
       fRunStop  = 0.;
-      if(runinfo->RunLength() > 0) {
+      if(runinfo->fRunLength > 0) {
 			if(fRunLength > 0) {
-				fRunLength += runinfo->RunLength();
+				fRunLength += runinfo->fRunLength;
 			} else {
-				fRunLength = runinfo->RunLength();
+				fRunLength = runinfo->fRunLength;
 			}
 		}
    }

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -173,14 +173,29 @@ public:
    Long64_t Merge(TCollection* list);
    void Add(TGRSIRunInfo* runinfo)
    {
-      fRunStart = 0.;
-      fRunStop  = 0.;
+		// add the run length together
       if(runinfo->fRunLength > 0) {
 			if(fRunLength > 0) {
 				fRunLength += runinfo->fRunLength;
 			} else {
 				fRunLength = runinfo->fRunLength;
 			}
+		}
+		if(runinfo->fRunNumber != fRunNumber) {
+			// the run number is meaningful only when the run numbers are the same
+			fRunNumber = 0;
+			fSubRunNumber = -1;
+			fRunStart = 0.;
+			fRunStop  = 0.;
+		} else if(runinfo->fSubRunNumber == fSubRunNumber + 1) {
+			// if the run numbers are the same and we have subsequent sub runs we can update the run stop
+			fRunStop = runinfo->fRunStop;
+			fSubRunNumber = runinfo->fSubRunNumber; // so we can check the next subrun as well
+		} else {
+			// with multiple files added, the sub run number has no meaning anymore
+			fSubRunNumber = -1;
+			fRunStart = 0.;
+			fRunStop  = 0.;
 		}
    }
 

--- a/libraries/GROOT/GCube.cxx
+++ b/libraries/GROOT/GCube.cxx
@@ -88,420 +88,6 @@ GCube::GCube(const GCube& rhs) : TH1()
 
 GCube::~GCube() = default;
 
-#if MAJOR_ROOT_VERSION < 6
-Bool_t GCube::Add(TF1* f1, Double_t c1, Option_t* option)
-{
-   /// Performs the operation: this = this + c1*f1
-   /// if errors are defined (see TH1::Sumw2), errors are also recalculated.
-   ///
-   /// By default, the function is computed at the centre of the bin.
-   /// if option "I" is specified (1-d histogram only), the integral of the
-   /// function in each bin is used instead of the value of the function at
-   /// the centre of the bin.
-   /// Only bins inside the function range are recomputed.
-   /// IMPORTANT NOTE: If you intend to use the errors of this histogram later
-   /// you should call Sumw2 before making this operation.
-   /// This is particularly important if you fit the histogram after TH1::Add
-   ///
-   /// The function return kFALSE if the Add operation failed
-
-   if(!f1) {
-      Error("Add", "Attempt to add a non-existing function");
-      return kFALSE;
-   }
-
-   TString opt = option;
-   opt.ToLower();
-   Bool_t integral                                   = kFALSE;
-   if(opt.Contains("i") && fDimension == 1) integral = kTRUE;
-
-   Int_t nbinsx = GetNbinsX();
-   Int_t nbinsy = GetNbinsY();
-   Int_t nbinsz = GetNbinsZ();
-
-   // delete buffer if it is there since it will become invalid
-   if(fBuffer) BufferEmpty(1);
-
-   //   - Add statistics
-   Double_t s1[10];
-   Int_t    i;
-   for(i = 0; i < 10; i++) {
-      s1[i] = 0;
-   }
-   PutStats(s1);
-   SetMinimum();
-   SetMaximum();
-
-   //   - Loop on bins (including underflows/overflows)
-   Int_t     bin, binx, biny, binz;
-   Double_t  cu = 0.;
-   Double_t  xx[3];
-   Double_t* params = nullptr;
-   f1->InitArgs(xx, params);
-   for(binz = 0; binz <= nbinsz + 1; ++binz) {
-      xx[2] = fYaxis.GetBinCenter(binz);
-      for(biny = 0; biny <= nbinsy + 1; ++biny) {
-         xx[1] = fYaxis.GetBinCenter(biny);
-         for(binx = 0; binx <= nbinsx + 1; ++binx) {
-            xx[0] = fXaxis.GetBinCenter(binx);
-            if(!f1->IsInside(xx)) continue;
-            TF1::RejectPoint(kFALSE);
-            bin = GetBin(binx, biny, binz);
-            if(integral) {
-               xx[0] = fXaxis.GetBinLowEdge(binx);
-               cu    = c1 * f1->EvalPar(xx);
-               cu +=
-                  c1 * f1->Integral(fXaxis.GetBinLowEdge(binx), fXaxis.GetBinUpEdge(binx)) * fXaxis.GetBinWidth(binx);
-            } else {
-               cu = c1 * f1->EvalPar(xx);
-            }
-            if(TF1::RejectedPoint()) continue;
-            Double_t error1 = GetBinError(bin);
-            AddBinContent(bin, cu);
-            if(fSumw2.fN) {
-               // errors are unchanged: error on f1 assumed 0
-               fSumw2.fArray[bin] = error1 * error1;
-            }
-         }
-      }
-   }
-
-   return kTRUE;
-}
-
-Bool_t GCube::Add(const TH1* h1, Double_t c1)
-{
-   /// Performs the operation: this = this + c1*h1
-   /// if errors are defined (see TH1::Sumw2), errors are also recalculated.
-   /// Note that if h1 has Sumw2 set, Sumw2 is automatically called for this
-   /// if not already set.
-   /// Note also that adding histogram with labels is not supported, histogram will be
-   /// added merging them by bin number independently of the labels.
-   /// For adding histogram with labels one should use TH1::Merge
-   ///
-   /// SPECIAL CASE (Average/Efficiency histograms)
-   /// For histograms representing averages or efficiencies, one should compute the average
-   /// of the two histograms and not the sum. One can mark a histogram to be an average
-   /// histogram by setting its bit kIsAverage with
-   ///    myhist.SetBit(TH1::kIsAverage);
-   /// Note that the two histograms must have their kIsAverage bit set
-   ///
-   /// IMPORTANT NOTE1: If you intend to use the errors of this histogram later
-   /// you should call Sumw2 before making this operation.
-   /// This is particularly important if you fit the histogram after TH1::Add
-   ///
-   /// IMPORTANT NOTE2: if h1 has a normalisation factor, the normalisation factor
-   /// is used , ie  this = this + c1*factor*h1
-   /// Use the other TH1::Add function if you do not want this feature
-   ///
-   /// The function return kFALSE if the Add operation failed
-
-   if(h1 == nullptr) {
-      Error("Add", "Attempt to add a non-existing histogram");
-      return kFALSE;
-   }
-
-   // delete buffer if it is there since it will become invalid
-   if(fBuffer) BufferEmpty(1);
-
-   Int_t nbinsx = GetNbinsX();
-   Int_t nbinsy = GetNbinsY();
-   Int_t nbinsz = GetNbinsZ();
-
-   try {
-      CheckConsistency(this, h1);
-   } catch(DifferentNumberOfBins&) {
-      Error("Add", "Attempt to add histograms with different number of bins");
-      return kFALSE;
-   } catch(DifferentAxisLimits&) {
-      Warning("Add", "Attempt to add histograms with different axis limits");
-   } catch(DifferentBinLimits&) {
-      Warning("Add", "Attempt to add histograms with different bin limits");
-   } catch(DifferentLabels&) {
-      Warning("Add", "Attempt to add histograms with different labels");
-   }
-
-   //    Create Sumw2 if h1 has Sumw2 set
-   if(fSumw2.fN == 0 && h1->GetSumw2N() != 0) Sumw2();
-
-   //   - Add statistics
-   Double_t entries = TMath::Abs(GetEntries() + c1 * h1->GetEntries());
-
-   // statistics can be preserved only in case of positive coefficients
-   // otherwise with negative c1 (histogram subtraction) one risks to get negative variances
-   Bool_t   resetStats = (c1 < 0);
-   Double_t s1[kNstat] = {0};
-   Double_t s2[kNstat] = {0};
-   if(!resetStats) {
-      // need to initialize to zero s1 and s2 since
-      // GetStats fills only used elements depending on dimension and type
-      GetStats(s1);
-      h1->GetStats(s2);
-   }
-
-   SetMinimum();
-   SetMaximum();
-
-   //   - Loop on bins (including underflows/overflows)
-   Int_t    bin, binx, biny, binz;
-   Double_t cu;
-   Double_t factor                     = 1.;
-   if(h1->GetNormFactor() != 0) factor = h1->GetNormFactor() / h1->GetSumOfWeights();
-
-   for(binz = 0; binz <= nbinsz + 1; ++binz) {
-      for(biny = 0; biny <= nbinsy + 1; ++biny) {
-         for(binx = 0; binx <= nbinsx + 1; ++binx) {
-            bin = GetBin(binx, biny, binz);
-            // special case where histograms have the kIsAverage bit set
-            if(TestBit(kIsAverage) && h1->TestBit(kIsAverage)) {
-               Double_t y1 = h1->GetBinContent(bin);
-               Double_t y2 = GetBinContent(bin);
-               Double_t e1 = h1->GetBinError(bin);
-               Double_t e2 = GetBinError(bin);
-               Double_t w1 = 1., w2 = 1.;
-               // consider all special cases  when bin errors are zero
-               // see http://root.cern.ch/phpBB3//viewtopic.php?f=3&t=13299
-               if(e1 > 0) {
-                  w1 = 1. / (e1 * e1);
-               } else if(h1->GetSumw2N()) {
-                  w1 = 1.E200; // use an arbitrary huge value
-                  if(y1 == 0) {
-                     // use an estimated error from the global histogram scale
-                     double sf = (s2[0] != 0) ? s2[1] / s2[0] : 1;
-                     w1        = 1. / (sf * sf);
-                  }
-               }
-               if(e2 > 0) {
-                  w2 = 1. / (e2 * e2);
-               } else if(fSumw2.fN) {
-                  w2 = 1.E200; // use an arbitrary huge value
-                  if(y2 == 0) {
-                     // use an estimated error from the global histogram scale
-                     double sf = (s1[0] != 0) ? s1[1] / s1[0] : 1;
-                     w2        = 1. / (sf * sf);
-                  }
-               }
-               double y = (w1 * y1 + w2 * y2) / (w1 + w2);
-               SetBinContent(bin, y);
-               if(fSumw2.fN) {
-                  double err2             = 1. / (w1 + w2);
-                  if(err2 < 1.E-200) err2 = 0; // to remove arbitrary value when e1=0 AND e2=0
-                  fSumw2.fArray[bin]      = err2;
-               }
-            } else { // normal case of addition between histograms
-               cu = c1 * factor * h1->GetBinContent(bin);
-               AddBinContent(bin, cu);
-               if(fSumw2.fN) {
-                  Double_t e1 = factor * h1->GetBinError(bin);
-                  fSumw2.fArray[bin] += c1 * c1 * e1 * e1;
-               }
-            }
-         }
-      }
-   }
-
-   // update statistics (do here to avoid changes by SetBinContent)
-   if(resetStats) {
-      // statistics need to be reset in case coefficient are negative
-      ResetStats();
-   } else {
-      for(Int_t i = 0; i < kNstat; i++) {
-         if(i == 1)
-            s1[i] += c1 * c1 * s2[i];
-         else
-            s1[i] += c1 * s2[i];
-      }
-      PutStats(s1);
-      SetEntries(entries);
-   }
-
-   return kTRUE;
-}
-
-Bool_t GCube::Add(const TH1* h1, const TH1* h2, Double_t c1, Double_t c2)
-{
-   ///   -*-*-*Replace contents of this histogram by the addition of h1 and h2*-*-*
-   ///         ===============================================================
-   ///
-   ///   this = c1*h1 + c2*h2
-   ///   if errors are defined (see TH1::Sumw2), errors are also recalculated
-   ///   Note that if h1 or h2 have Sumw2 set, Sumw2 is automatically called for this
-   ///   if not already set.
-   ///   Note also that adding histogram with labels is not supported, histogram will be
-   ///   added merging them by bin number independently of the labels.
-   ///   For adding histogram ith labels one should use TH1::Merge
-   ///
-   /// SPECIAL CASE (Average/Efficiency histograms)
-   /// For histograms representing averages or efficiencies, one should compute the average
-   /// of the two histograms and not the sum. One can mark a histogram to be an average
-   /// histogram by setting its bit kIsAverage with
-   ///    myhist.SetBit(TH1::kIsAverage);
-   /// Note that the two histograms must have their kIsAverage bit set
-   ///
-   /// IMPORTANT NOTE: If you intend to use the errors of this histogram later
-   /// you should call Sumw2 before making this operation.
-   /// This is particularly important if you fit the histogram after TH1::Add
-   ///
-   /// ANOTHER SPECIAL CASE : h1 = h2 and c2 < 0
-   /// do a scaling   this = c1 * h1 / (bin Volume)
-   ///
-   /// The function returns kFALSE if the Add operation failed
-
-   if(h1 == nullptr || h2 == nullptr) {
-      Error("Add", "Attempt to add a non-existing histogram");
-      return kFALSE;
-   }
-
-   // delete buffer if it is there since it will become invalid
-   if(fBuffer) BufferEmpty(1);
-
-   Bool_t normWidth = kFALSE;
-   if(h1 == h2 && c2 < 0) {
-      c2        = 0;
-      normWidth = kTRUE;
-   }
-   Int_t nbinsx = GetNbinsX();
-   Int_t nbinsy = GetNbinsY();
-   Int_t nbinsz = GetNbinsZ();
-
-   if(h1 != h2) {
-      try {
-         CheckConsistency(h1, h2);
-         CheckConsistency(this, h1);
-      } catch(DifferentNumberOfBins&) {
-         Error("Add", "Attempt to add histograms with different number of bins");
-         return kFALSE;
-      } catch(DifferentAxisLimits&) {
-         Warning("Add", "Attempt to add histograms with different axis limits");
-      } catch(DifferentBinLimits&) {
-         Warning("Add", "Attempt to add histograms with different bin limits");
-      } catch(DifferentLabels&) {
-         Warning("Add", "Attempt to add histograms with different labels");
-      }
-   }
-
-   //    Create Sumw2 if h1 or h2 have Sumw2 set
-   if(fSumw2.fN == 0 && (h1->GetSumw2N() != 0 || h2->GetSumw2N() != 0)) Sumw2();
-
-   //   - Add statistics
-   Double_t nEntries = TMath::Abs(c1 * h1->GetEntries() + c2 * h2->GetEntries());
-
-   // statistics can be preserved only in case of positive coefficients
-   // otherwise with negative c1 (histogram subtraction) one risks to get negative variances
-   // also in case of scaling with the width we cannot preserve the statistics
-   Double_t s1[kNstat] = {0};
-   Double_t s2[kNstat] = {0};
-   Double_t s3[kNstat];
-   Bool_t   resetStats = (c1 * c2 < 0) || normWidth;
-   if(!resetStats) {
-      // need to initialize to zero s1 and s2 since
-      // GetStats fills only used elements depending on dimension and type
-      h1->GetStats(s1);
-      h2->GetStats(s2);
-      for(Int_t i = 0; i < kNstat; i++) {
-         if(i == 1)
-            s3[i] = c1 * c1 * s1[i] + c2 * c2 * s2[i];
-         else
-            s3[i] = c1 * s1[i] + c2 * s2[i];
-      }
-   }
-
-   SetMinimum();
-   SetMaximum();
-
-   //    Reset the kCanRebin and time display option. Otherwise SetBinContent on the overflow bin
-   //    would resize the axis limits!
-   // we need to do for only X axis since only TH1x::SetBinContent resize the axis
-   Bool_t canRebin = TestBit(kCanRebin);
-   if(canRebin) ResetBit(kCanRebin);
-
-   Bool_t timeDisplayX = fXaxis.GetTimeDisplay();
-   if(timeDisplayX) fXaxis.SetTimeDisplay(0);
-
-   //   - Loop on bins (including underflows/overflows)
-   Int_t    bin, binx, biny, binz;
-   Double_t cu;
-   for(binz = 0; binz <= nbinsz + 1; ++binz) {
-      Double_t wz = h1->GetZaxis()->GetBinWidth(binz);
-      for(biny = 0; biny <= nbinsy + 1; ++biny) {
-         Double_t wy = h1->GetYaxis()->GetBinWidth(biny);
-         for(binx = 0; binx <= nbinsx + 1; ++binx) {
-            Double_t wx = h1->GetXaxis()->GetBinWidth(binx);
-            bin         = GetBin(binx, biny, binz);
-            // special case where histograms have the kIsAverage bit set
-            if(h1->TestBit(kIsAverage) && h2->TestBit(kIsAverage)) {
-               Double_t y1 = h1->GetBinContent(bin);
-               Double_t y2 = h2->GetBinContent(bin);
-               Double_t e1 = h1->GetBinError(bin);
-               Double_t e2 = h2->GetBinError(bin);
-               Double_t w1 = 1., w2 = 1.;
-               // consider all special cases  when bin errors are zero
-               // see http://root.cern.ch/phpBB3//viewtopic.php?f=3&t=13299
-               if(e1 > 0) {
-                  w1 = 1. / (e1 * e1);
-               } else if(h1->GetSumw2N()) {
-                  w1 = 1.E200; // use an arbitrary huge value
-                  if(y1 == 0) {
-                     // use an estimated error from the global histogram scale
-                     double sf = (s1[0] != 0) ? s1[1] / s1[0] : 1;
-                     w1        = 1. / (sf * sf);
-                  }
-               }
-               if(e2 > 0) {
-                  w2 = 1. / (e2 * e2);
-               } else if(h2->GetSumw2N()) {
-                  w2 = 1.E200; // use an arbitrary huge value
-                  if(y2 == 0) {
-                     // use an estimated error from the global histogram scale
-                     double sf = (s2[0] != 0) ? s2[1] / s2[0] : 1;
-                     w2        = 1. / (sf * sf);
-                  }
-               }
-               double y = (w1 * y1 + w2 * y2) / (w1 + w2);
-               SetBinContent(bin, y);
-               if(fSumw2.fN) {
-                  double err2             = 1. / (w1 + w2);
-                  if(err2 < 1.E-200) err2 = 0; // to remove arbitrary value when e1=0 AND e2=0
-                  fSumw2.fArray[bin]      = err2;
-               }
-            } else { // case of histogram Addition
-               if(normWidth) {
-                  Double_t w = wx * wy * wz; //??? not sure about this
-                  cu         = c1 * h1->GetBinContent(bin) / w;
-                  SetBinContent(bin, cu);
-                  if(fSumw2.fN) {
-                     Double_t e1        = h1->GetBinError(bin) / w;
-                     fSumw2.fArray[bin] = c1 * c1 * e1 * e1;
-                  }
-               } else {
-                  cu = c1 * h1->GetBinContent(bin) + c2 * h2->GetBinContent(bin);
-                  SetBinContent(bin, cu);
-                  if(fSumw2.fN) {
-                     Double_t e1        = h1->GetBinError(bin);
-                     Double_t e2        = h2->GetBinError(bin);
-                     fSumw2.fArray[bin] = c1 * c1 * e1 * e1 + c2 * c2 * e2 * e2;
-                  }
-               }
-            }
-         }
-      }
-   }
-   if(resetStats) {
-      // statistics need to be reset in case coefficient are negative
-      ResetStats();
-   } else {
-      // update statistics (do here to avoid changes by SetBinContent)
-      PutStats(s3);
-      SetEntries(nEntries);
-   }
-
-   if(canRebin) SetBit(kCanRebin);
-   if(timeDisplayX) fXaxis.SetTimeDisplay(1);
-
-   return kTRUE;
-}
-#endif
-
 Int_t GCube::BufferEmpty(Int_t action)
 {
    /// Fill histogram with all entries in the buffer.
@@ -529,13 +115,8 @@ Int_t GCube::BufferEmpty(Int_t action)
       fBuffer = buffer;
    }
 
-#if MAJOR_ROOT_VERSION < 6
-   if(TestBit(kCanRebin) || fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin() ||
-      fZaxis.GetXmax() <= fZaxis.GetXmin()) {
-#else
    if(CanExtendAllAxes() || fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin() ||
       fZaxis.GetXmax() <= fZaxis.GetXmin()) {
-#endif
       // find min, max of entries in buffer
       // for the symmetric matrix x- and y-range are the same
       Double_t min = fBuffer[2];
@@ -2165,13 +1746,8 @@ Long64_t GCube::Merge(TCollection* list)
    Double_t nentries = GetEntries();
    Int_t    binx, biny, binz, ix, iy, iz, nx, ny, nz, bin, ibin;
    Double_t cu;
-#if MAJOR_ROOT_VERSION < 6
-   Bool_t canRebin = TestBit(kCanRebin);
-   ResetBit(kCanRebin); // reset, otherwise setting the under/overflow will rebin
-#else
    Bool_t canExtend = CanExtendAllAxes();
    SetCanExtend(TH1::kNoAxis); // reset, otherwise setting the under/overflow will extend the axis
-#endif
 
    while((h = static_cast<GCube*>(next())) != nullptr) {
       // process only if the histogram has limits; otherwise it was processed before
@@ -2233,13 +1809,9 @@ Long64_t GCube::Merge(TCollection* list)
          }
       }
    }
-#if MAJOR_ROOT_VERSION < 6
-   if(canRebin) SetBit(kCanRebin);
-#else
    if(canExtend) {
       SetCanExtend(static_cast<UInt_t>(canExtend));
    }
-#endif
 
    // copy merged stats
    PutStats(totstats);
@@ -2584,12 +2156,6 @@ GCube* GCube::Rebin3D(Int_t ngroup, const char* newname)
       hnew->SetName(newname);
    }
 
-#if MAJOR_ROOT_VERSION < 6
-   // reset kCanRebin bit to avoid a rebinning in SetBinContent
-   Int_t bitRebin = hnew->TestBit(kCanRebin);
-   hnew->SetBit(kCanRebin, 0);
-#endif
-
    // save original statistics
    Double_t stat[kNstat];
    GetStats(stat);
@@ -2856,9 +2422,6 @@ GCube* GCube::Rebin3D(Int_t ngroup, const char* newname)
    if(!resetStat) {
       hnew->PutStats(stat);
    }
-#if MAJOR_ROOT_VERSION < 6
-   hnew->SetBit(kCanRebin, bitRebin);
-#endif
 
    delete[] oldBins;
    if(oldErrors != nullptr) {
@@ -3137,21 +2700,6 @@ void GCubeF::Copy(TObject& rh) const
    GCube::Copy(static_cast<GCubeF&>(rh));
 }
 
-#if MAJOR_ROOT_VERSION < 6
-TH1* GCubeF::DrawCopy(Option_t* option) const
-{
-   // Draw copy.
-
-   TString opt = option;
-   opt.ToLower();
-   if(gPad != nullptr && !opt.Contains("same")) gPad->Clear();
-   TH1* newth1 = static_cast<TH1*>(Clone());
-   newth1->SetDirectory(nullptr);
-   newth1->SetBit(kCanDelete);
-   newth1->AppendPad(option);
-   return newth1;
-}
-#else
 TH1* GCubeF::DrawCopy(Option_t* option, const char* name_postfix) const
 {
    // Draw copy.
@@ -3168,7 +2716,6 @@ TH1* GCubeF::DrawCopy(Option_t* option, const char* name_postfix) const
    newth1->AppendPad(option);
    return newth1;
 }
-#endif
 
 Double_t GCubeF::GetBinContent(Int_t bin) const
 {
@@ -3363,21 +2910,6 @@ void GCubeD::Copy(TObject& rh) const
    GCube::Copy(static_cast<GCubeD&>(rh));
 }
 
-#if MAJOR_ROOT_VERSION < 6
-TH1* GCubeD::DrawCopy(Option_t* option) const
-{
-   // Draw copy.
-
-   TString opt = option;
-   opt.ToLower();
-   if(gPad != nullptr && !opt.Contains("same")) gPad->Clear();
-   TH1* newth1 = static_cast<TH1*>(Clone());
-   newth1->SetDirectory(nullptr);
-   newth1->SetBit(kCanDelete);
-   newth1->AppendPad(option);
-   return newth1;
-}
-#else
 TH1* GCubeD::DrawCopy(Option_t* option, const char* name_postfix) const
 {
    // Draw copy.
@@ -3394,7 +2926,6 @@ TH1* GCubeD::DrawCopy(Option_t* option, const char* name_postfix) const
    newth1->AppendPad(option);
    return newth1;
 }
-#endif
 
 Double_t GCubeD::GetBinContent(Int_t bin) const
 {

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -39,7 +39,6 @@ void TGRSIRunInfo::SetRunInfo(TGRSIRunInfo* tmp)
 
 Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
 {
-
    TDirectory* savdir = gDirectory;
    if(tempf != nullptr) {
       tempf->cd();
@@ -87,38 +86,42 @@ void TGRSIRunInfo::Print(Option_t* opt) const
    // a: Print out more details.
    std::cout<<"Title: "<<fRunTitle<<std::endl;
    std::cout<<"Comment: "<<fRunComment<<std::endl;
+	time_t tmpStart = static_cast<time_t>(fRunStart);
+	time_t tmpStop  = static_cast<time_t>(fRunStop);
+	struct tm runStart = *localtime(const_cast<const time_t*>(&tmpStart));
+	struct tm runStop  = *localtime(const_cast<const time_t*>(&tmpStop));
+	printf("\t\tRunNumber:          %05i\n", fRunNumber);
+	printf("\t\tSubRunNumber:       %03i\n", fSubRunNumber);
+	if(fRunStart != 0 && fRunStop != 0) {
+		printf("\t\tRunStart:           %s", asctime(&runStart));
+		printf("\t\tRunStop:            %s", asctime(&runStop));
+		printf("\t\tRunLength:          %.0f\n", fRunLength);
+	} else {
+		printf("\t\tCombined RunLength: %.0f\n", fRunLength);
+	}
    if(strchr(opt, 'a') != nullptr) {
-      printf("\tTGRSIRunInfo Status:\n");
-      printf("\t\tRunNumber:    %05i\n", TGRSIRunInfo::Get()->fRunNumber);
-      printf("\t\tSubRunNumber: %03i\n", TGRSIRunInfo::Get()->fSubRunNumber);
-      printf("\t\tRunStart:     %.0f\n", TGRSIRunInfo::Get()->fRunStart);
-      printf("\t\tRunStop:      %.0f\n", TGRSIRunInfo::Get()->fRunStop);
-      printf("\t\tRunLength:    %.0f\n", TGRSIRunInfo::Get()->fRunLength);
-      printf("\t\tTIGRESS:      %s\n", Tigress() ? "true" : "false");
-      printf("\t\tSHARC:        %s\n", Sharc() ? "true" : "false");
-      printf("\t\tTRIFOIL:      %s\n", TriFoil() ? "true" : "false");
-      printf("\t\tTIP:          %s\n", Tip() ? "true" : "false");
-      printf("\t\tCSM:          %s\n", CSM() ? "true" : "false");
-      printf("\t\tSPICE:        %s\n", Spice() ? "true" : "false");
-      printf("\t\tS3:           %s\n", S3() ? "true" : "false");
-      printf("\t\tBAMBINO:      %s\n", Bambino() ? "true" : "false");
-      printf("\t\tRF:           %s\n", RF() ? "true" : "false");
-      printf("\t\tGRIFFIN:      %s\n", Griffin() ? "true" : "false");
-      printf("\t\tSCEPTAR:      %s\n", Sceptar() ? "true" : "false");
-      printf("\t\tPACES:        %s\n", Paces() ? "true" : "false");
-      printf("\t\tDESCANT:      %s\n", Descant() ? "true" : "false");
-      printf("\t\tZDS:          %s\n", ZeroDegree() ? "true" : "false");
-      printf("\t\tDANTE:        %s\n", Dante() ? "true" : "false");
-      printf("\t\tFIPPS:        %s\n", Fipps() ? "true" : "false");
+      printf("\t\tTIGRESS:            %s\n", Tigress() ? "true" : "false");
+      printf("\t\tSHARC:              %s\n", Sharc() ? "true" : "false");
+      printf("\t\tTRIFOIL:            %s\n", TriFoil() ? "true" : "false");
+      printf("\t\tTIP:                %s\n", Tip() ? "true" : "false");
+      printf("\t\tCSM:                %s\n", CSM() ? "true" : "false");
+      printf("\t\tSPICE:              %s\n", Spice() ? "true" : "false");
+      printf("\t\tS3:                 %s\n", S3() ? "true" : "false");
+      printf("\t\tBAMBINO:            %s\n", Bambino() ? "true" : "false");
+      printf("\t\tRF:                 %s\n", RF() ? "true" : "false");
+      printf("\t\tGRIFFIN:            %s\n", Griffin() ? "true" : "false");
+      printf("\t\tSCEPTAR:            %s\n", Sceptar() ? "true" : "false");
+      printf("\t\tPACES:              %s\n", Paces() ? "true" : "false");
+      printf("\t\tDESCANT:            %s\n", Descant() ? "true" : "false");
+      printf("\t\tZDS:                %s\n", ZeroDegree() ? "true" : "false");
+      printf("\t\tDANTE:              %s\n", Dante() ? "true" : "false");
+      printf("\t\tFIPPS:              %s\n", Fipps() ? "true" : "false");
       printf("\n");
       printf(DBLUE "\tArray Position (mm) = " DRED "%.01f" RESET_COLOR "\n", TGRSIRunInfo::HPGeArrayPosition());
       printf(DBLUE "\tDESCANT in ancillary positions = " DRED "%s" RESET_COLOR "\n",
              TGRSIRunInfo::DescantAncillary() ? "TRUE" : "FALSE");
       printf("\n");
       printf("\t==============================\n");
-   } else {
-      printf("\t\tRunNumber:    %05i\t", TGRSIRunInfo::Get()->fRunNumber);
-      printf("\t\tSubRunNumber: %03i\n", TGRSIRunInfo::Get()->fSubRunNumber);
    }
 }
 


### PR DESCRIPTION
- TGRSIRunInfo now correctly merges the run length
- the run number is only kept if the added files are from the same run
- the start and stop times are only kept if the files are subsequent sub-runs
- also removed shadow-warnings when using GRSIProof by removing code for ROOT 5