### PR TITLE
Fixed bug when executing macros from command line

### DIFF
--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -676,7 +676,7 @@ void TGRSIint::RunMacroFile(const std::string& filename)
 {
    /// Runs a macro file. This happens when --work-harder is used with a .C file
    if(file_exists(filename.c_str())) {
-      const char* command = Form(".x %s;", filename.c_str());
+      const char* command = Form(".x %s", filename.c_str());
       ProcessLine(command);
    } else {
       std::cerr<<R"(File ")"<<filename<<R"(" does not exist)"<<std::endl;


### PR DESCRIPTION
When trying to run a macro by calling ```grsisort <name>.C``` the macro would fail to execute. This was solved by removing the trailing semi-colon of the command line sent to ROOT. 