### PR TITLE
Fixed an energy/charge calculation issue when using cal file integration Parameter

### DIFF
--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -86,7 +86,7 @@ Float_t TGRSIDetectorHit::GetCharge() const
    if(channel == nullptr) {
       return Charge();
    }
-   if(fKValue > 0) {
+   if(fKValue > 0 && !channel->UseCalFileIntegration()) {
       return Charge() / (static_cast<Float_t>(fKValue)); // this will use the integration value
    }
    if(channel->UseCalFileIntegration()) {


### PR DESCRIPTION
One line fix. Shouldn't really bother anyone that is using data where they didn't have to force integration parameters, ie GRIFFIN circa 2014.