### PR TITLE
Fixed error where "dropped" fragments weren't removed from the map

### DIFF
--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -422,11 +422,11 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
    int           x   = 0;
    if(!SetGRIFHeader(data[x++], eventFrag, bank)) {
       printf(DYELLOW "data[0] = 0x%08x" RESET_COLOR "\n", data[0]);
-      TParsingDiagnostics::Get()->BadFragment(
-         -1); // we failed to get a good header, so we don't know which detector type this fragment would've belonged to
+		// we failed to get a good header, so we don't know which detector type this fragment would've belonged to
+      TParsingDiagnostics::Get()->BadFragment(-1); 
       // this is the first word, so no need to check is the state/failed word has been set before
       fState     = EDataParserState::kBadHeader;
-      failedWord = x;
+      failedWord = 0;
    }
 
    eventFrag->SetMidasTimeStamp(midasTime);
@@ -572,8 +572,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                } else {
                   multipleErrors = true;
                }
-               Push(*fBadOutputQueue,
-                    std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+               Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                throw TDataParserException(fState, failedWord, multipleErrors);
             }
 
@@ -598,8 +597,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      multipleErrors = true;
                   }
-                  Push(*fBadOutputQueue,
-                       std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                  Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   throw TDataParserException(fState, failedWord, multipleErrors);
                }
                eventFrag->SetCfd(tmpCfd[0]);
@@ -619,8 +617,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                } else {
                   multipleErrors = true;
                }
-               Push(*fBadOutputQueue,
-                    std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+               Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                throw TDataParserException(fState, failedWord, multipleErrors);
             }
             for(size_t h = 0; h < tmpCharge.size(); ++h) {
@@ -654,8 +651,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      // std::cout<<"Can't reconstruct time stamp, "<<fOptions->ReconstructTimeStamp()<<",
                      // state "<<fState<<" = "<<EDataParserState::kBadHighTS<<", "<<multipleErrors<<std::endl;
-                     Push(*fBadOutputQueue,
-                          std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                     Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   }
                }
             }
@@ -701,8 +697,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                } else {
                   multipleErrors = true;
                }
-               Push(*fBadOutputQueue,
-                    std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+               Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                throw TDataParserException(fState, failedWord, multipleErrors);
             }
             break;
@@ -747,8 +742,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      multipleErrors = true;
                   }
-                  Push(*fBadOutputQueue,
-                       std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                  Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   throw TDataParserException(fState, failedWord, multipleErrors);
                }
                break;
@@ -771,8 +765,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      multipleErrors = true;
                   }
-                  Push(*fBadOutputQueue,
-                       std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                  Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   throw TDataParserException(fState, failedWord, multipleErrors);
                }
                break;
@@ -863,8 +856,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      multipleErrors = true;
                   }
-                  Push(*fBadOutputQueue,
-                       std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                  Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   throw TDataParserException(fState, failedWord, multipleErrors);
                }
                break;
@@ -879,8 +871,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                } else {
                   multipleErrors = true;
                }
-               Push(*fBadOutputQueue,
-                    std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+               Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                throw TDataParserException(fState, failedWord, multipleErrors);
                break;
             }
@@ -903,8 +894,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                } else {
                   multipleErrors = true;
                }
-               Push(*fBadOutputQueue,
-                    std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+               Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                throw TDataParserException(fState, failedWord, multipleErrors);
             }
             // for descant types (6,10,11) there are two more words for banks > GRF2 (bank GRF2 used 0xf packet and bank
@@ -925,8 +915,7 @@ int TDataParser::GriffinDataToFragment(uint32_t* data, int size, EBank bank, uns
                   } else {
                      multipleErrors = true;
                   }
-                  Push(*fBadOutputQueue,
-                       std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
+                  Push(*fBadOutputQueue, std::make_shared<TBadFragment>(*eventFrag, data, size, failedWord, multipleErrors));
                   throw TDataParserException(fState, failedWord, multipleErrors);
                }
             }

--- a/libraries/TDataParser/TFragmentMap.cxx
+++ b/libraries/TDataParser/TFragmentMap.cxx
@@ -50,6 +50,10 @@ bool TFragmentMap::Add(std::shared_ptr<TFragment> frag, std::vector<Int_t> charg
    // check if this is the last fragment needed
    int  nofFrags   = 1;
    int  nofCharges = charge.size();
+	// equal_range returns a pair of iterators:
+	// the first points to the first fragment with this address,
+	// the second to the first fragment of the next address
+	// if no fragment with this address exists, both point to the first fragment of the next address
    auto range      = fMap.equal_range(frag->GetAddress());
    for(auto it = range.first; it != range.second; ++it) {
       ++nofFrags;
@@ -277,6 +281,9 @@ bool TFragmentMap::Add(std::shared_ptr<TFragment> frag, std::vector<Int_t> charg
       case 1: // dropped one
          // don't know how to handle these right now
          DropFragments(range);
+         if(fDebug) {
+            std::cout<<"3, single drop"<<std::endl;
+         }
          return false;
          break;
       case 2: // dropped two => as many left as there are fragments
@@ -311,6 +318,9 @@ bool TFragmentMap::Add(std::shared_ptr<TFragment> frag, std::vector<Int_t> charg
       // std::cerr<<"address "<<frag->GetAddress()<<": deconvolution of "<<nofCharges<<" charges for "<<nofFrags<<"
       // fragments not implemented yet!"<<std::endl;
       DropFragments(range);
+		if(fDebug) {
+			std::cout<<"unknown number of fragments "<<nofFrags<<std::endl;
+		}
       return false;
       break;
    } // switch(nofFrags)
@@ -436,16 +446,16 @@ void TFragmentMap::Solve(std::vector<std::shared_ptr<TFragment>> frag, std::vect
 void TFragmentMap::DropFragments(
    std::pair<
       std::multimap<UInt_t, std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t>>>::iterator,
-      std::multimap<UInt_t,
-                    std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t>>>::iterator>& range)
+      std::multimap<UInt_t, std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t>>>::iterator>& range)
 {
    /// put the fragments within the range of the two iterators into the bad output queue
    for(auto it = range.first; it != range.second; ++it) {
 		//(*it).second is a tuple, with the first element being a shared_ptr<TFragment>
-		//we need to conver this to a shared_ptr<TBadFragment>
-      //fBadOutputQueue->Push(std::make_shared<TBadFragment>(*(std::get<0>((*it).second).get())));
+		//we need to convert this to a shared_ptr<TBadFragment>
+      fBadOutputQueue->Push(std::make_shared<TBadFragment>(*(std::get<0>((*it).second).get())));
       if(fDebug) {
          std::cout<<"Added bad fragment "<<std::get<0>((*it).second)<<std::endl;
       }
    }
+	fMap.erase(range.first, range.second);
 }

--- a/libraries/TDataParser/TFragmentMap.cxx
+++ b/libraries/TDataParser/TFragmentMap.cxx
@@ -443,7 +443,7 @@ void TFragmentMap::DropFragments(
    for(auto it = range.first; it != range.second; ++it) {
 		//(*it).second is a tuple, with the first element being a shared_ptr<TFragment>
 		//we need to conver this to a shared_ptr<TBadFragment>
-      fBadOutputQueue->Push(std::make_shared<TBadFragment>(*(std::get<0>((*it).second).get())));
+      //fBadOutputQueue->Push(std::make_shared<TBadFragment>(*(std::get<0>((*it).second).get())));
       if(fDebug) {
          std::cout<<"Added bad fragment "<<std::get<0>((*it).second)<<std::endl;
       }

--- a/libraries/TGRSIFormat/TBadFragment.cxx
+++ b/libraries/TGRSIFormat/TBadFragment.cxx
@@ -37,9 +37,9 @@ TBadFragment::TBadFragment(TFragment& fragment, uint32_t* data, int size, int fa
 TBadFragment::TBadFragment(TFragment& fragment) : TFragment(fragment)
 {
    /// Construct a bad fragment from a fragment.
-   /// The data is left empty, failed word set to -1, and multiple errors set to false.
+   /// The data is left empty, failed word set to -2, and multiple errors set to false.
 	
-   fFailedWord     = -1;
+   fFailedWord     = -2;
    fMultipleErrors = false;
 }
 
@@ -81,13 +81,13 @@ void TBadFragment::Print(Option_t*) const
    /// highlighted/
    TFragment::Print();
 
-   std::cout<<"Raw data with "<<(fMultipleErrors ? "multiple errors" : "single error")<<":"<<std::endl;
+   std::cout<<"Raw data with "<<(fMultipleErrors ? "multiple errors" : "single error")<<" failed on word "<<fFailedWord<<":"<<std::endl;
    size_t i;
    for(i = 0; i < fData.size(); ++i) {
       if(i == static_cast<size_t>(fFailedWord)) {
          std::cout<<ALERTTEXT;
       }
-      std::cout<<"0x"<<std::setw(8)<<std::setfill('0')<<std::hex<<fData[i]<<std::dec;
+      std::cout<<"0x"<<std::setw(8)<<std::setfill('0')<<std::hex<<fData[i]<<std::dec<<std::setfill(' ');
       if(i == static_cast<size_t>(fFailedWord)) {
          std::cout<<RESET_COLOR;
       }


### PR DESCRIPTION
This error was introduced with a commit from April 29th 2017 and caused data to be sorted very slow (hours instead of minutes). The resulting fragment file would have many fragments in the BadFragmentTree with failed word -1, because the same fragments would be written again and again (but never deleted from the fragment map).
The changes in TDataParser.cxx are only formatting changes, and in TBadFragment.cxx the failed word for fragments copied into the bad-fragment queue was changed from the default -1 to -2.