### PR TITLE
Added second BG + performance tweaks in TBGSubtraction

### DIFF
--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -146,17 +146,23 @@ public:
    void UpdateBackground();
    void UpdatePeakSliders();
    void DoProjection();
-   void DoGating();
    void DrawOnNewCanvas();
+   void DrawAllMarkers();
    void DrawGateMarkers();
    void DrawBGMarkers1();
    void DrawBGMarkers2();
- //  void DrawBG2Markers();
    void DrawPeakMarkers();
    void DrawPeak();
    void WriteHistograms();
    void GateStatusInfo(Int_t event, Int_t px, Int_t py, TObject* selected);
    void ProjectionStatusInfo(Int_t event, Int_t px, Int_t py, TObject* selected);
+
+   void MakeGateHisto();
+   void MakeBGHisto1();
+   void MakeBGHisto2();
+   void DoAllGates();
+
+   void DoGateProjection();
 
 private:
    void BuildInterface();
@@ -165,6 +171,9 @@ private:
    void InitializeInterface();
    void StatusInfo(Int_t event, Int_t px, Int_t py, TObject* selected);
    void DrawBGMarkers(TGCheckButton *&check_button, GMarker *&low_marker, GMarker *&high_marker, TGNumberEntry *&low_entry, TGNumberEntry *&high_entry, Int_t color = kBlue);
+   void UpdateGateSlider();
+   void UpdateBGSlider1();
+   void UpdateBGSlider2();
 
    /// \cond CLASSIMP
    ClassDefOverride(TBGSubtraction, 6); // Background subtractor GUI

--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -28,7 +28,8 @@
 class TBGSubtraction : public TGMainFrame {
    enum ESliders {
       kGateSlider,
-      kBGSlider,
+      kBGSlider1,
+      kBGSlider2,
       kPeakSlider
    };
    enum EEntries {
@@ -38,12 +39,15 @@ class TBGSubtraction : public TGMainFrame {
       kPeakLowEntry,
       kPeakHighEntry,
       kPeakEntry,
-      kBGLowEntry,
-      kBGHighEntry,
+      kBGLowEntry1,
+      kBGHighEntry1,
+      kBGLowEntry2,
+      kBGHighEntry2,
       kWrite2FileNameEntry,
       kHistogramDescriptionEntry,
       kComboAxisEntry,
-      kBGCheckButton,
+      kBGCheckButton1,
+      kBGCheckButton2,
       kPeakSkewCheckButton
    };
 
@@ -55,18 +59,23 @@ private:
    TH2*                 fMatrix;
    TH1*                 fProjection;
    TH1*                 fGateHist;
-   TH1*                 fBGHist;
+   TH1*                 fBGHist1;
+   TH1*                 fBGHist2;
    TH1*                 fSubtractedHist;
    TGDoubleHSlider*     fGateSlider;
-   TGDoubleHSlider*     fBGSlider;
+   TGDoubleHSlider*     fBGSlider1;
+   TGDoubleHSlider*     fBGSlider2;
    TGTripleHSlider*     fPeakSlider;
    TGNumberEntry*       fBGParamEntry;
-   TGNumberEntry*       fBGEntryLow{nullptr};
-   TGNumberEntry*       fBGEntryHigh{nullptr};
+   TGNumberEntry*       fBGEntryLow1{nullptr};
+   TGNumberEntry*       fBGEntryHigh1{nullptr};
+   TGNumberEntry*       fBGEntryLow2{nullptr};
+   TGNumberEntry*       fBGEntryHigh2{nullptr};
    TGNumberEntry*       fGateEntryLow{nullptr};
    TGNumberEntry*       fGateEntryHigh{nullptr};
    TGLabel*             fBGParamLabel{nullptr};
-   TGCheckButton*       fBGCheckButton;
+   TGCheckButton*       fBGCheckButton1;
+   TGCheckButton*       fBGCheckButton2;
    TGCheckButton*       fPeakSkewCheckButton;
 
    TGLayoutHints* fBly;
@@ -89,7 +98,8 @@ private:
    TGHorizontalFrame* fPeakFitFrame{nullptr};
    TGHorizontalFrame* fBGParamFrame{nullptr};
    TGHorizontalFrame* fGateEntryFrame{nullptr};
-   TGHorizontalFrame* fBGEntryFrame{nullptr};
+   TGHorizontalFrame* fBGEntryFrame1{nullptr};
+   TGHorizontalFrame* fBGEntryFrame2{nullptr};
    TGHorizontalFrame* fDescriptionFrame{nullptr};
    TGHorizontalFrame* fButtonFrame{nullptr};
 
@@ -99,8 +109,10 @@ private:
    // Markers
    GMarker* fLowGateMarker;
    GMarker* fHighGateMarker;
-   GMarker* fLowBGMarker;
-   GMarker* fHighBGMarker;
+   GMarker* fLowBGMarker1;
+   GMarker* fHighBGMarker1;
+   GMarker* fLowBGMarker2;
+   GMarker* fHighBGMarker2;
    GMarker* fLowPeakMarker;
    GMarker* fHighPeakMarker;
    GMarker* fPeakMarker;
@@ -122,20 +134,24 @@ public:
    TBGSubtraction(TH2* mat, const char* gate_axis = "x");
    ~TBGSubtraction() override;
    void AxisComboSelected();
-   void ClickedBGButton();
+   void ClickedBGButton1();
+   void ClickedBGButton2();
+ //  void ClickedBG2Button();
    void DoPeakFit();
    void DoSlider(Int_t pos = 0);
    void DoEntry(Long_t);
    void DoProjectionCanvasZoomed();
    void DoGateCanvasZoomed();
    void UpdateProjectionSliders();
-   void UpdatePeakSliders();
    void UpdateBackground();
+   void UpdatePeakSliders();
    void DoProjection();
    void DoGating();
    void DrawOnNewCanvas();
    void DrawGateMarkers();
-   void DrawBGMarkers();
+   void DrawBGMarkers1();
+   void DrawBGMarkers2();
+ //  void DrawBG2Markers();
    void DrawPeakMarkers();
    void DrawPeak();
    void WriteHistograms();
@@ -148,6 +164,7 @@ private:
    void MakeConnections();
    void InitializeInterface();
    void StatusInfo(Int_t event, Int_t px, Int_t py, TObject* selected);
+   void DrawBGMarkers(TGCheckButton *&check_button, GMarker *&low_marker, GMarker *&high_marker, TGNumberEntry *&low_entry, TGNumberEntry *&high_entry, Int_t color = kBlue);
 
    /// \cond CLASSIMP
    ClassDefOverride(TBGSubtraction, 6); // Background subtractor GUI

--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -48,7 +48,8 @@ class TBGSubtraction : public TGMainFrame {
       kComboAxisEntry,
       kBGCheckButton1,
       kBGCheckButton2,
-      kPeakSkewCheckButton
+      kPeakSkewCheckButton,
+      kAutoUpdateCheckButton
    };
 
    //  RQ_OBJECT("TBGSubtraction")
@@ -77,6 +78,7 @@ private:
    TGCheckButton*       fBGCheckButton1;
    TGCheckButton*       fBGCheckButton2;
    TGCheckButton*       fPeakSkewCheckButton;
+   TGCheckButton*       fAutoUpdateCheckButton;
 
    TGLayoutHints* fBly;
    TGLayoutHints* fBly1;
@@ -163,6 +165,7 @@ public:
    void DoAllGates();
 
    void DoGateProjection();
+   void SetStatusFromUpdateCheckButton();
 
 private:
    void BuildInterface();

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -914,7 +914,7 @@ void TBGSubtraction::DoGateProjection(){
       fSubtractedHist->GetXaxis()->SetRange(first_bin, last_bin);
       fSubtractedHist->Draw("hist");
    }
- //  DrawPeakMarkers();
+   DrawPeakMarkers();
    fGateCanvas->GetCanvas()->Update();
 
 

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -49,9 +49,9 @@ void TBGSubtraction::MakeConnections(){
 
    //Connect Canvases to recognize that they have been zoomed
    //This function includes setting the slider, and drawing the gate markers.
-   fProjectionCanvas->GetCanvas()->Connect("RangeAxisChanged()", "TBGSubtraction", this, "DoProjectionCanvasZoomed()");
+   fProjectionCanvas->GetCanvas()->Connect("RangeChanged()", "TBGSubtraction", this, "DoProjectionCanvasZoomed()");
 
-   fGateCanvas->GetCanvas()->Connect("RangeAxisChanged()", "TBGSubtraction", this, "DoGateCanvasZoomed()");
+   fGateCanvas->GetCanvas()->Connect("RangeChanged()", "TBGSubtraction", this, "DoGateCanvasZoomed()");
 
    //Connect Status Info to canvases
    fProjectionCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TBGSubtraction", this,
@@ -251,7 +251,7 @@ void TBGSubtraction::BuildInterface(){
 
    fDescriptionFrame     = new TGHorizontalFrame(fGateFrame, 200, 200);
    fAutoUpdateCheckButton = new TGCheckButton(fDescriptionFrame, "Auto Update", kAutoUpdateCheckButton);
-   fAutoUpdateCheckButton->SetState(kButtonUp);
+   fAutoUpdateCheckButton->SetState(kButtonDown);
    fHistogramDescription = new TGTextEntry(fDescriptionFrame, "gated #gamma-#gamma", kHistogramDescriptionEntry);
 
    fButtonFrame    = new TGHorizontalFrame(fGateFrame, 200, 200);

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -11,11 +11,12 @@ ClassImp(TBGSubtraction)
 
    TBGSubtraction::TBGSubtraction(TH2* mat, const char* gate_axis)
    : TGMainFrame(nullptr, 10, 10, kHorizontalFrame), fProjectionCanvas(nullptr), fGateCanvas(nullptr), fMatrix(mat),
-     fProjection(nullptr), fGateHist(nullptr), fBGHist(nullptr), fSubtractedHist(nullptr), fGateSlider(nullptr),
-     fBGSlider(nullptr), fPeakSlider(nullptr), fBGParamEntry(nullptr), fBGCheckButton(nullptr), fPeakSkewCheckButton(nullptr), fBly(nullptr), 
-     fBly1(nullptr), fGateFrame(nullptr), fProjectionFrame(nullptr), fAxisCombo(nullptr), fLowGateMarker(nullptr),
-     fHighGateMarker(nullptr), fLowBGMarker(nullptr),  fHighBGMarker(nullptr), fLowPeakMarker(nullptr), fHighPeakMarker(nullptr),
-     fPeakMarker(nullptr), fGateAxis(0), fForceUpdate(true), fPeakFit(nullptr)
+     fProjection(nullptr), fGateHist(nullptr), fBGHist1(nullptr), fBGHist2(nullptr), fSubtractedHist(nullptr), fGateSlider(nullptr),
+     fBGSlider1(nullptr), fBGSlider2(nullptr), fPeakSlider(nullptr), fBGParamEntry(nullptr), fBGCheckButton1(nullptr), fBGCheckButton2(nullptr), 
+     fPeakSkewCheckButton(nullptr), fBly(nullptr), fBly1(nullptr), fGateFrame(nullptr), fProjectionFrame(nullptr), fAxisCombo(nullptr), 
+     fLowGateMarker(nullptr), fHighGateMarker(nullptr), fLowBGMarker1(nullptr),  fHighBGMarker1(nullptr), fLowBGMarker2(nullptr), 
+     fHighBGMarker2(nullptr), fLowPeakMarker(nullptr), fHighPeakMarker(nullptr), fPeakMarker(nullptr), fGateAxis(0), 
+     fForceUpdate(true), fPeakFit(nullptr)
 {
 
    // fProjection = (TH1*)(fMatrix->ProjectionX()->Clone());
@@ -59,8 +60,8 @@ void TBGSubtraction::MakeConnections(){
 
 
    //Connect Status Info to canvases
- //  fProjectionCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TBGSubtraction", this,
- //                                          "ProjectionStatusInfo(Int_t,Int_t,Int_t,TObject*)");
+   fProjectionCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TBGSubtraction", this,
+                                          "ProjectionStatusInfo(Int_t,Int_t,Int_t,TObject*)");
    fGateCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TBGSubtraction", this,
                                      "GateStatusInfo(Int_t,Int_t,Int_t,TObject*)");
 
@@ -70,9 +71,12 @@ void TBGSubtraction::MakeConnections(){
    fGateSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DoSlider()");
    fGateSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DrawGateMarkers()");
    fGateSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DoGating()");
-   fBGSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DoSlider()");
-   fBGSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DrawBGMarkers()");
-   fBGSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DoGating()");
+   fBGSlider1->Connect("PositionChanged()", "TBGSubtraction", this, "DoSlider()");
+   fBGSlider1->Connect("PositionChanged()", "TBGSubtraction", this, "DrawBGMarkers1()");
+   fBGSlider1->Connect("PositionChanged()", "TBGSubtraction", this, "DoGating()");
+   fBGSlider2->Connect("PositionChanged()", "TBGSubtraction", this, "DoSlider()");
+   fBGSlider2->Connect("PositionChanged()", "TBGSubtraction", this, "DrawBGMarkers2()");
+   fBGSlider2->Connect("PositionChanged()", "TBGSubtraction", this, "DoGating()");
 
    fPeakSlider->Connect("PointerPositionChanged()", "TBGSubtraction", this, "DoSlider()");
    fPeakSlider->Connect("PositionChanged()", "TBGSubtraction", this, "DoSlider()");
@@ -82,8 +86,10 @@ void TBGSubtraction::MakeConnections(){
    //Connect the clicking of buttons
    fPeakFitButton->Connect("Clicked()", "TBGSubtraction", this, "DoPeakFit()");
 
-   fBGCheckButton->Connect("Clicked()","TBGSubtraction",this,"UpdateBackground()");
-   fBGCheckButton->Connect("Clicked()","TBGSubtraction",this,"DoGating()");
+   fBGCheckButton1->Connect("Clicked()","TBGSubtraction",this,"UpdateBackground()");
+   fBGCheckButton1->Connect("Clicked()","TBGSubtraction",this,"DoGating()");
+   fBGCheckButton2->Connect("Clicked()","TBGSubtraction",this,"UpdateBackground()");
+   fBGCheckButton2->Connect("Clicked()","TBGSubtraction",this,"DoGating()");
 
    fWrite2FileButton->Connect("Clicked()", "TBGSubtraction", this, "WriteHistograms()");
 
@@ -98,12 +104,18 @@ void TBGSubtraction::MakeConnections(){
    fGateEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
    fGateEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
    fGateEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawGateMarkers()");
-   fBGEntryLow->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
-   fBGEntryLow->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
-   fBGEntryLow->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers()");
-   fBGEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
-   fBGEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
-   fBGEntryHigh->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers()");
+   fBGEntryLow1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
+   fBGEntryLow1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
+   fBGEntryLow1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers1()");
+   fBGEntryHigh1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
+   fBGEntryHigh1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
+   fBGEntryHigh1->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers1()");
+   fBGEntryLow2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
+   fBGEntryLow2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
+   fBGEntryLow2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers2()");
+   fBGEntryHigh2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DoEntry(Long_t)");
+   fBGEntryHigh2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "UpdateProjectionSliders()");
+   fBGEntryHigh2->Connect("ValueSet(Long_t)", "TBGSubtraction", this, "DrawBGMarkers2()");
 
    //Connect the bg paramater entry to do the proper thing
    fBGParamEntry->Connect("ValueSet(Long_t)","TBGSubtraction",this,"UpdateBackground()");
@@ -134,11 +146,16 @@ void TBGSubtraction::ResetInterface(){
    fGateEntryLow->SetLimitValues(xmin,xmax);
    fGateEntryHigh->SetLimitValues(xmin,xmax);
    
-   fBGEntryLow->SetNumber(xmin+def_bg_low*x_width);
-   fBGEntryHigh->SetNumber(xmax-(1.0-def_bg_high)*x_width);
-   fBGEntryLow->SetLimitValues(xmin,xmax);
-   fBGEntryHigh->SetLimitValues(xmin,xmax);
-   
+   fBGEntryLow1->SetNumber(xmin+def_bg_low*x_width);
+   fBGEntryHigh1->SetNumber(xmax-(1.0-def_bg_high)*x_width);
+   fBGEntryLow1->SetLimitValues(xmin,xmax);
+   fBGEntryHigh1->SetLimitValues(xmin,xmax);
+ 
+   fBGEntryLow2->SetNumber(xmin+def_bg_low*x_width);
+   fBGEntryHigh2->SetNumber(xmax-(1.0-def_bg_high)*x_width);
+   fBGEntryLow2->SetLimitValues(xmin,xmax);
+   fBGEntryHigh2->SetLimitValues(xmin,xmax);
+
    UpdateProjectionSliders();
    DoGating();
 
@@ -195,14 +212,24 @@ void TBGSubtraction::BuildInterface()
 
    fGateSlider = new TGDoubleHSlider(fProjectionFrame, 100, kDoubleScaleBoth, kGateSlider, kHorizontalFrame);
 
-   fBGEntryFrame = new TGHorizontalFrame(fProjectionFrame, 200, 200);
-   fBGEntryLow   = new TGNumberEntry(fBGEntryFrame, 0, 3, kBGLowEntry, TGNumberFormat::kNESReal,
+   fBGEntryFrame1 = new TGHorizontalFrame(fProjectionFrame, 200, 200);
+   fBGEntryLow1   = new TGNumberEntry(fBGEntryFrame1, 0, 3, kBGLowEntry1, TGNumberFormat::kNESReal,
                                    TGNumberFormat::kNEAAnyNumber, TGNumberFormat::kNELLimitMinMax, xmin, xmax);
 
-   fBGEntryHigh = new TGNumberEntry(fBGEntryFrame, 0, 3, kBGHighEntry, TGNumberFormat::kNESReal,
+   fBGEntryHigh1 = new TGNumberEntry(fBGEntryFrame1, 0, 3, kBGHighEntry1, TGNumberFormat::kNESReal,
                                     TGNumberFormat::kNEAAnyNumber, TGNumberFormat::kNELLimitMinMax, xmin, xmax);
 
-   fBGSlider = new TGDoubleHSlider(fProjectionFrame, 100, kDoubleScaleBoth, kBGSlider, kHorizontalFrame);
+
+   fBGEntryFrame2 = new TGHorizontalFrame(fProjectionFrame, 200, 200);
+   fBGEntryLow2   = new TGNumberEntry(fBGEntryFrame2, 0, 3, kBGLowEntry2, TGNumberFormat::kNESReal,
+                                   TGNumberFormat::kNEAAnyNumber, TGNumberFormat::kNELLimitMinMax, xmin, xmax);
+
+   fBGEntryHigh2 = new TGNumberEntry(fBGEntryFrame2, 0, 3, kBGHighEntry2, TGNumberFormat::kNESReal,
+                                    TGNumberFormat::kNEAAnyNumber, TGNumberFormat::kNELLimitMinMax, xmin, xmax);
+
+
+   fBGSlider1 = new TGDoubleHSlider(fProjectionFrame, 100, kDoubleScaleBoth, kBGSlider1, kHorizontalFrame);
+   fBGSlider2 = new TGDoubleHSlider(fProjectionFrame, 100, kDoubleScaleBoth, kBGSlider2, kHorizontalFrame);
 
    fGateFrame = new TGVerticalFrame(this, 200, 200);
    fGateCanvas = new TRootEmbeddedCanvas("GateCanvas", fGateFrame, 200, 200);
@@ -229,8 +256,11 @@ void TBGSubtraction::BuildInterface()
 
    fAxisCombo = new TGComboBox(fBGParamFrame, kComboAxisEntry);
 
-   fBGCheckButton = new TGCheckButton(fBGParamFrame, "BG On", kBGCheckButton);
-   fBGCheckButton->SetState(kButtonDown);
+   fBGCheckButton1 = new TGCheckButton(fBGParamFrame, "BG 1", kBGCheckButton1);
+   fBGCheckButton1->SetState(kButtonDown);
+
+   fBGCheckButton2 = new TGCheckButton(fBGParamFrame, "BG 2", kBGCheckButton2);
+   fBGCheckButton2->SetState(kButtonDown);
 
    fDescriptionFrame     = new TGHorizontalFrame(fGateFrame, 200, 200);
    fHistogramDescription = new TGTextEntry(fDescriptionFrame, "gated #gamma-#gamma", kHistogramDescriptionEntry);
@@ -247,7 +277,8 @@ void TBGSubtraction::BuildInterface()
 
    //Build smaller horizontal frames
    fBGParamFrame->AddFrame(fAxisCombo, fBly);
-   fBGParamFrame->AddFrame(fBGCheckButton, fBly);
+   fBGParamFrame->AddFrame(fBGCheckButton1, fBly);
+   fBGParamFrame->AddFrame(fBGCheckButton2, fBly);
    fBGParamFrame->AddFrame(fBGParamLabel, fBly);
    fBGParamFrame->AddFrame(fBGParamEntry, fBly);
 
@@ -257,8 +288,11 @@ void TBGSubtraction::BuildInterface()
    fPeakFitFrame->AddFrame(fPeakSkewCheckButton,fBly);
    fPeakFitFrame->AddFrame(fPeakFitButton,fBly);
 
-   fBGEntryFrame->AddFrame(fBGEntryLow, fBly);
-   fBGEntryFrame->AddFrame(fBGEntryHigh, fBly);
+   fBGEntryFrame1->AddFrame(fBGEntryLow1, fBly);
+   fBGEntryFrame1->AddFrame(fBGEntryHigh1, fBly);
+
+   fBGEntryFrame2->AddFrame(fBGEntryLow2, fBly);
+   fBGEntryFrame2->AddFrame(fBGEntryHigh2, fBly);
 
    fDescriptionFrame->AddFrame(fHistogramDescription, fBly);
 
@@ -269,9 +303,11 @@ void TBGSubtraction::BuildInterface()
    fProjectionFrame->AddFrame(fProjectionCanvas, fLayoutCanvases);
    fProjectionFrame->AddFrame(fProjectionStatus, fBly);
    fProjectionFrame->AddFrame(fGateSlider, fBly);
-   fProjectionFrame->AddFrame(fBGSlider, fBly);
+   fProjectionFrame->AddFrame(fBGSlider1, fBly);
+   fProjectionFrame->AddFrame(fBGSlider2, fBly);
    fProjectionFrame->AddFrame(fGateEntryFrame, fBly);
-   fProjectionFrame->AddFrame(fBGEntryFrame, fBly);
+   fProjectionFrame->AddFrame(fBGEntryFrame1, fBly);
+   fProjectionFrame->AddFrame(fBGEntryFrame2, fBly);
 
    fGateFrame->AddFrame(fGateCanvas, fLayoutCanvases);
    fGateFrame->AddFrame(fPeakSlider,fBly);
@@ -303,11 +339,17 @@ TBGSubtraction::~TBGSubtraction()
 {
    // Clean up used widgets: frames, buttons, layout hints
    Cleanup();
-   if(fLowBGMarker != nullptr) {
-      delete fLowBGMarker;
+   if(fLowBGMarker1 != nullptr) {
+      delete fLowBGMarker1;
    }
-   if(fHighBGMarker != nullptr) {
-      delete fHighBGMarker;
+   if(fHighBGMarker1 != nullptr) {
+      delete fHighBGMarker1;
+   }
+   if(fLowBGMarker2 != nullptr) {
+      delete fLowBGMarker2;
+   }
+   if(fHighBGMarker2 != nullptr) {
+      delete fHighBGMarker2;
    }
    if(fLowGateMarker != nullptr) {
       delete fLowGateMarker;
@@ -330,10 +372,11 @@ void TBGSubtraction::UpdateBackground(){
    // Draws function graphics in randomly chosen interval
    TCanvas* fCanvas = fProjectionCanvas->GetCanvas();
    fCanvas->cd();
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
+   //Make sure one of the backgrounds are checked in order to draw background
+   if(((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) || ((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown())) {
       fProjection->ShowBackground(fBGParamEntry->GetNumberEntry()->GetIntNumber())->Draw("same");
    }
-   else if((fBGCheckButton != nullptr) && !fBGCheckButton->IsDown()){
+   else if((fBGCheckButton1 != nullptr) && !fBGCheckButton1->IsDown() && (fBGCheckButton2 != nullptr) && !fBGCheckButton2->IsDown() ){
       fProjection->Draw();
    }
    fCanvas->Update();
@@ -360,9 +403,9 @@ void TBGSubtraction::DrawPeak(){
       fPeakFit->Draw("same");
 }
 
-void TBGSubtraction::ClickedBGButton()
+void TBGSubtraction::ClickedBGButton1()
 {
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
+   if((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) {
       fBGParamEntry->SetState(true);
    } else {
       fBGParamEntry->SetState(false);
@@ -375,8 +418,11 @@ void TBGSubtraction::UpdateProjectionSliders(){
    fGateSlider->SetPosition(fGateEntryLow->GetNumber(),fGateEntryHigh->GetNumber());
    fGateSlider->SetRange(fGateEntryLow->GetNumMin(), fGateEntryHigh->GetNumMax());
 
-   fBGSlider->SetPosition(fBGEntryLow->GetNumber(), fBGEntryHigh->GetNumber());
-   fBGSlider->SetRange(fBGEntryLow->GetNumMin(), fBGEntryHigh->GetNumMax());
+   fBGSlider1->SetPosition(fBGEntryLow1->GetNumber(), fBGEntryHigh1->GetNumber());
+   fBGSlider1->SetRange(fBGEntryLow1->GetNumMin(), fBGEntryHigh1->GetNumMax());
+
+   fBGSlider2->SetPosition(fBGEntryLow2->GetNumber(), fBGEntryHigh2->GetNumber());
+   fBGSlider2->SetRange(fBGEntryLow2->GetNumMin(), fBGEntryHigh2->GetNumMax());
 
 }
 
@@ -410,9 +456,13 @@ void TBGSubtraction::DoSlider(Int_t pos)
          fGateEntryLow->SetNumber(fGateSlider->GetMinPosition());
          fGateEntryHigh->SetNumber(fGateSlider->GetMaxPosition());
          break;
-      case kBGSlider:
-         fBGEntryLow->SetNumber(fBGSlider->GetMinPosition());
-         fBGEntryHigh->SetNumber(fBGSlider->GetMaxPosition());
+      case kBGSlider1:
+         fBGEntryLow1->SetNumber(fBGSlider1->GetMinPosition());
+         fBGEntryHigh1->SetNumber(fBGSlider1->GetMaxPosition());
+         break;    
+      case kBGSlider2:
+         fBGEntryLow2->SetNumber(fBGSlider2->GetMinPosition());
+         fBGEntryHigh2->SetNumber(fBGSlider2->GetMaxPosition());
          break;    
       case kPeakSlider:
          fPeakLowValue  = fPeakSlider->GetMinPosition();
@@ -516,46 +566,58 @@ void TBGSubtraction::DrawPeakMarkers(){
    }
 }
 
-void TBGSubtraction::DrawBGMarkers(){
-   if(fLowBGMarker == nullptr) {
-      fLowBGMarker = new GMarker();
-   }
-   if(fHighBGMarker == nullptr) {
-      fHighBGMarker = new GMarker();
-   }
-   fLowBGMarker->localx       = fBGEntryLow->GetNumber();
-   fHighBGMarker->localx      = fBGEntryHigh->GetNumber();
-   fLowBGMarker->binx      = fProjection->GetXaxis()->FindBin(fLowBGMarker->localx);
-   fHighBGMarker->binx     = fProjection->GetXaxis()->FindBin(fHighBGMarker->localx);
-   double low_bg_bin_edge    = fProjection->GetXaxis()->GetBinLowEdge(fLowBGMarker->binx);
-   double high_bg_bin_edge   = fProjection->GetXaxis()->GetBinLowEdge(fHighBGMarker->binx);
+void TBGSubtraction::DrawBGMarkers(TGCheckButton *&check_button, GMarker *&low_marker, GMarker *&high_marker, TGNumberEntry *&low_entry, TGNumberEntry *&high_entry, Int_t color){
+
+      //Only Draw the BG Markers if BG is applied.
+   if((check_button != nullptr) && check_button->IsDown()) {
+      if(low_marker == nullptr) {
+         low_marker = new GMarker();
+      }
+      if(high_marker == nullptr) {
+         high_marker = new GMarker();
+      }
+      low_marker->localx         = low_entry->GetNumber();
+      high_marker->localx        = high_entry->GetNumber();
+      low_marker->binx           = fProjection->GetXaxis()->FindBin(low_marker->localx);
+      high_marker->binx          = fProjection->GetXaxis()->FindBin(high_marker->localx);
+      double low_bg_bin_edge     = fProjection->GetXaxis()->GetBinLowEdge(low_marker->binx);
+      double high_bg_bin_edge    = fProjection->GetXaxis()->GetBinLowEdge(high_marker->binx);
    
-   if((fLowBGMarker->linex) == nullptr) {
-      fLowBGMarker->linex =
-         new TLine(low_bg_bin_edge, fProjection->GetMinimum(), low_bg_bin_edge, fProjection->GetMaximum());
-      fLowBGMarker->SetColor(kBlue);
+      if((low_marker->linex) == nullptr) {
+         low_marker->linex =
+            new TLine(low_bg_bin_edge, fProjection->GetMinimum(), low_bg_bin_edge, fProjection->GetMaximum());
+         low_marker->SetColor(color);
+      }
+
+      if((high_marker->linex) == nullptr) {
+         high_marker->linex =
+            new TLine(high_bg_bin_edge, fProjection->GetMinimum(), high_bg_bin_edge, fProjection->GetMaximum());
+         high_marker->SetColor(color);
+      }
+      low_marker->linex->SetX1(low_bg_bin_edge);
+      low_marker->linex->SetX2(low_bg_bin_edge);
+      low_marker->linex->SetY1(fProjection->GetMinimum());
+      low_marker->linex->SetY2(fProjection->GetMaximum());
+
+      high_marker->linex->SetX1(high_bg_bin_edge);
+      high_marker->linex->SetX2(high_bg_bin_edge);
+      high_marker->linex->SetY1(fProjection->GetMinimum());
+      high_marker->linex->SetY2(fProjection->GetMaximum());
+
+      fProjectionCanvas->GetCanvas()->cd();
+      low_marker->linex->Draw();
+      high_marker->linex->Draw();
+      fProjectionCanvas->GetCanvas()->Update();
    }
+   
+}
 
-   if((fHighBGMarker->linex) == nullptr) {
-      fHighBGMarker->linex =
-         new TLine(high_bg_bin_edge, fProjection->GetMinimum(), high_bg_bin_edge, fProjection->GetMaximum());
-      fHighBGMarker->SetColor(kBlue);
-   }
-   fLowBGMarker->linex->SetX1(low_bg_bin_edge);
-   fLowBGMarker->linex->SetX2(low_bg_bin_edge);
-   fLowBGMarker->linex->SetY1(fProjection->GetMinimum());
-   fLowBGMarker->linex->SetY2(fProjection->GetMaximum());
+void TBGSubtraction::DrawBGMarkers1(){
+   DrawBGMarkers(fBGCheckButton1, fLowBGMarker1, fHighBGMarker1, fBGEntryLow1, fBGEntryHigh1);
+}
 
-   fHighBGMarker->linex->SetX1(high_bg_bin_edge);
-   fHighBGMarker->linex->SetX2(high_bg_bin_edge);
-   fHighBGMarker->linex->SetY1(fProjection->GetMinimum());
-   fHighBGMarker->linex->SetY2(fProjection->GetMaximum());
-
-   fProjectionCanvas->GetCanvas()->cd();
-   fLowBGMarker->linex->Draw();
-   fHighBGMarker->linex->Draw();
-   fProjectionCanvas->GetCanvas()->Update();
-
+void TBGSubtraction::DrawBGMarkers2(){
+   DrawBGMarkers(fBGCheckButton2, fLowBGMarker2, fHighBGMarker2, fBGEntryLow2, fBGEntryHigh2,kMagenta);
 }
 
 void TBGSubtraction::DrawGateMarkers()
@@ -618,13 +680,21 @@ void TBGSubtraction::DoEntry(Long_t){
       if(fGateEntryHigh->GetNumber() < fGateEntryLow->GetNumber())
          fGateEntryHigh->SetNumber(fGateEntryLow->GetNumber());
       break;
-   case kBGLowEntry:
-      if(fBGEntryLow->GetNumber() > fBGEntryHigh->GetNumber())
-         fBGEntryLow->SetNumber(fBGEntryHigh->GetNumber());
+   case kBGLowEntry1:
+      if(fBGEntryLow1->GetNumber() > fBGEntryHigh1->GetNumber())
+         fBGEntryLow1->SetNumber(fBGEntryHigh1->GetNumber());
       break;
-   case kBGHighEntry:
-      if(fBGEntryHigh->GetNumber() < fBGEntryLow->GetNumber())
-         fBGEntryHigh->SetNumber(fBGEntryLow->GetNumber());
+   case kBGHighEntry1:
+      if(fBGEntryHigh1->GetNumber() < fBGEntryLow1->GetNumber())
+         fBGEntryHigh1->SetNumber(fBGEntryLow1->GetNumber());
+      break;
+   case kBGLowEntry2:
+      if(fBGEntryLow2->GetNumber() > fBGEntryHigh2->GetNumber())
+         fBGEntryLow2->SetNumber(fBGEntryHigh2->GetNumber());
+      break;
+   case kBGHighEntry2:
+      if(fBGEntryHigh2->GetNumber() < fBGEntryLow2->GetNumber())
+         fBGEntryHigh2->SetNumber(fBGEntryLow2->GetNumber());
       break;
    };
 }
@@ -667,28 +737,38 @@ void TBGSubtraction::DoProjectionCanvasZoomed(){
    // Get the old value
    Double_t old_lower_gate_val = fGateEntryLow->GetNumber();
    Double_t old_upper_gate_val = fGateEntryHigh->GetNumber();
-   Double_t old_lower_bg_val   = fBGEntryLow->GetNumber();
-   Double_t old_upper_bg_val   = fBGEntryHigh->GetNumber();
+   Double_t old_lower_bg1_val   = fBGEntryLow1->GetNumber();
+   Double_t old_upper_bg1_val   = fBGEntryHigh1->GetNumber();
+   Double_t old_lower_bg2_val   = fBGEntryLow2->GetNumber();
+   Double_t old_upper_bg2_val   = fBGEntryHigh2->GetNumber();
    // Now maintain the ratio of the position
    Double_t rel_lower_gate_val = (old_lower_gate_val - old_limit_min) / (old_limit_max - old_limit_min);
    Double_t rel_upper_gate_val = (old_upper_gate_val - old_limit_min) / (old_limit_max - old_limit_min);
-   Double_t rel_lower_bg_val   = (old_lower_bg_val - old_limit_min) / (old_limit_max - old_limit_min);
-   Double_t rel_upper_bg_val   = (old_upper_bg_val - old_limit_min) / (old_limit_max - old_limit_min);
+   Double_t rel_lower_bg1_val   = (old_lower_bg1_val - old_limit_min) / (old_limit_max - old_limit_min);
+   Double_t rel_upper_bg1_val   = (old_upper_bg1_val - old_limit_min) / (old_limit_max - old_limit_min);
+   Double_t rel_lower_bg2_val   = (old_lower_bg2_val - old_limit_min) / (old_limit_max - old_limit_min);
+   Double_t rel_upper_bg2_val   = (old_upper_bg2_val - old_limit_min) / (old_limit_max - old_limit_min);
    // set the new positions
    fGateEntryLow->SetNumber(xmin + rel_lower_gate_val * (xmax - xmin));
    fGateEntryHigh->SetNumber(xmin + rel_upper_gate_val * (xmax - xmin));
-   fBGEntryLow->SetNumber(xmin + rel_lower_bg_val * (xmax - xmin));
-   fBGEntryHigh->SetNumber(xmin + rel_upper_bg_val * (xmax - xmin));
+   fBGEntryLow1->SetNumber(xmin + rel_lower_bg1_val * (xmax - xmin));
+   fBGEntryHigh1->SetNumber(xmin + rel_upper_bg1_val * (xmax - xmin));
+   fBGEntryLow2->SetNumber(xmin + rel_lower_bg2_val * (xmax - xmin));
+   fBGEntryHigh2->SetNumber(xmin + rel_upper_bg2_val * (xmax - xmin));
    // Set the new limits
    fGateEntryLow->SetLimitValues(xmin, xmax);
    fGateEntryHigh->SetLimitValues(xmin, xmax);
-   fBGEntryLow->SetLimitValues(xmin, xmax);
-   fBGEntryHigh->SetLimitValues(xmin, xmax);
+   fBGEntryLow1->SetLimitValues(xmin, xmax);
+   fBGEntryHigh1->SetLimitValues(xmin, xmax);
+   fBGEntryLow2->SetLimitValues(xmin, xmax);
+   fBGEntryHigh2->SetLimitValues(xmin, xmax);
 
    fGateEntryLow->ValueSet(1);
    fGateEntryHigh->ValueSet(1);
-   fBGEntryLow->ValueSet(1);
-   fBGEntryHigh->ValueSet(1);
+   fBGEntryLow1->ValueSet(1);
+   fBGEntryHigh1->ValueSet(1);
+   fBGEntryLow2->ValueSet(1);
+   fBGEntryHigh2->ValueSet(1);
 }
 
 void TBGSubtraction::DoGating(){
@@ -712,31 +792,50 @@ void TBGSubtraction::DoGating(){
    }
    fGateHist->Sumw2();
 
-   if(fBGHist != nullptr) {
-      delete fBGHist;
+   if(fBGHist1 != nullptr) {
+      delete fBGHist1;
    }
-   const char* bg_name =
-      Form("bg_%d_%d", static_cast<Int_t>(fBGEntryLow->GetNumber()), static_cast<Int_t>(fBGEntryHigh->GetNumber()));
+   if(fBGHist2 != nullptr) {
+      delete fBGHist2;
+   }
+   const char* bg_name1 =
+      Form("bg1_%d_%d", static_cast<Int_t>(fBGEntryLow1->GetNumber()), static_cast<Int_t>(fBGEntryHigh1->GetNumber()));
+   const char* bg_name2 =
+      Form("bg2_%d_%d", static_cast<Int_t>(fBGEntryLow2->GetNumber()), static_cast<Int_t>(fBGEntryHigh2->GetNumber()));
 
    if(fGateAxis == 0) {
-      fBGHist = fMatrix->ProjectionX(bg_name, fMatrix->GetYaxis()->FindBin(fBGSlider->GetMinPosition()),
-                                     fMatrix->GetYaxis()->FindBin(fBGSlider->GetMaxPosition()));
+      fBGHist1 = fMatrix->ProjectionX(bg_name1, fMatrix->GetYaxis()->FindBin(fBGSlider1->GetMinPosition()),
+                                     fMatrix->GetYaxis()->FindBin(fBGSlider1->GetMaxPosition()));
+      fBGHist2 = fMatrix->ProjectionX(bg_name2, fMatrix->GetYaxis()->FindBin(fBGSlider2->GetMinPosition()),
+                                     fMatrix->GetYaxis()->FindBin(fBGSlider2->GetMaxPosition()));
    } else {
-      fBGHist = fMatrix->ProjectionY(bg_name, fMatrix->GetXaxis()->FindBin(fBGSlider->GetMinPosition()),
-                                     fMatrix->GetXaxis()->FindBin(fBGSlider->GetMaxPosition()));
+      fBGHist1 = fMatrix->ProjectionY(bg_name1, fMatrix->GetXaxis()->FindBin(fBGSlider1->GetMinPosition()),
+                                     fMatrix->GetXaxis()->FindBin(fBGSlider1->GetMaxPosition()));
+      fBGHist2 = fMatrix->ProjectionY(bg_name2, fMatrix->GetXaxis()->FindBin(fBGSlider2->GetMinPosition()),
+                                     fMatrix->GetXaxis()->FindBin(fBGSlider2->GetMaxPosition()));
    }
 
-   fBGHist->Sumw2();
+   fBGHist1->Sumw2();
+   fBGHist2->Sumw2();
    TH1*     bg_hist       = nullptr;
    Double_t under_peak_bg = 0.0;
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
+   //Make sure one of the two buttons are checked
+   if(((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) || ((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown())) {
       bg_hist       = fProjection->ShowBackground(fBGParamEntry->GetNumberEntry()->GetIntNumber());
       under_peak_bg = bg_hist->Integral(bg_hist->FindBin(fGateSlider->GetMinPosition()),
                                         bg_hist->FindBin(fGateSlider->GetMaxPosition()));
    }
 
-   Double_t bg_region = fProjection->Integral(fProjection->FindBin(fBGSlider->GetMinPosition()),
-                                              fProjection->FindBin(fBGSlider->GetMaxPosition()));
+   //Add the two background regions together;
+   Double_t bg_region = 0.0;
+   if((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()){
+      bg_region += fProjection->Integral(fProjection->FindBin(fBGSlider1->GetMinPosition()),
+                                              fProjection->FindBin(fBGSlider1->GetMaxPosition()));
+   }
+   if((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown()){
+      bg_region += fProjection->Integral(fProjection->FindBin(fBGSlider2->GetMinPosition()),
+                                              fProjection->FindBin(fBGSlider2->GetMaxPosition()));
+   }
    Double_t ratio = 0;
 
    if(bg_region != 0) {
@@ -750,10 +849,13 @@ void TBGSubtraction::DoGating(){
       last_bin  = fSubtractedHist->GetXaxis()->GetLast();
       delete fSubtractedHist;
    }
-   const char* sub_name = Form("%s_%s", fGateHist->GetName(), fBGHist->GetName());
+   const char* sub_name = Form("%s_%s", fGateHist->GetName(), fBGHist1->GetName()); //TO DO: Come up with better naming
    fSubtractedHist      = static_cast<TH1*>(fGateHist->Clone(sub_name));
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
-      fSubtractedHist->Add(fBGHist, -ratio);
+   if((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) {
+      fSubtractedHist->Add(fBGHist1, -ratio);
+   }
+   if((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown()) {
+      fSubtractedHist->Add(fBGHist2, -ratio);
    }
    fGateCanvas->GetCanvas()->cd();
    if(fSubtractedHist != nullptr) {
@@ -765,8 +867,7 @@ void TBGSubtraction::DoGating(){
 
 }
 
-void TBGSubtraction::DoProjection()
-{
+void TBGSubtraction::DoProjection(){
    Double_t xmin, ymin, xmax, ymax;
    if(fGateHist != nullptr) {
       delete fGateHist;
@@ -787,31 +888,50 @@ void TBGSubtraction::DoProjection()
    }
    fGateHist->Sumw2();
 
-   if(fBGHist != nullptr) {
-      delete fBGHist;
+   if(fBGHist1 != nullptr) {
+      delete fBGHist1;
    }
-   const char* bg_name =
-      Form("bg_%d_%d", static_cast<Int_t>(fBGEntryLow->GetNumber()), static_cast<Int_t>(fBGEntryHigh->GetNumber()));
+   if(fBGHist2 != nullptr) {
+      delete fBGHist2;
+   }
+   const char* bg_name1 =
+      Form("bg1_%d_%d", static_cast<Int_t>(fBGEntryLow1->GetNumber()), static_cast<Int_t>(fBGEntryHigh1->GetNumber()));
+   const char* bg_name2 =
+      Form("bg2_%d_%d", static_cast<Int_t>(fBGEntryLow2->GetNumber()), static_cast<Int_t>(fBGEntryHigh2->GetNumber()));
 
    if(fGateAxis == 0) {
-      fBGHist = fMatrix->ProjectionX(bg_name, fMatrix->GetYaxis()->FindBin(fBGSlider->GetMinPosition()),
-                                     fMatrix->GetYaxis()->FindBin(fBGSlider->GetMaxPosition()));
+      fBGHist1 = fMatrix->ProjectionX(bg_name1, fMatrix->GetYaxis()->FindBin(fBGSlider1->GetMinPosition()),
+                                     fMatrix->GetYaxis()->FindBin(fBGSlider1->GetMaxPosition()));
+      fBGHist2 = fMatrix->ProjectionX(bg_name1, fMatrix->GetYaxis()->FindBin(fBGSlider2->GetMinPosition()),
+                                     fMatrix->GetYaxis()->FindBin(fBGSlider2->GetMaxPosition()));
    } else {
-      fBGHist = fMatrix->ProjectionY(bg_name, fMatrix->GetXaxis()->FindBin(fBGSlider->GetMinPosition()),
-                                     fMatrix->GetXaxis()->FindBin(fBGSlider->GetMaxPosition()));
+      fBGHist1 = fMatrix->ProjectionY(bg_name1, fMatrix->GetXaxis()->FindBin(fBGSlider1->GetMinPosition()),
+                                     fMatrix->GetXaxis()->FindBin(fBGSlider1->GetMaxPosition()));
+      fBGHist2 = fMatrix->ProjectionY(bg_name2, fMatrix->GetXaxis()->FindBin(fBGSlider2->GetMinPosition()),
+                                     fMatrix->GetXaxis()->FindBin(fBGSlider2->GetMaxPosition()));
    }
 
-   fBGHist->Sumw2();
+   fBGHist1->Sumw2();
+   fBGHist2->Sumw2();
    TH1*     bg_hist       = nullptr;
    Double_t under_peak_bg = 0.0;
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
+   //Make sure one of the two buttons are checked
+   if(((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) || ((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown())) {
       bg_hist       = fProjection->ShowBackground(fBGParamEntry->GetNumberEntry()->GetIntNumber());
       under_peak_bg = bg_hist->Integral(bg_hist->FindBin(fGateSlider->GetMinPosition()),
                                         bg_hist->FindBin(fGateSlider->GetMaxPosition()));
    }
 
-   Double_t bg_region = fProjection->Integral(fProjection->FindBin(fBGSlider->GetMinPosition()),
-                                              fProjection->FindBin(fBGSlider->GetMaxPosition()));
+   //Add the two background regions together;
+   Double_t bg_region = 0.0;
+   if((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()){
+      bg_region += fProjection->Integral(fProjection->FindBin(fBGSlider1->GetMinPosition()),
+                                              fProjection->FindBin(fBGSlider1->GetMaxPosition()));
+   }
+   if((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown()){
+      bg_region += fProjection->Integral(fProjection->FindBin(fBGSlider2->GetMinPosition()),
+                                              fProjection->FindBin(fBGSlider2->GetMaxPosition()));
+   }
    Double_t ratio = 0;
 
    if(bg_region != 0) {
@@ -825,11 +945,16 @@ void TBGSubtraction::DoProjection()
       last_bin  = fSubtractedHist->GetXaxis()->GetLast();
       delete fSubtractedHist;
    }
-   const char* sub_name = Form("%s_%s", fGateHist->GetName(), fBGHist->GetName());
+   const char* sub_name = Form("%s_%s", fGateHist->GetName(), fBGHist1->GetName()); //TO DO: Come up with better naming
+   
    fSubtractedHist      = static_cast<TH1*>(fGateHist->Clone(sub_name));
-   if((fBGCheckButton != nullptr) && fBGCheckButton->IsDown()) {
-      fSubtractedHist->Add(fBGHist, -ratio);
+   if((fBGCheckButton1 != nullptr) && fBGCheckButton1->IsDown()) {
+      fSubtractedHist->Add(fBGHist1, -ratio);
    }
+   if((fBGCheckButton2 != nullptr) && fBGCheckButton2->IsDown()) {
+      fSubtractedHist->Add(fBGHist2, -ratio);
+   }
+   
    fGateCanvas->GetCanvas()->cd();
    if(fSubtractedHist != nullptr) {
       fSubtractedHist->GetXaxis()->SetRange(first_bin, last_bin);
@@ -868,13 +993,22 @@ void TBGSubtraction::WriteHistograms()
       fSubtractedHist->Write();
    }
 
-   if(fBGHist != nullptr) {
+   if(fBGHist1 != nullptr) {
       if(fHistogramDescription->GetText() != nullptr) {
-         fBGHist->SetTitle(Form("%s Background", fHistogramDescription->GetText()));
+         fBGHist1->SetTitle(Form("%s Background 1", fHistogramDescription->GetText()));
       }
 
-      fBGHist->Write();
+      fBGHist1->Write();
    }
+
+   if(fBGHist2 != nullptr) {
+      if(fHistogramDescription->GetText() != nullptr) {
+         fBGHist2->SetTitle(Form("%s Background 2", fHistogramDescription->GetText()));
+      }
+
+      fBGHist2->Write();
+   }
+
    if(fGateHist != nullptr) {
       if(fHistogramDescription->GetText() != nullptr) {
          fGateHist->SetTitle(Form("%s Gate only", fHistogramDescription->GetText()));


### PR DESCRIPTION
- Added second background for TBGSubtraction
- Ability to turn different background gates on and off
- Added Update check box to BGSubtraction 
- This increases speed when not interested in performing gating-on-the-fly 
- Default is on-the-fly is off 
- Fitting, and writing is disabled when you are not updating the gates. 
- Allows faster window expansion, gate setting etc, especially with multiple backgrounds 
- This was implemented because I'm not sure it's possible to connect to histogram range expansion without also connection to the window being expanded.