### PR TITLE
TGRSIDetectorHit::GetTime now uses TChannel::CalibratedCFD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ GRSIProof/*.?
 *.pyc
 __pycache__
 grsi_logon.C
+*.pcm

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -64,26 +64,26 @@ public:
    void SetNewPPG(EPpgPattern newPpg) { fNewPpg = newPpg; }
    void SetNewPPG(UInt_t newPpg)
 	{ 
-		fNewPpg = static_cast<EPpgPattern>(newPpg);
+		fNewPpg = static_cast<EPpgPattern>(newPpg&0xffff);
 		switch(fNewPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
 			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:
 				break;
 			default:
-				std::cout<<"Warning, unkown ppg pattern 0x"<<std::hex<<newPpg<<std::dec<<", setting new pattern to kJunk!"<<std::endl;
+				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<newPpg<<std::dec<<", setting new pattern to kJunk!"<<std::endl;
 				fNewPpg = EPpgPattern::kJunk;
 		}
 	}
    void SetOldPPG(EPpgPattern oldPpg) { fOldPpg = oldPpg; }
    void SetOldPPG(UInt_t oldPpg)
 	{
-		fOldPpg = static_cast<EPpgPattern>(oldPpg);
+		fOldPpg = static_cast<EPpgPattern>(oldPpg&0xffff);
 		switch(fOldPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
 			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:
 				break;
 			default:
-				std::cout<<"Warning, unkown ppg pattern 0x"<<std::hex<<oldPpg<<std::dec<<", setting old pattern to kJunk!"<<std::endl;
+				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<oldPpg<<std::dec<<", setting old pattern to kJunk!"<<std::endl;
 				fOldPpg = EPpgPattern::kJunk;
 		}
 	}

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -35,12 +35,12 @@
 #include "Globals.h"
 
 enum class EPpgPattern {
-	kBeamOn     = 0x0001,
-	kDecay      = 0x0004,
-	kTapeMove   = 0x0008,
-	kBackground = 0x0002,
-	kSync       = 0xc000,
-	kJunk       = 0xFFFF
+	kBeamOn     = 0x01,
+	kDecay      = 0x04,
+	kTapeMove   = 0x08,
+	kBackground = 0x02,
+	//kSync       = 0xc000,
+	kJunk       = 0xFF
 };
 
 class TPPGData : public TObject {
@@ -64,7 +64,7 @@ public:
    void SetNewPPG(EPpgPattern newPpg) { fNewPpg = newPpg; }
    void SetNewPPG(UInt_t newPpg)
 	{ 
-		fNewPpg = static_cast<EPpgPattern>(newPpg&0xffff);
+		fNewPpg = static_cast<EPpgPattern>(newPpg&0xff);
 		switch(fNewPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
 			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:
@@ -77,7 +77,7 @@ public:
    void SetOldPPG(EPpgPattern oldPpg) { fOldPpg = oldPpg; }
    void SetOldPPG(UInt_t oldPpg)
 	{
-		fOldPpg = static_cast<EPpgPattern>(oldPpg&0xffff);
+		fOldPpg = static_cast<EPpgPattern>(oldPpg&0xff);
 		switch(fOldPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
 			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -67,7 +67,7 @@ public:
 		fNewPpg = static_cast<EPpgPattern>(newPpg&0xff);
 		switch(fNewPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
-			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:
+			case EPpgPattern::kBackground: case EPpgPattern::kJunk:
 				break;
 			default:
 				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<newPpg<<std::dec<<", setting new pattern to kJunk!"<<std::endl;
@@ -80,7 +80,7 @@ public:
 		fOldPpg = static_cast<EPpgPattern>(oldPpg&0xff);
 		switch(fOldPpg) {
 			case EPpgPattern::kBeamOn: case EPpgPattern::kDecay: case EPpgPattern::kTapeMove:
-			case EPpgPattern::kBackground: case EPpgPattern::kSync: case EPpgPattern::kJunk:
+			case EPpgPattern::kBackground: case EPpgPattern::kJunk:
 				break;
 			default:
 				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<oldPpg<<std::dec<<", setting old pattern to kJunk!"<<std::endl;

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -65,13 +65,13 @@ Double_t TGRSIDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
       return SetTime(10. * (static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
    }
    switch(channel->GetDigitizerType()) {
-      Double_t dTime;
+		Double_t dTime;
 		case TMnemonic::EDigitizer::kGRF16:
 		dTime = (GetTimeStamp() & (~0x3ffff)) * 10. +
-              (GetCfd() + gRandom->Uniform()) / 1.6; // CFD is in 10/16th of a nanosecond
+              channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
 		return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
 		case TMnemonic::EDigitizer::kGRF4G:
-      dTime = GetTimeStamp() * 10. + (fCfd >> 22) + ((fCfd & 0x3fffff) + gRandom->Uniform()) / 256.;
+      dTime = GetTimeStamp() * 10. + channel->CalibrateCFD((fCfd >> 22) + ((fCfd & 0x3fffff) + gRandom->Uniform()) / 256.);
       return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
 		default:
 		dTime = static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform());

--- a/util/ErrorReport.sh
+++ b/util/ErrorReport.sh
@@ -1,9 +1,45 @@
 # Run this script to help report Errors in GRSISort
 # Author by Ryan Dunlop, 22/10/2015
-echo HOSTNAME     = `hostname`
-echo SYSTEM       = `uname`
-echo GRSISYS      = $GRSISYS
-echo ROOTSYS      = $ROOTSYS
+
+# taken from stackexchange (https://unix.stackexchange.com/questions/6345/how-can-i-get-distribution-name-and-version-number-in-a-simple-shell-script)
+if [ -f /etc/os-release ]; then
+	# freedesktop.org and systemd
+	. /etc/os-release
+	OS=$NAME
+	VER=$VERSION_ID
+elif type lsb_release >/dev/null 2>&1; then
+	# linuxbase.org
+	OS=$(lsb_release -si)
+	VER=$(lsb_release -sr)
+elif [ -f /etc/lsb-release ]; then
+	# For some versions of Debian/Ubuntu without lsb_release command
+	. /etc/lsb-release
+	OS=$DISTRIB_ID
+	VER=$DISTRIB_RELEASE
+elif [ -f /etc/debian_version ]; then
+	# Older Debian/Ubuntu/etc.
+	OS=Debian
+	VER=$(cat /etc/debian_version)
+elif [ -f /etc/SuSe-release ]; then
+	# Older SuSE/etc.
+	OS=SuSe
+	VER=unknown
+elif [ -f /etc/redhat-release ]; then
+	# Older Red Hat, CentOS, etc.
+	OS=$(cat /etc/redhat-release | awk '{print $1}')
+	VER=$(cat /etc/redhat-release | awk '{print $3}')
+else
+	# Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+	OS=$(uname -s)
+	VER=$(uname -r)
+fi
+
+echo "HOSTNAME     = `hostname`"
+echo "SYSTEM       = `uname`"
+echo "OS           = $OS"
+echo "VER          = $VER"
+echo "GRSISYS      = $GRSISYS"
+echo "ROOTSYS      = $ROOTSYS"
 
 echo ROOT Version = `root-config --version`
 printf "\nComputer and Path to File that failed: \n\n"


### PR DESCRIPTION
Fixes #960 and #884 
- Updated ErrorReport.sh to contain a guess of the OS.
- Updated .gitignore to exclude any ROOT 6 style dictionaries (*.pcm).
- TGRSIOptions now uses the program name (from argv[0]) to check which options are added to the rgParser object.