### PR TITLE
Fix TPeak segfault when attempting to fit a range with no data

### DIFF
--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -324,6 +324,10 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    } else {
       fitres = fitHist->Fit(this, Form("%sRSN", opt)); // The RS needs to always be there
    }
+   if((int) fitres == -1) {
+      printf("No data error.");
+      return false;
+   }
 
    for(int i = 0; i < GetNpar(); ++i) {
       SetParLimits(i, lowerLimit[i], upperLimit[i]);
@@ -334,6 +338,10 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
       fitres = fitHist->Fit(this, Form("%sRLS", opt)); // The RS needs to always be there
    } else {
       fitres = fitHist->Fit(this, Form("%sRS", opt)); // The RS needs to always be there
+   }
+   if((int) fitres == -1) {
+      printf("No data error.");
+      return false;
    }
 
    // After performing this fit I want to put something here that takes the fit result (good,bad,etc)

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -326,10 +326,7 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    }
    
    // Check fit exited successfully before continuing
-   if((int) fitres == -1) {
-      printf("No data error.");
-      return false;
-   }
+   if(static_cast<int> fitres == -1) return false;
 
    for(int i = 0; i < GetNpar(); ++i) {
       SetParLimits(i, lowerLimit[i], upperLimit[i]);
@@ -343,10 +340,7 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    }
    
    // Check fit exited successfully before continuing
-   if((int) fitres == -1) {
-      printf("No data error.");
-      return false;
-   }
+   if(static_cast<int> fitres == -1) return false;
 
    // After performing this fit I want to put something here that takes the fit result (good,bad,etc)
    // for printing out. RD

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -326,7 +326,7 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    }
    
    // Check fit exited successfully before continuing
-   if(static_cast<int> fitres == -1) return false;
+   if(static_cast<int>(fitres) == -1) return false;
 
    for(int i = 0; i < GetNpar(); ++i) {
       SetParLimits(i, lowerLimit[i], upperLimit[i]);
@@ -340,7 +340,7 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    }
    
    // Check fit exited successfully before continuing
-   if(static_cast<int> fitres == -1) return false;
+   if(static_cast<int>(fitres) == -1) return false;
 
    // After performing this fit I want to put something here that takes the fit result (good,bad,etc)
    // for printing out. RD

--- a/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIFit/TPeak.cxx
@@ -324,6 +324,8 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    } else {
       fitres = fitHist->Fit(this, Form("%sRSN", opt)); // The RS needs to always be there
    }
+   
+   // Check fit exited successfully before continuing
    if((int) fitres == -1) {
       printf("No data error.");
       return false;
@@ -339,6 +341,8 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    } else {
       fitres = fitHist->Fit(this, Form("%sRS", opt)); // The RS needs to always be there
    }
+   
+   // Check fit exited successfully before continuing
    if((int) fitres == -1) {
       printf("No data error.");
       return false;


### PR DESCRIPTION
When I run my GRSISort function, it may attempt to fit a TPeak to an empty range (for some datafiles). Instead of the expected bahavior (return false to indicate a failed fit), the TPeak->Fit function segfaults.
Output:
```
Warning in <ROOT::Fit::FillData>: fit range is outside histogram range, no fit data for xaxis
Warning in <Fit>: Fit data is empty 
Warning in <ROOT::Fit::FillData>: fit range is outside histogram range, no fit data for xaxis
Warning in <Fit>: Fit data is empty 
Error in <TFitResultPtr>: TFitResult is empty - use the fit option S

 *** Break *** segmentation violation
```
Using the fit option S does not fix the issue, the same errors are dislpayed.

I fixed the error by checking if the premininary fits in TPeak->Fit exited successfully (they are the source of the first 4 warnings) before attempting to read the fit parameters (which is the source of the segfault).