### PR TITLE
BGO saving and S3 mnemonic

### DIFF
--- a/include/TS3.h
+++ b/include/TS3.h
@@ -88,13 +88,15 @@ public:
 
    bool PixelsSet() const { return TestBitNumber(ES3Bits::kPixelsSet); }
    void SetPixels(bool flag = true) { SetBitNumber(ES3Bits::kPixelsSet, flag); }
-   void                BuildPixels();
+   void BuildPixels();
 
    static TVector3 GetPosition(int ring, int sector, bool smear = false);
    static TVector3 GetPosition(int ring, int sector, double offsetphi, double offsetZ, bool sectorsdownstream,
                                bool smear = false);
 
    void SetTargetDistance(double dist) { fTargetDistance = dist; }
+   
+   void ResetRingsSectors();
 
    void ClearTransients() override
    {

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -43,6 +43,8 @@ public:
 
    void SetRingNumber(TFragment& frag) { fRing = frag.GetSegment(); }
    void SetSectorNumber(TFragment& frag) { fSector = frag.GetSegment(); }
+   void SetRingNumber() { fRing = GetSegment(); }
+   void SetSectorNumber() { fSector = GetSegment(); }
    void SetSectorNumber(int n) { fSector = n; }
    void SetRingNumber(int n) { fRing = n; }
 

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -360,6 +360,16 @@ TVector3 TS3::GetPosition(int ring, int sector, double offsetphi, double offsetZ
    return TVector3(cos(phi) * radius, sin(phi) * radius, offsetZ);
 }
 
+void TS3::ResetRingsSectors(){
+	for(size_t i = 0; i < fS3SectorHits.size(); ++i) {
+		fS3SectorHits.at(i).SetSectorNumber();
+	}
+	for(size_t i = 0; i < fS3RingHits.size(); ++i) {
+		fS3RingHits.at(i).SetRingNumber();
+	}
+}
+
+
 TGRSIDetectorHit* TS3::GetHit(const int& idx)
 {
    return GetS3Hit(idx);

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -361,6 +361,7 @@ TVector3 TS3::GetPosition(int ring, int sector, double offsetphi, double offsetZ
 }
 
 void TS3::ResetRingsSectors(){
+	// This is necessary if you want mnemonics in a cal file to override those used during frag sort.
 	for(size_t i = 0; i < fS3SectorHits.size(); ++i) {
 		fS3SectorHits.at(i).SetSectorNumber();
 	}

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -107,6 +107,7 @@ void TTigress::Copy(TObject& rhs) const
    static_cast<TTigress&>(rhs).fTigressHits  = fTigressHits;
    static_cast<TTigress&>(rhs).fAddbackHits  = fAddbackHits;
    static_cast<TTigress&>(rhs).fAddbackFrags = fAddbackFrags;
+   static_cast<TTigress&>(rhs).fBgos = fBgos;
    static_cast<TTigress&>(rhs).fTigressBits  = 0;
 }
 


### PR DESCRIPTION
The BGO data for TTigress wasnt being saved to analysis tree.
This may have been intentional as the useful part (setting BGO hit on TTigressHit) is done during event construction.
It's easy enough to comment out the line I've added if someone wants to save that bit of disk space.

Also added a function to reset the S3 ring & sector numbers. Saves unnecessary resort in the case of mnemonic corrections.