### PR TITLE
Working version of TSingleton

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -41,8 +41,8 @@ void Analyze(const char* tree_type)
             // TODO: A smarter way of finding run info for run number and sub run number naming
             static bool info_set = false;
             if(!info_set) {
-               TGRSIRunInfo::Get().ReadInfoFromFile(in_file);
-					TGRSIRunInfo::Get().Print();
+               TGRSIRunInfo::Get()->ReadInfoFromFile(in_file);
+					TGRSIRunInfo::Get()->Print();
                info_set = true;
             }
          }

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -62,24 +62,6 @@ public:
    // order to write this class to a tree.
    // pcb.
 
-	//TGRSIRunInfo& operator=(TGRSIRunInfo const& rhs)
-	//{
-	//	std::cout<<__PRETTY_FUNCTION__<<std::endl;
-	//	std::cout<<fRunTitle<<"/"<<rhs.fRunTitle<<" => ";
-	//	fRunTitle = rhs.fRunTitle;
-	//	std::cout<<fRunTitle<<std::endl;
-	//	fRunComment = rhs.fRunComment;
-
-	//	std::cout<<fRunNumber<<"/"<<rhs.fRunNumber<<" => ";
-	//	fRunNumber = rhs.fRunNumber;
-	//	std::cout<<fRunNumber<<std::endl;
-	//	std::cout<<fSubRunNumber<<"/"<<rhs.fSubRunNumber<<" => ";
-	//	fSubRunNumber = rhs.fSubRunNumber;
-	//	std::cout<<fSubRunNumber<<std::endl;
-
-	//	return *this;
-	//}
-   //static void Set(TSingleton* tmp) override;
    static Bool_t ReadInfoFromFile(TFile* tempf = nullptr);
 
    static const char* GetGRSIVersion() { return fGRSIVersion.c_str(); }
@@ -96,120 +78,120 @@ public:
    static void SetRunInfo(int runnum = 0, int subrunnum = -1);
    static void SetAnalysisTreeBranches(TTree*);
 
-   static inline void SetRunNumber(int tmp) { Get().fRunNumber = tmp; }
-   static inline void SetSubRunNumber(int tmp) { Get().fSubRunNumber = tmp; }
+   static inline void SetRunNumber(int tmp) { Get()->fRunNumber = tmp; }
+   static inline void SetSubRunNumber(int tmp) { Get()->fSubRunNumber = tmp; }
 
-   static inline int RunNumber() { return Get().fRunNumber; }
-   static inline int SubRunNumber() { return Get().fSubRunNumber; }
+   static inline int RunNumber() { return Get()->fRunNumber; }
+   static inline int SubRunNumber() { return Get()->fSubRunNumber; }
 
-   inline void SetRunTitle(const char* run_title) { Get().fRunTitle.assign(run_title); }
-   inline void SetRunComment(const char* run_comment) { Get().fRunComment.assign(run_comment); }
+   inline void SetRunTitle(const char* run_title) { Get()->fRunTitle.assign(run_title); }
+   inline void SetRunComment(const char* run_comment) { Get()->fRunComment.assign(run_comment); }
 
-	static inline std::string RunTitle() { return Get().fRunTitle; }
-	static inline std::string RunComment() { return Get().fRunComment; }
+	static inline std::string RunTitle() { return Get()->fRunTitle; }
+	static inline std::string RunComment() { return Get()->fRunComment; }
 
-   static inline void SetRunStart(double tmp) { Get().fRunStart = tmp; }
-   static inline void SetRunStop(double tmp) { Get().fRunStop = tmp; }
-   static inline void SetRunLength(double tmp) { Get().fRunLength = tmp; }
-   static inline void SetRunLength() { Get().fRunLength = Get().fRunStop - Get().fRunStart; }
+   static inline void SetRunStart(double tmp) { Get()->fRunStart = tmp; }
+   static inline void SetRunStop(double tmp) { Get()->fRunStop = tmp; }
+   static inline void SetRunLength(double tmp) { Get()->fRunLength = tmp; }
+   static inline void SetRunLength() { Get()->fRunLength = Get()->fRunStop - Get()->fRunStart; }
 
-   static inline double RunStart() { return Get().fRunStart; }
-   static inline double RunStop() { return Get().fRunStop; }
-   static inline double RunLength() { return Get().fRunLength; }
+   static inline double RunStart() { return Get()->fRunStart; }
+   static inline double RunStop() { return Get()->fRunStop; }
+   static inline double RunLength() { return Get()->fRunLength; }
 
-   static inline void SetTigress(bool flag = true) { Get().fTigress = flag; }
-   static inline void SetSharc(bool flag = true) { Get().fSharc = flag; }
-   static inline void SetTriFoil(bool flag = true) { Get().fTriFoil = flag; }
-   static inline void SetRF(bool flag = true) { Get().fRf = flag; }
-   static inline void SetCSM(bool flag = true) { Get().fCSM = flag; }
-   static inline void SetSpice(bool flag = true) { Get().fSpice = flag; }
-   static inline void SetS3(bool flag = true) { Get().fS3 = flag; }
-   static inline void SetGeneric(bool flag = true) { Get().fGeneric = flag; }
-   static inline void SetTip(bool flag = true) { Get().fTip = flag; }
-   static inline void SetBambino(bool flag = true) { Get().fBambino = flag; }
+   static inline void SetTigress(bool flag = true) { Get()->fTigress = flag; }
+   static inline void SetSharc(bool flag = true) { Get()->fSharc = flag; }
+   static inline void SetTriFoil(bool flag = true) { Get()->fTriFoil = flag; }
+   static inline void SetRF(bool flag = true) { Get()->fRf = flag; }
+   static inline void SetCSM(bool flag = true) { Get()->fCSM = flag; }
+   static inline void SetSpice(bool flag = true) { Get()->fSpice = flag; }
+   static inline void SetS3(bool flag = true) { Get()->fS3 = flag; }
+   static inline void SetGeneric(bool flag = true) { Get()->fGeneric = flag; }
+   static inline void SetTip(bool flag = true) { Get()->fTip = flag; }
+   static inline void SetBambino(bool flag = true) { Get()->fBambino = flag; }
 
-   static inline void SetGriffin(bool flag = true) { Get().fGriffin = flag; }
-   static inline void SetSceptar(bool flag = true) { Get().fSceptar = flag; }
-   static inline void SetPaces(bool flag = true) { Get().fPaces = flag; }
-   static inline void SetDante(bool flag = true) { Get().fDante = flag; }
-   static inline void SetZeroDegree(bool flag = true) { Get().fZeroDegree = flag; }
-   static inline void SetDescant(bool flag = true) { Get().fDescant = flag; }
-   static inline void SetFipps(bool flag = true) { Get().fFipps = flag; }
+   static inline void SetGriffin(bool flag = true) { Get()->fGriffin = flag; }
+   static inline void SetSceptar(bool flag = true) { Get()->fSceptar = flag; }
+   static inline void SetPaces(bool flag = true) { Get()->fPaces = flag; }
+   static inline void SetDante(bool flag = true) { Get()->fDante = flag; }
+   static inline void SetZeroDegree(bool flag = true) { Get()->fZeroDegree = flag; }
+   static inline void SetDescant(bool flag = true) { Get()->fDescant = flag; }
+   static inline void SetFipps(bool flag = true) { Get()->fFipps = flag; }
 
-   static inline void SetCalFileName(const char* name) { Get().fCalFileName.assign(name); }
-   static inline void SetCalFileData(const char* data) { Get().fCalFile.assign(data); }
+   static inline void SetCalFileName(const char* name) { Get()->fCalFileName.assign(name); }
+   static inline void SetCalFileData(const char* data) { Get()->fCalFile.assign(data); }
 
-   static inline void SetXMLODBFileName(const char* name) { Get().fXMLODBFileName.assign(name); }
-   static inline void SetXMLODBFileData(const char* data) { Get().fXMLODBFile.assign(data); }
+   static inline void SetXMLODBFileName(const char* name) { Get()->fXMLODBFileName.assign(name); }
+   static inline void SetXMLODBFileData(const char* data) { Get()->fXMLODBFile.assign(data); }
 
-   static const char* GetCalFileName() { return Get().fCalFileName.c_str(); }
-   static const char* GetCalFileData() { return Get().fCalFile.c_str(); }
+   static const char* GetCalFileName() { return Get()->fCalFileName.c_str(); }
+   static const char* GetCalFileData() { return Get()->fCalFile.c_str(); }
 
-   static const char* GetXMLODBFileName() { return Get().fXMLODBFileName.c_str(); }
-   static const char* GetXMLODBFileData() { return Get().fXMLODBFile.c_str(); }
+   static const char* GetXMLODBFileName() { return Get()->fXMLODBFileName.c_str(); }
+   static const char* GetXMLODBFileData() { return Get()->fXMLODBFile.c_str(); }
 
-   static const char* GetRunInfoFileName() { return Get().fRunInfoFileName.c_str(); }
-   static const char* GetRunInfoFileData() { return Get().fRunInfoFile.c_str(); }
+   static const char* GetRunInfoFileName() { return Get()->fRunInfoFileName.c_str(); }
+   static const char* GetRunInfoFileData() { return Get()->fRunInfoFile.c_str(); }
 
    static Bool_t ReadInfoFile(const char* filename = "");
    static Bool_t ParseInputData(const char* inputdata = "", Option_t* opt = "q");
 
-   static inline int GetNumberOfSystems() { return Get().fNumberOfTrueSystems; }
+   static inline int GetNumberOfSystems() { return Get()->fNumberOfTrueSystems; }
 
-   static inline bool Tigress() { return Get().fTigress; }
-   static inline bool Sharc() { return Get().fSharc; }
-   static inline bool TriFoil() { return Get().fTriFoil; }
-   static inline bool RF() { return Get().fRf; }
-   static inline bool CSM() { return Get().fCSM; }
-   static inline bool Spice() { return Get().fSpice; }
-   static inline bool Bambino() { return Get().fBambino; }
-   static inline bool Tip() { return Get().fTip; }
-   static inline bool S3() { return Get().fS3; }
-   static inline bool Generic() { return Get().fGeneric; }
+   static inline bool Tigress() { return Get()->fTigress; }
+   static inline bool Sharc() { return Get()->fSharc; }
+   static inline bool TriFoil() { return Get()->fTriFoil; }
+   static inline bool RF() { return Get()->fRf; }
+   static inline bool CSM() { return Get()->fCSM; }
+   static inline bool Spice() { return Get()->fSpice; }
+   static inline bool Bambino() { return Get()->fBambino; }
+   static inline bool Tip() { return Get()->fTip; }
+   static inline bool S3() { return Get()->fS3; }
+   static inline bool Generic() { return Get()->fGeneric; }
 
-   static inline bool Griffin() { return Get().fGriffin; }
-   static inline bool Sceptar() { return Get().fSceptar; }
-   static inline bool Paces() { return Get().fPaces; }
-   static inline bool Dante() { return Get().fDante; }
-   static inline bool ZeroDegree() { return Get().fZeroDegree; }
-   static inline bool Descant() { return Get().fDescant; }
-   static inline bool Fipps() { return Get().fFipps; }
+   static inline bool Griffin() { return Get()->fGriffin; }
+   static inline bool Sceptar() { return Get()->fSceptar; }
+   static inline bool Paces() { return Get()->fPaces; }
+   static inline bool Dante() { return Get()->fDante; }
+   static inline bool ZeroDegree() { return Get()->fZeroDegree; }
+   static inline bool Descant() { return Get()->fDescant; }
+   static inline bool Fipps() { return Get()->fFipps; }
 
-   inline void SetRunInfoFileName(const char* fname) { Get().fRunInfoFileName.assign(fname); }
-   inline void SetRunInfoFile(const char* ffile) { Get().fRunInfoFile.assign(ffile); }
+   inline void SetRunInfoFileName(const char* fname) { Get()->fRunInfoFileName.assign(fname); }
+   inline void SetRunInfoFile(const char* ffile) { Get()->fRunInfoFile.assign(ffile); }
 
-   inline void SetHPGeArrayPosition(const double arr_pos) { Get().fHPGeArrayPosition = arr_pos; }
-   static inline double                          HPGeArrayPosition() { return Get().fHPGeArrayPosition; }
+   inline void SetHPGeArrayPosition(const double arr_pos) { Get()->fHPGeArrayPosition = arr_pos; }
+   static inline double                          HPGeArrayPosition() { return Get()->fHPGeArrayPosition; }
 
-   static inline void SetDescantAncillary(bool flag = true) { Get().fDescantAncillary = flag; }
-   static inline bool                          DescantAncillary() { return Get().fDescantAncillary; }
+   static inline void SetDescantAncillary(bool flag = true) { Get()->fDescantAncillary = flag; }
+   static inline bool                          DescantAncillary() { return Get()->fDescantAncillary; }
 
    Long64_t Merge(TCollection* list);
    void Add(TGRSIRunInfo* runinfo)
    {
 		// add the run length together
       if(runinfo->fRunLength > 0) {
-			if(Get().fRunLength > 0) {
-				Get().fRunLength += runinfo->fRunLength;
+			if(Get()->fRunLength > 0) {
+				Get()->fRunLength += runinfo->fRunLength;
 			} else {
-				Get().fRunLength = runinfo->fRunLength;
+				Get()->fRunLength = runinfo->fRunLength;
 			}
 		}
-		if(runinfo->fRunNumber != Get().fRunNumber) {
+		if(runinfo->fRunNumber != Get()->fRunNumber) {
 			// the run number is meaningful only when the run numbers are the same
-			Get().fRunNumber = 0;
-			Get().fSubRunNumber = -1;
-			Get().fRunStart = 0.;
-			Get().fRunStop  = 0.;
-		} else if(runinfo->fSubRunNumber == Get().fSubRunNumber + 1) {
+			Get()->fRunNumber = 0;
+			Get()->fSubRunNumber = -1;
+			Get()->fRunStart = 0.;
+			Get()->fRunStop  = 0.;
+		} else if(runinfo->fSubRunNumber == Get()->fSubRunNumber + 1) {
 			// if the run numbers are the same and we have subsequent sub runs we can update the run stop
-			Get().fRunStop = runinfo->fRunStop;
-			Get().fSubRunNumber = runinfo->fSubRunNumber; // so we can check the next subrun as well
+			Get()->fRunStop = runinfo->fRunStop;
+			Get()->fSubRunNumber = runinfo->fSubRunNumber; // so we can check the next subrun as well
 		} else {
 			// with multiple files added, the sub run number has no meaning anymore
-			Get().fSubRunNumber = -1;
-			Get().fRunStart = 0.;
-			Get().fRunStop  = 0.;
+			Get()->fSubRunNumber = -1;
+			Get()->fRunStart = 0.;
+			Get()->fRunStop  = 0.;
 		}
    }
 

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -33,6 +33,7 @@
 #include "TCollection.h"
 
 #include "Globals.h"
+#include "TSingleton.h"
 
 enum class EPpgPattern {
 	kBeamOn     = 0x01,
@@ -117,11 +118,11 @@ private:
    /// \endcond
 };
 
-class TPPG : public TObject {
+class TPPG : public TSingleton<TPPG> {
 public:
-   typedef std::map<ULong_t, TPPGData*> PPGMap_t;
+	friend class TSingleton<TPPG>;
 
-   static TPPG* Get(TFile* fileWithPPg = nullptr);
+   typedef std::map<ULong_t, TPPGData*> PPGMap_t;
 
    TPPG();
    TPPG(const TPPG&);
@@ -187,7 +188,7 @@ private:
    std::vector<int>   fOdbDurations; ///< duration of ppg state as read from odb
 
    /// \cond CLASSIMP
-   ClassDefOverride(TPPG, 3) // Contains PPG information
+   ClassDefOverride(TPPG, 4) // Contains PPG information
    /// \endcond
 };
 /*! @} */

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -28,21 +28,17 @@
 #include "TObject.h"
 #include "TH1F.h"
 
+#include "TSingleton.h"
 #include "TPPG.h"
 #include "TFragment.h"
 
-class TParsingDiagnostics : public TObject {
+class TParsingDiagnostics : public TSingleton<TParsingDiagnostics> {
 public:
+	friend class TSingleton<TParsingDiagnostics>;
+
    TParsingDiagnostics();
    TParsingDiagnostics(const TParsingDiagnostics&);
    ~TParsingDiagnostics() override;
-   static TParsingDiagnostics* Get()
-   {
-      if(fParsingDiagnostics == nullptr) {
-         fParsingDiagnostics = new TParsingDiagnostics;
-      }
-      return fParsingDiagnostics;
-   }
 
 private:
    // fragment tree diagnostics (should these all be static?)
@@ -71,8 +67,6 @@ private:
 
    //
    TH1F* fIdHist; ///< histogram of event survival
-
-   static TParsingDiagnostics* fParsingDiagnostics;
 
 public:
 //"setter" functions
@@ -111,7 +105,7 @@ public:
    void Draw(Option_t* opt = "") override;
 
    /// \cond CLASSIMP
-   ClassDefOverride(TParsingDiagnostics, 1);
+   ClassDefOverride(TParsingDiagnostics, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TSingleton.h
+++ b/include/TSingleton.h
@@ -4,8 +4,12 @@
 #include <iostream>
 
 #include "TObject.h"
+#include "TDirectory.h"
+#include "TFile.h"
 #include "TList.h"
 #include "TKey.h"
+
+#include "Globals.h"
 
 /** \addtogroup Sorting
  *  *  @{
@@ -13,7 +17,15 @@
 
 ///////////////////////////////////////////////////////////////
 ///
-/// \class TGRSIRunInfo
+/// \class TSingleton<T>
+///
+/// This class is intended as a base class for singletons,
+/// especially those that are written to file.
+/// The Get() function is written such that it reads the class
+/// from file if needed. This is the case if it hasn't been 
+/// read yet, or if the gDirectory has been changed.
+/// This means in a loop over different input files, Get() will
+/// always return the info of the current file.
 ///
 ///////////////////////////////////////////////////////////////
 
@@ -21,37 +33,52 @@ template <class T>
 class TSingleton : public TObject
 {
 public:
-	static T& Get()
+	static T* Get()
 	{
-		static T singleton;
-		//if((gDirectory->GetFile()) != nullptr) {
-		//	TList* list = gDirectory->GetFile()->GetListOfKeys();
-		//	TIter  iter(list);
-		//	std::cout<<"Reading "<<T::Class()->GetName()<<R"( from file ")"<<CYAN<<gDirectory->GetFile()->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
-		//	while(TKey* key = static_cast<TKey*>(iter.Next())) {
-		//		if(strcmp(key->GetClassName(), T::Class()->GetName()) != 0) {
-		//			continue;
-		//		}
-
-		//		Set(*static_cast<T*>(key->ReadObj()));
-		//		//std::cout<<"read from file "<<this<<":"<<std::endl;
-		//		//this->Print();
-		//	}
-		//}
-		return singleton;
+		// if we don't have an instance yet or changed into another directory
+		// we want to read from the current directory
+		if(fSingleton == nullptr || fDir != gDirectory) {
+			delete fSingleton; // in case we just changed directories
+			fSingleton = nullptr;
+			if((gDirectory->GetFile()) != nullptr) {
+				TList* list = gDirectory->GetFile()->GetListOfKeys();
+				TIter  iter(list);
+				if(fDir != nullptr && fDir != gDirectory) {
+					std::cout<<"Switched from '"<<fDir->GetName()<<"' to '"<<gDirectory->GetName()<<"' => ";
+				}
+				std::cout<<"Reading "<<T::Class()->GetName()<<R"( from file ")"<<CYAN<<gDirectory->GetFile()->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
+				while(TKey* key = static_cast<TKey*>(iter.Next())) {
+					if(strcmp(key->GetClassName(), T::Class()->GetName()) != 0) {
+						continue;
+					}
+					Set(static_cast<T*>(key->ReadObj()));
+				}
+			}
+			if(fSingleton == nullptr) {
+				fSingleton = new T;
+			}
+			fDir = gDirectory; // in either case (read from file or created new), gDirectory is the current directory
+		}
+		return fSingleton;
 	}
-	static void Set(T val)
+	static void Set(T* val)
 	{
-		Get() = val;
+		if(fSingleton != val) {
+			delete fSingleton;
+			fSingleton = val;
+		}
 	}
 
-	TSingleton() {}
+protected:
+	TSingleton();
 	//TSingleton(TSingleton const &) = delete;
 	// note, we can't delete this, because that wouldn't allow us to use the Set function above!
 	//TSingleton& operator=(TSingleton const &) = delete;
-	~TSingleton() {}
+	~TSingleton();
 
 private:
+	static T* fSingleton;
+	static TDirectory* fDir;
 
 	/// \cond CLASSIMP
 	ClassDef(TSingleton, 1)
@@ -61,32 +88,32 @@ private:
 templateClassImp(TSingleton)
 
 template<class T>
+T* TSingleton<T>::fSingleton = nullptr;
+
+template<class T>
+TDirectory* TSingleton<T>::fDir = nullptr;
+
+template<class T>
+TSingleton<T>::TSingleton()
+{
+}
+
+template<class T>
+TSingleton<T>::~TSingleton()
+{
+	//if(fSingleton != this) delete fSingleton;
+}
+
+template<class T>
 void TSingleton<T>::Streamer(TBuffer& R__b) 
 {
 	/// Stream an object of class T.
-	std::cout<<__PRETTY_FUNCTION__<<std::endl;
-	std::cout<<"Calling "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">, TBuffer size "<<R__b.BufferSize()<<std::endl;
-	std::cout<<this<<".Print():"<<std::endl;
-	//static_cast<T*>(this)->Print();
-	//std::cout<<&Get()<<".Print():"<<std::endl;
-	//Get().Print();
 	if(R__b.IsReading()) {
-		//std::cout<<"ReadClassBuffer("<<T::Class()->GetName()<<", "<<&(Get())<<") "<<this<<std::endl;
-		////R__b.ReadClassBuffer(T::Class(), &(Get()));
-		//std::cout<<"this "<<this<<", &Get() "<<&(Get());
-		////Set(*static_cast<T*>(this));
-		//std::cout<<"=> &Get() "<<&(Get())<<std::endl;
+		//R__b.ReadClassBuffer(T::Class(), &(Get()));
+		//Set(static_cast<T*>(this));
 	} else {
-		std::cout<<"WriteClassBuffer("<<T::Class()->GetName()<<", "<<&(Get())<<") "<<this<<std::endl;
 		//R__b.WriteClassBuffer(T::Class(), &(Get()));
-		std::cout<<"done"<<std::endl<<std::endl;
 	}
-	std::cout<<"Done with "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">, TBuffer size "<<R__b.BufferSize()<<std::endl;
-	std::cout<<this<<".Print():"<<std::endl;
-	//static_cast<T*>(this)->Print();
-	//std::cout<<&Get()<<".Print():"<<std::endl;
-	//Get().Print();
-	std::cout<<"----------------------------------------"<<std::endl;
 }
 
 template<class T>

--- a/include/TSingleton.h
+++ b/include/TSingleton.h
@@ -4,16 +4,18 @@
 #include <iostream>
 
 #include "TObject.h"
+#include "TList.h"
+#include "TKey.h"
 
 /** \addtogroup Sorting
  *  *  @{
  *   */
 
-/////////////////////////////////////////////////////////////////
-/////
-///// \class TGRSIRunInfo
-/////
-/////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////
+///
+/// \class TGRSIRunInfo
+///
+///////////////////////////////////////////////////////////////
 
 template <class T>
 class TSingleton : public TObject
@@ -22,6 +24,20 @@ public:
 	static T& Get()
 	{
 		static T singleton;
+		//if((gDirectory->GetFile()) != nullptr) {
+		//	TList* list = gDirectory->GetFile()->GetListOfKeys();
+		//	TIter  iter(list);
+		//	std::cout<<"Reading "<<T::Class()->GetName()<<R"( from file ")"<<CYAN<<gDirectory->GetFile()->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
+		//	while(TKey* key = static_cast<TKey*>(iter.Next())) {
+		//		if(strcmp(key->GetClassName(), T::Class()->GetName()) != 0) {
+		//			continue;
+		//		}
+
+		//		Set(*static_cast<T*>(key->ReadObj()));
+		//		//std::cout<<"read from file "<<this<<":"<<std::endl;
+		//		//this->Print();
+		//	}
+		//}
 		return singleton;
 	}
 	static void Set(T val)
@@ -29,14 +45,13 @@ public:
 		Get() = val;
 	}
 
-	TSingleton() { fStreamerInstance = 0; }
+	TSingleton() {}
 	//TSingleton(TSingleton const &) = delete;
 	// note, we can't delete this, because that wouldn't allow us to use the Set function above!
 	//TSingleton& operator=(TSingleton const &) = delete;
 	~TSingleton() {}
 
 private:
-	int fStreamerInstance;
 
 	/// \cond CLASSIMP
 	ClassDef(TSingleton, 1)
@@ -49,22 +64,29 @@ template<class T>
 void TSingleton<T>::Streamer(TBuffer& R__b) 
 {
 	/// Stream an object of class T.
-	++fStreamerInstance;
-	std::cout<<"Calling "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">"<<std::endl;
-	if(fStreamerInstance == 1) {
-		Get().Streamer(R__b);
-	}
+	std::cout<<__PRETTY_FUNCTION__<<std::endl;
+	std::cout<<"Calling "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">, TBuffer size "<<R__b.BufferSize()<<std::endl;
+	std::cout<<this<<".Print():"<<std::endl;
+	//static_cast<T*>(this)->Print();
+	//std::cout<<&Get()<<".Print():"<<std::endl;
+	//Get().Print();
 	if(R__b.IsReading()) {
-		//std::cout<<"ReadClassBuffer("<<T::Class()<<", "<<&(Get())<<") "<<this<<std::endl;
-		//R__b.ReadClassBuffer(T::Class(), &(Get()));
-		std::cout<<"this "<<this<<", &Get() "<<&(Get());
-		//Set(*static_cast<T*>(this));
-		std::cout<<"=> &Get() "<<&(Get())<<std::endl;
+		//std::cout<<"ReadClassBuffer("<<T::Class()->GetName()<<", "<<&(Get())<<") "<<this<<std::endl;
+		////R__b.ReadClassBuffer(T::Class(), &(Get()));
+		//std::cout<<"this "<<this<<", &Get() "<<&(Get());
+		////Set(*static_cast<T*>(this));
+		//std::cout<<"=> &Get() "<<&(Get())<<std::endl;
 	} else {
-		//std::cout<<"WriteClassBuffer("<<T::Class()<<", "<<&(Get())<<") "<<this<<std::endl;
+		std::cout<<"WriteClassBuffer("<<T::Class()->GetName()<<", "<<&(Get())<<") "<<this<<std::endl;
 		//R__b.WriteClassBuffer(T::Class(), &(Get()));
-		//std::cout<<"done"<<std::endl<<std::endl;
+		std::cout<<"done"<<std::endl<<std::endl;
 	}
+	std::cout<<"Done with "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">, TBuffer size "<<R__b.BufferSize()<<std::endl;
+	std::cout<<this<<".Print():"<<std::endl;
+	//static_cast<T*>(this)->Print();
+	//std::cout<<&Get()<<".Print():"<<std::endl;
+	//Get().Print();
+	std::cout<<"----------------------------------------"<<std::endl;
 }
 
 template<class T>

--- a/include/TSortingDiagnostics.h
+++ b/include/TSortingDiagnostics.h
@@ -24,29 +24,23 @@
 #include "TObject.h"
 #include "TH1F.h"
 
+#include "TSortingDiagnostics.h"
 #include "TPPG.h"
 #include "TFragment.h"
 
-class TSortingDiagnostics : public TObject {
+class TSortingDiagnostics : public TSingleton<TSortingDiagnostics> {
 public:
+	friend class TSingleton<TSortingDiagnostics>;
+
    TSortingDiagnostics();
    TSortingDiagnostics(const TSortingDiagnostics&);
    ~TSortingDiagnostics() override;
-   static TSortingDiagnostics* Get()
-   {
-      if(fSortingDiagnostics == nullptr) {
-         fSortingDiagnostics = new TSortingDiagnostics;
-      }
-      return fSortingDiagnostics;
-   }
 
 private:
-   // analysis tree diagnostics (should these all be static?)
+   // analysis tree diagnostics 
    std::map<long, std::pair<long, long>> fFragmentsOutOfOrder;
    std::vector<Long_t> fPreviousTimeStamps; ///< timestamps of previous fragments, saved every 'BuildWindow' entries
    long                fMaxEntryDiff{0};
-
-   static TSortingDiagnostics* fSortingDiagnostics;
 
 public:
    //"setter" functions
@@ -67,7 +61,7 @@ public:
    void Draw(Option_t* opt = "") override;
 
    /// \cond CLASSIMP
-   ClassDefOverride(TSortingDiagnostics, 1);
+   ClassDefOverride(TSortingDiagnostics, 2);
    /// \endcond
 };
 /*! @} */

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -12,7 +12,7 @@
 
 #pragma link C++ class std::string+;
 #pragma link C++ class TSingleton+;
-#pragma link C++ class TGRSIRunInfo-;
+#pragma link C++ class TGRSIRunInfo+;
 #pragma link C++ class TSingleton<TGRSIRunInfo>-;
 
 #pragma link C++ class TFragment+;

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -25,6 +25,7 @@
 #pragma link C++ class TGRSISortList+;
 
 #pragma link C++ class TPPG-;
+#pragma link C++ class TSingleton<TPPG>-;
 #pragma link C++ class TPPGData+;
 #pragma link C++ class std::map<ULong64_t,TPPGData*>;
 #pragma link C++ class TScaler+;
@@ -32,7 +33,9 @@
 #pragma link C++ class std::map<UInt_t, std::map<ULong64_t, TScalerData*> >;
 #pragma link C++ class std::map<ULong64_t, TScalerData*>;
 #pragma link C++ class TParsingDiagnostics+;
+#pragma link C++ class TSingleton<TParsingDiagnostics>-;
 #pragma link C++ class TSortingDiagnostics+;
+#pragma link C++ class TSingleton<TSortingDiagnostics>-;
 #pragma link C++ class TMnemonic+;
 
 #pragma link C++ class TTransientBits<UChar_t>+;

--- a/libraries/TGRSIFormat/TEpicsFrag.cxx
+++ b/libraries/TGRSIFormat/TEpicsFrag.cxx
@@ -111,13 +111,13 @@ void TEpicsFrag::BuildScalerMap(TTree* tree)
    if(tree->SetBranchAddress("TEpicsFrag", &my_frag) == 0) {
       for(int i = 0; i < tree->GetEntries(); ++i) {
          tree->GetEntry(i);
-         if((static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart())) <
+         if((static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart())) <
             fSmallestTime) {
             fSmallestTime =
-               static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart());
+               static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart());
          }
          fScalerMap[static_cast<Long64_t>(my_frag->fMidasTimeStamp) -
-                    static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart())] = *my_frag;
+                    static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart())] = *my_frag;
       }
    } else {
       std::cout<<DRED<<"Could not build map from tree"<<RESET_COLOR<<std::endl;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -61,6 +61,8 @@ Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
       }
 
       Set(*static_cast<TGRSIRunInfo*>(key->ReadObj()));
+		std::cout<<"read from file "<<&Get()<<":"<<std::endl;
+		Get().Print();
       savdir->cd();
       return true;
    }
@@ -549,14 +551,26 @@ std::string TGRSIRunInfo::PrintToString(Option_t*)
    return buffer;
 }
 
-void TGRSIRunInfo::Streamer(TBuffer& R__b)
-{
-	std::cout<<__PRETTY_FUNCTION__<<std::endl;
-	if(R__b.IsReading()) {
-      R__b.ReadClassBuffer(TGRSIRunInfo::Class(),this);
-		std::cout<<"ReadClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<")"<<std::endl;
-	} else {
-      R__b.WriteClassBuffer(TGRSIRunInfo::Class(),this);
-		std::cout<<"WriteClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<")"<<std::endl;
-	}
-}
+//void TGRSIRunInfo::Streamer(TBuffer& R__b)
+//{
+//	std::cout<<__PRETTY_FUNCTION__<<std::endl;
+//	std::cout<<this<<".Print():"<<std::endl;
+//	Print();
+//	std::cout<<&Get()<<".Print():"<<std::endl;
+//	Get().Print();
+//	if(R__b.IsReading()) {
+//		std::cout<<"Reading TBuffer size "<<R__b.BufferSize()<<", "<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<std::endl;
+//      R__b.ReadClassBuffer(TGRSIRunInfo::Class(),this);
+//		//Set(*this);
+//		std::cout<<"ReadClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<"), TBuffer size "<<R__b.BufferSize()<<std::endl;
+//	} else {
+//		std::cout<<"Writing TBuffer size "<<R__b.BufferSize()<<std::endl;
+//      R__b.WriteClassBuffer(TGRSIRunInfo::Class(),this);
+//		std::cout<<"WriteClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<"), TBuffer size "<<R__b.BufferSize()<<std::endl;
+//	}
+//	std::cout<<this<<".Print():"<<std::endl;
+//	Print();
+//	std::cout<<&Get()<<".Print():"<<std::endl;
+//	Get().Print();
+//	std::cout<<"----------------------------------------"<<std::endl;
+//}

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -6,7 +6,9 @@
 #include <algorithm>
 #include <iostream>
 
-#include <TGRSIOptions.h>
+#include "TROOT.h"
+
+#include "TGRSIOptions.h"
 
 /// \cond CLASSIMP
 ClassImp(TGRSIRunInfo)
@@ -54,15 +56,12 @@ Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
 
    TList* list = tempf->GetListOfKeys();
    TIter  iter(list);
-	std::cout<<R"(Reading run info from file ")"<<CYAN<<tempf->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
    while(TKey* key = static_cast<TKey*>(iter.Next())) {
       if((key == nullptr) || (strcmp(key->GetClassName(), "TGRSIRunInfo") != 0)) {
          continue;
       }
 
-      Set(*static_cast<TGRSIRunInfo*>(key->ReadObj()));
-		std::cout<<"read from file "<<&Get()<<":"<<std::endl;
-		Get().Print();
+      Set(static_cast<TGRSIRunInfo*>(key->ReadObj()));
       savdir->cd();
       return true;
    }
@@ -94,7 +93,7 @@ void TGRSIRunInfo::Print(Option_t* opt) const
 	struct tm runStop  = *localtime(const_cast<const time_t*>(&tmpStop));
 	printf("\t\tRunNumber:          %05i\n", RunNumber());
 	printf("\t\tSubRunNumber:       %03i\n", SubRunNumber());
-	if(Get().RunStart != 0 && Get().RunStop != 0) {
+	if(Get()->RunStart != 0 && Get()->RunStop != 0) {
 		printf("\t\tRunStart:           %s", asctime(&runStart));
 		printf("\t\tRunStop:            %s", asctime(&runStop));
 		printf("\t\tRunLength:          %.0f s\n", RunLength());
@@ -190,85 +189,85 @@ void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum)
       switch(iter->second->GetMnemonic()->System()) {
 			case TMnemonic::ESystem::kTigress:
 				if(!Tigress()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetTigress();
 				break;
 			case TMnemonic::ESystem::kSharc:
 				if(!Sharc()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetSharc();
 				break;
 			case TMnemonic::ESystem::kTriFoil:
 				if(!TriFoil()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetTriFoil();
 				break;
 			case TMnemonic::ESystem::kRF:
 				if(!RF()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetRF();
 				break;
 			case TMnemonic::ESystem::kCSM:
 				if(!CSM()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetCSM();
 				break;
 			case TMnemonic::ESystem::kTip:
 				if(!Tip()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetTip();
 				break;
 			case TMnemonic::ESystem::kGriffin:
 				if(!Griffin()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetGriffin();
 				break;
 			case TMnemonic::ESystem::kSceptar:
 				if(!Sceptar()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetSceptar();
 				break;
 			case TMnemonic::ESystem::kPaces:
 				if(!Paces()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetPaces();
 				break;
 			case TMnemonic::ESystem::kLaBr:
 				if(!Dante()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetDante();
 				break;
 			case TMnemonic::ESystem::kZeroDegree:
 				if(!ZeroDegree()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetZeroDegree();
 				break;
 			case TMnemonic::ESystem::kDescant:
 				if(!Descant()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetDescant();
 				break;
 			case TMnemonic::ESystem::kFipps:
 				if(!Fipps()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetFipps();
 				break;
 			case TMnemonic::ESystem::kGeneric:
 				if(!Generic()) {
-					Get().fNumberOfTrueSystems++;
+					Get()->fNumberOfTrueSystems++;
 				}
 				SetGeneric();
 				break;
@@ -277,28 +276,28 @@ void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum)
 				if(!Spice() && !S3()) {
 					if(system.compare("SP") == 0) {
 						if(!Spice()) {
-							Get().fNumberOfTrueSystems++;
+							Get()->fNumberOfTrueSystems++;
 						}
 						SetSpice();
 						if(!S3()) {
-							Get().fNumberOfTrueSystems++;
+							Get()->fNumberOfTrueSystems++;
 						}
 						SetS3();
 					}
 				} else if(!Bambino()) {
 					if(system.compare("BA") == 0) {
-						Get().fNumberOfTrueSystems++;
+						Get()->fNumberOfTrueSystems++;
 					}
 					SetBambino();
 				}
 		};
 	}
 
-	if(Get().fRunInfoFile.length() != 0u) {
-		ParseInputData(Get().fRunInfoFile.c_str());
+	if(Get()->fRunInfoFile.length() != 0u) {
+		ParseInputData(Get()->fRunInfoFile.c_str());
 	}
 
-   // Get().Print("a");
+   // Get()->Print("a");
 }
 
 void TGRSIRunInfo::SetAnalysisTreeBranches(TTree*)
@@ -334,8 +333,8 @@ Bool_t TGRSIRunInfo::ReadInfoFile(const char* filename)
    infile.seekg(0, std::ios::beg);
    infile.read(buffer, length);
 
-   Get().SetRunInfoFileName(filename);
-   Get().SetRunInfoFile(buffer);
+   Get()->SetRunInfoFileName(filename);
+   Get()->SetRunInfoFile(buffer);
 
    return ParseInputData(const_cast<const char*>(buffer));
 }
@@ -384,17 +383,17 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
          std::istringstream ss(line);
          double             temp_double;
          ss >> temp_double;
-         Get().SetHPGeArrayPosition(temp_double);
+         Get()->SetHPGeArrayPosition(temp_double);
       } else if(type.compare("DESCANTANCILLARY") == 0) {
          std::istringstream ss(line);
          int                temp_int;
          ss >> temp_int;
-         Get().SetDescantAncillary(temp_int != 0);
+         Get()->SetDescantAncillary(temp_int != 0);
       } else if(type.compare("BADCYCLE") == 0) {
          std::istringstream ss(line);
          int                tmp_int;
          while(!(ss >> tmp_int).fail() ) {
-            Get().AddBadCycle(tmp_int);
+            Get()->AddBadCycle(tmp_int);
          }
       }
    }
@@ -441,10 +440,10 @@ Long64_t TGRSIRunInfo::Merge(TCollection* list)
 void TGRSIRunInfo::PrintBadCycles() const
 {
    std::cout<<"Bad Cycles:\t";
-   if(Get().fBadCycleList.empty()) {
+   if(Get()->fBadCycleList.empty()) {
       std::cout<<"NONE"<<std::endl;
    } else {
-      for(int it : Get().fBadCycleList) {
+      for(int it : Get()->fBadCycleList) {
          std::cout<<" "<<it;
       }
       std::cout<<std::endl;
@@ -458,23 +457,23 @@ void TGRSIRunInfo::AddBadCycle(int bad_cycle)
         fBadCycleList.push_back(bad_cycle);
         std::sort(fBadCycleList.begin(), fBadCycleList.end());
      }*/
-   if(!(std::binary_search(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), bad_cycle))) {
-      Get().fBadCycleList.push_back(bad_cycle);
-      std::sort(Get().fBadCycleList.begin(), Get().fBadCycleList.end());
+   if(!(std::binary_search(Get()->fBadCycleList.begin(), Get()->fBadCycleList.end(), bad_cycle))) {
+      Get()->fBadCycleList.push_back(bad_cycle);
+      std::sort(Get()->fBadCycleList.begin(), Get()->fBadCycleList.end());
    }
-   Get().fBadCycleListSize = Get().fBadCycleList.size();
+   Get()->fBadCycleListSize = Get()->fBadCycleList.size();
 }
 
 void TGRSIRunInfo::RemoveBadCycle(int cycle)
 {
-   Get().fBadCycleList.erase(std::remove(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), cycle), Get().fBadCycleList.end());
-   std::sort(Get().fBadCycleList.begin(), Get().fBadCycleList.end());
-   Get().fBadCycleListSize = Get().fBadCycleList.size();
+   Get()->fBadCycleList.erase(std::remove(Get()->fBadCycleList.begin(), Get()->fBadCycleList.end(), cycle), Get()->fBadCycleList.end());
+   std::sort(Get()->fBadCycleList.begin(), Get()->fBadCycleList.end());
+   Get()->fBadCycleListSize = Get()->fBadCycleList.size();
 }
 
 bool TGRSIRunInfo::IsBadCycle(int cycle) const
 {
-   return std::binary_search(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), cycle);
+   return std::binary_search(Get()->fBadCycleList.begin(), Get()->fBadCycleList.end(), cycle);
 }
 
 bool TGRSIRunInfo::WriteToRoot(TFile* fileptr)
@@ -483,6 +482,8 @@ bool TGRSIRunInfo::WriteToRoot(TFile* fileptr)
    // Maintain old gDirectory info
    bool        bool2return = true;
    TDirectory* savdir      = gDirectory;
+	gROOT->cd();
+	TGRSIRunInfo* runInfo   = Get();
 
    if(fileptr == nullptr) {
       fileptr = gDirectory->GetFile();
@@ -496,7 +497,7 @@ bool TGRSIRunInfo::WriteToRoot(TFile* fileptr)
       printf("No file opened to write to.\n");
       bool2return = false;
    } else {
-      Get().Write();
+      runInfo->Write();
    }
 
    printf("Writing TGRSIRunInfo to %s\n", gDirectory->GetFile()->GetName());
@@ -515,7 +516,7 @@ bool TGRSIRunInfo::WriteInfoFile(const std::string& filename)
    if(filename.length() > 0) {
       std::ofstream infoout;
       infoout.open(filename.c_str());
-      std::string infostr = Get().PrintToString();
+      std::string infostr = Get()->PrintToString();
       infoout<<infostr.c_str();
       infoout<<std::endl;
       infoout<<std::endl;
@@ -532,17 +533,17 @@ std::string TGRSIRunInfo::PrintToString(Option_t*)
 {
    std::string buffer;
    buffer.append("//The Array Position in mm.\n");
-   buffer.append(Form("HPGePos: %lf\n", Get().HPGeArrayPosition()));
+   buffer.append(Form("HPGePos: %lf\n", Get()->HPGeArrayPosition()));
    buffer.append("\n\n");
-   if(Get().DescantAncillary()) {
+   if(Get()->DescantAncillary()) {
       buffer.append("//Is DESCANT in Ancillary positions?.\n");
       buffer.append(Form("DescantAncillary: %d\n", 1));
       buffer.append("\n\n");
    }
-   if(!Get().fBadCycleList.empty()) {
+   if(!Get()->fBadCycleList.empty()) {
       buffer.append("//A List of bad cycles.\n");
       buffer.append("BadCycle:");
-      for(int& it : Get().fBadCycleList) {
+      for(int& it : Get()->fBadCycleList) {
          buffer.append(Form(" %d", it));
       }
       buffer.append("\n\n");
@@ -551,26 +552,3 @@ std::string TGRSIRunInfo::PrintToString(Option_t*)
    return buffer;
 }
 
-//void TGRSIRunInfo::Streamer(TBuffer& R__b)
-//{
-//	std::cout<<__PRETTY_FUNCTION__<<std::endl;
-//	std::cout<<this<<".Print():"<<std::endl;
-//	Print();
-//	std::cout<<&Get()<<".Print():"<<std::endl;
-//	Get().Print();
-//	if(R__b.IsReading()) {
-//		std::cout<<"Reading TBuffer size "<<R__b.BufferSize()<<", "<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<std::endl;
-//      R__b.ReadClassBuffer(TGRSIRunInfo::Class(),this);
-//		//Set(*this);
-//		std::cout<<"ReadClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<"), TBuffer size "<<R__b.BufferSize()<<std::endl;
-//	} else {
-//		std::cout<<"Writing TBuffer size "<<R__b.BufferSize()<<std::endl;
-//      R__b.WriteClassBuffer(TGRSIRunInfo::Class(),this);
-//		std::cout<<"WriteClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<"), TBuffer size "<<R__b.BufferSize()<<std::endl;
-//	}
-//	std::cout<<this<<".Print():"<<std::endl;
-//	Print();
-//	std::cout<<&Get()<<".Print():"<<std::endl;
-//	Get().Print();
-//	std::cout<<"----------------------------------------"<<std::endl;
-//}

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -64,7 +64,7 @@ TPPG::TPPG()
    //std::cout<<"default constructor called on "<<this<<std::endl;
 }
 
-TPPG::TPPG(const TPPG& rhs) : TObject()
+TPPG::TPPG(const TPPG& rhs) : TSingleton<TPPG>()
 {
    fPPGStatusMap = new PPGMap_t;
    rhs.Copy(*this);
@@ -85,27 +85,6 @@ TPPG::~TPPG()
       delete fPPGStatusMap;
    }
    //std::cout<<"destructor called on "<<this<<std::endl;
-}
-
-TPPG* TPPG::Get(TFile* fileWithPpg)
-{
-   /// The getter for the singleton TPPG. Unfortunately ROOT doesn't allow true
-   /// singletons, so one should take care to always use this method and not
-   /// the constructor.
-	TDirectory* fileToGetPpgFrom = gDirectory;
-
-	if(fileWithPpg != nullptr) {
-		fileToGetPpgFrom = static_cast<TDirectory*>(fileWithPpg);
-	}
-
-	// we want to get the ppg if we haven't done so yet, or if a file was provided
-   if(fPPG == nullptr || fileWithPpg != nullptr) {
-      fPPG = static_cast<TPPG*>(fileToGetPpgFrom->Get("TPPG"));
-      if(fPPG == nullptr) {
-         fPPG = new TPPG();
-      }
-   }
-   return fPPG;
 }
 
 void TPPG::Copy(TObject& obj) const
@@ -276,9 +255,9 @@ void TPPG::Print(Option_t* opt) const
 
    // the print statement itself
    printf("Cycle length is %lld in 10 ns units = %.3lf seconds.\n", cycleLength, cycleLength / 1e8);
-   printf("Cycle: %.3lf s tape move, %.3lf background, %.3lf beam on, and %.3lf decay\n", stateLength[0] / 1e8,
+   printf("Cycle: %.3lf s tape move, %.3lf s background, %.3lf s beam on, and %.3lf s decay\n", stateLength[0] / 1e8,
           stateLength[1] / 1e8, stateLength[2] / 1e8, stateLength[3] / 1e8);
-   printf("Offset is %d\n", offset);
+   printf("Offset is %d [10 ns]\n", offset);
    printf("Got %ld PPG words:\n", fPPGStatusMap->size() - 1);
    for(auto& statu : status) {
       printf("\tfound status 0x%04x %d times\n", static_cast<std::underlying_type<EPpgPattern>::type>(statu.first), statu.second);

--- a/libraries/TGRSIFormat/TParsingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TParsingDiagnostics.cxx
@@ -4,15 +4,13 @@
 
 #include "TChannel.h"
 
-TParsingDiagnostics* TParsingDiagnostics::fParsingDiagnostics = nullptr;
-
-TParsingDiagnostics::TParsingDiagnostics() : TObject()
+TParsingDiagnostics::TParsingDiagnostics() : TSingleton<TParsingDiagnostics>()
 {
    fIdHist         = nullptr;
    Clear();
 }
 
-TParsingDiagnostics::TParsingDiagnostics(const TParsingDiagnostics&) : TObject()
+TParsingDiagnostics::TParsingDiagnostics(const TParsingDiagnostics&) : TSingleton<TParsingDiagnostics>()
 {
    fIdHist         = nullptr;
    Clear();

--- a/libraries/TGRSIFormat/TSortingDiagnostics.cxx
+++ b/libraries/TGRSIFormat/TSortingDiagnostics.cxx
@@ -6,14 +6,12 @@
 #include "TChannel.h"
 #include "TGRSIOptions.h"
 
-TSortingDiagnostics* TSortingDiagnostics::fSortingDiagnostics = nullptr;
-
-TSortingDiagnostics::TSortingDiagnostics() : TObject()
+TSortingDiagnostics::TSortingDiagnostics() : TSingleton<TSortingDiagnostics>()
 {
    Clear();
 }
 
-TSortingDiagnostics::TSortingDiagnostics(const TSortingDiagnostics&) : TObject()
+TSortingDiagnostics::TSortingDiagnostics(const TSortingDiagnostics&) : TSingleton<TSortingDiagnostics>()
 {
    Clear();
 }

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -152,14 +152,16 @@ void TGRSISelector::Terminate()
    /// The Terminate() function is the last function to be called during
    /// a query. It always runs on the client, it can be used to present
    /// the results graphically or save the results to file.
-   Int_t runnumber    = TGRSIRunInfo::Get()->RunNumber();
-   Int_t subrunnumber = TGRSIRunInfo::Get()->SubRunNumber();
+	TGRSIOptions* options = TGRSIOptions::Get();
+	TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
+   Int_t runnumber    = runInfo->RunNumber();
+   Int_t subrunnumber = runInfo->SubRunNumber();
 
    std::cout<<runnumber<<" "<<subrunnumber<<std::endl;
    TFile outputFile(Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runnumber, subrunnumber), "RECREATE");
    fOutput->Write();
-   TGRSIRunInfo::Get()->Write();
-   TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(&outputFile);
+   runInfo->Write();
+   options->AnalysisOptions()->WriteToFile(&outputFile);
    outputFile.Close();
 }
 

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -128,7 +128,7 @@ Bool_t TGRSISelector::Process(Long64_t entry)
       current_file = fChain->GetCurrentFile();
       std::cout<<"Starting to sort: "<<current_file<<std::endl;
       TChannel::ReadCalFromFile(current_file);
-      TGRSIRunInfo::Get().ReadInfoFromFile(current_file);
+      TGRSIRunInfo::Get()->ReadInfoFromFile(current_file);
       //   TChannel::WriteCalFile();
    }
 
@@ -152,13 +152,13 @@ void TGRSISelector::Terminate()
    /// The Terminate() function is the last function to be called during
    /// a query. It always runs on the client, it can be used to present
    /// the results graphically or save the results to file.
-   Int_t runnumber    = TGRSIRunInfo::Get().RunNumber();
-   Int_t subrunnumber = TGRSIRunInfo::Get().SubRunNumber();
+   Int_t runnumber    = TGRSIRunInfo::Get()->RunNumber();
+   Int_t subrunnumber = TGRSIRunInfo::Get()->SubRunNumber();
 
    std::cout<<runnumber<<" "<<subrunnumber<<std::endl;
    TFile outputFile(Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runnumber, subrunnumber), "RECREATE");
    fOutput->Write();
-   TGRSIRunInfo::Get().Write();
+   TGRSIRunInfo::Get()->Write();
    TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(&outputFile);
    outputFile.Close();
 }

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -137,12 +137,12 @@ void TGRSIint::ApplyOptions()
 
    SetupPipeline();
 
-   for(auto& filename : opt->MacroInputFiles()) {
-      RunMacroFile(filename);
-   }
-
    if(opt->StartGui()) {
       StartGUI();
+   }
+
+   for(auto& filename : opt->MacroInputFiles()) {
+      RunMacroFile(filename);
    }
 
    std::cout<<StoppableThread::AllThreadHeader()<<std::endl;
@@ -578,9 +578,9 @@ void TGRSIint::SetupPipeline()
    }
 	// Set the run number and sub-run number
    if(!fRawFiles.empty()) {
-      TGRSIRunInfo::Get().SetRunInfo(fRawFiles[0]->GetRunNumber(), fRawFiles[0]->GetSubRunNumber());
+      TGRSIRunInfo::Get()->SetRunInfo(fRawFiles[0]->GetRunNumber(), fRawFiles[0]->GetSubRunNumber());
    } else {
-      TGRSIRunInfo::Get().SetRunInfo(0, -1);
+      TGRSIRunInfo::Get()->SetRunInfo(0, -1);
    }
 
    TPPG::Get()->Setup();
@@ -588,12 +588,12 @@ void TGRSIint::SetupPipeline()
       GValue::ReadValFile(val_filename.c_str());
    }
    for(const auto& info_filename : opt->ExternalRunInfo()) {
-      TGRSIRunInfo::Get().ReadInfoFile(info_filename.c_str());
+      TGRSIRunInfo::Get()->ReadInfoFile(info_filename.c_str());
    }
 
    // this happens here, because the TDataLoop constructor is where we read the midas file ODB
    TEventBuildingLoop::EBuildMode event_build_mode = TEventBuildingLoop::EBuildMode::kTriggerId;
-   if(TGRSIRunInfo::Get().Griffin() || TGRSIRunInfo::Get().Fipps()) {
+   if(TGRSIRunInfo::Get()->Griffin() || TGRSIRunInfo::Get()->Fipps()) {
       event_build_mode = TEventBuildingLoop::EBuildMode::kTimestamp;
    }
 
@@ -674,9 +674,10 @@ void TGRSIint::SetupPipeline()
 
 void TGRSIint::RunMacroFile(const std::string& filename)
 {
-   /// Runs a macro file. This happens when --work-harder is used with a .C file
+   /// Runs a macro file. This happens when a .C file is provided on the command line
    if(file_exists(filename.c_str())) {
-      const char* command = Form(".x %s;", filename.c_str());
+      const char* command = Form(".x %s", filename.c_str());
+		std::cout<<"trying to run '"<<command<<"'"<<std::endl;
       ProcessLine(command);
    } else {
       std::cerr<<R"(File ")"<<filename<<R"(" does not exist)"<<std::endl;

--- a/libraries/TLoops/StoppableThread.cxx
+++ b/libraries/TLoops/StoppableThread.cxx
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <utility>
 
-#include <TString.h>
+#include "TString.h"
 
 #include "TDataLoop.h"
 #include "TFragmentChainLoop.h"

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -5,6 +5,7 @@
 
 #include "TFile.h"
 #include "TThread.h"
+#include "TROOT.h"
 
 #include "GValue.h"
 #include "TChannel.h"
@@ -40,12 +41,13 @@ TAnalysisWriteLoop::TAnalysisWriteLoop(std::string name, std::string output_file
 
    if(output_filename != "/dev/null") {
       // TPreserveGDirectory preserve;
+		TGRSIOptions* options = TGRSIOptions::Get(); // get the pointer before we switch to the new file
       fOutputFile = new TFile(output_filename.c_str(), "RECREATE");
 		if(fOutputFile == nullptr || !fOutputFile->IsOpen()) {
 			throw std::runtime_error(Form("Failed to open \"%s\"\n", output_filename.c_str()));
 		}
       fEventTree  = new TTree("AnalysisTree", "AnalysisTree");
-      if(TGRSIOptions::Get()->SeparateOutOfOrder()) {
+      if(options->SeparateOutOfOrder()) {
          fOutOfOrderTree = new TTree("OutOfOrderTree", "OutOfOrderTree");
          fOutOfOrderFrag = new TFragment;
          fOutOfOrderTree->Branch("Fragment", &fOutOfOrderFrag);
@@ -118,109 +120,118 @@ void TAnalysisWriteLoop::Write()
 {
 
    if(fOutputFile != nullptr) {
-      fOutputFile->cd();
+		// get all singletons before switching to the output file
+		gROOT->cd();
+		TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
+		TGRSIOptions* options = TGRSIOptions::Get();
+		TPPG* ppg = TPPG::Get();
+		TSortingDiagnostics* sortingDiagnostics = TSortingDiagnostics::Get();
+		GValue* gValues = GValue::Get();
 
-      fEventTree->Write(fEventTree->GetName(), TObject::kOverwrite);
+		fOutputFile->cd();
 
-      if(fOutOfOrderTree != nullptr) {
-         fOutOfOrderTree->Write(fOutOfOrderTree->GetName(), TObject::kOverwrite);
-      }
+		fEventTree->Write(fEventTree->GetName(), TObject::kOverwrite);
 
-      if(GValue::Size() != 0) {
-         GValue::Get()->Write();
-      }
-      if(TChannel::GetNumberOfChannels() != 0) {
-         TChannel::WriteToRoot();
-      }
-      TGRSIRunInfo::Get().WriteToRoot(fOutputFile);
-      TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
-      TPPG::Get()->Write();
+		if(fOutOfOrderTree != nullptr) {
+			fOutOfOrderTree->Write(fOutOfOrderTree->GetName(), TObject::kOverwrite);
+		}
 
-      if(TGRSIOptions::Get()->WriteDiagnostics()) {
-         TSortingDiagnostics::Get()->Write();
-      }
+		if(GValue::Size() != 0) {
+			gValues->Write();
+		}
+		if(TChannel::GetNumberOfChannels() != 0) {
+			TChannel::WriteToRoot();
+		}
+		runInfo->WriteToRoot(fOutputFile);
+		options->AnalysisOptions()->WriteToFile(fOutputFile);
+		ppg->Write();
 
-      fOutputFile->Close();
-      fOutputFile->Delete();
-   }
+		if(options->WriteDiagnostics()) {
+			sortingDiagnostics->Write();
+		}
+
+		fOutputFile->Close();
+		fOutputFile->Delete();
+		gROOT->cd();
+	}
 }
 
 void TAnalysisWriteLoop::AddBranch(TClass* cls)
 {
-   if(fDetMap.count(cls) == 0u) {
-      // This uses the ROOT dictionaries, so we need to lock the threads.
-      TThread::Lock();
+	if(fDetMap.count(cls) == 0u) {
+		// This uses the ROOT dictionaries, so we need to lock the threads.
+		TThread::Lock();
 
-      // Make a default detector of that type.
-      TDetector* det_p  = reinterpret_cast<TDetector*>(cls->New());
-      fDefaultDets[cls] = det_p;
+		// Make a default detector of that type.
+		TDetector* det_p  = reinterpret_cast<TDetector*>(cls->New());
+		fDefaultDets[cls] = det_p;
 
-      // Make the TDetector**
-      auto** det_pp = new TDetector*;
-      *det_pp       = det_p;
-      fDetMap[cls]  = det_pp;
+		// Make the TDetector**
+		auto** det_pp = new TDetector*;
+		*det_pp       = det_p;
+		fDetMap[cls]  = det_pp;
 
-      // Make a new branch.
-      TBranch* new_branch = fEventTree->Branch(cls->GetName(), cls->GetName(), det_pp);
+		// Make a new branch.
+		TBranch* new_branch = fEventTree->Branch(cls->GetName(), cls->GetName(), det_pp);
 
-      // Fill the new branch up to the point where the tree is filled.
-      // Explanation:
-      //   When TTree::Fill is called, it calls TBranch::Fill for each
-      // branch, then increments the number of entries.  We may be
-      // adding branches after other branches have already been filled.
-      // If the S800 branch has been filled 100 times before the Gretina
-      // branch is created, then the next call to TTree::Fill will fill
-      // entry 101 of S800, but entry 1 of Gretina, rather than entry
-      // 101 of both.
-      //   Therefore, we need to fill the new branch as many times as
-      // TTree::Fill has been called before.
-      std::lock_guard<std::mutex> lock(ttree_fill_mutex);
-      for(int i = 0; i < fEventTree->GetEntries(); i++) {
-         new_branch->Fill();
-      }
+		// Fill the new branch up to the point where the tree is filled.
+		// Explanation:
+		//   When TTree::Fill is called, it calls TBranch::Fill for each
+		// branch, then increments the number of entries.  We may be
+		// adding branches after other branches have already been filled.
+		// If the S800 branch has been filled 100 times before the Gretina
+		// branch is created, then the next call to TTree::Fill will fill
+		// entry 101 of S800, but entry 1 of Gretina, rather than entry
+		// 101 of both.
+		//   Therefore, we need to fill the new branch as many times as
+		// TTree::Fill has been called before.
+		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
+		for(int i = 0; i < fEventTree->GetEntries(); i++) {
+			new_branch->Fill();
+		}
 
-      std::cout<<"\r"<<std::string(30, ' ')<<"\rAdded \""<<cls->GetName()<<R"(" branch)"<<std::endl;
+		std::cout<<"\r"<<std::string(30, ' ')<<"\rAdded \""<<cls->GetName()<<R"(" branch)"<<std::endl;
 
-      // Unlock after we are done.
-      TThread::UnLock();
-   }
+		// Unlock after we are done.
+		TThread::UnLock();
+	}
 }
 
 void TAnalysisWriteLoop::WriteEvent(TUnpackedEvent& event)
 {
-   if(fEventTree != nullptr) {
-      // Clear pointers from previous writes.
-      // Note that we cannot just set this equal to nullptr,
-      //   because ROOT would then construct a new object.
-      // This contradicts the ROOT documentation for TBranchElement::SetAddress,
-      //   which suggests that a new object would be constructed only when setting the address,
-      //   not when filling the TTree.
-      for(auto& elem : fDetMap) {
-         //*elem.second = fDefaultDets[elem.first];
-         (*elem.second)->Clear();
-      }
+	if(fEventTree != nullptr) {
+		// Clear pointers from previous writes.
+		// Note that we cannot just set this equal to nullptr,
+		//   because ROOT would then construct a new object.
+		// This contradicts the ROOT documentation for TBranchElement::SetAddress,
+		//   which suggests that a new object would be constructed only when setting the address,
+		//   not when filling the TTree.
+		for(auto& elem : fDetMap) {
+			//*elem.second = fDefaultDets[elem.first];
+			(*elem.second)->Clear();
+		}
 
-      // Load current events
-      for(const auto& det : event.GetDetectors()) {
-         TClass* cls = det->IsA();
-         try {
-            **fDetMap.at(cls) = *(det.get());
-         } catch(std::out_of_range& e) {
-            AddBranch(cls);
-            **fDetMap.at(cls) = *(det.get());
-         }
-         (*fDetMap.at(cls))->ClearTransients();
-         // if(cls == TDescant::Class()) {
-         //	for(int i = 0; i < static_cast<TDescant*>(det)->GetMultiplicity(); ++i) {
-         //		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == nullptr ?
-         //"
-         // has no debug data": " has debug data")<<std::endl;
-         //	}
-         //}
-      }
+		// Load current events
+		for(const auto& det : event.GetDetectors()) {
+			TClass* cls = det->IsA();
+			try {
+				**fDetMap.at(cls) = *(det.get());
+			} catch(std::out_of_range& e) {
+				AddBranch(cls);
+				**fDetMap.at(cls) = *(det.get());
+			}
+			(*fDetMap.at(cls))->ClearTransients();
+			// if(cls == TDescant::Class()) {
+			//	for(int i = 0; i < static_cast<TDescant*>(det)->GetMultiplicity(); ++i) {
+			//		std::cout<<"Descant hit "<<i<<(static_cast<TDescant*>(det)->GetDescantHit(i)->GetDebugData() == nullptr ?
+			//"
+			// has no debug data": " has debug data")<<std::endl;
+			//	}
+			//}
+		}
 
-      // Fill
-      std::lock_guard<std::mutex> lock(ttree_fill_mutex);
-      fEventTree->Fill();
-   }
+		// Fill
+		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
+		fEventTree->Fill();
+	}
 }

--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -99,7 +99,7 @@ void TDataLoop::SetFileOdb(uint32_t time, char* data, int size)
 void TDataLoop::SetRunInfo(uint32_t time)
 {
 #ifdef HAS_XML
-   TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
+   TGRSIRunInfo* runInfo = &(TGRSIRunInfo::Get());
    TXMLNode*     node    = fOdb->FindPath("/Runinfo/Start time binary");
    if(node != nullptr) {
 		std::stringstream str(node->GetText());

--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -99,7 +99,7 @@ void TDataLoop::SetFileOdb(uint32_t time, char* data, int size)
 void TDataLoop::SetRunInfo(uint32_t time)
 {
 #ifdef HAS_XML
-   TGRSIRunInfo* runInfo = &(TGRSIRunInfo::Get());
+   TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
    TXMLNode*     node    = fOdb->FindPath("/Runinfo/Start time binary");
    if(node != nullptr) {
 		std::stringstream str(node->GetText());

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -7,6 +7,7 @@
 
 #include "TFile.h"
 #include "TThread.h"
+#include "TROOT.h"
 
 #include "GValue.h"
 #include "TChannel.h"
@@ -133,12 +134,20 @@ bool TFragWriteLoop::Iteration()
 void TFragWriteLoop::Write()
 {
    if(fOutputFile != nullptr) {
+		// get all singletons before switching to the output file
+		gROOT->cd();
+		TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
+		TGRSIOptions* options = TGRSIOptions::Get();
+		TPPG* ppg = TPPG::Get();
+		TParsingDiagnostics* parsingDiagnostics = TParsingDiagnostics::Get();
+		GValue* gValues = GValue::Get();
+
       fOutputFile->cd();
       fEventTree->Write(fEventTree->GetName(), TObject::kOverwrite);
       fBadEventTree->Write(fBadEventTree->GetName(), TObject::kOverwrite);
       fScalerTree->Write(fScalerTree->GetName(), TObject::kOverwrite);
       if(GValue::Size() != 0) {
-         GValue::Get()->Write();
+         gValues->Write();
       }
 
       if(TChannel::GetNumberOfChannels() != 0) {
@@ -146,17 +155,18 @@ void TFragWriteLoop::Write()
          TChannel::WriteToRoot();
       }
 
-      TGRSIRunInfo::Get().WriteToRoot(fOutputFile);
-      TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
-      TPPG::Get()->Write();
+      runInfo->WriteToRoot(fOutputFile);
+      options->AnalysisOptions()->WriteToFile(fOutputFile);
+      ppg->Write();
 
-      if(TGRSIOptions::Get()->WriteDiagnostics()) {
-         TParsingDiagnostics::Get()->ReadPPG(TPPG::Get());
-         TParsingDiagnostics::Get()->Write();
+      if(options->WriteDiagnostics()) {
+         parsingDiagnostics->ReadPPG(ppg);
+         parsingDiagnostics->Write();
       }
 
       fOutputFile->Close();
       fOutputFile->Delete();
+		gROOT->cd();
    }
 }
 

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -709,7 +709,7 @@ int TMidasEvent::Process(TDataParser& parser)
 			// end of file ODB
 #ifdef HAS_XML
 			TXMLOdb* odb = new TXMLOdb(GetData(), GetDataSize());
-			TGRSIRunInfo* runInfo = &(TGRSIRunInfo::Get());
+			TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
 			TXMLNode*     node    = odb->FindPath("/Runinfo/Stop time binary");
 			if(node != nullptr) {
 				std::stringstream str(node->GetText());


### PR DESCRIPTION
- New class TSingleton<T> provides templated base-class for singletons
  that are written to file. The Get() function automatically reads
  from the current file, keeping the information updated even in a
  loop over input files (such as used with grsiproof).
- Adding a new class involves
  - including the TSingleton.h header,
  - changing the base to TSingleton<T>,
  - adding TSingleton<T> as a friend class (might not be needed?),
  - removing old Get() function and static pointer to instance,
  - updating class definition version,
  - adding ```#pragma link C++ class TSingleton<T>-;``` to
    libraries/TGRSIFormat/LinkDef.h,
  - constructors must now call TSingleton<T> constructor instead of
    TObject constructor, and
  - existing static WriteToRoot functions must be modified to be
    in the right directory before using Get() so that writing doesn't
    create a new (empty) instance because the directory has been
    changed.
- TGRSIRunInfo, TPPG, TParsingDiagnostics, and TSortingDiagnostics
  are now based on TSingleton.