### PR TITLE
Convolution (gaussian+decay) function

### DIFF
--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -47,6 +47,9 @@ Double_t CsIFitFunction(Double_t* i, Double_t* p);
 Double_t DeadTimeCorrect(Double_t* dim, Double_t deadtime, Double_t binWidth = 1.0);
 Double_t DeadTimeAffect(Double_t function, Double_t deadtime, Double_t binWidth = 1.0);
 
+// Timing functions
+ Double_t ConvolutedDecay(Double_t *x, Double_t *par);
+
 #ifdef HAS_MATHMORE
 // Angular correlation fitting
 Double_t LegendrePolynomial(Double_t* x, Double_t* p);

--- a/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -359,3 +359,18 @@ Double_t TGRSIFunctions::PhotoEfficiency(Double_t* dim, Double_t* par)
 
    return TMath::Exp(sum);
 }
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+Double_t TGRSIFunctions::ConvolutedDecay(Double_t *x, Double_t *par){
+//This function is derived from the convolution of a gaussian with an exponential decay, to fit TAC spectra of long half-lives (above 100 ps)
+//Requires the following parameters:
+//   - par[0]:  Normalization factor
+//   - par[1]:  Centroid of gaussian
+//   - par[2]:  Width of gaussian 
+//   - par[3]:  Lambda of the level
+
+  Double_t val;
+  val = TMath::Sqrt(3.1415)*par[0]*par[3]/2*TMath::Exp(par[3]/2*(2*par[1]+par[3]*pow(par[2],2)-2*x[0]))*TMath::Erfc((par[1]+par[3]*pow(par[2],2)-x[0])/(TMath::Sqrt(2)*par[2]));
+  return val;
+
+}


### PR DESCRIPTION
Added a function to TGRSIFunctions that is the convolution of a gaussian and an exponential decay. This is useful, for example, when you have a TAC with a long half-life. I have already succesfully fitted the 1.4 ns lifetime in Eu-152 with this function

![fit](https://user-images.githubusercontent.com/8836668/30086600-bfaa1186-9250-11e7-86e7-502ca7b57e9b.jpg)
