### PR TITLE
Allow un-setting of FileInt

### DIFF
--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -248,9 +248,7 @@ void TChannel::AppendChannel(TChannel* chan)
    if(chan->GetEFFChi2() != 0.0) {
       SetEFFChi2(chan->GetEFFChi2());
    }
-   if(chan->UseCalFileIntegration()) {
-      SetUseCalFileIntegration(chan->UseCalFileIntegration());
-   }
+	SetUseCalFileIntegration(chan->UseCalFileIntegration());
    if(chan->UseWaveParam()) {
       SetWaveParam(chan->GetWaveParam());
    }


### PR DESCRIPTION
This allows users to set FileInt to false, which might be necessary due to PR #944.

