### PR TITLE
Added TBgo class

### DIFF
--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -29,11 +29,11 @@ public:
 public:
    TBgoHit* GetBgoHit(const Int_t& i);
    TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
-   Int_t   GetMultiplicity() const;
+   Short_t   GetMultiplicity() const;
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
 #ifndef __CINT__
-   void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan); //!<!
 #endif
    void ClearTransients()
    {

--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -1,0 +1,61 @@
+#ifndef TBGO_H
+#define TBGO_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <vector>
+#include <cstdio>
+#include <functional>
+//#include <tuple>
+
+#include "TBits.h"
+#include "TVector3.h"
+
+#include "Globals.h"
+#include "TBgoHit.h"
+#include "TGRSIDetector.h"
+#include "TGRSIRunInfo.h"
+#include "TTransientBits.h"
+#include "TSpline.h"
+
+class TBgo : public TGRSIDetector {
+public:
+   TBgo();
+   TBgo(const TBgo&);
+   virtual ~TBgo();
+
+public:
+   TBgoHit* GetBgoHit(const Int_t& i);
+   TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
+   Int_t   GetMultiplicity() const;
+
+   static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
+#ifndef __CINT__
+   void AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan); //!<!
+#endif
+   void ClearTransients()
+   {
+      for(auto hit : fBgoHits) hit.ClearTransients();
+   }
+   void ResetFlags() const;
+
+   TBgo& operator=(const TBgo&); //!<!
+
+private:
+   std::vector<TBgoHit> fBgoHits; //  The set of crystal hits
+
+   static TVector3 gScintPosition[17];                      //!<! Position of each BGO scintillator
+
+public:
+   virtual void Copy(TObject&) const;            //!<!
+   virtual void Clear(Option_t* opt = "all");    //!<!
+   virtual void Print(Option_t* opt = "") const; //!<!
+
+   /// \cond CLASSIMP
+   ClassDef(TBgo, 1) // Bgo Physics structure
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/libraries/TGRSIAnalysis/TBgo/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TBgo/LinkDef.h
@@ -1,4 +1,4 @@
-//TTigress.h TTigressHit.h
+//TBgo.h TBgoHit.h
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -6,8 +6,8 @@
 #pragma link off all functions;
 #pragma link C++ nestedclasses;
 
-#pragma link C++ class TTigressHit+;
-#pragma link C++ class TTigress+;
+#pragma link C++ class TBgoHit+;
+#pragma link C++ class TBgo+;
 
 #endif
 

--- a/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
@@ -137,7 +137,7 @@ TBgo& TBgo::operator=(const TBgo& rhs)
    return *this;
 }
 
-void TBgo::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan)
+void TBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
 {
    // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
    // observables.

--- a/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
@@ -1,0 +1,181 @@
+#include "TBgo.h"
+
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+
+#include "TRandom.h"
+#include "TMath.h"
+#include "TInterpreter.h"
+#include "TMnemonic.h"
+
+#include "TGRSIOptions.h"
+
+////////////////////////////////////////////////////////////
+//
+// TBgo
+//
+// The TBgo class defines the observables and algorithms used
+// when analyzing BGO data. It includes detector positions,
+// etc.
+//
+////////////////////////////////////////////////////////////
+
+/// \cond CLASSIMP
+ClassImp(TBgo)
+/// \endcond
+
+// This seems unnecessary, and why 17?;//  they are static members, and need
+//  to be defined outside the header
+//  17 is to have the detectors go from 1-16
+//  plus we can use position zero
+//  when the detector winds up back in
+//  one of the stands like Alex used in the
+//  gps run. pcb.
+// Initiallizes the HPGe Clover positions as per the wiki
+// <https://www.triumf.info/wiki/tigwiki/index.php/HPGe_Coordinate_Table>
+//                                                                             theta                                 phi
+//                                                                             theta                                phi
+//                                                                             theta
+TVector3 TBgo::gScintPosition[17] = {
+   TVector3(TMath::Sin(TMath::DegToRad() * (0.0)) * TMath::Cos(TMath::DegToRad() * (0.0)),
+            TMath::Sin(TMath::DegToRad() * (0.0)) * TMath::Sin(TMath::DegToRad() * (0.0)),
+            TMath::Cos(TMath::DegToRad() * (0.0))),
+   // Downstream lampshade
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
+            TMath::Cos(TMath::DegToRad() * (45.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
+            TMath::Cos(TMath::DegToRad() * (45.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
+            TMath::Cos(TMath::DegToRad() * (45.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
+            TMath::Sin(TMath::DegToRad() * (45.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
+            TMath::Cos(TMath::DegToRad() * (45.0))),
+   // Corona
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (22.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (22.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (112.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (112.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (202.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (202.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (292.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (292.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
+            TMath::Sin(TMath::DegToRad() * (90.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
+            TMath::Cos(TMath::DegToRad() * (90.0))),
+   // Upstream lampshade
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (67.5)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (67.5)),
+            TMath::Cos(TMath::DegToRad() * (135.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (157.5)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (157.5)),
+            TMath::Cos(TMath::DegToRad() * (135.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (247.5)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (247.5)),
+            TMath::Cos(TMath::DegToRad() * (135.0))),
+   TVector3(TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Cos(TMath::DegToRad() * (337.5)),
+            TMath::Sin(TMath::DegToRad() * (135.0)) * TMath::Sin(TMath::DegToRad() * (337.5)),
+            TMath::Cos(TMath::DegToRad() * (135.0)))};
+
+TBgo::TBgo() : TGRSIDetector()
+{
+	/// Default ctor.
+   Clear();
+}
+
+TBgo::TBgo(const TBgo& rhs) : TGRSIDetector()
+{
+	/// Copy ctor.
+   rhs.Copy(*this);
+}
+
+void TBgo::Copy(TObject& rhs) const
+{
+   // Copy function.
+   TGRSIDetector::Copy(rhs);
+
+   static_cast<TBgo&>(rhs).fBgoHits   = fBgoHits;
+}
+
+TBgo::~TBgo()
+{
+   // Default Destructor
+}
+
+void TBgo::Clear(Option_t* opt)
+{
+   /// Clears the mother, and all of the hits
+   TGRSIDetector::Clear(opt);
+   fBgoHits.clear();
+}
+
+void TBgo::Print(Option_t*) const
+{
+   std::cout<<"Bgo Contains: "<<std::endl;
+   std::cout<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
+}
+
+TBgo& TBgo::operator=(const TBgo& rhs)
+{
+   rhs.Copy(*this);
+   return *this;
+}
+
+void TBgo::AddFragment(std::shared_ptr<const TFragment> frag, TChannel* chan)
+{
+   // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
+   // observables.
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+	TBgoHit hit(*frag);
+	fBgoHits.push_back(std::move(hit));
+}
+
+TVector3 TBgo::GetPosition(int DetNbr, int CryNbr, double dist)
+{
+   // Gets the position vector for a crystal specified by CryNbr within Clover DetNbr at a distance of dist mm away.
+   // This is calculated to the most likely interaction point within the crystal.
+   if(DetNbr > 16) return TVector3(0, 0, 1);
+
+   TVector3 temp_pos(gScintPosition[DetNbr]);
+
+   // Interaction points may eventually be set externally. May make these members of each crystal, or pass from
+	// waveforms.
+	Double_t cp = 26.0; // Crystal Center Point  mm.
+	Double_t id = 45.0; // 45.0;  //Crystal interaction depth mm.
+	// Set Theta's of the center of each DETECTOR face
+	////Define one Detector position
+	TVector3 shift;
+	switch(CryNbr) {
+		case 0: shift.SetXYZ(-cp, cp, id); break;
+		case 1: shift.SetXYZ(cp, cp, id); break;
+		case 2: shift.SetXYZ(cp, -cp, id); break;
+		case 3: shift.SetXYZ(-cp, -cp, id); break;
+		default: shift.SetXYZ(0, 0, 1); break;
+	};
+	shift.RotateY(temp_pos.Theta());
+	shift.RotateZ(temp_pos.Phi());
+
+	temp_pos.SetMag(dist);
+
+	return (temp_pos + shift);
+}
+

--- a/libraries/TGRSIAnalysis/TBgo/TBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TBgoHit.cxx
@@ -2,13 +2,11 @@
 
 #include "TClass.h"
 
-#include "TTigress.h"
-
 /// \cond CLASSIMP
 ClassImp(TBgoHit)
-   /// \endcond
+/// \endcond
 
-   TBgoHit::TBgoHit()
+TBgoHit::TBgoHit()
 {
    Clear();
 }

--- a/util/grsi-config
+++ b/util/grsi-config
@@ -44,7 +44,7 @@ incdir=$GRSISYS/include
 utildir=$GRSISYS/etc
 
 grsilibs="-lTGRSIDetector -lTDetector -lTGRSIFormat -lTNucleus -lTKinematics -lTSRIM -lTBetaDecay -lTGRSIFit -lTCal -lGROOT -lTReaction -lTAngularCorrelation"
-detlibs="-lTFipps -lTTigress -lTGriffin -lTSharc -lTTriFoil -lTSceptar -lTPaces -lTDescant -lTTip -lTCSM -lTS3 -lTSiLi -lTRF -lTPulseAnalyzer -lTTAC -lTLaBr -lTZeroDegree"
+detlibs="-lTFipps -lTTigress -lTGriffin -lTBgo -lTSharc -lTTriFoil -lTSceptar -lTPaces -lTDescant -lTTip -lTCSM -lTS3 -lTSiLi -lTRF -lTPulseAnalyzer -lTTAC -lTLaBr -lTZeroDegree"
 grsimore="-lTMidas -lTDataParser -lTGRSIint -lTLoops -lTHistogramming -lMakeAnalysisHistograms -lMakeGriffinFragmentHistograms -lMakeTigressHistograms"
 
 cflags="-std=c++0x -I$incdir"


### PR DESCRIPTION
Added TBgo class. This class uses the already existing TBgoHits (used to store BGO data in TTigress) to store BGO data. The plan is to add a method than can be used to check if a TGriffinHit or a TLaBrHit is suppressed by the BGO (and whose condition for suppressing can be changed). Not sure yet whether this is the right way to do it (all BGO hits in a single vector), or if we should split the BGO hits up into two vectors, one for "primary" suppressors (aka GRIFFIN suppressors), and one for ancillary suppressors (aka LaBr suppressors).
The advantage of the latter would be an easy implementation of the suppression condition (GRIFFIN detector suppressed by GRIFFIN-BGO of same detector number, and LaBr detector suppressed by LaBr-BGO of same detector number). But it would add a second vector and thus increase the data written to disk (another variable is needed to keep track of the size of the second vector).

This was also done in preparation of a program to convert simulation data directly into EventTrees. This data will have BGOs in it before we have any real BGO data for GRIFFIN. If the whole method works well, we might want to consider using the same approach for TIGRESS.