### PR TITLE
Change .grsirc prompt color based on root version. Fixes #958

### DIFF
--- a/.grsirc
+++ b/.grsirc
@@ -7,7 +7,7 @@ Rint.Logon: $(GRSISYS)/grsi_logon.C
 Rint.History $(GRSISYS)/.grsi_history
 Rint.HistSize: 1000000 
 
-Rint.PromptColor: #CCCC00
+Rint.PromptColor: %CCCC00
 Rint.BracketColor: bold green
 Rint.BadBracketColor: bold red underlined
 Rint.TabComColor: magenta

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all extras docs doxygen
+.PHONY: clean all extras docs doxygen grsirc
 .SECONDARY:
 .SECONDEXPANSION:
 
@@ -16,6 +16,7 @@ SRC_SUFFIX = cxx
 # EVERYTHING PAST HERE SHOULD WORK AUTOMATICALLY
 
 MAJOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f1)
+MINOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f2 | cut -d '/' -f1)
 ROOT_PYTHON_VERSION=$(shell root-config --python-version)
 
 MATHMORE_INSTALLED:=$(shell root-config --has-mathmore)
@@ -120,7 +121,7 @@ run_and_test =@printf "%b%b%b" " $(3)$(4)$(5)" $(notdir $(2)) "$(NO_COLOR)\r";  
                 rm -f $(2).log $(2).error
 endif
 
-all: include/GVersion.h $(EXECUTABLES) $(LIBRARY_OUTPUT) lib/libGRSI.so config $(HISTOGRAM_SO) $(FILTER_SO)
+all: include/GVersion.h grsirc $(EXECUTABLES) $(LIBRARY_OUTPUT) lib/libGRSI.so config $(HISTOGRAM_SO) $(FILTER_SO)
 	@$(FIND) .build users -name "*.pcm" -exec cp {} lib/ \;
 	@printf "$(OK_COLOR)Compilation successful, $(WARN_COLOR)woohoo!$(NO_COLOR)\n"
 
@@ -154,6 +155,9 @@ include/GVersion.h:
 	$(call run_and_test,util/gen_version.sh,$@,$(COM_COLOR),$(COM_STRING),$(OBJ_COLOR) )
 
 #include/GVersion.h: .git/HEAD .git/index util/gen_version.sh
+
+grsirc:
+	$(call run_and_test,util/gen_grsirc.sh,$@,$(COM_COLOR),$(BLD_STRING),$(OBJ_COLOR) )
 
 lib/lib%.so: .build/histos/%.o | lib include/GVersion.h
 	$(call run_and_test,$(CPP) -fPIC $^ $(SHAREDSWITCH)lib$*.so $(ROOT_LIBFLAGS) -o $@,$@,$(BLD_COLOR),$(BLD_STRING),$(OBJ_COLOR) )

--- a/util/gen_grsirc.sh
+++ b/util/gen_grsirc.sh
@@ -11,7 +11,7 @@ fi
 
 if [ $MAJOR_ROOT_VERSION -eq 6 ] && [ $MINOR_ROOT_VERSION -le 8 ]
 then
-	sed -i 's/\(Rint.PromptColor:[[:space:]]*\)\(%\)\([0-9A-Fa-f]\{6\}\)/\1#\3/g' .grsirc 
+	sed -i -e 's/\(Rint.PromptColor:[[:space:]]*\)\(%\)\([0-9A-Fa-f]\{6\}\)/\1#\3/g' .grsirc 
 else
-	sed -i 's/\(Rint.PromptColor:[[:space:]]*\)\(#\)\([0-9A-Fa-f]\{6\}\)/\1%\3/g' .grsirc 
+	sed -i -e 's/\(Rint.PromptColor:[[:space:]]*\)\(#\)\([0-9A-Fa-f]\{6\}\)/\1%\3/g' .grsirc 
 fi

--- a/util/gen_grsirc.sh
+++ b/util/gen_grsirc.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MAJOR_ROOT_VERSION=$(root-config --version | cut -d '.' -f1)
+MINOR_ROOT_VERSION=$(root-config --version | cut -d '.' -f2 | cut -d '/' -f1)
+
+if [ $MAJOR_ROOT_VERSION -le 5 ]
+then
+	echo "Wrong ROOT version ${MAJOR_ROOT_VERSION}.${MINOR_ROOT_VERSION}, need at least ROOT 6!";
+	exit 1;
+fi
+
+if [ $MAJOR_ROOT_VERSION -eq 6 ] && [ $MINOR_ROOT_VERSION -le 8 ]
+then
+	sed -i 's/\(Rint.PromptColor:[[:space:]]*\)\(%\)\([0-9A-Fa-f]\{6\}\)/\1#\3/g' .grsirc 
+else
+	sed -i 's/\(Rint.PromptColor:[[:space:]]*\)\(#\)\([0-9A-Fa-f]\{6\}\)/\1%\3/g' .grsirc 
+fi


### PR DESCRIPTION
The new util/gen_grsirc.sh script also creates an error if ROOT versions lower than 6 are being used.