### PR TITLE
merge of TSingleton class branch

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -41,8 +41,8 @@ void Analyze(const char* tree_type)
             // TODO: A smarter way of finding run info for run number and sub run number naming
             static bool info_set = false;
             if(!info_set) {
-               TGRSIRunInfo::Get().ReadInfoFromFile(in_file);
-					TGRSIRunInfo::Get().Print();
+               TGRSIRunInfo::Get()->ReadInfoFromFile(in_file);
+					TGRSIRunInfo::Get()->Print();
                info_set = true;
             }
          }

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -41,8 +41,8 @@ void Analyze(const char* tree_type)
             // TODO: A smarter way of finding run info for run number and sub run number naming
             static bool info_set = false;
             if(!info_set) {
-               TGRSIRunInfo::Get()->ReadInfoFromFile(in_file);
-					TGRSIRunInfo::Get()->Print();
+               TGRSIRunInfo::Get().ReadInfoFromFile(in_file);
+					TGRSIRunInfo::Get().Print();
                info_set = true;
             }
          }

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -34,7 +34,7 @@ public:
 	void Load(int argc, char** argv);
 	void Print(Option_t* opt = "") const override;
 
-	static bool WriteToRoot(TFile* file = nullptr);
+	static bool WriteToFile(TFile* file = nullptr);
 	static void SetOptions(TGRSIOptions* tmp);
 	static Bool_t ReadFromFile(TFile* file = nullptr);
 

--- a/include/TGRSIRunInfo.h
+++ b/include/TGRSIRunInfo.h
@@ -18,19 +18,9 @@
 /// TGRSIRunInfo designed to be made as the FragmentTree
 /// is created.  Right now, it simple remembers the run and
 /// subrunnumber and sets which systems are present in the odb.
-/// This information will be used when automatically creating the
-/// AnalysisTree to know which detector branches to create and fill.
 ///
 /// Due to some root quarkiness, I have done something a bit strange.
 /// The info is written ok at the end of the fragment tree process.
-/// After reading the TGRSIRunInfo object from a TFile, the static function
-///
-///   TGRSIRunInfo::ReadInfoFromFile(ptr_to_runinfo);
-///
-/// must be called for any of the functions here to work.
-///
-/// Live example:
-///
 /// \code
 /// root [1] TGRSIRunInfo *info = (TGRSIRunInfo*)_file0->Get("TGRSIRunInfo")
 /// root [2] TGRSIRunInfo::ReadInfoFromFile(info);
@@ -58,11 +48,13 @@
 
 #include "Globals.h"
 
+#include "TSingleton.h"
 #include "TChannel.h"
 
-class TGRSIRunInfo : public TObject {
+class TGRSIRunInfo : public TSingleton<TGRSIRunInfo> {
 public:
-   static TGRSIRunInfo* Get();
+	friend class TSingleton<TGRSIRunInfo>;
+
    ~TGRSIRunInfo() override;
    TGRSIRunInfo(); // This should not be used.
    // root forces me have this here instead
@@ -70,7 +62,24 @@ public:
    // order to write this class to a tree.
    // pcb.
 
-   static void SetRunInfo(TGRSIRunInfo* tmp);
+	//TGRSIRunInfo& operator=(TGRSIRunInfo const& rhs)
+	//{
+	//	std::cout<<__PRETTY_FUNCTION__<<std::endl;
+	//	std::cout<<fRunTitle<<"/"<<rhs.fRunTitle<<" => ";
+	//	fRunTitle = rhs.fRunTitle;
+	//	std::cout<<fRunTitle<<std::endl;
+	//	fRunComment = rhs.fRunComment;
+
+	//	std::cout<<fRunNumber<<"/"<<rhs.fRunNumber<<" => ";
+	//	fRunNumber = rhs.fRunNumber;
+	//	std::cout<<fRunNumber<<std::endl;
+	//	std::cout<<fSubRunNumber<<"/"<<rhs.fSubRunNumber<<" => ";
+	//	fSubRunNumber = rhs.fSubRunNumber;
+	//	std::cout<<fSubRunNumber<<std::endl;
+
+	//	return *this;
+	//}
+   //static void Set(TSingleton* tmp) override;
    static Bool_t ReadInfoFromFile(TFile* tempf = nullptr);
 
    static const char* GetGRSIVersion() { return fGRSIVersion.c_str(); }
@@ -87,117 +96,120 @@ public:
    static void SetRunInfo(int runnum = 0, int subrunnum = -1);
    static void SetAnalysisTreeBranches(TTree*);
 
-   static inline void SetRunNumber(int tmp) { fGRSIRunInfo->fRunNumber = tmp; }
-   static inline void SetSubRunNumber(int tmp) { fGRSIRunInfo->fSubRunNumber = tmp; }
+   static inline void SetRunNumber(int tmp) { Get().fRunNumber = tmp; }
+   static inline void SetSubRunNumber(int tmp) { Get().fSubRunNumber = tmp; }
 
-   static inline int RunNumber() { return fGRSIRunInfo->fRunNumber; }
-   static inline int SubRunNumber() { return fGRSIRunInfo->fSubRunNumber; }
+   static inline int RunNumber() { return Get().fRunNumber; }
+   static inline int SubRunNumber() { return Get().fSubRunNumber; }
 
-   inline void SetRunTitle(const char* run_title) { fRunTitle.assign(run_title); }
-   inline void SetRunComment(const char* run_comment) { fRunComment.assign(run_comment); }
+   inline void SetRunTitle(const char* run_title) { Get().fRunTitle.assign(run_title); }
+   inline void SetRunComment(const char* run_comment) { Get().fRunComment.assign(run_comment); }
 
-   static inline void SetRunStart(double tmp) { fGRSIRunInfo->fRunStart = tmp; }
-   static inline void SetRunStop(double tmp) { fGRSIRunInfo->fRunStop = tmp; }
-   static inline void SetRunLength(double tmp) { fGRSIRunInfo->fRunLength = tmp; }
-   static inline void SetRunLength() { fGRSIRunInfo->fRunLength = fGRSIRunInfo->fRunStop - fGRSIRunInfo->fRunStart; }
+	static inline std::string RunTitle() { return Get().fRunTitle; }
+	static inline std::string RunComment() { return Get().fRunComment; }
 
-   static inline double RunStart() { return fGRSIRunInfo->fRunStart; }
-   static inline double RunStop() { return fGRSIRunInfo->fRunStop; }
-   static inline double RunLength() { return fGRSIRunInfo->fRunLength; }
+   static inline void SetRunStart(double tmp) { Get().fRunStart = tmp; }
+   static inline void SetRunStop(double tmp) { Get().fRunStop = tmp; }
+   static inline void SetRunLength(double tmp) { Get().fRunLength = tmp; }
+   static inline void SetRunLength() { Get().fRunLength = Get().fRunStop - Get().fRunStart; }
 
-   static inline void SetTigress(bool flag = true) { fGRSIRunInfo->fTigress = flag; }
-   static inline void SetSharc(bool flag = true) { fGRSIRunInfo->fSharc = flag; }
-   static inline void SetTriFoil(bool flag = true) { fGRSIRunInfo->fTriFoil = flag; }
-   static inline void SetRF(bool flag = true) { fGRSIRunInfo->fRf = flag; }
-   static inline void SetCSM(bool flag = true) { fGRSIRunInfo->fCSM = flag; }
-   static inline void SetSpice(bool flag = true) { fGRSIRunInfo->fSpice = flag; }
-   static inline void SetS3(bool flag = true) { fGRSIRunInfo->fS3 = flag; }
-   static inline void SetGeneric(bool flag = true) { fGRSIRunInfo->fGeneric = flag; }
-   static inline void SetTip(bool flag = true) { fGRSIRunInfo->fTip = flag; }
-   static inline void SetBambino(bool flag = true) { fGRSIRunInfo->fBambino = flag; }
+   static inline double RunStart() { return Get().fRunStart; }
+   static inline double RunStop() { return Get().fRunStop; }
+   static inline double RunLength() { return Get().fRunLength; }
 
-   static inline void SetGriffin(bool flag = true) { fGRSIRunInfo->fGriffin = flag; }
-   static inline void SetSceptar(bool flag = true) { fGRSIRunInfo->fSceptar = flag; }
-   static inline void SetPaces(bool flag = true) { fGRSIRunInfo->fPaces = flag; }
-   static inline void SetDante(bool flag = true) { fGRSIRunInfo->fDante = flag; }
-   static inline void SetZeroDegree(bool flag = true) { fGRSIRunInfo->fZeroDegree = flag; }
-   static inline void SetDescant(bool flag = true) { fGRSIRunInfo->fDescant = flag; }
-   static inline void SetFipps(bool flag = true) { fGRSIRunInfo->fFipps = flag; }
+   static inline void SetTigress(bool flag = true) { Get().fTigress = flag; }
+   static inline void SetSharc(bool flag = true) { Get().fSharc = flag; }
+   static inline void SetTriFoil(bool flag = true) { Get().fTriFoil = flag; }
+   static inline void SetRF(bool flag = true) { Get().fRf = flag; }
+   static inline void SetCSM(bool flag = true) { Get().fCSM = flag; }
+   static inline void SetSpice(bool flag = true) { Get().fSpice = flag; }
+   static inline void SetS3(bool flag = true) { Get().fS3 = flag; }
+   static inline void SetGeneric(bool flag = true) { Get().fGeneric = flag; }
+   static inline void SetTip(bool flag = true) { Get().fTip = flag; }
+   static inline void SetBambino(bool flag = true) { Get().fBambino = flag; }
 
-   static inline void SetCalFileName(const char* name) { fGRSIRunInfo->fCalFileName.assign(name); }
-   static inline void SetCalFileData(const char* data) { fGRSIRunInfo->fCalFile.assign(data); }
+   static inline void SetGriffin(bool flag = true) { Get().fGriffin = flag; }
+   static inline void SetSceptar(bool flag = true) { Get().fSceptar = flag; }
+   static inline void SetPaces(bool flag = true) { Get().fPaces = flag; }
+   static inline void SetDante(bool flag = true) { Get().fDante = flag; }
+   static inline void SetZeroDegree(bool flag = true) { Get().fZeroDegree = flag; }
+   static inline void SetDescant(bool flag = true) { Get().fDescant = flag; }
+   static inline void SetFipps(bool flag = true) { Get().fFipps = flag; }
 
-   static inline void SetXMLODBFileName(const char* name) { fGRSIRunInfo->fXMLODBFileName.assign(name); }
-   static inline void SetXMLODBFileData(const char* data) { fGRSIRunInfo->fXMLODBFile.assign(data); }
+   static inline void SetCalFileName(const char* name) { Get().fCalFileName.assign(name); }
+   static inline void SetCalFileData(const char* data) { Get().fCalFile.assign(data); }
 
-   static const char* GetCalFileName() { return fGRSIRunInfo->fCalFileName.c_str(); }
-   static const char* GetCalFileData() { return fGRSIRunInfo->fCalFile.c_str(); }
+   static inline void SetXMLODBFileName(const char* name) { Get().fXMLODBFileName.assign(name); }
+   static inline void SetXMLODBFileData(const char* data) { Get().fXMLODBFile.assign(data); }
 
-   static const char* GetXMLODBFileName() { return fGRSIRunInfo->fXMLODBFileName.c_str(); }
-   static const char* GetXMLODBFileData() { return fGRSIRunInfo->fXMLODBFile.c_str(); }
+   static const char* GetCalFileName() { return Get().fCalFileName.c_str(); }
+   static const char* GetCalFileData() { return Get().fCalFile.c_str(); }
 
-   static const char* GetRunInfoFileName() { return fGRSIRunInfo->fRunInfoFileName.c_str(); }
-   static const char* GetRunInfoFileData() { return fGRSIRunInfo->fRunInfoFile.c_str(); }
+   static const char* GetXMLODBFileName() { return Get().fXMLODBFileName.c_str(); }
+   static const char* GetXMLODBFileData() { return Get().fXMLODBFile.c_str(); }
+
+   static const char* GetRunInfoFileName() { return Get().fRunInfoFileName.c_str(); }
+   static const char* GetRunInfoFileData() { return Get().fRunInfoFile.c_str(); }
 
    static Bool_t ReadInfoFile(const char* filename = "");
    static Bool_t ParseInputData(const char* inputdata = "", Option_t* opt = "q");
 
-   static inline int GetNumberOfSystems() { return fGRSIRunInfo->fNumberOfTrueSystems; }
+   static inline int GetNumberOfSystems() { return Get().fNumberOfTrueSystems; }
 
-   static inline bool Tigress() { return fGRSIRunInfo->fTigress; }
-   static inline bool Sharc() { return fGRSIRunInfo->fSharc; }
-   static inline bool TriFoil() { return fGRSIRunInfo->fTriFoil; }
-   static inline bool RF() { return fGRSIRunInfo->fRf; }
-   static inline bool CSM() { return fGRSIRunInfo->fCSM; }
-   static inline bool Spice() { return fGRSIRunInfo->fSpice; }
-   static inline bool Bambino() { return fGRSIRunInfo->fBambino; }
-   static inline bool Tip() { return fGRSIRunInfo->fTip; }
-   static inline bool S3() { return fGRSIRunInfo->fS3; }
-   static inline bool Generic() { return fGRSIRunInfo->fGeneric; }
+   static inline bool Tigress() { return Get().fTigress; }
+   static inline bool Sharc() { return Get().fSharc; }
+   static inline bool TriFoil() { return Get().fTriFoil; }
+   static inline bool RF() { return Get().fRf; }
+   static inline bool CSM() { return Get().fCSM; }
+   static inline bool Spice() { return Get().fSpice; }
+   static inline bool Bambino() { return Get().fBambino; }
+   static inline bool Tip() { return Get().fTip; }
+   static inline bool S3() { return Get().fS3; }
+   static inline bool Generic() { return Get().fGeneric; }
 
-   static inline bool Griffin() { return fGRSIRunInfo->fGriffin; }
-   static inline bool Sceptar() { return fGRSIRunInfo->fSceptar; }
-   static inline bool Paces() { return fGRSIRunInfo->fPaces; }
-   static inline bool Dante() { return fGRSIRunInfo->fDante; }
-   static inline bool ZeroDegree() { return fGRSIRunInfo->fZeroDegree; }
-   static inline bool Descant() { return fGRSIRunInfo->fDescant; }
-   static inline bool Fipps() { return fGRSIRunInfo->fFipps; }
+   static inline bool Griffin() { return Get().fGriffin; }
+   static inline bool Sceptar() { return Get().fSceptar; }
+   static inline bool Paces() { return Get().fPaces; }
+   static inline bool Dante() { return Get().fDante; }
+   static inline bool ZeroDegree() { return Get().fZeroDegree; }
+   static inline bool Descant() { return Get().fDescant; }
+   static inline bool Fipps() { return Get().fFipps; }
 
-   inline void SetRunInfoFileName(const char* fname) { fRunInfoFileName.assign(fname); }
-   inline void SetRunInfoFile(const char* ffile) { fRunInfoFile.assign(ffile); }
+   inline void SetRunInfoFileName(const char* fname) { Get().fRunInfoFileName.assign(fname); }
+   inline void SetRunInfoFile(const char* ffile) { Get().fRunInfoFile.assign(ffile); }
 
-   inline void SetHPGeArrayPosition(const double arr_pos) { fHPGeArrayPosition = arr_pos; }
-   static inline double                          HPGeArrayPosition() { return Get()->fHPGeArrayPosition; }
+   inline void SetHPGeArrayPosition(const double arr_pos) { Get().fHPGeArrayPosition = arr_pos; }
+   static inline double                          HPGeArrayPosition() { return Get().fHPGeArrayPosition; }
 
-   static inline void SetDescantAncillary(bool flag = true) { fGRSIRunInfo->fDescantAncillary = flag; }
-   static inline bool                          DescantAncillary() { return fGRSIRunInfo->fDescantAncillary; }
+   static inline void SetDescantAncillary(bool flag = true) { Get().fDescantAncillary = flag; }
+   static inline bool                          DescantAncillary() { return Get().fDescantAncillary; }
 
    Long64_t Merge(TCollection* list);
    void Add(TGRSIRunInfo* runinfo)
    {
 		// add the run length together
       if(runinfo->fRunLength > 0) {
-			if(fRunLength > 0) {
-				fRunLength += runinfo->fRunLength;
+			if(Get().fRunLength > 0) {
+				Get().fRunLength += runinfo->fRunLength;
 			} else {
-				fRunLength = runinfo->fRunLength;
+				Get().fRunLength = runinfo->fRunLength;
 			}
 		}
-		if(runinfo->fRunNumber != fRunNumber) {
+		if(runinfo->fRunNumber != Get().fRunNumber) {
 			// the run number is meaningful only when the run numbers are the same
-			fRunNumber = 0;
-			fSubRunNumber = -1;
-			fRunStart = 0.;
-			fRunStop  = 0.;
-		} else if(runinfo->fSubRunNumber == fSubRunNumber + 1) {
+			Get().fRunNumber = 0;
+			Get().fSubRunNumber = -1;
+			Get().fRunStart = 0.;
+			Get().fRunStop  = 0.;
+		} else if(runinfo->fSubRunNumber == Get().fSubRunNumber + 1) {
 			// if the run numbers are the same and we have subsequent sub runs we can update the run stop
-			fRunStop = runinfo->fRunStop;
-			fSubRunNumber = runinfo->fSubRunNumber; // so we can check the next subrun as well
+			Get().fRunStop = runinfo->fRunStop;
+			Get().fSubRunNumber = runinfo->fSubRunNumber; // so we can check the next subrun as well
 		} else {
 			// with multiple files added, the sub run number has no meaning anymore
-			fSubRunNumber = -1;
-			fRunStart = 0.;
-			fRunStop  = 0.;
+			Get().fSubRunNumber = -1;
+			Get().fRunStart = 0.;
+			Get().fRunStop  = 0.;
 		}
    }
 
@@ -207,8 +219,6 @@ public:
    bool IsBadCycle(int cycle) const;
 
 private:
-   static TGRSIRunInfo* fGRSIRunInfo; // Static pointer to TGRSIRunInfo
-
    std::string fRunTitle;     ///< The title of the run
    std::string fRunComment;   ///< The comment on the run
    int         fRunNumber;    // The current run number
@@ -224,20 +234,6 @@ private:
 
    //  detector types to switch over in SetRunInfo()
    //  for more info, see: https://www.triumf.info/wiki/tigwiki/index.php/Detector_Nomenclature
-   // enum det_types {"TI", // TIGRESS
-   //                "SH", // SHARC
-   //                "TR", // TriFoil
-   //                "RF", // RF
-   //                "CS", // Colorado
-   //                "SP", // SPICE
-   //                "TP", // TIP
-   //                "GR", // GRIFFIN
-   //                "SE", // SCEPTAR
-   //                "PA", // PACES
-   //                "DA", // DANTE
-   //                "ZD", // Zero Degree
-   //                "DS"  // DESCANT
-   //               };
 
    bool fTigress{false}; // flag for Tigress on/off
    bool fSharc{false};   // flag for Sharc on/off
@@ -287,7 +283,7 @@ public:
    std::string PrintToString(Option_t* opt = "");
 
    /// \cond CLASSIMP
-   ClassDefOverride(TGRSIRunInfo, 12); // Contains the run-dependent information.
+   ClassDefOverride(TGRSIRunInfo, 13); // Contains the run-dependent information.
    /// \endcond
 };
 /*! @} */

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -51,6 +51,10 @@ public:
 
    void Copy(TObject& rhs) const override;
 
+   void Print(Option_t* opt = "") const override;
+   void Clear(Option_t* opt = "") override;
+
+	// -------------------- setter functions
    void SetLowTimeStamp(UInt_t lowTime)
    {
       fLowTimeStamp = lowTime;
@@ -70,7 +74,7 @@ public:
 			case EPpgPattern::kBackground: case EPpgPattern::kJunk:
 				break;
 			default:
-				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<newPpg<<std::dec<<", setting new pattern to kJunk!"<<std::endl;
+				if(newPpg != 0) std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<newPpg<<std::dec<<", setting new pattern to kJunk!"<<std::endl;
 				fNewPpg = EPpgPattern::kJunk;
 		}
 	}
@@ -83,7 +87,7 @@ public:
 			case EPpgPattern::kBackground: case EPpgPattern::kJunk:
 				break;
 			default:
-				std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<oldPpg<<std::dec<<", setting old pattern to kJunk!"<<std::endl;
+				if(oldPpg != 0) std::cout<<"Warning, unknown ppg pattern 0x"<<std::hex<<oldPpg<<std::dec<<", setting old pattern to kJunk!"<<std::endl;
 				fOldPpg = EPpgPattern::kJunk;
 		}
 	}
@@ -91,6 +95,7 @@ public:
 
    void SetTimeStamp();
 
+	// -------------------- getter functions
    UInt_t      GetLowTimeStamp() const { return fLowTimeStamp; }
    UInt_t      GetHighTimeStamp() const { return fHighTimeStamp; }
    EPpgPattern GetNewPPG() const { return fNewPpg; }
@@ -98,9 +103,6 @@ public:
    UInt_t      GetNetworkPacketId() const { return fNetworkPacketId; }
 
    Long64_t GetTimeStamp() const { return fTimeStamp; }
-
-   void Print(Option_t* opt = "") const override;
-   void Clear(Option_t* opt = "") override;
 
 private:
    ULong64_t   fTimeStamp;
@@ -111,7 +113,7 @@ private:
    UInt_t      fHighTimeStamp;
 
    /// \cond CLASSIMP
-   ClassDefOverride(TPPGData, 2) // Contains PPG data information
+   ClassDefOverride(TPPGData, 3) // Contains PPG data information
    /// \endcond
 };
 
@@ -119,7 +121,6 @@ class TPPG : public TObject {
 public:
    typedef std::map<ULong_t, TPPGData*> PPGMap_t;
 
-public:
    static TPPG* Get(TFile* fileWithPPg = nullptr);
 
    TPPG();
@@ -127,14 +128,18 @@ public:
    ~TPPG() override;
 
    void Copy(TObject& obj) const override;
-   void  Setup();
    Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) override
    {
-      return ((const TPPG*)this)->Write(name, option, bufsize);
+      return static_cast<const TPPG*>(this)->Write(name, option, bufsize);
    }
    Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) const override;
 
-public:
+   void Print(Option_t* opt = "") const override;
+   void Clear(Option_t* opt = "") override;
+
+   void  Setup();
+   bool Correct(bool verbose = false);
+
    void AddData(TPPGData* pat);
    EPpgPattern GetStatus(ULong64_t time) const;
    ULong64_t GetLastStatusTime(ULong64_t time, EPpgPattern pat = EPpgPattern::kJunk) const;
@@ -147,7 +152,7 @@ public:
 
    void SetCycleLength(ULong64_t length) { fCycleLength = length; }
 
-   bool Correct(bool verbose = false);
+	// -------------------- getter functions
    ULong64_t GetCycleLength();
    ULong64_t GetNumberOfCycles();
    ULong64_t GetTimeInCycle(ULong64_t real_time);
@@ -166,11 +171,8 @@ public:
       fOdbDurations = std::move(durations);
    }
 
-   void Print(Option_t* opt = "") const override;
-   void Clear(Option_t* opt = "") override;
-
 private:
-   static TPPG*       fPPG; //< static pointer to TPPG
+   static TPPG*       fPPG; ///< static pointer to TPPG
    PPGMap_t::iterator MapBegin() const { return ++(fPPGStatusMap->begin()); }
    PPGMap_t::iterator MapEnd() const { return fPPGStatusMap->end(); }
    PPGMap_t::iterator fCurrIterator; //!<!
@@ -179,6 +181,8 @@ private:
    ULong64_t fCycleLength;
    std::map<ULong64_t, int> fNumberOfCycleLengths;
 
+	//bool               fUseOdb;
+	//uint16_t           fCycleOffset;  ///< offset of cycle
    std::vector<short> fOdbPPGCodes;  ///< ppg state codes read from odb
    std::vector<int>   fOdbDurations; ///< duration of ppg state as read from odb
 

--- a/include/TSingleton.h
+++ b/include/TSingleton.h
@@ -1,0 +1,76 @@
+#ifndef TSINGLETON_H
+#define TSINGLETON_H
+
+#include <iostream>
+
+#include "TObject.h"
+
+/** \addtogroup Sorting
+ *  *  @{
+ *   */
+
+/////////////////////////////////////////////////////////////////
+/////
+///// \class TGRSIRunInfo
+/////
+/////////////////////////////////////////////////////////////////
+
+template <class T>
+class TSingleton : public TObject
+{
+public:
+	static T& Get()
+	{
+		static T singleton;
+		return singleton;
+	}
+	static void Set(T val)
+	{
+		Get() = val;
+	}
+
+	TSingleton() { fStreamerInstance = 0; }
+	//TSingleton(TSingleton const &) = delete;
+	// note, we can't delete this, because that wouldn't allow us to use the Set function above!
+	//TSingleton& operator=(TSingleton const &) = delete;
+	~TSingleton() {}
+
+private:
+	int fStreamerInstance;
+
+	/// \cond CLASSIMP
+	ClassDef(TSingleton, 1)
+	/// \endcond
+};
+
+templateClassImp(TSingleton)
+
+template<class T>
+void TSingleton<T>::Streamer(TBuffer& R__b) 
+{
+	/// Stream an object of class T.
+	++fStreamerInstance;
+	std::cout<<"Calling "<<(R__b.IsReading() ? "reading" : "writing")<<" streamer for TSingleton<"<<T::Class()->GetName()<<">"<<std::endl;
+	if(fStreamerInstance == 1) {
+		Get().Streamer(R__b);
+	}
+	if(R__b.IsReading()) {
+		//std::cout<<"ReadClassBuffer("<<T::Class()<<", "<<&(Get())<<") "<<this<<std::endl;
+		//R__b.ReadClassBuffer(T::Class(), &(Get()));
+		std::cout<<"this "<<this<<", &Get() "<<&(Get());
+		//Set(*static_cast<T*>(this));
+		std::cout<<"=> &Get() "<<&(Get())<<std::endl;
+	} else {
+		//std::cout<<"WriteClassBuffer("<<T::Class()<<", "<<&(Get())<<") "<<this<<std::endl;
+		//R__b.WriteClassBuffer(T::Class(), &(Get()));
+		//std::cout<<"done"<<std::endl<<std::endl;
+	}
+}
+
+template<class T>
+TClass* TSingleton<T>::Class()
+{
+	return T::Class();
+}
+/*! @} */
+#endif

--- a/libraries/TGRSIFormat/LinkDef.h
+++ b/libraries/TGRSIFormat/LinkDef.h
@@ -1,4 +1,4 @@
-// TFragment.h TBadFragment.h TChannel.h TGRSIRunInfo.h TGRSISortInfo.h TPPG.h TEpicsFrag.h TScaler.h TScalerQueue.h TParsingDiagnostics.h TGRSIUtilities.h TMnemonic.h TSortingDiagnostics.h TTransientBits.h TPriorityValue.h
+// TFragment.h TBadFragment.h TChannel.h TGRSIRunInfo.h TGRSISortInfo.h TPPG.h TEpicsFrag.h TScaler.h TScalerQueue.h TParsingDiagnostics.h TGRSIUtilities.h TMnemonic.h TSortingDiagnostics.h TTransientBits.h TPriorityValue.h TSingleton.h
 
 
 #ifdef __CINT__
@@ -10,12 +10,17 @@
 
 #pragma link C++ class std::vector<Int_t>+;
 
+#pragma link C++ class std::string+;
+#pragma link C++ class TSingleton+;
+#pragma link C++ class TGRSIRunInfo-;
+#pragma link C++ class TSingleton<TGRSIRunInfo>-;
+
 #pragma link C++ class TFragment+;
 #pragma link C++ class TBadFragment+;
 
 #pragma link C++ class TEpicsFrag+;
 #pragma link C++ class TChannel-;
-#pragma link C++ class TGRSIRunInfo+;
+#pragma link C++ class TGRSIRunInfo-;
 #pragma link C++ class TGRSISortInfo+;
 #pragma link C++ class TGRSISortList+;
 

--- a/libraries/TGRSIFormat/TEpicsFrag.cxx
+++ b/libraries/TGRSIFormat/TEpicsFrag.cxx
@@ -111,13 +111,13 @@ void TEpicsFrag::BuildScalerMap(TTree* tree)
    if(tree->SetBranchAddress("TEpicsFrag", &my_frag) == 0) {
       for(int i = 0; i < tree->GetEntries(); ++i) {
          tree->GetEntry(i);
-         if((static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart())) <
+         if((static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart())) <
             fSmallestTime) {
             fSmallestTime =
-               static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart());
+               static_cast<Long64_t>(my_frag->fMidasTimeStamp) - static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart());
          }
          fScalerMap[static_cast<Long64_t>(my_frag->fMidasTimeStamp) -
-                    static_cast<Long64_t>(TGRSIRunInfo::Get()->RunStart())] = *my_frag;
+                    static_cast<Long64_t>(TGRSIRunInfo::Get().RunStart())] = *my_frag;
       }
    } else {
       std::cout<<DRED<<"Could not build map from tree"<<RESET_COLOR<<std::endl;

--- a/libraries/TGRSIFormat/TGRSIRunInfo.cxx
+++ b/libraries/TGRSIFormat/TGRSIRunInfo.cxx
@@ -12,30 +12,30 @@
 ClassImp(TGRSIRunInfo)
 /// \endcond
 
-TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
+//TGRSIRunInfo* TGRSIRunInfo::fGRSIRunInfo = new TGRSIRunInfo();
 
 std::string TGRSIRunInfo::fGRSIVersion;
 
-TGRSIRunInfo* TGRSIRunInfo::Get()
-{
-   // The Getter for the singleton TGRSIRunInfo. This makes it
-   // so there is only even one instance of the run info during
-   // a session and it can be accessed from anywhere during that
-   // session.
-   if(fGRSIRunInfo == nullptr) {
-      fGRSIRunInfo = new TGRSIRunInfo();
-   }
-   return fGRSIRunInfo;
-}
+//TGRSIRunInfo* TGRSIRunInfo::Get()
+//{
+//   // The Getter for the singleton TGRSIRunInfo. This makes it
+//   // so there is only even one instance of the run info during
+//   // a session and it can be accessed from anywhere during that
+//   // session.
+//   if(fGRSIRunInfo == nullptr) {
+//      fGRSIRunInfo = new TGRSIRunInfo();
+//   }
+//   return fGRSIRunInfo;
+//}
 
-void TGRSIRunInfo::SetRunInfo(TGRSIRunInfo* tmp)
-{
-   // Sets the TGRSIRunInfo to the info passes as tmp.
-   if((fGRSIRunInfo != nullptr) && (tmp != fGRSIRunInfo)) {
-      delete fGRSIRunInfo;
-   }
-   fGRSIRunInfo = tmp;
-}
+//void TGRSIRunInfo::Set(TSingleton* tmp)
+//{
+//   // Sets the TGRSIRunInfo to the info passes as tmp.
+//   if((fGRSIRunInfo != nullptr) && (tmp != fGRSIRunInfo)) {
+//      delete fGRSIRunInfo;
+//   }
+//   fGRSIRunInfo = tmp;
+//}
 
 Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
 {
@@ -60,7 +60,7 @@ Bool_t TGRSIRunInfo::ReadInfoFromFile(TFile* tempf)
          continue;
       }
 
-      TGRSIRunInfo::SetRunInfo(static_cast<TGRSIRunInfo*>(key->ReadObj()));
+      Set(*static_cast<TGRSIRunInfo*>(key->ReadObj()));
       savdir->cd();
       return true;
    }
@@ -84,20 +84,20 @@ void TGRSIRunInfo::Print(Option_t* opt) const
 {
    // Prints the TGRSIRunInfo. Options:
    // a: Print out more details.
-   std::cout<<"Title: "<<fRunTitle<<std::endl;
-   std::cout<<"Comment: "<<fRunComment<<std::endl;
-	time_t tmpStart = static_cast<time_t>(fRunStart);
-	time_t tmpStop  = static_cast<time_t>(fRunStop);
+   std::cout<<"Title: "<<RunTitle()<<std::endl;
+   std::cout<<"Comment: "<<RunComment()<<std::endl;
+	time_t tmpStart = static_cast<time_t>(RunStart());
+	time_t tmpStop  = static_cast<time_t>(RunStop());
 	struct tm runStart = *localtime(const_cast<const time_t*>(&tmpStart));
 	struct tm runStop  = *localtime(const_cast<const time_t*>(&tmpStop));
-	printf("\t\tRunNumber:          %05i\n", fRunNumber);
-	printf("\t\tSubRunNumber:       %03i\n", fSubRunNumber);
-	if(fRunStart != 0 && fRunStop != 0) {
+	printf("\t\tRunNumber:          %05i\n", RunNumber());
+	printf("\t\tSubRunNumber:       %03i\n", SubRunNumber());
+	if(Get().RunStart != 0 && Get().RunStop != 0) {
 		printf("\t\tRunStart:           %s", asctime(&runStart));
 		printf("\t\tRunStop:            %s", asctime(&runStop));
-		printf("\t\tRunLength:          %.0f\n", fRunLength);
+		printf("\t\tRunLength:          %.0f s\n", RunLength());
 	} else {
-		printf("\t\tCombined RunLength: %.0f\n", fRunLength);
+		printf("\t\tCombined RunLength: %.0f s\n", RunLength());
 	}
    if(strchr(opt, 'a') != nullptr) {
       printf("\t\tTIGRESS:            %s\n", Tigress() ? "true" : "false");
@@ -188,85 +188,85 @@ void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum)
       switch(iter->second->GetMnemonic()->System()) {
 			case TMnemonic::ESystem::kTigress:
 				if(!Tigress()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetTigress();
 				break;
 			case TMnemonic::ESystem::kSharc:
 				if(!Sharc()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetSharc();
 				break;
 			case TMnemonic::ESystem::kTriFoil:
 				if(!TriFoil()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetTriFoil();
 				break;
 			case TMnemonic::ESystem::kRF:
 				if(!RF()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetRF();
 				break;
 			case TMnemonic::ESystem::kCSM:
 				if(!CSM()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetCSM();
 				break;
 			case TMnemonic::ESystem::kTip:
 				if(!Tip()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetTip();
 				break;
 			case TMnemonic::ESystem::kGriffin:
 				if(!Griffin()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetGriffin();
 				break;
 			case TMnemonic::ESystem::kSceptar:
 				if(!Sceptar()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetSceptar();
 				break;
 			case TMnemonic::ESystem::kPaces:
 				if(!Paces()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetPaces();
 				break;
 			case TMnemonic::ESystem::kLaBr:
 				if(!Dante()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetDante();
 				break;
 			case TMnemonic::ESystem::kZeroDegree:
 				if(!ZeroDegree()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetZeroDegree();
 				break;
 			case TMnemonic::ESystem::kDescant:
 				if(!Descant()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetDescant();
 				break;
 			case TMnemonic::ESystem::kFipps:
 				if(!Fipps()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetFipps();
 				break;
 			case TMnemonic::ESystem::kGeneric:
 				if(!Generic()) {
-					TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+					Get().fNumberOfTrueSystems++;
 				}
 				SetGeneric();
 				break;
@@ -275,28 +275,28 @@ void TGRSIRunInfo::SetRunInfo(int runnum, int subrunnum)
 				if(!Spice() && !S3()) {
 					if(system.compare("SP") == 0) {
 						if(!Spice()) {
-							TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+							Get().fNumberOfTrueSystems++;
 						}
 						SetSpice();
 						if(!S3()) {
-							TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+							Get().fNumberOfTrueSystems++;
 						}
 						SetS3();
 					}
 				} else if(!Bambino()) {
 					if(system.compare("BA") == 0) {
-						TGRSIRunInfo::Get()->fNumberOfTrueSystems++;
+						Get().fNumberOfTrueSystems++;
 					}
 					SetBambino();
 				}
 		};
 	}
 
-	if(Get()->fRunInfoFile.length() != 0u) {
-		ParseInputData(Get()->fRunInfoFile.c_str());
+	if(Get().fRunInfoFile.length() != 0u) {
+		ParseInputData(Get().fRunInfoFile.c_str());
 	}
 
-   // TGRSIRunInfo::Get()->Print("a");
+   // Get().Print("a");
 }
 
 void TGRSIRunInfo::SetAnalysisTreeBranches(TTree*)
@@ -332,8 +332,8 @@ Bool_t TGRSIRunInfo::ReadInfoFile(const char* filename)
    infile.seekg(0, std::ios::beg);
    infile.read(buffer, length);
 
-   Get()->SetRunInfoFileName(filename);
-   Get()->SetRunInfoFile(buffer);
+   Get().SetRunInfoFileName(filename);
+   Get().SetRunInfoFile(buffer);
 
    return ParseInputData(const_cast<const char*>(buffer));
 }
@@ -382,17 +382,17 @@ Bool_t TGRSIRunInfo::ParseInputData(const char* inputdata, Option_t* opt)
          std::istringstream ss(line);
          double             temp_double;
          ss >> temp_double;
-         Get()->SetHPGeArrayPosition(temp_double);
+         Get().SetHPGeArrayPosition(temp_double);
       } else if(type.compare("DESCANTANCILLARY") == 0) {
          std::istringstream ss(line);
          int                temp_int;
          ss >> temp_int;
-         Get()->SetDescantAncillary(temp_int != 0);
+         Get().SetDescantAncillary(temp_int != 0);
       } else if(type.compare("BADCYCLE") == 0) {
          std::istringstream ss(line);
          int                tmp_int;
          while(!(ss >> tmp_int).fail() ) {
-            Get()->AddBadCycle(tmp_int);
+            Get().AddBadCycle(tmp_int);
          }
       }
    }
@@ -439,10 +439,10 @@ Long64_t TGRSIRunInfo::Merge(TCollection* list)
 void TGRSIRunInfo::PrintBadCycles() const
 {
    std::cout<<"Bad Cycles:\t";
-   if(fBadCycleList.empty()) {
+   if(Get().fBadCycleList.empty()) {
       std::cout<<"NONE"<<std::endl;
    } else {
-      for(int it : fBadCycleList) {
+      for(int it : Get().fBadCycleList) {
          std::cout<<" "<<it;
       }
       std::cout<<std::endl;
@@ -456,23 +456,23 @@ void TGRSIRunInfo::AddBadCycle(int bad_cycle)
         fBadCycleList.push_back(bad_cycle);
         std::sort(fBadCycleList.begin(), fBadCycleList.end());
      }*/
-   if(!(std::binary_search(fBadCycleList.begin(), fBadCycleList.end(), bad_cycle))) {
-      fBadCycleList.push_back(bad_cycle);
-      std::sort(fBadCycleList.begin(), fBadCycleList.end());
+   if(!(std::binary_search(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), bad_cycle))) {
+      Get().fBadCycleList.push_back(bad_cycle);
+      std::sort(Get().fBadCycleList.begin(), Get().fBadCycleList.end());
    }
-   fBadCycleListSize = fBadCycleList.size();
+   Get().fBadCycleListSize = Get().fBadCycleList.size();
 }
 
 void TGRSIRunInfo::RemoveBadCycle(int cycle)
 {
-   fBadCycleList.erase(std::remove(fBadCycleList.begin(), fBadCycleList.end(), cycle), fBadCycleList.end());
-   std::sort(fBadCycleList.begin(), fBadCycleList.end());
-   fBadCycleListSize = fBadCycleList.size();
+   Get().fBadCycleList.erase(std::remove(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), cycle), Get().fBadCycleList.end());
+   std::sort(Get().fBadCycleList.begin(), Get().fBadCycleList.end());
+   Get().fBadCycleListSize = Get().fBadCycleList.size();
 }
 
 bool TGRSIRunInfo::IsBadCycle(int cycle) const
 {
-   return std::binary_search(fBadCycleList.begin(), fBadCycleList.end(), cycle);
+   return std::binary_search(Get().fBadCycleList.begin(), Get().fBadCycleList.end(), cycle);
 }
 
 bool TGRSIRunInfo::WriteToRoot(TFile* fileptr)
@@ -494,7 +494,7 @@ bool TGRSIRunInfo::WriteToRoot(TFile* fileptr)
       printf("No file opened to write to.\n");
       bool2return = false;
    } else {
-      Get()->Write();
+      Get().Write();
    }
 
    printf("Writing TGRSIRunInfo to %s\n", gDirectory->GetFile()->GetName());
@@ -513,7 +513,7 @@ bool TGRSIRunInfo::WriteInfoFile(const std::string& filename)
    if(filename.length() > 0) {
       std::ofstream infoout;
       infoout.open(filename.c_str());
-      std::string infostr = Get()->PrintToString();
+      std::string infostr = Get().PrintToString();
       infoout<<infostr.c_str();
       infoout<<std::endl;
       infoout<<std::endl;
@@ -530,21 +530,33 @@ std::string TGRSIRunInfo::PrintToString(Option_t*)
 {
    std::string buffer;
    buffer.append("//The Array Position in mm.\n");
-   buffer.append(Form("HPGePos: %lf\n", Get()->HPGeArrayPosition()));
+   buffer.append(Form("HPGePos: %lf\n", Get().HPGeArrayPosition()));
    buffer.append("\n\n");
-   if(Get()->DescantAncillary()) {
+   if(Get().DescantAncillary()) {
       buffer.append("//Is DESCANT in Ancillary positions?.\n");
       buffer.append(Form("DescantAncillary: %d\n", 1));
       buffer.append("\n\n");
    }
-   if(!fBadCycleList.empty()) {
+   if(!Get().fBadCycleList.empty()) {
       buffer.append("//A List of bad cycles.\n");
       buffer.append("BadCycle:");
-      for(int& it : fBadCycleList) {
+      for(int& it : Get().fBadCycleList) {
          buffer.append(Form(" %d", it));
       }
       buffer.append("\n\n");
    }
 
    return buffer;
+}
+
+void TGRSIRunInfo::Streamer(TBuffer& R__b)
+{
+	std::cout<<__PRETTY_FUNCTION__<<std::endl;
+	if(R__b.IsReading()) {
+      R__b.ReadClassBuffer(TGRSIRunInfo::Class(),this);
+		std::cout<<"ReadClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<")"<<std::endl;
+	} else {
+      R__b.WriteClassBuffer(TGRSIRunInfo::Class(),this);
+		std::cout<<"WriteClassBuffer("<<Class()->GetName()<<", "<<&(Get())<<"/"<<this<<")"<<std::endl;
+	}
 }

--- a/libraries/TGRSIFormat/TPPG.cxx
+++ b/libraries/TGRSIFormat/TPPG.cxx
@@ -61,14 +61,14 @@ TPPG::TPPG()
 {
    fPPGStatusMap = new PPGMap_t;
    Clear();
-   // std::cout<<"default constructor called on "<<this<<std::endl;
+   //std::cout<<"default constructor called on "<<this<<std::endl;
 }
 
 TPPG::TPPG(const TPPG& rhs) : TObject()
 {
    fPPGStatusMap = new PPGMap_t;
    rhs.Copy(*this);
-   // std::cout<<"copy constructor called on "<<this<<" from "<<&rhs<<std::endl;
+   //std::cout<<"copy constructor called on "<<this<<" from "<<&rhs<<std::endl;
 }
 
 TPPG::~TPPG()
@@ -84,7 +84,7 @@ TPPG::~TPPG()
       }
       delete fPPGStatusMap;
    }
-   // std::cout<<"destructor called on "<<this<<std::endl;
+   //std::cout<<"destructor called on "<<this<<std::endl;
 }
 
 TPPG* TPPG::Get(TFile* fileWithPpg)
@@ -123,6 +123,9 @@ void TPPG::Copy(TObject& obj) const
       }
       static_cast<TPPG&>(obj).fCurrIterator = static_cast<TPPG&>(obj).fPPGStatusMap->begin();
    }
+
+   static_cast<TPPG&>(obj).fOdbPPGCodes     = fOdbPPGCodes;
+   static_cast<TPPG&>(obj).fOdbDurations    = fOdbDurations;
 }
 
 Bool_t TPPG::MapIsEmpty() const
@@ -325,6 +328,8 @@ void TPPG::Clear(Option_t*)
    fCurrIterator = fPPGStatusMap->begin();
    fCycleLength  = 0;
    fNumberOfCycleLengths.clear();
+   fOdbPPGCodes.clear();
+   fOdbDurations.clear();
 }
 
 Int_t TPPG::Write(const char*, Int_t, Int_t) const

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -128,7 +128,7 @@ Bool_t TGRSISelector::Process(Long64_t entry)
       current_file = fChain->GetCurrentFile();
       std::cout<<"Starting to sort: "<<current_file<<std::endl;
       TChannel::ReadCalFromFile(current_file);
-      TGRSIRunInfo::Get()->ReadInfoFromFile(current_file);
+      TGRSIRunInfo::Get().ReadInfoFromFile(current_file);
       //   TChannel::WriteCalFile();
    }
 
@@ -152,13 +152,13 @@ void TGRSISelector::Terminate()
    /// The Terminate() function is the last function to be called during
    /// a query. It always runs on the client, it can be used to present
    /// the results graphically or save the results to file.
-   Int_t runnumber    = TGRSIRunInfo::Get()->RunNumber();
-   Int_t subrunnumber = TGRSIRunInfo::Get()->SubRunNumber();
+   Int_t runnumber    = TGRSIRunInfo::Get().RunNumber();
+   Int_t subrunnumber = TGRSIRunInfo::Get().SubRunNumber();
 
    std::cout<<runnumber<<" "<<subrunnumber<<std::endl;
    TFile outputFile(Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runnumber, subrunnumber), "RECREATE");
    fOutput->Write();
-   TGRSIRunInfo::Get()->Write();
+   TGRSIRunInfo::Get().Write();
    TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(&outputFile);
    outputFile.Close();
 }

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -77,17 +77,19 @@ void TAnalysisOptions::ReadFromFile(const std::string& file)
    if(f != nullptr && f->IsOpen()) {
       TList* list = f->GetListOfKeys();
       TIter  iter(list);
-      std::cout<<R"(Reading analysis options from file ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
       while(TKey* key = static_cast<TKey*>(iter.Next())) {
          if((key == nullptr) || (strcmp(key->GetClassName(), "TAnalysisOptions") != 0)) {
             continue;
          }
 
+			std::cout<<R"(Reading analysis options from file ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
          *this = *static_cast<TAnalysisOptions*>(key->ReadObj());
          f->Close();
          oldDir->cd();
          return;
       }
+		std::cout<<R"(Failed to find analysis options in file ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
+		f->Close();
    } else {
       std::cout<<R"(Failed to open file ")"<<file<<R"(")"<<std::endl;
    }

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -481,7 +481,7 @@ std::string TGRSIOptions::GenerateOutputFilename(const std::vector<std::string>&
    return "temp_from_multi.root";
 }
 
-bool TGRSIOptions::WriteToRoot(TFile* file)
+bool TGRSIOptions::WriteToFile(TFile* file)
 {
    /// Writes options information to the tree
    // Maintain old gDirectory info
@@ -501,6 +501,7 @@ bool TGRSIOptions::WriteToRoot(TFile* file)
       success = false;
    } else {
       Get()->Write();
+		fAnalysisOptions->Write();
    }
 
    printf("Writing TGRSIOptions to %s\n", gDirectory->GetFile()->GetName());

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -198,7 +198,9 @@ void TGRSIOptions::Load(int argc, char** argv)
    }
 
 	// Get name of the program calling this function (removing any path from the name)
-	std::string program = argv[0];
+	std::string program;
+	if(argc > 0) program = argv[0];
+	else program = "unknown";
 	size_t lastSlash = program.rfind('/');
 	if(lastSlash != std::string::npos) {
 		program.erase(0, lastSlash+1);

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -41,6 +41,9 @@ TAnalysisWriteLoop::TAnalysisWriteLoop(std::string name, std::string output_file
    if(output_filename != "/dev/null") {
       // TPreserveGDirectory preserve;
       fOutputFile = new TFile(output_filename.c_str(), "RECREATE");
+		if(fOutputFile == nullptr || !fOutputFile->IsOpen()) {
+			throw std::runtime_error(Form("Failed to open \"%s\"\n", output_filename.c_str()));
+		}
       fEventTree  = new TTree("AnalysisTree", "AnalysisTree");
       if(TGRSIOptions::Get()->SeparateOutOfOrder()) {
          fOutOfOrderTree = new TTree("OutOfOrderTree", "OutOfOrderTree");
@@ -129,7 +132,7 @@ void TAnalysisWriteLoop::Write()
       if(TChannel::GetNumberOfChannels() != 0) {
          TChannel::WriteToRoot();
       }
-      TGRSIRunInfo::Get()->WriteToRoot(fOutputFile);
+      TGRSIRunInfo::Get().WriteToRoot(fOutputFile);
       TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
       TPPG::Get()->Write();
 

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -12,7 +12,6 @@
 #include "TGRSIRunInfo.h"
 #include "TGRSIOptions.h"
 #include "TTreeFillMutex.h"
-#include "TAnalysisOptions.h"
 #include "TSortingDiagnostics.h"
 #include "TDescant.h"
 
@@ -118,7 +117,6 @@ bool TAnalysisWriteLoop::Iteration()
 
 void TAnalysisWriteLoop::Write()
 {
-
    if(fOutputFile != nullptr) {
 		// get all singletons before switching to the output file
 		gROOT->cd();
@@ -143,7 +141,7 @@ void TAnalysisWriteLoop::Write()
 			TChannel::WriteToRoot();
 		}
 		runInfo->WriteToRoot(fOutputFile);
-		options->AnalysisOptions()->WriteToFile(fOutputFile);
+		options->WriteToFile(fOutputFile);
 		ppg->Write();
 
 		if(options->WriteDiagnostics()) {

--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -114,13 +114,13 @@ void TDataLoop::SetRunInfo(uint32_t time)
    node = fOdb->FindPath("/Experiment/Run parameters/Run Title");
    if(node != nullptr) {
       runInfo->SetRunTitle(node->GetText());
-      std::cout<<DBLUE<<"Title: "<<node->GetText()<<RESET_COLOR<<std::endl;
+      std::cout<<"Title: "<<DBLUE<<node->GetText()<<RESET_COLOR<<std::endl;
    }
 
    if(node != nullptr) {
       node = fOdb->FindPath("/Experiment/Run parameters/Comment");
       runInfo->SetRunComment(node->GetText());
-      std::cout<<DBLUE<<"Comment: "<<node->GetText()<<RESET_COLOR<<std::endl;
+      std::cout<<"Comment: "<<DBLUE<<node->GetText()<<RESET_COLOR<<std::endl;
    }
 #endif
 }
@@ -176,10 +176,10 @@ void TDataLoop::SetGRIFFOdb()
          }
          tempChan->SetName(names.at(x).c_str());
          tempChan->SetAddress(address.at(x));
-         tempChan->SetNumber(x, EPriority::kDefault);
+         tempChan->SetNumber(TPriorityValue<int>(x, EPriority::kDefault));
          // printf("temp chan(%s) number set to: %i\n",tempChan->GetChannelName(),tempChan->GetNumber());
 
-         tempChan->SetUserInfoNumber(x, EPriority::kDefault);
+         tempChan->SetUserInfoNumber(TPriorityValue<int>(x, EPriority::kDefault));
          tempChan->AddENGCoefficient(offsets.at(x));
          tempChan->AddENGCoefficient(gains.at(x));
          // TChannel::UpdateChannel(tempChan);
@@ -326,11 +326,10 @@ void TDataLoop::SetTIGOdb()
          tempChan->SetName(names.at(x).c_str());
       }
       tempChan->SetAddress(address.at(x));
-      tempChan->SetNumber(x, EPriority::kDefault);
+      tempChan->SetNumber(TPriorityValue<int>(x, EPriority::kDefault));
       int temp_integration = 0;
       if(type.at(x) != 0) {
-         tempChan->SetTypeName(typemap[type.at(x)].first, EPriority::kDefault);
-         tempChan->SetDigitizerType(typemap[type.at(x)].second.c_str(), EPriority::kDefault);
+         tempChan->SetDigitizerType(TPriorityValue<std::string>(typemap[type.at(x)].second.c_str(), EPriority::kDefault));
          if(strcmp(tempChan->GetDigitizerTypeString(), "Tig64") ==
             0) { // TODO: maybe use enumerations via GetDigitizerType()
             temp_integration = 25;
@@ -338,8 +337,8 @@ void TDataLoop::SetTIGOdb()
             temp_integration = 125;
          }
       }
-      tempChan->SetIntegration(temp_integration, EPriority::kDefault);
-      tempChan->SetUserInfoNumber(x, EPriority::kDefault);
+      tempChan->SetIntegration(TPriorityValue<int>(temp_integration, EPriority::kDefault));
+      tempChan->SetUserInfoNumber(TPriorityValue<int>(x, EPriority::kDefault));
       tempChan->AddENGCoefficient(offsets.at(x));
       tempChan->AddENGCoefficient(gains.at(x));
 

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -45,6 +45,9 @@ TFragWriteLoop::TFragWriteLoop(std::string name, std::string fOutputFilename)
       TThread::Lock();
 
       fOutputFile = new TFile(fOutputFilename.c_str(), "RECREATE");
+		if(fOutputFile == nullptr || !fOutputFile->IsOpen()) {
+			throw std::runtime_error(Form("Failed to open \"%s\"\n", fOutputFilename.c_str()));
+		}
 
       fEventTree    = new TTree("FragmentTree", "FragmentTree");
       fEventAddress = new TFragment;
@@ -143,7 +146,7 @@ void TFragWriteLoop::Write()
          TChannel::WriteToRoot();
       }
 
-      TGRSIRunInfo::Get()->WriteToRoot(fOutputFile);
+      TGRSIRunInfo::Get().WriteToRoot(fOutputFile);
       TGRSIOptions::Get()->AnalysisOptions()->WriteToFile(fOutputFile);
       TPPG::Get()->Write();
 

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -15,7 +15,6 @@
 #include "TGRSIOptions.h"
 #include "TThread.h"
 #include "TTreeFillMutex.h"
-#include "TAnalysisOptions.h"
 #include "TParsingDiagnostics.h"
 
 #include "TBadFragment.h"
@@ -156,7 +155,7 @@ void TFragWriteLoop::Write()
       }
 
       runInfo->WriteToRoot(fOutputFile);
-      options->AnalysisOptions()->WriteToFile(fOutputFile);
+      options->WriteToFile(fOutputFile);
       ppg->Write();
 
       if(options->WriteDiagnostics()) {

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -709,8 +709,8 @@ int TMidasEvent::Process(TDataParser& parser)
 			// end of file ODB
 #ifdef HAS_XML
 			TXMLOdb* odb = new TXMLOdb(GetData(), GetDataSize());
-			TGRSIRunInfo* runInfo = TGRSIRunInfo::Get();
-			TXMLNode*     node     = odb->FindPath("/Runinfo/Stop time binary");
+			TGRSIRunInfo* runInfo = &(TGRSIRunInfo::Get());
+			TXMLNode*     node    = odb->FindPath("/Runinfo/Stop time binary");
 			if(node != nullptr) {
 				std::stringstream str(node->GetText());
 				unsigned int odbTime;

--- a/util/AddToChannelNumber.cxx
+++ b/util/AddToChannelNumber.cxx
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
       TChannel* chan    = it->second;
       auto*     newchan = new TChannel(chan);
       chanlist.push_back(newchan);
-      newchan->SetNumber(newchan->GetNumber() + num_to_add, EPriority::kUser);
+      newchan->SetNumber(TPriorityValue<int>(newchan->GetNumber() + num_to_add, EPriority::kUser));
    }
 
    TChannel::DeleteAllChannels();


### PR DESCRIPTION
- New class TSingleton<T> provides templated base-class for singletons
  that are written to file. The Get() function automatically reads
  from the current file, keeping the information updated even in a
  loop over input files (such as used with grsiproof).
- Adding a new class involves
  - including the TSingleton.h header,
  - changing the base to TSingleton<T>,
  - adding TSingleton<T> as a friend class (might not be needed?),
  - removing old Get() function and static pointer to instance,
  - updating class definition version,
  - adding ```#pragma link C++ class TSingleton<T>-;``` to
    libraries/TGRSIFormat/LinkDef.h,
  - constructors must now call TSingleton<T> constructor instead of
    TObject constructor, and
  - existing static WriteToRoot functions must be modified to be
    in the right directory before using Get() so that writing doesn't
    create a new (empty) instance because the directory has been
    changed.
- TGRSIRunInfo, TPPG, TParsingDiagnostics, and TSortingDiagnostics
  are now based on TSingleton.