### PR TITLE
Added scripts for processing PACES data

### DIFF
--- a/GRSIProof/BasicPACESEventSelector.C
+++ b/GRSIProof/BasicPACESEventSelector.C
@@ -1,0 +1,55 @@
+#define BasicPACESEventSelector_cxx
+// The class definition in BasicPACESEventSelector.h has been generated automatically
+#include "BasicPACESEventSelector.h"
+//DEFS
+std::vector<double> xtmp, ytmp;
+int px=0, py=2000, pbins=4000;	//paces energy bins
+
+void BasicPACESEventSelector::CreateHistograms() {
+
+	fH1["pE"] = new TH1D("pE","PACES summed singles",pbins,px,py);
+	for(int i=0;i<5;++i){
+		fH1[Form("pE_%i",i)] = new TH1D(Form("pE_%i",i),Form("PACES %i singles; Energy (keV); Counts per 0.33 keV",i),pbins,px,py);
+		fH2[Form("pE_NonLinearity%i",i)] = new TH2D(Form("pE_NonLinearity%i",i),Form("PACES %i energy vs residual; Energy (keV); Residual (keV)",i),pbins,px,py,400,-20,20);
+	}
+
+	for(auto it : fH1) {
+		GetOutputList()->Add(it.second);
+	}
+	for(auto it : fH2) {
+		GetOutputList()->Add(it.second);
+	}
+}
+
+void BasicPACESEventSelector::FillHistograms() {
+		int thisrun = TGRSIRunInfo::Get()->RunNumber();
+
+		if(fPaces){
+		for(auto i = 0; i < fPaces->GetMultiplicity(); ++i){
+
+		//PACES numbering system begins at #1 for experiments circa October 2017 and at #0 preceding this time.
+		//An offset is applied in the former case so that all PACES channels fall in the range 0-4.
+		int pdet;
+		if(thisrun<=runRef){
+		   pdet = fPaces->GetPacesHit(i)->GetDetector();
+		} else {
+		   pdet = fPaces->GetPacesHit(i)->GetDetector()-1;
+		}
+		double pEn = fPaces->GetPacesHit(i)->GetEnergy();
+		//non-linearity correction>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		for (int j = 0; j < dp; j++){
+		   xtmp.push_back (x[pdet][j]); ytmp.push_back (y[pdet][j]);
+		}
+
+		TGraph *tmpgraph = new TGraph(xtmp.size(), &(xtmp[0]), &(ytmp[0]));
+		double corr = tmpgraph->Eval(pEn);
+		delete tmpgraph; xtmp.clear(); ytmp.clear();
+
+		double pEnc = pEn-corr;
+		fH1[Form("pE_%i",pdet)]->Fill(pEnc);
+		fH2[Form("pE_NonLinearity%i",pdet)]->Fill(pEn,corr);
+		fH1["pE"]->Fill(pEnc);
+		//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		}
+		}
+}

--- a/GRSIProof/BasicPACESEventSelector.h
+++ b/GRSIProof/BasicPACESEventSelector.h
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////
+
+#ifndef BasicPACESEventSelector_h
+#define BasicPACESEventSelector_h
+
+#include "TChain.h"
+#include "TFile.h"
+
+#include "TH1.h"
+#include "TH2.h"
+#include "THnSparse.h"
+#include "TGraph.h"
+
+// Header file for the classes stored in the TTree if any.
+#include "TPaces.h"
+#include "TGRSISelector.h"
+#include "TGRSIRunInfo.h"
+
+// Fixed size dimensions of array or collections stored in the TTree if any.
+
+class BasicPACESEventSelector : public TGRSISelector {
+
+ public :
+   TPaces      * fPaces;
+
+   //PACES numbering system begins at #1 for experiments circa October 2017 (after run 10097) and #0 preceding this time.
+   int runRef = 10097;
+   //Array of residuals to correct PACES non-linearities.
+   //x = measured energy (keV), y = energy residual (correction, keV), dp = number of data points
+   int dp = 10;
+   double x[5][10]={{50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.}
+		    };
+   double y[5][10]={{0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.}
+		    };
+
+   BasicPACESEventSelector(TTree * /*tree*/ =0) : TGRSISelector(), fPaces(0) {
+      SetOutputPrefix("BasicPACESEvent");
+   }
+   virtual ~BasicPACESEventSelector() { }
+   virtual Int_t   Version() const { return 2; }
+   void CreateHistograms();
+   void FillHistograms();
+   void InitializeBranches(TTree *tree);
+
+   ClassDef(BasicPACESEventSelector,2);
+};
+
+#endif
+
+#ifdef BasicPACESEventSelector_cxx
+void BasicPACESEventSelector::InitializeBranches(TTree* tree) {
+   if (!tree) return;
+   tree->SetBranchAddress("TPaces", &fPaces);
+
+}
+
+#endif // #ifdef BasicPACESEventSelector_cxx

--- a/GRSIProof/PACESAngularCorrelationEventSelector.C
+++ b/GRSIProof/PACESAngularCorrelationEventSelector.C
@@ -1,0 +1,151 @@
+#define PACESAngularCorrelationEventSelector_cxx
+// The class definition in PACESAngularCorrelationEventSelector.h has been generated automatically
+#include "PACESAngularCorrelationEventSelector.h"
+//DEFS
+std::vector<double> xtmp, ytmp;
+double gePrompt = 400.;		//ns
+double geRandom1 = 400.;	//ns
+double geRandom2 = 2000.;	//ns
+int gx=0, gy=500, gbins=500;
+int px=0, py=500, pbins=500;
+int event_mixing_depth = 11;
+int check, lgsize; 
+std::vector<TGriffin> lastgrif;
+
+//TIMING CONDITIONS ::
+bool CoincidenceCondition(TGriffinHit* hit_one, TPacesHit* hit_two){	
+   return TMath::Abs(hit_one->GetTime() - hit_two->GetTime()) < gePrompt; 
+}
+bool BGCondition(TGriffinHit* hit_one, TPacesHit* hit_two){		
+   return (TMath::Abs(hit_one->GetTime() - hit_two->GetTime()) < geRandom2) && (TMath::Abs(hit_one->GetTime() - hit_two->GetTime()) > geRandom1); 
+}
+
+void PACESAngularCorrelationEventSelector::CreateHistograms() {
+
+	//Angle mapping diagostics - very important
+	fH2["PACESAngleMap_Index"] = new TH2D("PACESAngleMap_Index","Correlated #gamma-e^{-} coincidence angle index vs map index; Index; Index",320,0,320,320,0,320);
+	fH2["PACESAngleMap_Bin"] = new TH2D("PACESAngleMap_Bin","Correlated #gamma-e^{-} coincidence angle index vs angle bin; Index; Angle Bin",320,0,320,70,0,70);
+	//Timing
+        fH1["geCFD"] = new TH1D("geCFD","#gamma-PACES time difference; [ns]; Counts per 2 ns",2500,-2500,2500);
+	fH1["geCFDMixed"] = new TH1D("geCFDMixed","#gamma-PACES time difference (Event Mixed); Time difference [ns]; Counts per 1000 ns",1000,0,1000000);
+	//e-y matrices
+
+	//for(int i = 0; i < static_cast<int>(fPACESAngleCombinations.size()); ++i) {
+	for(int i = 0; i < (maxanglebin+1); ++i) {
+           fH2[Form("gammaElectron%i",i)] = new TH2D(Form("gammaElectron%i",i),
+           Form("index%i #gamma-e^{-}, |#Deltat_{#gamma-e^{-}}| < %.1f; GRIFFIN Energy (keV); PACES Energy (keV)",i,gePrompt),gbins,gx,gy,pbins,px,py);
+           fH2[Form("gammaElectronBG%i", i)] = new TH2D(Form("gammaElectronBG%i", i), 
+           Form("index%i #gamma-e^{-}, #Deltat_{#gamma-e^{-}} = %.1f - %.1f; GRIFFIN Energy (keV); PACES Energy (keV)",i,geRandom1,geRandom2),gbins,gx,gy,pbins,px,py);
+           fH2[Form("gammaElectronMixed%d", i)] = new TH2D(Form("gammaElectronMixed%d", i), 
+           Form("index%i: #gamma-#e^{-} (Event Mixed); GRIFFIN Energy (keV); PACES Energy (keV)",i),gbins,gx,gy,pbins,px,py);
+	}
+
+	for(auto it : fH1) {
+		GetOutputList()->Add(it.second);
+	}
+	for(auto it : fH2) {
+		GetOutputList()->Add(it.second);
+	}
+}
+
+void PACESAngularCorrelationEventSelector::FillHistograms() {
+		int thisrun = TGRSIRunInfo::Get()->RunNumber();
+
+		for(auto j = 0; j < fPaces->GetMultiplicity(); ++j){
+
+		//PACES numbering system begins at #1 for experiments circa October 2017 and at #0 preceding this time.
+		//An offset is applied in the former case so that all PACES channels fall in the range 0-4.
+		int pdet;
+		if(thisrun<=runRef){
+		   pdet = fPaces->GetPacesHit(j)->GetDetector();
+		} else {
+		   pdet = fPaces->GetPacesHit(j)->GetDetector()-1;
+		}
+		double ptime = fPaces->GetPacesHit(j)->GetTime();
+		double pEn = fPaces->GetPacesHit(j)->GetEnergy();
+		//non-linearity correction>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		for (int j = 0; j < dp; j++){
+		   xtmp.push_back (x[pdet][j]); ytmp.push_back (y[pdet][j]);
+		}
+
+		TGraph *tmpgraph = new TGraph(xtmp.size(), &(xtmp[0]), &(ytmp[0]));
+		double corr = tmpgraph->Eval(pEn);
+		delete tmpgraph; xtmp.clear(); ytmp.clear();
+
+		double pEnc = pEn-corr;
+		//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		//ELECTRON-GAMMA COINCIDENCE (CORRELATED)
+			for(auto i = 0; i < fGrif->GetMultiplicity(); ++i){
+			int gdet = fGrif->GetGriffinHit(i)->GetDetector();
+			int gcry = fGrif->GetGriffinHit(i)->GetCrystal();
+			double gtime1 = fGrif->GetGriffinHit(i)->GetTime();
+			double gEn = fGrif->GetGriffinHit(i)->GetEnergy();
+
+			fH1["geCFD"]->Fill(gtime1-ptime);
+
+			double combo = (64*pdet)+(((gdet-1)*4)+gcry);
+			auto index = fPACESAngleMap.lower_bound(combo-0.5);
+			int whichindex = int(index->first);
+			int whichbin = int(index->second);
+			fH2["PACESAngleMap_Index"]->Fill(combo, whichindex);		//check correct index is retrieved 
+			fH2["PACESAngleMap_Bin"]->Fill(whichindex, whichbin);		//check this index falls in correct bin
+
+				//for(int k = 0; k < static_cast<int>(fPACESAngleCombinations.size()); ++k){
+				for(int k = 0; k < (maxanglebin+1); ++k){
+				   if(k==whichbin){
+            			      if(CoincidenceCondition(fGrif->GetGriffinHit(i),fPaces->GetPacesHit(j))){
+				      fH2[Form("gammaElectron%i",whichbin)]->Fill(gEn, pEnc);
+				      }
+            			      if(BGCondition(fGrif->GetGriffinHit(i),fPaces->GetPacesHit(j))){
+				      fH2[Form("gammaElectronBG%i",whichbin)]->Fill(gEn, pEnc);
+				      }
+				   break;
+				   }
+				}
+			}//end GrifMult
+
+		//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		//ELECTRON-GAMMA COINCIDENCE (UNCORRELATED/EVENT-MIXED)
+			check = (int)lastgrif.size();
+	     		if(check>=event_mixing_depth) {
+
+			//loop over all 'last' events in the vector, except the most recent event:
+			for(auto lg = 0; lg < (check-1); ++lg) {
+			int multLG = lastgrif.at(lg).GetMultiplicity();
+
+				for(auto i = 0; i < multLG; ++i){
+	        		TGriffinHit *ghit = lastgrif.at(lg).GetGriffinHit(i);
+
+				int gdet = ghit->GetDetector();
+				int gcry = ghit->GetCrystal();
+				double gtime1 = ghit->GetTime();
+				double gEn = ghit->GetEnergy();
+
+				fH1["geCFDMixed"]->Fill(gtime1-ptime);
+
+				double combo = (64*pdet)+(((gdet-1)*4)+gcry);
+				auto index = fPACESAngleMap.lower_bound(combo-0.5);
+				int whichindex = int(index->first);
+				int whichbin = int(index->second);
+			
+					//for(int k = 0; k < static_cast<int>(fPACESAngleCombinations.size()); ++k){
+					for(int k = 0; k < (maxanglebin+1); ++k){
+			  		   if(k==whichbin){
+			      		   fH2[Form("gammaElectronMixed%i",k)]->Fill(gEn, pEnc);
+			      		   break;
+			   		   }
+					}
+				}//end GrifMult
+			}//end LastGrif vector
+			}//end event_mixing_depth restriction
+		//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+		}//end PacesMult
+
+    //Maintain a vector containing the last (N=event_mixing_depth) GRIFFIN physics events
+    lastgrif.push_back(*fGrif);
+    lgsize = (int)lastgrif.size();
+    if(lgsize>event_mixing_depth) {
+      lastgrif.erase(lastgrif.begin());
+    }
+    //END
+}

--- a/GRSIProof/PACESAngularCorrelationEventSelector.h
+++ b/GRSIProof/PACESAngularCorrelationEventSelector.h
@@ -1,0 +1,169 @@
+//////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////
+
+#ifndef PACESAngularCorrelationEventSelector_h
+#define PACESAngularCorrelationEventSelector_h
+
+#include "TChain.h"
+#include "TFile.h"
+
+#include "TH1.h"
+#include "TH2.h"
+#include "THnSparse.h"
+#include "TGraph.h"
+
+// Header file for the classes stored in the TTree if any.
+#include "TGriffin.h"
+#include "TPaces.h"
+#include "TGRSISelector.h"
+#include "TGRSIRunInfo.h"
+
+// Fixed size dimensions of array or collections stored in the TTree if any.
+std::vector<std::pair<double, double>> PACESAngleCombinations(bool group_all);
+
+class PACESAngularCorrelationEventSelector : public TGRSISelector {
+
+ public :
+   TGriffin    * fGrif;
+   TPaces      * fPaces;
+
+   std::vector<std::pair<double, double>> fPACESAngleCombinations;   
+   std::map<double, double> fPACESAngleMap;
+
+   //USER DEFS::
+   //PACES numbering system begins at #1 for experiments circa October 2017 (after run 10097) and #0 preceding this time.
+   int runRef = 10097;
+   int maxanglebin;
+   //Correct PACES non-linearities, x = measured energy (keV), y = energy residual (correction, keV), dp = number of data points
+   int dp = 10;
+   double x[5][10]={{50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.},
+		    {50.,100.,200.,300.,400.,500.,600.,700.,800.,900.}
+		    };
+   double y[5][10]={{0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.},
+		    {0.,0.,0.,0.,0.,0.,0.,0.,0.,0.}
+		    };
+   //END USER DEFS.
+
+   PACESAngularCorrelationEventSelector(TTree * /*tree*/ =0) : TGRSISelector(), fGrif(0), fPaces(0) {
+      SetOutputPrefix("PACESAngularCorrelationEvent");
+
+      fPACESAngleCombinations = PACESAngleCombinations(true);
+
+      //The number of matrices to be made corresponds to the maximum angle bin (not the size of the map), 'maxanglebin'.
+      for(int i = 0; i < static_cast<int>(fPACESAngleCombinations.size()); ++i) {
+         if(fPACESAngleCombinations[i].second>0) maxanglebin = fPACESAngleCombinations[i].second;
+         fPACESAngleMap.insert(std::make_pair(fPACESAngleCombinations[i].first, fPACESAngleCombinations[i].second));
+      }
+   }
+
+   virtual ~PACESAngularCorrelationEventSelector() { }
+   virtual Int_t   Version() const { return 2; }
+   void CreateHistograms();
+   void FillHistograms();
+   void InitializeBranches(TTree *tree);
+
+   ClassDef(PACESAngularCorrelationEventSelector,2);
+};
+
+#endif
+
+#ifdef PACESAngularCorrelationEventSelector_cxx
+void PACESAngularCorrelationEventSelector::InitializeBranches(TTree* tree) {
+   if (!tree) return;
+   tree->SetBranchAddress("TGriffin", &fGrif);
+   tree->SetBranchAddress("TPaces", &fPaces);
+}
+
+#endif // #ifdef PACESAngularCorrelationEventSelector_cxx
+
+//GRIFFIN-PACES angle combinations ::
+//Position 13 in the GRIFFIN array is empty to allow space for PACES LN2 dewar.
+
+std::vector<std::pair<double, double>> PACESAngleCombinations(bool group_all)
+{
+   double dist=110;
+   double angleBin = 0.001;
+   //ALL PACES detectors.
+   const int nga = 31, wa=19;
+   double groupA[nga][wa]={
+			  {251, 180, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {319, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {183, 248, 157, 230, 18, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {90, 297, 17, 250, 318, 181, 302, 158, 85, 60, -1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {229, 182, 249, 316, 61, 225, 162, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,},
+			  {89, 298, 317, 45, 301, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {156, 231, 86, 22, 19, 118, 16, 296, 91, 303, 313, 159, 119, 84, 228, -1,-1,-1,-1},
+			  {312, 153, 226, 63, 224, 163, 161, 234, 62, 88, 299, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {245, 44, 300, 186, 87, 23, 46, 94, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {293, 21, 244, 152, 227, 187, 160, 235, 274, 117, -1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {81, 314, 116, 154, 254, 315, 233, 47, 133, 202, 95, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {270, 292, 20, 65, 134, 221, 201, 246, 166, 275, 185, 93, -1,-1,-1,-1,-1,-1,-1},
+			  {125, 80, 13, 155, 294, 255, 2, 269, 232, 247, 66, 184, 41, 273, -1,-1,-1,-1,-1},
+			  {82, 220, 26, 167, 253, 57, 92, 54, 70, 295, -1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {265, 14, 132, 124, 203, 271, 222, 149, 64, 1, 40, 272, 135, 238, 126, 165, 200, 12, 83},
+			  {3, 27, 122, 252, 309, 268, 197, 67, 42, 58, 138, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {98, 53, 148, 71, 223, 264, 190, 289, 25, 56, 121, 164, 239, 310, 69, 189, 55, 266, -1},
+			  {278, 127, 15, 109, 0, 196, 150, 139, 43, 237, 99, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {288, 24, 129, 123, 206, 217, 308, 59, 198, 279, 170, 52, 97, 68, 137, 267, -1,-1,-1},
+			  {108, 128, 290, 151, 207, 236, 191, 120, 37, 277, 311, -1,-1,-1,-1,-1,-1,-1},
+			  {110, 188, 30, 216, 258, 199, 136, 171, 77, 259, 96, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {76, 291, 218, 145, 130, 210, 169, 205, 36, 276, -1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {111, 31, 38, 102, 131, 285, 29, 204, 8, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {282, 9, 105, 7, 219, 144, 146, 209, 6, 211, 168, 257, 213, -1,-1,-1,-1,-1,-1},
+			  {101, 78, 174, 256, 286, 106, 281, 33, 79, 34, 39, 103, 214, 173, -1,-1,-1,-1,-1},
+			  {284, 75, 28, 260, 283, 104, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {147, 11, 74, 208, 4, 261, 192, 10, 143, 212, -1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {5, 100, 175, 287, 140, 263, 72, 195, 32, 280, 107, -1,-1,-1,-1,-1,-1,-1,-1},
+			  {35, 215, 172, 193, 142, -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {73, 262,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
+			  {141, 194,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1} 
+			  };
+   //SINGLE PACES detector at 90 degrees.
+   const int ngb = 20, wb=3;
+   double groupB[ngb][wb]={{90,85,-1},{86,118,91},{119,84,88},{87,94,-1},{117,81,116},{95,65,93},{125,80,66},{82,92,70},{124,64,126},{83,122,67},{98,71,121},
+                          {69,127,109},{99,123,97},{68,108,120},{110,77,96},{111,102,105},{101,78,106},{79,103,75},{104,74,-1},{100,72,107}};
+   std::vector<std::pair<double, double>> paces_hpge_angle_pair;
+   std::vector<std::pair<double, double>> result;
+
+   //Index between 0-319 identifies PACES-HPGe crystal combination.
+   for (int firstDet = 1; firstDet <= 16; ++firstDet){
+      if(firstDet==13) continue;
+      for (int firstCry = 0; firstCry < 4; ++firstCry){
+	 for (int secondCry = 0; secondCry < 5; ++secondCry){
+	 //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+	    int index = (64*secondCry)+(((firstDet-1)*4)+firstCry);
+	    double ge_angle = TGriffin::GetPosition(firstDet, firstCry, dist).Angle(TPaces::GetPosition(secondCry))*180./TMath::Pi(); 
+	    paces_hpge_angle_pair.push_back(std::make_pair(ge_angle, index));
+	 }
+      }
+   }
+
+   // GROUPING :: Two options are provided. Detector combinations are grouped into pre-determined bins.
+   // If 'group_all' is false, grouping of GRIFFIN-PACES angles is restricted to a SINGLE PACES detector (@phi=90 degrees). If true, grouping is performed for all PACES detectors. 
+   // For new or modified angle combinations (e.g. to adjust relative statistical weighting), run "GRIFFIN_PACES_AngleCalc.C" to find an appropriate grouping.
+
+   if(group_all){
+      for(int i=0;i<int(nga);++i){
+         for(int j=0;j<int(wa);++j){
+	    if(groupA[i][j]==-1) continue;   
+	    result.push_back(std::make_pair(groupA[i][j], double(i)));
+         }
+      }   
+   return result;
+
+   } else if(!group_all){
+      for(int i=0;i<int(ngb);++i){
+         for(int j=0;j<int(wb);++j){
+	    if(groupB[i][j]==-1) continue;   
+	    result.push_back(std::make_pair(groupB[i][j], double(i)));
+         }
+      }   
+   return result;
+   }
+}

--- a/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
+++ b/libraries/TGRSIAnalysis/TPaces/TPaces.cxx
@@ -90,9 +90,28 @@ TPacesHit* TPaces::GetPacesHit(const int& i)
 	return nullptr;
 }
 
-TVector3 TPaces::GetPosition(int)
+TVector3 TPaces::GetPosition(int DetNbr)
 {
 	// Gets the position vector for a crystal specified by DetNbr
-	// Does not currently contain any positons.
-	return TVector3(0, 0, 1);
+	// Angles measured 12 December 2017 (Garnsworthy/Bowry)
+	double PACESTHETA[5] = {120.1780, 120.8275, 119.7421, 120.2992, 120.1934};
+	double PACESPHI[5] = {21.0000, 94.0000, 166.0000, 237.0000, 313.0000};
+
+	TVector3 pacesPosition [5] = {
+		TVector3(TMath::Sin(TMath::DegToRad()*PACESTHETA[0]) *TMath::Cos(TMath::DegToRad()*PACESPHI [0] ), TMath::Sin(TMath::DegToRad()*PACESTHETA[0]) *TMath::Sin(TMath::DegToRad()*PACESPHI [0] ), 
+		TMath::Cos(TMath::DegToRad()*PACESTHETA[0])), 
+		
+		TVector3(TMath::Sin(TMath::DegToRad()*PACESTHETA[1]) *TMath::Cos(TMath::DegToRad()*PACESPHI [1] ), TMath::Sin(TMath::DegToRad()*PACESTHETA[1]) *TMath::Sin(TMath::DegToRad()*PACESPHI [1] ), 
+		TMath::Cos(TMath::DegToRad()*PACESTHETA[1])), 
+		
+		TVector3(TMath::Sin(TMath::DegToRad()*PACESTHETA[2]) *TMath::Cos(TMath::DegToRad()*PACESPHI [2] ), TMath::Sin(TMath::DegToRad()*PACESTHETA[2]) *TMath::Sin(TMath::DegToRad()*PACESPHI [2] ), 
+		TMath::Cos(TMath::DegToRad()*PACESTHETA[2])), 
+		
+		TVector3(TMath::Sin(TMath::DegToRad()*PACESTHETA[3]) *TMath::Cos(TMath::DegToRad()*PACESPHI [3] ), TMath::Sin(TMath::DegToRad()*PACESTHETA[3]) *TMath::Sin(TMath::DegToRad()*PACESPHI [3] ), 
+		TMath::Cos(TMath::DegToRad()*PACESTHETA[3])), 
+		
+		TVector3(TMath::Sin(TMath::DegToRad()*PACESTHETA[4]) *TMath::Cos(TMath::DegToRad()*PACESPHI [4] ), TMath::Sin(TMath::DegToRad()*PACESTHETA[4]) *TMath::Sin(TMath::DegToRad()*PACESPHI [4] ), 
+		TMath::Cos(TMath::DegToRad()*PACESTHETA[4])) 	
+	};
+	return pacesPosition[DetNbr];
 }

--- a/scripts/GRIFFIN_PACES_AngleCalc.C
+++ b/scripts/GRIFFIN_PACES_AngleCalc.C
@@ -1,0 +1,57 @@
+void GRIFFIN_PACES_AngleCalc(){
+	printf("Calculates expected electron-gamma coincidence angles\n");
+	printf("_____________________________________________________\n");
+	//USER defs::
+	double dist = 110;	//HPGe distance (mm)
+	double angleBin=5.0;	//bin width, degrees
+	int pstart=0,pend=5;	//range of PACES detectors to include (0-5 for all).
+        bool table = true;	//FILE FORMART:: true = table output, false = angle indexes ONLY.
+	//END USER defs.
+   	std::vector<std::pair<double, int>> eg, storeA;
+	double a, ap, x=0, y=0;
+	int b, gr=0;
+	const char* name = "GRIFFIN_PACES_AngleGroups.dat";
+        FILE *ascii = fopen(name,"w");
+
+   	for (int gd = 1; gd <= 16; ++gd){
+		if(gd==13) continue;
+      		for (int gc = 0; gc < 4; ++gc){
+			for (int p = pstart; p < pend; ++p){
+				//index assigned 0-319 based on HPGe and PACES det#
+				double angle = TGriffin::GetPosition(gd, gc, dist).Angle(TPaces::GetPosition(p))*180./TMath::Pi();
+				eg.push_back(std::make_pair(angle, ((64*p)+(((gd-1)*4)+gc))));
+	 		}
+      		}
+   	}
+	
+	int size = int(eg.size());
+	printf("Found %i individual PACES-GRIFFIN angles (including %i PACES detector(s))\n",size,(size/60));
+	//'sort' will default to sorting by the key (angle in degrees) which is OK here.
+   	std::sort(eg.begin(), eg.end());
+
+	//GROUPING
+	fprintf(ascii,"Group\tAngle\tIndex\n");
+	fprintf(ascii,"-----\tDegr.\t-----\n");
+        if(size!=0) ap=eg[0].first;
+
+	for(int i=0;i<size;++i){
+	   a=eg[i].first; b=eg[i].second;
+	   if(a<=(ap+angleBin)){
+	      x++;
+	      storeA.push_back(std::make_pair(a, b));
+	      if(table) fprintf(ascii,"%i\t%.2f\t%i\n",gr,a,b);
+	      if(!table) fprintf(ascii,"%i, ",b);
+
+	   } else if(a>(ap+angleBin)){
+	      y++; gr++; storeA.clear();
+	      storeA.push_back(std::make_pair(a, b));
+	      if(table) fprintf(ascii,"%i\t%.2f\t%i\n",gr,a,b); //def.
+	      if(!table){ fprintf(ascii,"\n"); fprintf(ascii,"%i, ",b); }
+	   }
+	   ap = storeA[0].first;
+	   //printf("%.0f/%.0f::%.2f/%.2f\n",x,y,a,ap);	//diagnostic
+	   x=y=0;
+	}
+	printf("Found %i PACES-GRIFFIN angle groups. For suggested grouping see ./%s\n",gr+1,name);
+	fclose(ascii);
+}


### PR DESCRIPTION
Added to GRSIProof/ : a basic script ("BasicPACES") and a more complex version ("PACESAngularCorrelation") for gamma-electron angular correlations. Both include functions for energy non-linearity corrections in PACES. "GRIFFIN_PACES_Angle_Calc" can be used to generate GRIFFIN-PACES angle groups for insertion into the PACESAngularCorrelation header file. Theta and Phi measurements for PACES were also updated to the current values in the GetPosition() function of TPaces.