### PR TITLE
Tigress B core case mistake

### DIFF
--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -23,12 +23,17 @@ public:
    Short_t GetSector() const { return fSector; }
    Bool_t  GetIsDownstream() const { return fIsDownstream; }
    Int_t   GetArrayPosition() const {
-	   if(GetChannel()){
+	   if(GetChannel()!= nullptr){
 		   return GetChannel()->GetMnemonic()->ArrayPosition(); 
 	   }
 	   return -1;
-}
-   std::string GetDistanceStr() const { if(GetChannel())return GetChannel()->GetMnemonic()->ArraySubPositionString(); return "0";}
+   }
+   std::string GetDistanceStr() const {
+	   if(GetChannel()!= nullptr){
+		   return GetChannel()->GetMnemonic()->ArraySubPositionString();
+	   }
+	   return "0";
+   }
    
 
    Double_t fTimeFit{0.};

--- a/include/TS3Hit.h
+++ b/include/TS3Hit.h
@@ -22,8 +22,13 @@ public:
    Short_t GetRing() const { return fRing; }
    Short_t GetSector() const { return fSector; }
    Bool_t  GetIsDownstream() const { return fIsDownstream; }
-   Int_t   GetArrayPosition() const { return GetChannel()->GetMnemonic()->ArrayPosition(); }
-   std::string GetDistanceStr() const { return GetChannel()->GetMnemonic()->ArraySubPositionString(); }
+   Int_t   GetArrayPosition() const {
+	   if(GetChannel()){
+		   return GetChannel()->GetMnemonic()->ArrayPosition(); 
+	   }
+	   return -1;
+}
+   std::string GetDistanceStr() const { if(GetChannel())return GetChannel()->GetMnemonic()->ArraySubPositionString(); return "0";}
    
 
    Double_t fTimeFit{0.};

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -235,12 +235,9 @@ void TTigress::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
       return;
    }
 
-   // if((chan->GetMnemonic()->subsystem.compare(0,1,"G")==0) &&
    if((chan->GetMnemonic()->SubSystem() == TMnemonic::EMnemonic::kG) &&
       (chan->GetSegmentNumber() == 0 || chan->GetSegmentNumber() == 9)) { // it is a core
-      // if(frag->Charge.size() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a
-      // good energy and time (cfd or led).
-      //  return;
+
       TTigressHit corehit; //(*frag);
       // loop over existing hits to see if this core was already created by a previously found segment
       // of course this means if we have a core in "coincidence" with itself we will overwrite the first hit
@@ -248,19 +245,18 @@ void TTigress::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
          TTigressHit* hit = GetTigressHit(i);
          if((hit->GetDetector() == chan->GetDetectorNumber()) &&
             (hit->GetCrystal() == chan->GetCrystalNumber())) { // we have a match;
-            // if(hit->Charge() == 0 || (frag->Cfd.size() == 0 && frag->Led.size() == 0))   // sanity check, it has a
-            // good energy and time (cfd or led).
-            // if(chan->GetMnemonic()->outputsensor.compare(0,1,"b")==0) {
+
+	    // B cores will not replace A cores,
+	    // but they will replace no-core hits created if segments are processed first.
             if(chan->GetMnemonic()->OutputSensor() == TMnemonic::EMnemonic::kB) {
-               if(hit->GetName()[9] == 'a') {
-                  return;
-               }
-               hit->CopyFragment(*frag);
-               if(TestGlobalBit(ETigressGlobalBits::kSetCoreWave)) {
-                  frag->CopyWave(*hit);
-               }
-               return;
+		 TChannel* hitchan = hit->GetChannel();
+		 if(hitchan != nullptr) {  
+			if(hitchan->GetMnemonic()->OutputSensor() == TMnemonic::EMnemonic::kA) {
+				return;
+			}
+		 }
             }
+            
             hit->CopyFragment(*frag);
             if(TestGlobalBit(ETigressGlobalBits::kSetCoreWave)) {
                frag->CopyWave(*hit);


### PR DESCRIPTION
A line in the tigress code for checking B vs A core had a case issue.
`if(hit->GetName()[9] == 'a')`
It seems at some point in the past a/b were lowercase, and this line got missed during iterations.
The result was that ~10% of data replaced the A core with B core, which is a problem as often the B core is un-calibrated/set to 0.
I've checked with some recent 2017 erbium data and @jhenderson88 looked at some older Mg data. We both found this had cause a ~10% data loss, which does not appear to be energy correlated.
This could still be a problem for other TIGRESS analysis as presumably there may be some correlations with combinations of events in the DAQ as to which core A or B is processed first.
I have updated the section to centralise things to the mnemonic class
`if(hitchan->GetMnemonic()->OutputSensor() == TMnemonic::EMnemonic::kA)`
this should be done everywhere possible to abolish such manual checks and avoid problems in future. I don't think this is a problem in GRIFFIN as A & B are treated differently?