### PR TITLE
Improved peak fitting

### DIFF
--- a/include/TAB3Peak.h
+++ b/include/TAB3Peak.h
@@ -1,0 +1,67 @@
+#ifndef TAB3PEAK_H
+#define TAB3PEAK_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+
+#include "TSinglePeak.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TAB3Peak
+///
+///  This class is used to fit Addback peaks in data
+///
+/////////////////////////////////////////////////////////////////
+
+class TAB3Peak : public TSinglePeak {
+public:
+   // ctors and dtors
+   ~TAB3Peak() override {};
+   TAB3Peak();
+   TAB3Peak(Double_t centroid);
+
+   void InitParNames() override;
+   void InitializeParameters(TH1* hist) override;
+
+   Double_t Centroid() const override;
+   Double_t CentroidErr() const override;
+   Double_t Width() const override;
+
+   void Print(Option_t *opt = "") const override;
+
+   void DrawComponents(Option_t *opt = "") override;
+
+protected:
+   Double_t PeakFunction(Double_t *dim, Double_t *par) override;
+   Double_t BackgroundFunction(Double_t *dim, Double_t *par) override;
+
+private:
+   Double_t OneHitPeakFunction(Double_t *dim, Double_t *par);
+   Double_t TwoHitPeakFunction(Double_t *dim, Double_t *par);
+   Double_t ThreeHitPeakFunction(Double_t *dim, Double_t *par);
+   Double_t OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par);
+   Double_t TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par);
+   Double_t ThreeHitPeakOnGlobalFunction(Double_t *dim, Double_t *par);
+
+   TF1* fOneHitOnGlobal{nullptr};
+   TF1* fTwoHitOnGlobal{nullptr};
+   TF1* fThreeHitOnGlobal{nullptr};
+
+public:
+   /// \cond CLASSIMP
+   ClassDefOverride(TAB3Peak, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -1,0 +1,51 @@
+#ifndef TABPEAK_H
+#define TABPEAK_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+
+#include "TSinglePeak.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TABPeak
+///
+///  This class is used to fit Addback peaks in data
+///
+/////////////////////////////////////////////////////////////////
+
+class TABPeak : public TSinglePeak {
+public:
+   // ctors and dtors
+   ~TABPeak() override {};
+   TABPeak();
+   TABPeak(Double_t centroid);
+
+   void InitParNames() override;
+   void InitializeParameters(TH1* hist) override;
+
+   Double_t Centroid() const override;
+   Double_t CentroidErr() const override;
+
+   void Print(Option_t *opt = "") const override;
+
+protected:
+   Double_t FitFunction(Double_t *dim, Double_t *par) override;
+
+public:
+   /// \cond CLASSIMP
+   ClassDefOverride(TABPeak, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -39,7 +39,7 @@ public:
 
    void Print(Option_t *opt = "") const override;
 
-   void DrawComponents(Option_t *opt = "");
+   void DrawComponents(Option_t *opt = "") override;
 
 protected:
    Double_t PeakFunction(Double_t *dim, Double_t *par) override;

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -36,6 +36,7 @@ public:
 
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
+   Double_t Width() const override;
 
    void Print(Option_t *opt = "") const override;
 

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -39,9 +39,20 @@ public:
 
    void Print(Option_t *opt = "") const override;
 
+   void DrawComponents(Option_t *opt = "");
+
 protected:
    Double_t PeakFunction(Double_t *dim, Double_t *par) override;
    Double_t BackgroundFunction(Double_t *dim, Double_t *par) override;
+
+private:
+   Double_t OneHitPeakFunction(Double_t *dim, Double_t *par);
+   Double_t TwoHitPeakFunction(Double_t *dim, Double_t *par);
+   Double_t OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par);
+   Double_t TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par);
+
+   TF1* fOneHitOnGlobal{nullptr};
+   TF1* fTwoHitOnGlobal{nullptr};
 
 public:
    /// \cond CLASSIMP

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -40,7 +40,8 @@ public:
    void Print(Option_t *opt = "") const override;
 
 protected:
-   Double_t FitFunction(Double_t *dim, Double_t *par) override;
+   Double_t PeakFunction(Double_t *dim, Double_t *par) override;
+   Double_t BackgroundFunction(Double_t *dim, Double_t *par) override;
 
 public:
    /// \cond CLASSIMP

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -49,7 +49,7 @@ public:
    void SetRange(const Double_t &low, const Double_t &high);
    Int_t GetNParameters() const;
    void Fit(TH1* fit_hist);
-   void DrawPeaks(Option_t *opt = "") const;
+   void DrawPeaks(Option_t * = "") const;
 
 private:
    void UpdateFitterParameters();

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -68,6 +68,7 @@ private:
    Double_t fRangeHigh;
    
    Double_t FitFunction(Double_t *dim, Double_t *par);
+   Double_t BackgroundFunction(Double_t *dim, Double_t *par);
 
    /// \cond CLASSIMP
    ClassDefOverride(TPeakFitter, 1);

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -70,6 +70,8 @@ private:
    Double_t FitFunction(Double_t *dim, Double_t *par);
    Double_t BackgroundFunction(Double_t *dim, Double_t *par);
 
+   bool fInitFlag{false};
+
    /// \cond CLASSIMP
    ClassDefOverride(TPeakFitter, 1);
    /// \endcond

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -48,7 +48,7 @@ public:
    TF1 * GetBackground() { return fBGToFit; }
    void SetRange(const Double_t &low, const Double_t &high);
    Int_t GetNParameters() const;
-   void Fit(TH1* fit_hist);
+   void Fit(TH1* fit_hist,Option_t *opt="");
    void DrawPeaks(Option_t * = "") const;
 
 private:

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -1,0 +1,77 @@
+#ifndef TPEAKFITTER_H
+#define TPEAKFITTER_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+#include "TGraph.h"
+
+#include "TGRSIFunctions.h"
+#include "TSinglePeak.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TPeakFitter
+///
+///  This class is used to fit things that resemble "peaks" in data
+///
+/////////////////////////////////////////////////////////////////
+class TSinglePeak;
+typedef std::list<TSinglePeak*> MultiplePeak_t;
+
+class TPeakFitter : public TObject {
+public:
+   // ctors and dtors
+   ~TPeakFitter() override {};
+   TPeakFitter();
+   TPeakFitter(const Double_t& range_low, const Double_t& range_high);
+
+public:
+   void AddPeak(TSinglePeak *p)     { fPeaksToFit.push_back(p); }
+   void RemovePeak(TSinglePeak *p)  { fPeaksToFit.remove(p); }
+//   void SetPeakToFit(TMultiplePeak * peaks_to_fit) { fPeaksToFit = peaks_to_fit; }
+   void SetBackground(TF1* bg_to_fit)                 { fBGToFit = bg_to_fit; }
+   void InitializeParameters(TH1* fit_hist);
+   void InitializeBackgroundParameters(TH1* fit_hist);
+
+   virtual void Print(Option_t * opt = "") const override;
+
+   TF1 * GetBackground() { return fBGToFit; }
+   void SetRange(const Double_t &low, const Double_t &high);
+   Int_t GetNParameters() const;
+   void Fit(TH1* fit_hist);
+   void DrawPeaks(Option_t *opt = "") const;
+
+private:
+   void UpdateFitterParameters();
+   void UpdatePeakParameters(TFitResultPtr fit_res,TH1* fit_hist);
+   Double_t DefaultBackgroundFunction(Double_t *dim, Double_t *par);
+
+
+private:
+//   TMultiplePeak *fPeaksToFit{nullptr};
+   MultiplePeak_t fPeaksToFit;
+   TF1 *fBGToFit{nullptr};
+
+   TF1* fTotalFitFunction;
+
+   Double_t fRangeLow;
+   Double_t fRangeHigh;
+   
+   Double_t FitFunction(Double_t *dim, Double_t *par);
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TPeakFitter, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -1,0 +1,55 @@
+#ifndef TRWPEAK_H
+#define TRWPEAK_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+#include "TGraph.h"
+
+#include "TGRSIFunctions.h"
+#include "TGRSIFit.h"
+#include "TSinglePeak.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TRWPeak
+///
+///  This class is used to fit RadWare like peaks in data
+///
+/////////////////////////////////////////////////////////////////
+
+class TRWPeak : public TSinglePeak {
+public:
+   // ctors and dtors
+   ~TRWPeak() override {};
+   TRWPeak();
+   TRWPeak(Double_t centroid);
+
+   void InitParNames() override;
+   void InitializeParameters(TH1* hist) override;
+
+   Double_t Centroid() const override;
+   Double_t CentroidErr() const override;
+
+   void Print(Option_t *opt = "") const override;
+
+protected:
+   Double_t FitFunction(Double_t *dim, Double_t *par) override;
+   
+
+public:
+   /// \cond CLASSIMP
+   ClassDefOverride(TRWPeak, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -43,8 +43,8 @@ public:
    void Print(Option_t *opt = "") const override;
 
 protected:
-   Double_t FitFunction(Double_t *dim, Double_t *par) override;
-   
+   Double_t PeakFunction(Double_t *dim, Double_t *par) override;
+   Double_t BackgroundFunction(Double_t *dim, Double_t *par) override;
 
 public:
    /// \cond CLASSIMP

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -39,6 +39,7 @@ public:
 
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
+   Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }
 
    void Print(Option_t *opt = "") const override;
 

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -36,7 +36,7 @@ public:
    TSinglePeak();
 
    virtual void InitParNames() {}
-   virtual void InitializeParameters(TH1* hist = nullptr) {}
+   virtual void InitializeParameters(TH1* = nullptr) {}
    bool IsBackgroundParameter(const Int_t& par) const;
    bool IsPeakParameter(const Int_t& par) const;
    void SetListOfBGPar(std::vector<bool> list_of_bg_par) { fListOfBGPars = list_of_bg_par; }
@@ -51,9 +51,9 @@ public:
    virtual Double_t Centroid() const = 0;
    virtual Double_t CentroidErr() const = 0;
 
-   virtual void Print(Option_t * opt = "" ) const override;
+   virtual void Print(Option_t * = "" ) const override;
    virtual void Draw(Option_t * opt = "") override;
-   virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw("same");}
+   virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw(opt);}
    virtual void DrawComponents(Option_t* opt = "");
 
    TF1* GetFitFunction() { return fTotalFunction; }
@@ -65,8 +65,8 @@ public:
 
 protected:
    Double_t TotalFunction(Double_t* dim, Double_t* par);
-   virtual Double_t BackgroundFunction(Double_t* dim, Double_t* par) { return 0.0; }
-   virtual Double_t PeakFunction(Double_t* dim, Double_t* par) {return 0.0; }
+   virtual Double_t BackgroundFunction(Double_t*, Double_t*) { return 0.0; }
+   virtual Double_t PeakFunction(Double_t*, Double_t*) {return 0.0; }
    virtual Double_t PeakOnGlobalFunction(Double_t* dim, Double_t* par);
 
 protected:

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -72,12 +72,12 @@ protected:
 protected:
    TF1* fTotalFunction{nullptr};
    TF1* fBackgroundFunction{nullptr};
+   TF1* fGlobalBackground{nullptr};
+   TF1* fPeakOnGlobal{nullptr};
+
    std::vector<bool> fListOfBGPars;
    Double_t fArea{-0.1};
    Double_t fAreaErr{0.0};
-
-private:
-   TF1* fGlobalBackground{nullptr};
 
 public:
    /// \cond CLASSIMP

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -50,6 +50,7 @@ public:
 
    virtual Double_t Centroid() const = 0;
    virtual Double_t CentroidErr() const = 0;
+   virtual Double_t Width() const = 0;
 
    virtual void Print(Option_t * = "" ) const override;
    virtual void Draw(Option_t * opt = "") override;
@@ -63,11 +64,19 @@ public:
 
    void UpdateBackgroundParameters();
 
+   Double_t GetChi2() const { return fChi2; }
+   Double_t GetNDF() const { return fNDF; }
+   Double_t GetReducedChi2() const { return fChi2/fNDF; }
+
+
 protected:
    Double_t TotalFunction(Double_t* dim, Double_t* par);
    virtual Double_t BackgroundFunction(Double_t*, Double_t*) { return 0.0; }
    virtual Double_t PeakFunction(Double_t*, Double_t*) {return 0.0; }
    virtual Double_t PeakOnGlobalFunction(Double_t* dim, Double_t* par);
+
+   void SetChi2(const Double_t& chi2) { fChi2 = chi2; }
+   void SetNDF(const Int_t& ndf) { fNDF = ndf; } 
 
 protected:
    TF1* fTotalFunction{nullptr};
@@ -78,6 +87,8 @@ protected:
    std::vector<bool> fListOfBGPars;
    Double_t fArea{-0.1};
    Double_t fAreaErr{0.0};
+   Double_t fChi2{std::numeric_limits<Double_t>::quiet_NaN()};
+   Int_t fNDF{0};
 
 public:
    /// \cond CLASSIMP

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -52,17 +52,23 @@ public:
    virtual Double_t CentroidErr() const = 0;
 
    virtual void Print(Option_t * opt = "" ) const override;
-   virtual void Draw(Option_t * opt = "") override { fFitFunction->Draw(opt);}
+   virtual void Draw(Option_t * opt = "") override { fTotalFunction->Draw(opt);}
    virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw("same");}
 
-   TF1* GetFitFunction() { return fFitFunction; }
+   TF1* GetFitFunction() { return fTotalFunction; }
+   TF1* GetBackgroundFunction();
    void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg; }
 
-protected:
-   virtual Double_t FitFunction(Double_t*, Double_t *) {return 0.0;}
+   void UpdateBackgroundParameters();
 
 protected:
-   TF1* fFitFunction{nullptr};
+   Double_t TotalFunction(Double_t* dim, Double_t* par);
+   virtual Double_t BackgroundFunction(Double_t* dim, Double_t* par) { return 0.0; }
+   virtual Double_t PeakFunction(Double_t* dim, Double_t* par) {return 0.0; }
+
+protected:
+   TF1* fTotalFunction{nullptr};
+   TF1* fBackgroundFunction{nullptr};
    std::vector<bool> fListOfBGPars;
    Double_t fArea{-0.1};
    Double_t fAreaErr{0.0};

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -1,0 +1,79 @@
+#ifndef TSINGLEPEAK_H
+#define TSINGLEPEAK_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TObject.h"
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+#include "TGraph.h"
+#include "TMath.h"
+#include "TVirtualFitter.h"
+#include "TPeakFitter.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TSinglePeak
+///
+///  This class is used to fit things that resemble "peaks" in data
+///
+/////////////////////////////////////////////////////////////////
+class TPeakFitter;
+
+class TSinglePeak : public TObject {
+public:
+   friend class TPeakFitter;
+   // ctors and dtors
+   ~TSinglePeak() override{};
+   TSinglePeak();
+
+   virtual void InitParNames() {}
+   virtual void InitializeParameters(TH1* hist = nullptr) {}
+   bool IsBackgroundParameter(const Int_t& par) const;
+   bool IsPeakParameter(const Int_t& par) const;
+   void SetListOfBGPar(std::vector<bool> list_of_bg_par) { fListOfBGPars = list_of_bg_par; }
+   Int_t GetNParameters() const;
+
+   void SetArea(const Double_t& area) { fArea = area; }
+   void SetAreaErr(const Double_t& area_err) { fAreaErr = area_err; }
+
+   Double_t Area() const { return fArea; }
+   Double_t AreaErr() const { return fAreaErr; }
+
+   virtual Double_t Centroid() const = 0;
+   virtual Double_t CentroidErr() const = 0;
+
+   virtual void Print(Option_t * opt = "" ) const override;
+   virtual void Draw(Option_t * opt = "") override { fFitFunction->Draw(opt);}
+   virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw("same");}
+
+   TF1* GetFitFunction() { return fFitFunction; }
+   void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg; }
+
+protected:
+   virtual Double_t FitFunction(Double_t*, Double_t *) {return 0.0;}
+
+protected:
+   TF1* fFitFunction{nullptr};
+   std::vector<bool> fListOfBGPars;
+   Double_t fArea{-0.1};
+   Double_t fAreaErr{0.0};
+
+private:
+   TF1* fGlobalBackground{nullptr};
+
+public:
+   /// \cond CLASSIMP
+   ClassDefOverride(TSinglePeak, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -52,12 +52,14 @@ public:
    virtual Double_t CentroidErr() const = 0;
 
    virtual void Print(Option_t * opt = "" ) const override;
-   virtual void Draw(Option_t * opt = "") override { fTotalFunction->Draw(opt);}
+   virtual void Draw(Option_t * opt = "") override;
    virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw("same");}
+   virtual void DrawComponents(Option_t* opt = "");
 
    TF1* GetFitFunction() { return fTotalFunction; }
    TF1* GetBackgroundFunction();
-   void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg; }
+   void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg;
+      fGlobalBackground->SetLineStyle(kDashed);}
 
    void UpdateBackgroundParameters();
 
@@ -65,6 +67,7 @@ protected:
    Double_t TotalFunction(Double_t* dim, Double_t* par);
    virtual Double_t BackgroundFunction(Double_t* dim, Double_t* par) { return 0.0; }
    virtual Double_t PeakFunction(Double_t* dim, Double_t* par) {return 0.0; }
+   virtual Double_t PeakOnGlobalFunction(Double_t* dim, Double_t* par);
 
 protected:
    TF1* fTotalFunction{nullptr};

--- a/libraries/TGRSIAnalysis/TGRSIFit/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TGRSIFit/LinkDef.h
@@ -6,9 +6,12 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ nestedclasses;
+#pragma link C++ nestedclass;
+#pragma link C++ nestedtypedef;
 
 #pragma link C++ class TGRSIFit+;
-#pragma link C++ class TGRSIFunctions+;
+#pragma link C++ namespace TGRSIFunctions;
+#pragma link C++ defined_in namespace TGRSIFunctions;
 
 #pragma link C++ class TPeak+;
 #pragma link C++ class TMultiPeak+;

--- a/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
@@ -1,0 +1,22 @@
+//TSinglePeak.h TABPeak.h TRWPeak.h TPeakFitter.h 
+
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
+
+#pragma link C++ class TSinglePeak+;
+#pragma link C++ class std::list<TSinglePeak*>+;
+#pragma link C++ class TABPeak+;
+#pragma link C++ class TRWPeak+;
+#pragma link C++ class TPeakFitter+;
+
+#endif
+
+
+
+
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
@@ -1,4 +1,4 @@
-//TSinglePeak.h TABPeak.h TRWPeak.h TPeakFitter.h 
+//TSinglePeak.h TRWPeak.h TPeakFitter.h TABPeak.h
 
 #ifdef __CINT__
 

--- a/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TPeakFitting/LinkDef.h
@@ -1,4 +1,4 @@
-//TSinglePeak.h TRWPeak.h TPeakFitter.h TABPeak.h
+//TSinglePeak.h TRWPeak.h TPeakFitter.h TABPeak.h TAB3Peak.h
 
 #ifdef __CINT__
 
@@ -11,6 +11,7 @@
 #pragma link C++ class TSinglePeak+;
 #pragma link C++ class std::list<TSinglePeak*>+;
 #pragma link C++ class TABPeak+;
+#pragma link C++ class TAB3Peak+;
 #pragma link C++ class TRWPeak+;
 #pragma link C++ class TPeakFitter+;
 

--- a/libraries/TGRSIAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -1,0 +1,179 @@
+#include "TAB3Peak.h"
+#include "TH1.h"
+
+/// \cond CLASSIMP
+ClassImp(TAB3Peak)
+/// \endcond
+
+TAB3Peak::TAB3Peak() : TSinglePeak(){ }
+
+TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak() {
+
+   fTotalFunction = new TF1("ab_fit",this,&TAB3Peak::TotalFunction,0,1,8,"TAB3Peak","TotalFunction");
+   InitParNames();
+   fTotalFunction->SetParameter(1,centroid);
+   SetListOfBGPar(std::vector<bool> {0,0,0,0,0,0,0,1});
+   fTotalFunction->SetLineColor(kMagenta);
+}
+
+void TAB3Peak::InitParNames(){
+   fTotalFunction->SetParName(0, "Height");
+   fTotalFunction->SetParName(1, "centroid");
+   fTotalFunction->SetParName(2, "sigma");
+   fTotalFunction->SetParName(3, "rel_height1");
+   fTotalFunction->SetParName(4, "rel_sigma1");
+   fTotalFunction->SetParName(5, "rel_height2");
+   fTotalFunction->SetParName(6, "rel_sigma2");
+   fTotalFunction->SetParName(7, "step");
+}
+
+void TAB3Peak::InitializeParameters(TH1* fit_hist){
+   // Makes initial guesses at parameters for the fit. Uses the histogram to
+   Double_t xlow, xhigh, low, high;
+   fTotalFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fTotalFunction->GetParLimits(1, low, high);
+   fTotalFunction->GetParLimits(2, low, high);
+   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+   fTotalFunction->SetParLimits(3, 0.000001, 1.0);
+   fTotalFunction->SetParLimits(4, 1.0, 100); 
+   fTotalFunction->SetParLimits(5, 0.000001, 1.0);
+   fTotalFunction->SetParLimits(6, 1.0, 100); 
+   // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+   fTotalFunction->SetParLimits(7, 0.0, 1.0E2);
+   
+   // Make initial guesses
+   // Actually set the parameters in the photopeak function
+   // Fixing has to come after setting
+   // Might have to include bin widths eventually
+   // The centroid should already be set by this point in the ctor
+   fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+   fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
+   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fTotalFunction->SetParameter("rel_sigma1", 2.);
+   fTotalFunction->SetParameter("rel_sigma2", 6.);
+   fTotalFunction->SetParameter("rel_height1", 0.25);
+   fTotalFunction->SetParameter("rel_height2", 0.25);
+   fTotalFunction->SetParameter("step", 1.0);
+}
+
+Double_t TAB3Peak::Centroid() const{
+   return fTotalFunction->GetParameter("centroid");
+}
+
+Double_t TAB3Peak::CentroidErr() const{
+   return fTotalFunction->GetParError(1);
+}
+
+Double_t TAB3Peak::Width() const{
+   return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma2");
+}
+
+Double_t TAB3Peak::PeakFunction(Double_t *dim, Double_t *par){
+   return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par) + ThreeHitPeakFunction(dim,par);
+}
+
+Double_t TAB3Peak::OneHitPeakFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+
+   return height * TMath::Gaus(x, c, sigma);
+}
+
+Double_t TAB3Peak::TwoHitPeakFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+   Double_t rel_height  = par[3]; // relative height of 2-hit peak
+   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
+   
+   return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
+}
+
+Double_t TAB3Peak::ThreeHitPeakFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+   Double_t rel_height  = par[5]; // relative height of 2-hit peak
+   Double_t rel_sigma   = par[6]; // relative sigma of 2-hit peak
+   
+   return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
+}
+
+
+Double_t TAB3Peak::OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+   return OneHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
+}
+
+Double_t TAB3Peak::TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+   return TwoHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
+}
+
+Double_t TAB3Peak::ThreeHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+   return ThreeHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
+}
+
+Double_t TAB3Peak::BackgroundFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+   Double_t step        = par[7]; // Size of the step function;
+
+   Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
+   
+   return step_func;
+}
+
+void TAB3Peak::Print(Option_t * opt) const{
+   std::cout << "Addback-like peak:" << std::endl;
+   TSinglePeak::Print(opt);
+}
+
+void TAB3Peak::DrawComponents(Option_t * opt){
+   //We need to draw this on top of the global background. Probably easiest to make another temporary TF1?
+   if(!fGlobalBackground)
+      return;
+
+   Double_t low, high;
+   fGlobalBackground->GetRange(low,high);
+   if(fOneHitOnGlobal) fOneHitOnGlobal->Delete();
+   if(fTwoHitOnGlobal) fTwoHitOnGlobal->Delete();
+   if(fThreeHitOnGlobal) fThreeHitOnGlobal->Delete();
+   //Make a copy of the total function, and then tack on the global background parameters.
+   fOneHitOnGlobal = new TF1("draw_component1", this, &TAB3Peak::OneHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","OneHitPeakOnGlobalFunction");
+   fTwoHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::TwoHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","TwoHitPeakOnGlobalFunction");
+   fThreeHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::ThreeHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","ThreeHitPeakOnGlobalFunction");
+   for(int i = 0; i < fTotalFunction->GetNpar(); ++i){
+      fOneHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
+      fTwoHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
+      fThreeHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
+   }
+   for(int i = 0; i < fGlobalBackground->GetNpar(); ++i){
+      fOneHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+      fTwoHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+      fThreeHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+   }
+   //Draw a copy of this function
+   fOneHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+   fTwoHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+   fThreeHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+   fOneHitOnGlobal->SetLineStyle(8);
+   fTwoHitOnGlobal->SetLineStyle(3);
+   fThreeHitOnGlobal->SetLineStyle(2);
+   fOneHitOnGlobal->Draw(opt);
+   fTwoHitOnGlobal->Draw(opt);
+   fThreeHitOnGlobal->Draw(opt);
+
+}
+
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
@@ -70,9 +70,6 @@ Double_t TABPeak::OneHitPeakFunction(Double_t *dim, Double_t *par){
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
    Double_t sigma       = par[2]; // standard deviation of gaussian
-   Double_t rel_height  = par[3]; // relative height of 2-hit peak
-   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
-   Double_t step        = par[5]; // Size of the step function;
 
    return height * TMath::Gaus(x, c, sigma);
 }
@@ -85,7 +82,6 @@ Double_t TABPeak::TwoHitPeakFunction(Double_t *dim, Double_t *par){
    Double_t sigma       = par[2]; // standard deviation of gaussian
    Double_t rel_height  = par[3]; // relative height of 2-hit peak
    Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
-   Double_t step        = par[5]; // Size of the step function;
    
    return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
 }
@@ -104,8 +100,6 @@ Double_t TABPeak::BackgroundFunction(Double_t *dim, Double_t *par){
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
    Double_t sigma       = par[2]; // standard deviation of gaussian
-   Double_t rel_height  = par[3]; // relative height of 2-hit peak
-   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
    Double_t step        = par[5]; // Size of the step function;
 
    Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));

--- a/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
@@ -1,0 +1,85 @@
+#include "TABPeak.h"
+#include "TH1.h"
+
+/// \cond CLASSIMP
+ClassImp(TABPeak)
+/// \endcond
+
+TABPeak::TABPeak() : TSinglePeak(){ }
+
+TABPeak::TABPeak(Double_t centroid) : TSinglePeak() {
+
+   fFitFunction = new TF1("ab_fit",this,&TABPeak::FitFunction,0,1,6,"TABPeak","FitFunction");
+   InitParNames();
+   fFitFunction->SetParameter(1,centroid);
+   SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
+   fFitFunction->SetLineColor(kMagenta);
+}
+
+void TABPeak::InitParNames(){
+   fFitFunction->SetParName(0, "Height");
+   fFitFunction->SetParName(1, "centroid");
+   fFitFunction->SetParName(2, "sigma");
+   fFitFunction->SetParName(3, "rel_height");
+   fFitFunction->SetParName(4, "rel_sigma");
+   fFitFunction->SetParName(5, "step");
+}
+
+void TABPeak::InitializeParameters(TH1* fit_hist){
+   // Makes initial guesses at parameters for the fit. Uses the histogram to
+   Double_t xlow, xhigh, low, high;
+   fFitFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fFitFunction->GetParameter(1));
+   fFitFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fFitFunction->GetParLimits(1, low, high);
+   fFitFunction->GetParLimits(2, low, high);
+   fFitFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+   fFitFunction->SetParLimits(3, 0.000001, 1.0);
+   fFitFunction->SetParLimits(4, 1.0, 100); 
+   // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+   fFitFunction->SetParLimits(5, 0.0, 1.0E2);
+   
+   // Make initial guesses
+   // Actually set the parameters in the photopeak function
+   // Fixing has to come after setting
+   // Might have to include bin widths eventually
+   // The centroid should already be set by this point in the ctor
+   fFitFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+   fFitFunction->SetParameter("centroid", fFitFunction->GetParameter(1));
+   fFitFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fFitFunction->GetParameter("centroid") / 1000. +                                  0.9*TMath::Power(fFitFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fFitFunction->SetParameter("rel_sigma", fFitFunction->GetParameter(2)*2);
+   fFitFunction->SetParameter("rel_height", fFitFunction->GetParameter(0)/2.);
+   fFitFunction->SetParameter("step", 1.0);
+}
+
+Double_t TABPeak::Centroid() const{
+   return fFitFunction->GetParameter("centroid");
+}
+
+Double_t TABPeak::CentroidErr() const{
+   return fFitFunction->GetParError(1);
+}
+
+Double_t TABPeak::FitFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+   Double_t rel_height  = par[3]; // relative height of 2-hit peak
+   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
+   Double_t step        = par[5]; // Size of the step function;
+
+   Double_t gauss1      = height * TMath::Gaus(x, c, sigma);
+   Double_t gauss2      = height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
+   Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
+   
+   return gauss1 + gauss2 + step_func;
+}
+
+void TABPeak::Print(Option_t * opt) const{
+   std::cout << "Addback-like peak:" << std::endl;
+   TSinglePeak::Print(opt);
+}
+
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
@@ -46,9 +46,9 @@ void TABPeak::InitializeParameters(TH1* fit_hist){
    // The centroid should already be set by this point in the ctor
    fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
    fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +                                  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
-   fTotalFunction->SetParameter("rel_sigma", fTotalFunction->GetParameter(2)*2);
-   fTotalFunction->SetParameter("rel_height", fTotalFunction->GetParameter(0)/2.);
+   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fTotalFunction->SetParameter("rel_sigma", 2.);
+   fTotalFunction->SetParameter("rel_height", 0.25);
    fTotalFunction->SetParameter("step", 1.0);
 }
 
@@ -58,6 +58,10 @@ Double_t TABPeak::Centroid() const{
 
 Double_t TABPeak::CentroidErr() const{
    return fTotalFunction->GetParError(1);
+}
+
+Double_t TABPeak::Width() const{
+   return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma");
 }
 
 Double_t TABPeak::PeakFunction(Double_t *dim, Double_t *par){

--- a/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TABPeak.cxx
@@ -9,58 +9,58 @@ TABPeak::TABPeak() : TSinglePeak(){ }
 
 TABPeak::TABPeak(Double_t centroid) : TSinglePeak() {
 
-   fFitFunction = new TF1("ab_fit",this,&TABPeak::FitFunction,0,1,6,"TABPeak","FitFunction");
+   fTotalFunction = new TF1("ab_fit",this,&TABPeak::TotalFunction,0,1,6,"TABPeak","TotalFunction");
    InitParNames();
-   fFitFunction->SetParameter(1,centroid);
+   fTotalFunction->SetParameter(1,centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
-   fFitFunction->SetLineColor(kMagenta);
+   fTotalFunction->SetLineColor(kMagenta);
 }
 
 void TABPeak::InitParNames(){
-   fFitFunction->SetParName(0, "Height");
-   fFitFunction->SetParName(1, "centroid");
-   fFitFunction->SetParName(2, "sigma");
-   fFitFunction->SetParName(3, "rel_height");
-   fFitFunction->SetParName(4, "rel_sigma");
-   fFitFunction->SetParName(5, "step");
+   fTotalFunction->SetParName(0, "Height");
+   fTotalFunction->SetParName(1, "centroid");
+   fTotalFunction->SetParName(2, "sigma");
+   fTotalFunction->SetParName(3, "rel_height");
+   fTotalFunction->SetParName(4, "rel_sigma");
+   fTotalFunction->SetParName(5, "step");
 }
 
 void TABPeak::InitializeParameters(TH1* fit_hist){
    // Makes initial guesses at parameters for the fit. Uses the histogram to
    Double_t xlow, xhigh, low, high;
-   fFitFunction->GetRange(xlow, xhigh);
-   Int_t bin     = fit_hist->FindBin(fFitFunction->GetParameter(1));
-   fFitFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
-   fFitFunction->GetParLimits(1, low, high);
-   fFitFunction->GetParLimits(2, low, high);
-   fFitFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
-   fFitFunction->SetParLimits(3, 0.000001, 1.0);
-   fFitFunction->SetParLimits(4, 1.0, 100); 
+   fTotalFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fTotalFunction->GetParLimits(1, low, high);
+   fTotalFunction->GetParLimits(2, low, high);
+   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+   fTotalFunction->SetParLimits(3, 0.000001, 1.0);
+   fTotalFunction->SetParLimits(4, 1.0, 100); 
    // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
-   fFitFunction->SetParLimits(5, 0.0, 1.0E2);
+   fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
    
    // Make initial guesses
    // Actually set the parameters in the photopeak function
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   fFitFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
-   fFitFunction->SetParameter("centroid", fFitFunction->GetParameter(1));
-   fFitFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fFitFunction->GetParameter("centroid") / 1000. +                                  0.9*TMath::Power(fFitFunction->GetParameter("centroid")/1000.,2)) / 2.35);
-   fFitFunction->SetParameter("rel_sigma", fFitFunction->GetParameter(2)*2);
-   fFitFunction->SetParameter("rel_height", fFitFunction->GetParameter(0)/2.);
-   fFitFunction->SetParameter("step", 1.0);
+   fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+   fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
+   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +                                  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fTotalFunction->SetParameter("rel_sigma", fTotalFunction->GetParameter(2)*2);
+   fTotalFunction->SetParameter("rel_height", fTotalFunction->GetParameter(0)/2.);
+   fTotalFunction->SetParameter("step", 1.0);
 }
 
 Double_t TABPeak::Centroid() const{
-   return fFitFunction->GetParameter("centroid");
+   return fTotalFunction->GetParameter("centroid");
 }
 
 Double_t TABPeak::CentroidErr() const{
-   return fFitFunction->GetParError(1);
+   return fTotalFunction->GetParError(1);
 }
 
-Double_t TABPeak::FitFunction(Double_t *dim, Double_t *par){
+Double_t TABPeak::PeakFunction(Double_t *dim, Double_t *par){
    
    Double_t x           = dim[0]; // channel number used for fitting
    Double_t height      = par[0]; // height of photopeak
@@ -72,10 +72,26 @@ Double_t TABPeak::FitFunction(Double_t *dim, Double_t *par){
 
    Double_t gauss1      = height * TMath::Gaus(x, c, sigma);
    Double_t gauss2      = height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
+   
+   return gauss1 + gauss2;
+}
+
+Double_t TABPeak::BackgroundFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x           = dim[0]; // channel number used for fitting
+   Double_t height      = par[0]; // height of photopeak
+   Double_t c           = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma       = par[2]; // standard deviation of gaussian
+   Double_t rel_height  = par[3]; // relative height of 2-hit peak
+   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
+   Double_t step        = par[5]; // Size of the step function;
+
    Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
    
-   return gauss1 + gauss2 + step_func;
+   return step_func;
 }
+
+
 
 void TABPeak::Print(Option_t * opt) const{
    std::cout << "Addback-like peak:" << std::endl;

--- a/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -66,10 +66,11 @@ void TPeakFitter::Fit(TH1* fit_hist){
       fTotalFitFunction = new TF1("total_fit",this,&TPeakFitter::FitFunction,fRangeLow,fRangeHigh,GetNParameters(),"TPeakFitter","FitFunction");
    }
    //We need to initialize all of the parameters based on the peak parameters
-   if(last_hist_fit != fit_hist){
+   if(!fInitFlag){
       std::cout << "Initializing Fit...." << std::endl;
       InitializeBackgroundParameters(fit_hist);
       InitializeParameters(fit_hist);
+      fInitFlag = true;
    }
    last_hist_fit = fit_hist;
    UpdateFitterParameters();

--- a/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -1,0 +1,282 @@
+#include "TPeakFitter.h"
+#include "Math/Minimizer.h"
+#include "TH1.h"
+
+/// \cond CLASSIMP
+ClassImp(TPeakFitter)
+/// \endcond
+
+TPeakFitter::TPeakFitter() : TObject(){
+   fBGToFit = new TF1("fbg",this, &TPeakFitter::DefaultBackgroundFunction,fRangeLow,fRangeHigh,4,"TPeakFitter","DefaultBackgroundFunction"); 
+   fBGToFit->FixParameter(3,0);
+   fTotalFitFunction = nullptr;
+   fBGToFit->SetLineColor(kRed);
+}
+
+TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) : TPeakFitter(){
+   fRangeLow = range_low;
+   fRangeHigh = range_high;
+}
+
+void TPeakFitter::Print(Option_t * opt) const{
+   std::cout << "Range: " << fRangeLow << " to " << fRangeHigh << std::endl;
+   Int_t counter = 0;
+   if(fPeaksToFit.size()){
+      std::cout << "Peaks: " << std::endl;
+      for(auto i : fPeaksToFit){
+         std::cout << "Peak #" << counter++ <<std::endl;
+         i->Print(opt);
+      }
+   }
+   else{
+      std::cout << "Could not find peak to print" << std::endl;
+   }
+   if(fBGToFit){
+      std::cout << "BG: " << std::endl;
+      fBGToFit->Print(opt);
+   }
+   else{
+      std::cout << "Could not find a BG to print" << std::endl;
+   }
+   std::cout << "Myself " << std::endl;
+   fTotalFitFunction->Print(opt);
+}
+
+Int_t TPeakFitter::GetNParameters() const{
+   Int_t n_par = 0;
+   for(auto i : fPeaksToFit)
+      n_par += i->GetNParameters();
+   if(fBGToFit)
+      n_par += fBGToFit->GetNpar();
+
+   return n_par;
+}
+
+void TPeakFitter::SetRange(const Double_t &low, const Double_t &high){
+   fRangeLow = low;
+   fRangeHigh = high;
+}
+
+void TPeakFitter::Fit(TH1* fit_hist){
+   static TH1* last_hist_fit = nullptr;
+   ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2", "Combination");
+   TVirtualFitter::SetMaxIterations(100000);
+   TVirtualFitter::SetPrecision(1e-3);
+   if(!fTotalFitFunction){
+      fTotalFitFunction = new TF1("total_fit",this,&TPeakFitter::FitFunction,fRangeLow,fRangeHigh,GetNParameters(),"TPeakFitter","FitFunction");
+   }
+   //We need to initialize all of the parameters based on the peak parameters
+   if(last_hist_fit != fit_hist){
+      InitializeBackgroundParameters(fit_hist);
+      InitializeParameters(fit_hist);
+   }
+   UpdateFitterParameters();
+   TFitResultPtr fit_res = fit_hist->Fit(fTotalFitFunction,"SRL");
+   fTotalFitFunction->SetFitResult(*fit_res); //Not sure if this is needed
+
+   //Once we do the fit, we want to update all of the Peak parameters.
+   UpdatePeakParameters(fit_res,fit_hist);
+
+   std::cout << "****************" <<std::endl;
+   std::cout << "Summary of Fit: " << std::endl;
+   Print();
+
+}
+
+void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
+   //We enter this function once we have performed a fit and need to tell the peaks
+   //what their new parameters should be.
+   Int_t peak_counter = 0;
+   Int_t param_counter = 0;
+   TF1* global_bg = new TF1;
+   fTotalFitFunction->Copy(*global_bg);
+
+   //Start by looping through all of the peaks in the fitter.
+   for(auto p_it : fPeaksToFit){
+      TF1* peak_func = p_it->GetFitFunction();
+      //We need to make a clone of the main fit function, and set all of the non-peak parameters to 0.
+      //This will allow us to do the proper integrals. We have to do the same with the covariance matrix
+      //We get the covariance matrix that we are using to update the individual peaks
+  //    TF1* total_function_copy = static_cast<TF1*>(fTotalFitFunction->Clone());
+      TF1* total_function_copy = new TF1;
+      fTotalFitFunction->Copy(*total_function_copy);
+      TMatrixDSym covariance_matrix = fit_res->GetCovarianceMatrix();
+      //Now we need to remove all of the parts of the covariance peak that has nothing to do with this particular peak
+      //This would be the diagonals of the background, and all of the other peaks.
+      Int_t param_to_zero_counter = 0;
+      for(auto other_p_it : fPeaksToFit){
+         if(other_p_it != p_it){
+            for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i){
+               covariance_matrix(param_to_zero_counter,param_to_zero_counter) = 0.0;
+               total_function_copy->SetParameter(param_to_zero_counter,0.0);
+               ++param_to_zero_counter;
+            }
+         }
+         else{
+            for(int i = 0; i < peak_func->GetNpar(); ++i){
+               if(p_it->IsBackgroundParameter(i)){
+                  covariance_matrix(param_to_zero_counter,param_to_zero_counter) = 0.0;
+                  total_function_copy->SetParameter(param_to_zero_counter,0.0);
+               }
+               else{
+                  global_bg->SetParameter(param_to_zero_counter,0.0);
+               }
+               peak_func->SetParameter(i,fTotalFitFunction->GetParameter(param_to_zero_counter));
+               peak_func->SetParError(i,fTotalFitFunction->GetParError(param_to_zero_counter));
+               Double_t low, high;
+               fTotalFitFunction->GetParLimits(param_to_zero_counter,low,high);
+               peak_func->SetParLimits(i,low,high);
+               ++param_to_zero_counter;
+            }
+            Double_t low_range, high_range;
+            fTotalFitFunction->GetRange(low_range, high_range);
+            peak_func->SetRange(low_range,high_range);
+         }
+      }
+      //We have no taken care to zero all of the non-peak parameters in the peak list, so we want to remove the total background contribution
+      for(int i = param_to_zero_counter; i < fTotalFitFunction->GetNpar(); ++i){
+         covariance_matrix(i,i) = 0.0;
+         total_function_copy->SetParameter(i,0.0);
+      }
+
+      if(peak_func){
+         for(int i = 0;i < peak_func->GetNpar(); ++i){
+            peak_func->SetParameter(i,fTotalFitFunction->GetParameter(param_counter));
+            peak_func->SetParError(i,fTotalFitFunction->GetParError(param_counter));
+            ++param_counter;
+            //Lets do some integrals meow.
+            p_it->SetArea(total_function_copy->Integral(fRangeLow, fRangeHigh)/fit_hist->GetBinWidth(1));
+            p_it->SetAreaErr(total_function_copy->IntegralError(fRangeLow, fRangeHigh, total_function_copy->GetParameters(), 
+                     covariance_matrix.GetMatrixArray())/fit_hist->GetBinWidth(1));
+         }
+         ++peak_counter;
+      }
+      total_function_copy->Delete();
+   }
+   if(fBGToFit){
+      for(int i = 0;i < fBGToFit->GetNpar(); ++i){
+         fBGToFit->SetParameter(i,fTotalFitFunction->GetParameter(param_counter));
+         fBGToFit->SetParError(i,fTotalFitFunction->GetParError(param_counter));
+         ++param_counter;
+       }
+   }
+   //We now have a copy of the global background. Copy and send to every peak
+   for(auto p_it : fPeaksToFit){
+      p_it->SetGlobalBackground(new TF1(*global_bg));
+   }
+   global_bg->Delete();
+}
+
+void TPeakFitter::InitializeParameters(TH1* fit_hist){
+   for(auto p_it : fPeaksToFit){
+      p_it->InitializeParameters(fit_hist);
+   }
+}
+
+void TPeakFitter::UpdateFitterParameters() {
+   Int_t param_counter = 0;
+   Int_t peak_counter = 0;
+   for(auto p_it : fPeaksToFit){
+      TF1* peak_func = p_it->GetFitFunction();
+      if(peak_func){
+         for(int i = 0;i < peak_func->GetNpar(); ++i){
+            fTotalFitFunction->SetParName(param_counter, Form("%s_%i",peak_func->GetParName(i),peak_counter));
+            fTotalFitFunction->SetParameter(param_counter,peak_func->GetParameter(i));
+            fTotalFitFunction->SetParError(param_counter,peak_func->GetParError(i));
+            Double_t limit_low, limit_high;
+            peak_func->GetParLimits(i,limit_low, limit_high);
+            fTotalFitFunction->SetParLimits(param_counter,limit_low, limit_high);
+            ++param_counter;
+         }
+         ++peak_counter;
+      }
+   }
+   if(fBGToFit){
+      for(int i = 0;i < fBGToFit->GetNpar(); ++i){
+         fTotalFitFunction->SetParName(param_counter,fBGToFit->GetParName(i));
+         fTotalFitFunction->SetParameter(param_counter,fBGToFit->GetParameter(i));
+         fTotalFitFunction->SetParError(param_counter,fBGToFit->GetParError(i));
+         Double_t limit_low, limit_high;
+         fBGToFit->GetParLimits(i,limit_low, limit_high);
+         fTotalFitFunction->SetParLimits(param_counter,limit_low, limit_high);
+         ++param_counter;
+       }
+   }
+}
+
+
+Double_t TPeakFitter::FitFunction(Double_t *dim, Double_t *par){
+   //I want to use the EvalPar command here in order to ge the individual peaks
+   Double_t sum = 0;
+   Int_t params_so_far = 0;
+   for(auto p_it : fPeaksToFit){
+      TF1* peak_func = p_it->GetFitFunction();
+      sum+=peak_func->EvalPar(dim,&par[params_so_far]);
+      params_so_far += peak_func->GetNpar();
+   }
+   sum += fBGToFit->EvalPar(dim,&par[params_so_far]);
+
+   return sum;
+
+}
+
+void TPeakFitter::InitializeBackgroundParameters(TH1* fit_hist){
+  fBGToFit->SetParName(0, "A");
+  fBGToFit->SetParName(1, "B");
+  fBGToFit->SetParName(2, "C");
+  fBGToFit->SetParName(3, "bg_offset");
+  fBGToFit->SetParLimits(0, 0.0, fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)) * 100.);
+  fBGToFit->SetParLimits(3, fRangeLow, fRangeHigh);
+  fBGToFit->SetParameter("A", fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)));
+  fBGToFit->SetParameter("B", fit_hist->GetBinWidth(1)*((fit_hist->GetBinContent(fit_hist->FindBin(fRangeLow)) - fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh))) / (fRangeLow - fRangeHigh)) );
+  fBGToFit->SetParameter("C", 0.0000);
+  fBGToFit->SetParameter("bg_offset", (fRangeHigh + fRangeLow)/2.);
+  fBGToFit->FixParameter(2, 0.00);
+}
+
+Double_t TPeakFitter::DefaultBackgroundFunction(Double_t *dim, Double_t *par){
+   Double_t x = dim[0];
+   Double_t A = par[0];
+   Double_t B = par[1];
+   Double_t C = par[2];
+   Double_t bg_offset = par[3];
+
+   return A + B*(x-bg_offset) + C*TMath::Power(x-bg_offset,2.);
+
+}
+
+void TPeakFitter::DrawPeaks(Option_t *opt) const{
+   //First we are going to draw the background
+   TF1* bg_to_draw = new TF1;
+   fTotalFitFunction->Copy(*bg_to_draw);
+   bg_to_draw->SetLineColor(kRed);
+   
+   for(auto p_it : fPeaksToFit){
+      TF1* peak_func = p_it->GetFitFunction();
+      TF1* total_function_copy = new TF1;
+      fTotalFitFunction->Copy(*total_function_copy);
+      total_function_copy->SetLineColor(kMagenta);
+      //Now we need to remove all of the parts of the covariance peak that has nothing to do with this particular peak
+      //This would be the diagonals of the background, and all of the other peaks.
+      Int_t param_to_zero_counter = 0;
+      for(auto other_p_it : fPeaksToFit){
+         if(other_p_it != p_it){
+            for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i){
+               total_function_copy->SetParameter(param_to_zero_counter,0.0);
+               ++param_to_zero_counter;
+            }
+         }
+         else{
+            for(int i = 0; i < peak_func->GetNpar(); ++i){
+               if(!p_it->IsBackgroundParameter(i)){
+                  bg_to_draw->SetParameter(param_to_zero_counter,0.0);
+               }
+               ++param_to_zero_counter;
+            }
+         }
+      }
+      total_function_copy->Draw("same");
+   }
+   bg_to_draw->Draw("same");
+}
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -38,8 +38,6 @@ void TPeakFitter::Print(Option_t * opt) const{
    else{
       std::cout << "Could not find a BG to print" << std::endl;
    }
-   std::cout << "Myself " << std::endl;
-   fTotalFitFunction->Print(opt);
 }
 
 Int_t TPeakFitter::GetNParameters() const{
@@ -79,6 +77,7 @@ void TPeakFitter::Fit(TH1* fit_hist){
 
    //Once we do the fit, we want to update all of the Peak parameters.
    UpdatePeakParameters(fit_res,fit_hist);
+   fPeaksToFit.front()->DrawBackground("same");
 
    std::cout << "****************" <<std::endl;
    std::cout << "Summary of Fit: " << std::endl;
@@ -259,7 +258,7 @@ Double_t TPeakFitter::DefaultBackgroundFunction(Double_t *dim, Double_t *par){
 
 }
 
-void TPeakFitter::DrawPeaks(Option_t *opt) const{
+void TPeakFitter::DrawPeaks(Option_t *) const{
    //First we are going to draw the background
    TF1* bg_to_draw = new TF1;
    fTotalFitFunction->Copy(*bg_to_draw);

--- a/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
@@ -70,7 +70,6 @@ Double_t TRWPeak::PeakFunction(Double_t *dim, Double_t *par){
    Double_t sigma  = par[2]; // standard deviation of gaussian
    Double_t beta   = par[3]; // Skewness parameter
    Double_t R      = par[4]; // relative height of skewed gaussian
-   Double_t step   = par[5]; // Size of the step function;
 
    Double_t gauss      = height * (1.0 - R / 100.0) * TMath::Gaus(x, c, sigma);
    
@@ -87,8 +86,6 @@ Double_t TRWPeak::BackgroundFunction(Double_t *dim, Double_t *par){
    Double_t height = par[0]; // height of photopeak
    Double_t c      = par[1]; // Peak Centroid of non skew gaus
    Double_t sigma  = par[2]; // standard deviation of gaussian
-   Double_t beta   = par[3]; // Skewness parameter
-   Double_t R      = par[4]; // relative height of skewed gaussian
    Double_t step   = par[5]; // Size of the step function;
 
    Double_t step_func  = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));

--- a/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
@@ -8,69 +8,61 @@ TRWPeak::TRWPeak() : TSinglePeak(){ }
 
 TRWPeak::TRWPeak(Double_t centroid) : TSinglePeak() {
 
-   fFitFunction = new TF1("rw_fit",this,&TRWPeak::FitFunction,0,1,6,"TRWPeak","FitFunction");
+   fTotalFunction = new TF1("rw_total",this,&TRWPeak::TotalFunction,0,1,6,"TRWPeak","TotalFunction");
    InitParNames();
-   fFitFunction->SetParameter(1,centroid);
+   fTotalFunction->SetParameter(1,centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
-   fFitFunction->SetLineColor(kMagenta);
+   fTotalFunction->SetLineColor(kMagenta);
 }
 
 void TRWPeak::InitParNames(){
-   fFitFunction->SetParName(0, "Height");
-   fFitFunction->SetParName(1, "centroid");
-   fFitFunction->SetParName(2, "sigma");
-   fFitFunction->SetParName(3, "beta");
-   fFitFunction->SetParName(4, "R");
-   fFitFunction->SetParName(5, "step");
+   fTotalFunction->SetParName(0, "Height");
+   fTotalFunction->SetParName(1, "centroid");
+   fTotalFunction->SetParName(2, "sigma");
+   fTotalFunction->SetParName(3, "beta");
+   fTotalFunction->SetParName(4, "R");
+   fTotalFunction->SetParName(5, "step");
 }
 
 void TRWPeak::InitializeParameters(TH1* fit_hist){
    // Makes initial guesses at parameters for the fit. Uses the histogram to
    Double_t xlow, xhigh, low, high;
-   fFitFunction->GetRange(xlow, xhigh);
-   Int_t bin     = fit_hist->FindBin(fFitFunction->GetParameter(1));
- //  Int_t binlow  = fitHist->GetXaxis()->FindBin(xlow);
- //  Int_t binhigh = fitHist->GetXaxis()->FindBin(xhigh);
-   // Double_t binWidth = fitHist->GetBinWidth(bin);
-   fFitFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
-   fFitFunction->GetParLimits(1, low, high);
- //  if(low == high && low == 0.) {
- //     SetParLimits(1, xlow, xhigh);
- //  }
-   fFitFunction->GetParLimits(2, low, high);
- //  if(low == high && low == 0.) {
-      fFitFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
- //  }
-   fFitFunction->SetParLimits(3, 0.000001, 10);
-   fFitFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
+   fTotalFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fTotalFunction->GetParLimits(1, low, high);
+   fTotalFunction->GetParLimits(2, low, high);
+   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+   fTotalFunction->SetParLimits(3, 0.000001, 10);
+   fTotalFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
    // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
-   fFitFunction->SetParLimits(5, 0.0, 1.0E2);
+   fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
    
    // Make initial guesses
    // Actually set the parameters in the photopeak function
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   fFitFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
-   fFitFunction->SetParameter("centroid", fFitFunction->GetParameter(1));
- //  fFitFunction->SetParameter("sigma", TMath::Sqrt(9.0 + 2. * fFitFunction->GetParameter("centroid") / 1000.) / 2.35);
-   fFitFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fFitFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fFitFunction->GetParameter("centroid")/1000.,2)) / 2.35);
-   fFitFunction->SetParameter("beta", fFitFunction->GetParameter("sigma") / 2.0);
-   fFitFunction->SetParameter("R", 0.001);
-   fFitFunction->SetParameter("step", 1.0);
-   fFitFunction->FixParameter(3, fFitFunction->GetParameter("beta"));
-   fFitFunction->FixParameter(4, 0.00);
+   fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+   fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
+ //  fTotalFunction->SetParameter("sigma", TMath::Sqrt(9.0 + 2. * fTotalFunction->GetParameter("centroid") / 1000.) / 2.35);
+   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fTotalFunction->SetParameter("beta", fTotalFunction->GetParameter("sigma") / 2.0);
+   fTotalFunction->SetParameter("R", 0.001);
+   fTotalFunction->SetParameter("step", 1.0);
+   fTotalFunction->FixParameter(3, fTotalFunction->GetParameter("beta"));
+   fTotalFunction->FixParameter(4, 0.00);
 }
 
 Double_t TRWPeak::Centroid() const{
-   return fFitFunction->GetParameter("centroid");
+   return fTotalFunction->GetParameter("centroid");
 }
 
 Double_t TRWPeak::CentroidErr() const{
-   return fFitFunction->GetParError(1);
+   return fTotalFunction->GetParError(1);
 }
 
-Double_t TRWPeak::FitFunction(Double_t *dim, Double_t *par){
+Double_t TRWPeak::PeakFunction(Double_t *dim, Double_t *par){
    
    Double_t x      = dim[0]; // channel number used for fitting
    Double_t height = par[0]; // height of photopeak
@@ -81,14 +73,29 @@ Double_t TRWPeak::FitFunction(Double_t *dim, Double_t *par){
    Double_t step   = par[5]; // Size of the step function;
 
    Double_t gauss      = height * (1.0 - R / 100.0) * TMath::Gaus(x, c, sigma);
-   Double_t step_func  = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
    
    if(beta == 0.0)
-      return gauss + step_func;
+      return gauss;
    else
-      return gauss + step_func + R * height / 100.0 * (TMath::Exp((x - c) / beta)) *
+      return gauss + R * height / 100.0 * (TMath::Exp((x - c) / beta)) *
           (TMath::Erfc(((x - c) / (TMath::Sqrt(2.0) * sigma)) + sigma / (TMath::Sqrt(2.0) * beta)));
 }
+
+Double_t TRWPeak::BackgroundFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x      = dim[0]; // channel number used for fitting
+   Double_t height = par[0]; // height of photopeak
+   Double_t c      = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma  = par[2]; // standard deviation of gaussian
+   Double_t beta   = par[3]; // Skewness parameter
+   Double_t R      = par[4]; // relative height of skewed gaussian
+   Double_t step   = par[5]; // Size of the step function;
+
+   Double_t step_func  = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
+   
+   return step_func;
+}
+
 
 void TRWPeak::Print(Option_t * opt) const{
    std::cout << "RadWare-like peak:" << std::endl;

--- a/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
@@ -1,0 +1,97 @@
+#include "TRWPeak.h"
+
+/// \cond CLASSIMP
+ClassImp(TRWPeak)
+/// \endcond
+
+TRWPeak::TRWPeak() : TSinglePeak(){ }
+
+TRWPeak::TRWPeak(Double_t centroid) : TSinglePeak() {
+
+   fFitFunction = new TF1("rw_fit",this,&TRWPeak::FitFunction,0,1,6,"TRWPeak","FitFunction");
+   InitParNames();
+   fFitFunction->SetParameter(1,centroid);
+   SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
+   fFitFunction->SetLineColor(kMagenta);
+}
+
+void TRWPeak::InitParNames(){
+   fFitFunction->SetParName(0, "Height");
+   fFitFunction->SetParName(1, "centroid");
+   fFitFunction->SetParName(2, "sigma");
+   fFitFunction->SetParName(3, "beta");
+   fFitFunction->SetParName(4, "R");
+   fFitFunction->SetParName(5, "step");
+}
+
+void TRWPeak::InitializeParameters(TH1* fit_hist){
+   // Makes initial guesses at parameters for the fit. Uses the histogram to
+   Double_t xlow, xhigh, low, high;
+   fFitFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fFitFunction->GetParameter(1));
+ //  Int_t binlow  = fitHist->GetXaxis()->FindBin(xlow);
+ //  Int_t binhigh = fitHist->GetXaxis()->FindBin(xhigh);
+   // Double_t binWidth = fitHist->GetBinWidth(bin);
+   fFitFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fFitFunction->GetParLimits(1, low, high);
+ //  if(low == high && low == 0.) {
+ //     SetParLimits(1, xlow, xhigh);
+ //  }
+   fFitFunction->GetParLimits(2, low, high);
+ //  if(low == high && low == 0.) {
+      fFitFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+ //  }
+   fFitFunction->SetParLimits(3, 0.000001, 10);
+   fFitFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
+   // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+   fFitFunction->SetParLimits(5, 0.0, 1.0E2);
+   
+   // Make initial guesses
+   // Actually set the parameters in the photopeak function
+   // Fixing has to come after setting
+   // Might have to include bin widths eventually
+   // The centroid should already be set by this point in the ctor
+   fFitFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+   fFitFunction->SetParameter("centroid", fFitFunction->GetParameter(1));
+ //  fFitFunction->SetParameter("sigma", TMath::Sqrt(9.0 + 2. * fFitFunction->GetParameter("centroid") / 1000.) / 2.35);
+   fFitFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fFitFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fFitFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fFitFunction->SetParameter("beta", fFitFunction->GetParameter("sigma") / 2.0);
+   fFitFunction->SetParameter("R", 0.001);
+   fFitFunction->SetParameter("step", 1.0);
+   fFitFunction->FixParameter(3, fFitFunction->GetParameter("beta"));
+   fFitFunction->FixParameter(4, 0.00);
+}
+
+Double_t TRWPeak::Centroid() const{
+   return fFitFunction->GetParameter("centroid");
+}
+
+Double_t TRWPeak::CentroidErr() const{
+   return fFitFunction->GetParError(1);
+}
+
+Double_t TRWPeak::FitFunction(Double_t *dim, Double_t *par){
+   
+   Double_t x      = dim[0]; // channel number used for fitting
+   Double_t height = par[0]; // height of photopeak
+   Double_t c      = par[1]; // Peak Centroid of non skew gaus
+   Double_t sigma  = par[2]; // standard deviation of gaussian
+   Double_t beta   = par[3]; // Skewness parameter
+   Double_t R      = par[4]; // relative height of skewed gaussian
+   Double_t step   = par[5]; // Size of the step function;
+
+   Double_t gauss      = height * (1.0 - R / 100.0) * TMath::Gaus(x, c, sigma);
+   Double_t step_func  = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
+   
+   if(beta == 0.0)
+      return gauss + step_func;
+   else
+      return gauss + step_func + R * height / 100.0 * (TMath::Exp((x - c) / beta)) *
+          (TMath::Erfc(((x - c) / (TMath::Sqrt(2.0) * sigma)) + sigma / (TMath::Sqrt(2.0) * beta)));
+}
+
+void TRWPeak::Print(Option_t * opt) const{
+   std::cout << "RadWare-like peak:" << std::endl;
+   TSinglePeak::Print(opt);
+}
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TRWPeak.cxx
@@ -29,10 +29,10 @@ void TRWPeak::InitializeParameters(TH1* fit_hist){
    Double_t xlow, xhigh, low, high;
    fTotalFunction->GetRange(xlow, xhigh);
    Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*2.);
    fTotalFunction->GetParLimits(1, low, high);
    fTotalFunction->GetParLimits(2, low, high);
-   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+   fTotalFunction->SetParLimits(2, 0.01, 10.); // sigma should be less than the window width - JKS
    fTotalFunction->SetParLimits(3, 0.000001, 10);
    fTotalFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
    // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
@@ -46,10 +46,10 @@ void TRWPeak::InitializeParameters(TH1* fit_hist){
    fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
    fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
  //  fTotalFunction->SetParameter("sigma", TMath::Sqrt(9.0 + 2. * fTotalFunction->GetParameter("centroid") / 1000.) / 2.35);
-   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+   fTotalFunction->SetParameter("sigma", TMath::Sqrt(5 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
    fTotalFunction->SetParameter("beta", fTotalFunction->GetParameter("sigma") / 2.0);
    fTotalFunction->SetParameter("R", 0.001);
-   fTotalFunction->SetParameter("step", 1.0);
+   fTotalFunction->SetParameter("step", 0.1);
    fTotalFunction->FixParameter(3, fTotalFunction->GetParameter("beta"));
    fTotalFunction->FixParameter(4, 0.00);
 }

--- a/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -1,0 +1,45 @@
+#include "TSinglePeak.h"
+
+/// \cond CLASSIMP
+ClassImp(TSinglePeak)
+/// \endcond
+
+TSinglePeak::TSinglePeak() : TObject(){
+}
+
+bool TSinglePeak::IsBackgroundParameter(const Int_t& par) const{
+   try{
+      return fListOfBGPars.at(par);
+   }
+   catch(const std::out_of_range& oor){
+      std::cerr << "Parameter not in list: " << par << std::endl;
+      return true;
+   }
+   return true; //never gets here...appeals to some compilers.
+}
+
+bool TSinglePeak::IsPeakParameter(const Int_t& par) const{
+   return !IsBackgroundParameter(par);
+}
+
+Int_t TSinglePeak::GetNParameters() const{
+   if(fFitFunction)
+      return fFitFunction->GetNpar();
+   else
+      return 0;
+}
+
+void TSinglePeak::Print(Option_t *opt) const{
+
+   std::cout << "Centroid = " << Centroid() << " +/- " << CentroidErr() << std::endl;
+   std::cout << "Area = " << Area() << " +/- " << AreaErr() << std::endl;
+/*   std::cout << "BG params = ";
+   for(int i = 0; i < 6; ++i){
+      if(IsBackgroundParameter(i)){
+         std::cout << fFitFunction->GetParName(i) << ", ";
+      }
+   }*/
+   std::cout << std::endl;
+
+}
+

--- a/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -60,7 +60,8 @@ void TSinglePeak::UpdateBackgroundParameters(){
 }
 
 void TSinglePeak::DrawComponents(Option_t *opt){
-
+   //This behaves like the draw function except each daughter class decides how to break the draw into multiple components.
+   //This means that we should delegate this task to the daughted class.
 }
 
 Double_t TSinglePeak::PeakOnGlobalFunction(Double_t *dim, Double_t *par){
@@ -78,18 +79,18 @@ void TSinglePeak::Draw(Option_t *opt){
 
    Double_t low, high;
    fGlobalBackground->GetRange(low,high);
+   if(fPeakOnGlobal) fPeakOnGlobal->Delete();
    //Make a copy of the total function, and then tack on the global background parameters.
-   TF1* tmp_func = new TF1("draw_peak", this, &TSinglePeak::PeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TSinglePeak","PeakOnGlobalFunction");
+   fPeakOnGlobal = new TF1("draw_peak", this, &TSinglePeak::PeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TSinglePeak","PeakOnGlobalFunction");
    for(int i = 0; i < fTotalFunction->GetNpar(); ++i){
-      tmp_func->SetParameter(i,fTotalFunction->GetParameter(i));
+      fPeakOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
    }
    for(int i = 0; i < fGlobalBackground->GetNpar(); ++i){
-      tmp_func->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+      fPeakOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
    }
    //Draw a copy of this function
-   tmp_func->SetLineColor(fTotalFunction->GetLineColor());
-   tmp_func->SetLineStyle(fTotalFunction->GetLineStyle());
-   tmp_func->Draw(opt);
-   tmp_func->Delete();
+   fPeakOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+   fPeakOnGlobal->SetLineStyle(fTotalFunction->GetLineStyle());
+   fPeakOnGlobal->Draw(opt);
 }
 

--- a/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -59,7 +59,7 @@ void TSinglePeak::UpdateBackgroundParameters(){
    fBackgroundFunction->SetParameters(fTotalFunction->GetParameters());
 }
 
-void TSinglePeak::DrawComponents(Option_t *opt){
+void TSinglePeak::DrawComponents(Option_t *){
    //This behaves like the draw function except each daughter class decides how to break the draw into multiple components.
    //This means that we should delegate this task to the daughted class.
 }

--- a/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -37,9 +37,9 @@ TF1* TSinglePeak::GetBackgroundFunction(){
    return fBackgroundFunction;
 }
 
-void TSinglePeak::Print(Option_t *opt) const{
+void TSinglePeak::Print(Option_t *) const{
 
-   std::cout << "Centroid = " << Centroid() << " +/- " << CentroidErr() << std::endl;
+   std::cout << "Centroid = " << std::fixed << Centroid() << " +/- " << CentroidErr() << std::endl;
    std::cout << "Area = " << Area() << " +/- " << AreaErr() << std::endl;
 /*   std::cout << "BG params = ";
    for(int i = 0; i < 6; ++i){

--- a/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TGRSIAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -23,10 +23,17 @@ bool TSinglePeak::IsPeakParameter(const Int_t& par) const{
 }
 
 Int_t TSinglePeak::GetNParameters() const{
-   if(fFitFunction)
-      return fFitFunction->GetNpar();
+   if(fTotalFunction)
+      return fTotalFunction->GetNpar();
    else
       return 0;
+}
+
+TF1* TSinglePeak::GetBackgroundFunction(){
+   if(!fBackgroundFunction){
+      fBackgroundFunction = new TF1("peak_bg", this, &TSinglePeak::BackgroundFunction,0,1, fTotalFunction->GetNpar(), "TSinglePeak", "BackgroundFunction");
+   }
+   return fBackgroundFunction;
 }
 
 void TSinglePeak::Print(Option_t *opt) const{
@@ -41,5 +48,13 @@ void TSinglePeak::Print(Option_t *opt) const{
    }*/
    std::cout << std::endl;
 
+}
+
+Double_t TSinglePeak::TotalFunction(Double_t *dim, Double_t *par){
+   return PeakFunction(dim,par) + BackgroundFunction(dim,par);
+}
+
+void TSinglePeak::UpdateBackgroundParameters(){
+   fBackgroundFunction->SetParameters(fTotalFunction->GetParameters());
 }
 


### PR DESCRIPTION
This is just some stuff I've been working on here and there. It improves how we fit peaks and is a large step up from TPeak and TMultiPeak. This lets you add different types of peak fit functions to the same fit routine, and then easily alter the peak parameters and refit. It also takes care of the covariance matrix properly for every type of peak in the fit as long as you define what is the background portion properly. The impetus of this was getting an "Addback" style peak into the fitting routines. This new method also allows much much easier (not implemented) cross parameter correlation and limiting. It should in principle also allow easier interfacing with a GUI if that ever gets built. There are still a few bugs in using it (you need to have the peak in the range you are fitting or it crashes), but it gives very reliable fits with correct uncertainties.