### PR TITLE
Write Cal File format exception

### DIFF
--- a/include/TSiLiHit.h
+++ b/include/TSiLiHit.h
@@ -135,7 +135,7 @@ private:
    Double_t fFitBase{0.};
 
    /// \cond CLASSIMP
-   ClassDefOverride(TSiLiHit, 9);
+   ClassDefOverride(TSiLiHit, 10);
    /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -715,7 +715,8 @@ std::string TChannel::PrintToString(Option_t*)
    buffer.append(Form("Digitizer: %s\n", fDigitizerTypeString.Value().c_str()));
    buffer.append("EngCoeff:  ");
    for(float fENGCoefficient : fENGCoefficients.Value()) {
-      buffer.append(Form("%f\t", fENGCoefficient));
+      if(fENGCoefficient<0.001)buffer.append(Form("%e\t", fENGCoefficient));
+      else buffer.append(Form("%f\t", fENGCoefficient));
    }
    buffer.append("\n");
    buffer.append(Form("Integration: %d\n", fIntegration.Value()));


### PR DESCRIPTION
Took me far longer than it should have to work out what had happened to my gamma spectra.
I have quadratic calibration terms that are ~1E-8 which were being zeroed by WriteCalFile.
I've put an exception in as I understand that generally its easier to read things not in scientific notation when it isnt needed.
This might only be a problem for tigress with the different standards for charge integration, but give we deal with numbers on a wide scale, this is something to keep an eye on, make sure we aren't formatting away precision elsewhere.