### PR TITLE
 Removed compiler warning from TPeakFitter

### DIFF
--- a/GRSIProof/AngularCorrelationSelector.h
+++ b/GRSIProof/AngularCorrelationSelector.h
@@ -64,7 +64,9 @@ void AngularCorrelationSelector::InitializeBranches(TTree* tree)
 {
    if(tree == nullptr) return;
    tree->SetBranchAddress("TGriffin", &fGrif);
-   tree->SetBranchAddress("TSceptar", &fScep);
+   if(tree->SetBranchAddress("TSceptar", &fScep) == TTree::kMissingBranch) {
+		fScep = new TSceptar;
+	}
 }
 
 #endif // #ifdef AngularCorrelationSelector_cxx

--- a/GRSIProof/ExampleEventSelector.h
+++ b/GRSIProof/ExampleEventSelector.h
@@ -47,8 +47,12 @@ class ExampleEventSelector : public TGRSISelector { //Must be same name as .C an
 void ExampleEventSelector::InitializeBranches(TTree* tree)
 {
    if(!tree) return;
-   tree->SetBranchAddress("TGriffin", &fGrif);
-   tree->SetBranchAddress("TSceptar", &fScep);
+   if(tree->SetBranchAddress("TGriffin", &fGrif) == TTree::kMissingBranch) {
+		fGrif = new TGriffin;
+	}
+   if(tree->SetBranchAddress("TSceptar", &fScep) == TTree::kMissingBranch) {
+		fScep = new TSceptar;
+	}
 }
 
 #endif // #ifdef ExampleEventSelector_cxx

--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -28,8 +28,8 @@ public:
 
 public:
    TBgoHit* GetBgoHit(const Int_t& i);
-   TGRSIDetectorHit* GetHit(const Int_t& idx = 0);
-   Short_t   GetMultiplicity() const;
+   TGRSIDetectorHit* GetHit(const Int_t& idx = 0) { return GetBgoHit(idx); }
+   Short_t   GetMultiplicity() const { return fBgoHits.size(); }
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
 #ifndef __CINT__

--- a/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TBgo.cxx
@@ -179,3 +179,15 @@ TVector3 TBgo::GetPosition(int DetNbr, int CryNbr, double dist)
 	return (temp_pos + shift);
 }
 
+TBgoHit* TBgo::GetBgoHit(const Int_t& i)
+{
+	try {
+		return &(fBgoHits.at(i));
+	} catch(const std::out_of_range& oor) {
+		std::cerr<<ClassName()<<" Hits are out of range: "<<oor.what()<<std::endl;
+		if(!gInterpreter) {
+			throw grsi::exit_exception(1);
+		}
+	}
+	return nullptr;
+}


### PR DESCRIPTION
Also change default status width from 80 to 120 characters. This enables the user to see the output of 6 threads, which is the number of threads used for sorting a midas file into fragment and analysis tree.

In addition I've updated the example selector to deal with missing branches, see issue #930.