### PR TITLE
Added TSuppressed class and derived TGriffin from it

### DIFF
--- a/include/TAnalysisOptions.h
+++ b/include/TAnalysisOptions.h
@@ -35,6 +35,8 @@ public:
    // sorting options
    inline void SetBuildWindow(const long int t_bw) { fBuildWindow = t_bw; }
    inline void SetAddbackWindow(const double t_abw) { fAddbackWindow = t_abw; }
+   inline void SetSuppressionWindow(const double t_sup) { fSuppressionWindow = t_sup; }
+   inline void SetSuppressionEnergy(const double e_sup) { fSuppressionEnergy = e_sup; }
 
    inline void SetWaveformFitting(const bool flag) { fWaveformFitting = flag; }
    inline bool                               IsWaveformFitting() { return fWaveformFitting; }
@@ -51,6 +53,16 @@ public:
       return fAddbackWindow;
    }
 
+   inline double   SuppressionWindow()
+   {
+      return fSuppressionWindow;
+   }
+
+   inline double   SuppressionEnergy()
+   {
+      return fSuppressionEnergy;
+   }
+
    bool StaticWindow() const { return fStaticWindow; }
 
 private:
@@ -58,13 +70,15 @@ private:
    long int
         fBuildWindow;   ///< if building with a window(GRIFFIN) this is the size of the window. (default = 2us (200))
    int  fAddbackWindow; ///< Time used to build Addback-Ge-Events for TIGRESS/GRIFFIN.   (default = 150 ns (150))
+   double fSuppressionWindow; ///< Time used to suppress Ge-Events.   (default = 150 ns (150))
+   double fSuppressionEnergy; ///< Minimum energy used to suppress Ge-Events.   (default = 0 keV)
    bool fIsCorrectingCrossTalk; ///< True if we are correcting for cross-talk in GRIFFIN at analysis-level
    bool fWaveformFitting;       ///< If true, waveform fitting with SFU algorithm will be performed
    bool fStaticWindow;          ///< Flag to use static window (default moving)
 
    /// \cond CLASSIMP
-   ClassDefOverride(TAnalysisOptions, 2); ///< Class for storing options in GRSISort
-                                          /// \endcond
+   ClassDefOverride(TAnalysisOptions, 3); ///< Class for storing options in GRSISort
+	/// \endcond
 };
 /*! @} */
 #endif /* TANALYSISOPTIONS_H */

--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -30,6 +30,7 @@ public:
    TBgoHit* GetBgoHit(const Int_t& i);
    TGRSIDetectorHit* GetHit(const Int_t& idx = 0) { return GetBgoHit(idx); }
    Short_t   GetMultiplicity() const { return fBgoHits.size(); }
+	const std::vector<TBgoHit>& GetHitVector() const { return fBgoHits; }
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
 #ifndef __CINT__

--- a/include/TFippsHit.h
+++ b/include/TFippsHit.h
@@ -35,7 +35,7 @@ public:
    // returns a number 1-64 ( 1 = Detector 1 blue;  64 =  Detector 16 white; )
 
    static bool CompareEnergy(const TFippsHit*, const TFippsHit*); //!<!
-   void        Add(const TFippsHit*);                             //!<!
+   void        Add(const TGRSIDetectorHit*) override;             //!<!
 
 public:
    void Clear(Option_t* opt = "") override;       //!<!

--- a/include/TGRSIDetectorHit.h
+++ b/include/TGRSIDetectorHit.h
@@ -177,6 +177,7 @@ public:
 
    static TVector3* GetBeamDirection() { return &fBeamDirection; }
 
+   virtual void Add(const TGRSIDetectorHit*) {} //!<!
 private:
    //     virtual TVector3 GetChannelPosition(Double_t dist) const { AbstractMethod("GetChannelPosition"); return
    //     TVector3(0., 0., 0.); }

--- a/include/TGriffin.h
+++ b/include/TGriffin.h
@@ -16,22 +16,22 @@
 
 #include "Globals.h"
 #include "TGriffinHit.h"
-#include "TGRSIDetector.h"
+#include "TSuppressed.h"
 #include "TGRSIRunInfo.h"
 #include "TTransientBits.h"
 #include "TSpline.h"
 
-class TGriffin : public TGRSIDetector {
+class TGriffin : public TSuppressed {
 public:
    enum class EGriffinBits {
-      kIsLowGainAddbackSet    = 1<<0,
-      kIsHighGainAddbackSet   = 1<<1,
-      kIsLowGainCrossTalkSet  = 1<<2,
-      kIsHighGainCrossTalkSet = 1<<3,
-      kBit4                   = 1<<4,
-      kBit5                   = 1<<5,
-      kBit6                   = 1<<6,
-      kBit7                   = 1<<7
+      kIsLowGainAddbackSet            = 1<<0,
+      kIsHighGainAddbackSet           = 1<<1,
+      kIsLowGainCrossTalkSet          = 1<<2,
+      kIsHighGainCrossTalkSet         = 1<<3,
+      kIsLowGainSuppressed            = 1<<4,
+      kIsHighGainSuppressed           = 1<<5,
+      kIsLowGainSuppressedAddbackSet  = 1<<6,
+      kIsHighGainSuppressedAddbackSet = 1<<7
    };
    enum class EGainBits { kLowGain, kHighGain };
 
@@ -46,7 +46,7 @@ public:
    TGRSIDetectorHit* GetHit(const Int_t& idx = 0) override;
    Short_t GetLowGainMultiplicity() const { return fGriffinLowGainHits.size(); }
    Short_t GetHighGainMultiplicity() const { return fGriffinHighGainHits.size(); }
-   Short_t   GetMultiplicity() const override { return GetMultiplicity(GetDefaultGainType()); }
+   Short_t GetMultiplicity() const override { return GetMultiplicity(GetDefaultGainType()); }
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double dist = 110.0); //!<!
    static const char* GetColorFromNumber(Int_t number);
@@ -68,16 +68,18 @@ public:
    TGriffin& operator=(const TGriffin&); //!<!
 
 #if !defined(__CINT__) && !defined(__CLING__)
-   void SetAddbackCriterion(std::function<bool(TGriffinHit&, TGriffinHit&)> criterion)
+   void SetAddbackCriterion(std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> criterion)
    {
       fAddbackCriterion = std::move(criterion);
    }
-   std::function<bool(TGriffinHit&, TGriffinHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
+   std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
+
+   bool AddbackCriterion(const TGRSIDetectorHit& hit1, const TGRSIDetectorHit& hit2) override { return fAddbackCriterion(hit1, hit2); }
 #endif
 
-   Int_t        GetAddbackLowGainMultiplicity();
-   Int_t        GetAddbackHighGainMultiplicity();
-   Int_t        GetAddbackMultiplicity() { return GetAddbackMultiplicity(GetDefaultGainType()); }
+   Short_t      GetAddbackLowGainMultiplicity();
+   Short_t      GetAddbackHighGainMultiplicity();
+   Short_t      GetAddbackMultiplicity() { return GetAddbackMultiplicity(GetDefaultGainType()); }
    TGriffinHit* GetAddbackLowGainHit(const int& i);
    TGriffinHit* GetAddbackHighGainHit(const int& i);
    TGriffinHit* GetAddbackHit(const int& i) { return GetAddbackHit(i, GetDefaultGainType()); }
@@ -89,10 +91,47 @@ public:
    UShort_t GetNLowGainAddbackFrags(const size_t& idx);
    UShort_t GetNAddbackFrags(const size_t& idx) { return GetNAddbackFrags(idx, GetDefaultGainType()); }
 
+#if !defined(__CINT__) && !defined(__CLING__)
+   void SetSuppressionCriterion(std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> criterion)
+   {
+      fSuppressionCriterion = std::move(criterion);
+   }
+   std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> GetSuppressionCriterion() const { return fSuppressionCriterion; }
+
+   bool SuppressionCriterion(const TGRSIDetectorHit& hit, const TBgoHit& bgoHit) override { return fSuppressionCriterion(hit, bgoHit); }
+#endif
+
+   TGriffinHit* GetSuppressedLowGainHit(const int& i);                                              //!<!
+   TGriffinHit* GetSuppressedHighGainHit(const int& i);                                             //!<!
+   TGriffinHit* GetSuppressedHit(const Int_t& i) { return GetSuppressedHit(i, GetDefaultGainType()); } //!<!
+   Short_t GetSuppressedLowGainMultiplicity(const TBgo* bgo);
+   Short_t GetSuppressedHighGainMultiplicity(const TBgo* bgo);
+   Short_t GetSuppressedMultiplicity(const TBgo* bgo) { return GetSuppressedMultiplicity(bgo, GetDefaultGainType()); }
+   bool IsSuppressed(const EGainBits& gain_type) const;
+   void     ResetLowGainSuppressed();                                 //!<!
+   void     ResetHighGainSuppressed();                                //!<!
+   void     ResetSuppressed() { ResetSuppressed(GetDefaultGainType()); } //!<!
+
+   Short_t      GetSuppressedAddbackLowGainMultiplicity(const TBgo* bgo);
+   Short_t      GetSuppressedAddbackHighGainMultiplicity(const TBgo* bgo);
+   Short_t      GetSuppressedAddbackMultiplicity(const TBgo* bgo) { return GetSuppressedAddbackMultiplicity(bgo, GetDefaultGainType()); }
+   TGriffinHit* GetSuppressedAddbackLowGainHit(const int& i);
+   TGriffinHit* GetSuppressedAddbackHighGainHit(const int& i);
+   TGriffinHit* GetSuppressedAddbackHit(const int& i) { return GetSuppressedAddbackHit(i, GetDefaultGainType()); }
+   bool IsSuppressedAddbackSet(const EGainBits& gain_type) const;
+   void     ResetLowGainSuppressedAddback();                                 //!<!
+   void     ResetHighGainSuppressedAddback();                                //!<!
+   void     ResetSuppressedAddback() { ResetSuppressedAddback(GetDefaultGainType()); } //!<!
+   UShort_t GetNHighGainSuppressedAddbackFrags(const size_t& idx);
+   UShort_t GetNLowGainSuppressedAddbackFrags(const size_t& idx);
+   UShort_t GetNSuppressedAddbackFrags(const size_t& idx) { return GetNSuppressedAddbackFrags(idx, GetDefaultGainType()); }
+
 private:
 #if !defined(__CINT__) && !defined(__CLING__)
-   static std::function<bool(TGriffinHit&, TGriffinHit&)> fAddbackCriterion;
+   static std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> fAddbackCriterion;
+   static std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> fSuppressionCriterion;
 #endif
+
    std::vector<TGriffinHit> fGriffinLowGainHits;  //  The set of crystal hits
    std::vector<TGriffinHit> fGriffinHighGainHits; //  The set of crystal hits
 
@@ -108,6 +147,14 @@ private:
    mutable std::vector<TGriffinHit> fAddbackHighGainHits; //!<! Used to create addback hits on the fly
    mutable std::vector<UShort_t> fAddbackLowGainFrags;  //!<! Number of crystals involved in creating in the addback hit
    mutable std::vector<UShort_t> fAddbackHighGainFrags; //!<! Number of crystals involved in creating in the addback hit
+
+   std::vector<TGriffinHit> fSuppressedLowGainHits;  //  The set of suppressed crystal hits
+   std::vector<TGriffinHit> fSuppressedHighGainHits; //  The set of suppressed crystal hits
+
+   mutable std::vector<TGriffinHit> fSuppressedAddbackLowGainHits;  //!<! Used to create suppressed addback hits on the fly
+   mutable std::vector<TGriffinHit> fSuppressedAddbackHighGainHits; //!<! Used to create suppressed addback hits on the fly
+   mutable std::vector<UShort_t> fSuppressedAddbackLowGainFrags;  //!<! Number of crystals involved in creating in the suppressed addback hit
+   mutable std::vector<UShort_t> fSuppressedAddbackHighGainFrags; //!<! Number of crystals involved in creating in the suppressed addback hit
 
    static EGainBits fDefaultGainType;
 
@@ -145,16 +192,30 @@ public:
 
 private:
    // This is where the general untouchable functions live.
-   std::vector<TGriffinHit>* GetHitVector(const EGainBits& gain_type);      //!<!
-   std::vector<TGriffinHit>* GetAddbackVector(const EGainBits& gain_type);  //!<!
-   std::vector<UShort_t>* GetAddbackFragVector(const EGainBits& gain_type); //!<!
+   std::vector<TGriffinHit>& GetHitVector(const EGainBits& gain_type);      //!<!
+   std::vector<TGriffinHit>& GetAddbackVector(const EGainBits& gain_type);  //!<!
+   std::vector<UShort_t>& GetAddbackFragVector(const EGainBits& gain_type); //!<!
    TGriffinHit* GetGriffinHit(const Int_t& i, const EGainBits& gain_type);  //!<!
-   Int_t GetMultiplicity(const EGainBits& gain_type) const;
+   Short_t GetMultiplicity(const EGainBits& gain_type) const;
    TGriffinHit* GetAddbackHit(const int& i, const EGainBits& gain_type);
-   Int_t GetAddbackMultiplicity(const EGainBits& gain_type);
+   Short_t GetAddbackMultiplicity(const EGainBits& gain_type);
    void SetAddback(const EGainBits& gain_type, bool flag = true) const;
    void ResetAddback(const EGainBits& gain_type); //!<!
    UShort_t GetNAddbackFrags(const size_t& idx, const EGainBits& gain_type);
+
+   std::vector<TGriffinHit>& GetSuppressedVector(const EGainBits& gain_type);      //!<!
+   std::vector<TGriffinHit>& GetSuppressedAddbackVector(const EGainBits& gain_type);  //!<!
+   std::vector<UShort_t>& GetSuppressedAddbackFragVector(const EGainBits& gain_type); //!<!
+   TGriffinHit* GetSuppressedHit(const Int_t& i, const EGainBits& gain_type);  //!<!
+   Short_t GetSuppressedMultiplicity(const TBgo* bgo, const EGainBits& gain_type);
+   void SetSuppressed(const EGainBits& gain_type, bool flag = true) const;
+   void ResetSuppressed(const EGainBits& gain_type); //!<!
+   TGriffinHit* GetSuppressedAddbackHit(const int& i, const EGainBits& gain_type);
+   Short_t GetSuppressedAddbackMultiplicity(const TBgo* bgo, const EGainBits& gain_type);
+   void SetSuppressedAddback(const EGainBits& gain_type, bool flag = true) const;
+   void ResetSuppressedAddback(const EGainBits& gain_type); //!<!
+   UShort_t GetNSuppressedAddbackFrags(const size_t& idx, const EGainBits& gain_type);
+
    void FixCrossTalk(const EGainBits& gain_type);
    void SetCrossTalk(const EGainBits& gain_type, bool flag = true) const;
 

--- a/include/TGriffinHit.h
+++ b/include/TGriffinHit.h
@@ -76,8 +76,7 @@ public:
    bool InFilter(Int_t); //!<!
 
    static bool CompareEnergy(const TGriffinHit*, const TGriffinHit*); //!<!
-   void        Add(const TGriffinHit*);                               //!<!
-                                                                      // Bool_t BremSuppressed(TSceptarHit*);
+   void        Add(const TGRSIDetectorHit*) override;                      //!<!
 
 public:
    void Clear(Option_t* opt = "") override;       //!<!

--- a/include/TPeak.h
+++ b/include/TPeak.h
@@ -16,8 +16,6 @@
 #include "TGRSIFunctions.h"
 #include "TGRSIFit.h"
 
-using namespace TGRSIFunctions;
-
 /////////////////////////////////////////////////////////////////
 ///
 /// \class TPeak

--- a/include/TSuppressed.h
+++ b/include/TSuppressed.h
@@ -1,0 +1,47 @@
+#ifndef TSUPPRESSED_H
+#define TSUPPRESSED_H
+
+#include "TGRSIDetector.h"
+#include "TGRSIDetectorHit.h"
+#include "TBgo.h"
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TSuppressed
+///
+/// This is an abstract class that adds basic functionality for
+/// Compton suppressed detectors like GRIFFIN.
+///
+/////////////////////////////////////////////////////////////////
+
+class TSuppressed : public TGRSIDetector {
+public:
+	TSuppressed() {}
+	~TSuppressed() {}
+
+#if !defined(__CINT__) && !defined(__CLING__)
+	void SetAddbackCriterion(std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> criterion) { fAddbackCriterion = criterion; }
+	std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
+	void SetSuppressionCriterion(std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> criterion) { fSuppressionCriterion = criterion; }
+	std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> GetSuppressionCriterion() const { return fSuppressionCriterion; }
+#endif
+private:
+	void CreateAddback(const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments);
+	void CreateSuppressed(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& suppressedHits);
+	void CreateSuppressedAddback(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments);
+
+#if !defined(__CINT__) && !defined(__CLING__)
+	static std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> fAddbackCriterion;
+	static std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> fSuppressionCriterion;
+#endif
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TSuppressed, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TSuppressed.h
+++ b/include/TSuppressed.h
@@ -20,28 +20,109 @@
 
 class TSuppressed : public TGRSIDetector {
 public:
-	TSuppressed() {}
+	TSuppressed() : TGRSIDetector() {}
 	~TSuppressed() {}
 
-#if !defined(__CINT__) && !defined(__CLING__)
-	void SetAddbackCriterion(std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> criterion) { fAddbackCriterion = criterion; }
-	std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> GetAddbackCriterion() const { return fAddbackCriterion; }
-	void SetSuppressionCriterion(std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> criterion) { fSuppressionCriterion = criterion; }
-	std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> GetSuppressionCriterion() const { return fSuppressionCriterion; }
-#endif
-private:
-	void CreateAddback(const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments);
-	void CreateSuppressed(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& suppressedHits);
-	void CreateSuppressedAddback(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments);
+	virtual bool AddbackCriterion(const TGRSIDetectorHit&, const TGRSIDetectorHit&) { return false; }
+	virtual bool SuppressionCriterion(const TGRSIDetectorHit&, const TBgoHit&) { return false; }
 
-#if !defined(__CINT__) && !defined(__CLING__)
-	static std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> fAddbackCriterion;
-	static std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> fSuppressionCriterion;
-#endif
+   void Copy(TObject&) const override;            //!<!
+   void Clear(Option_t* opt = "all") override;    //!<!
+   
+protected:
+	template<class T>
+	void CreateAddback(const std::vector<T>& hits, std::vector<T>& addbacks, std::vector<UShort_t>& nofFragments)
+	{
+		/// This funxtion always(!) re-creates the vectors of addback hits and number of fragments per addback hit based on the provided vector of hits
+		addbacks.clear();
+		nofFragments.clear();
+		size_t j;
+		for(auto detHit : hits) {
+			TGRSIDetectorHit& hit = static_cast<TGRSIDetectorHit&>(detHit);
+			//check for each existing addback hit if this hit should be added to it
+			for(j = 0; j < addbacks.size(); ++j) {
+				if(AddbackCriterion(addbacks[j], hit)) {
+					addbacks[j].Add(&hit);
+					// copy constructor does not copy the bit field, so we need to set it
+					addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
+					addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
+					++(nofFragments.at(j));
+					break;
+				}
+			}
+			// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
+			if(j == addbacks.size()) {
+				addbacks.push_back(detHit);
+				nofFragments.push_back(1);
+			}
+		}
+	}
 
-   /// \cond CLASSIMP
-   ClassDefOverride(TSuppressed, 1)
-   /// \endcond
+	template<class T>
+	void CreateSuppressed(const TBgo* bgo, const std::vector<T>& hits, std::vector<T>& suppressedHits)
+	{
+		/// This function always(!) re-creates the vector of suppressed hits based on the provided TBgo and vector of hits
+		suppressedHits.clear();
+		for(auto detHit : hits) {
+			TGRSIDetectorHit& hit = static_cast<TGRSIDetectorHit&>(detHit);
+			bool suppress = false;
+			for(auto b : bgo->GetHitVector()) {
+				if(SuppressionCriterion(hit, b)) {
+					suppress = true;
+					break;
+				}
+			}
+			if(!suppress) suppressedHits.push_back(detHit);
+		}
+	}
+
+	template<class T>
+	void CreateSuppressedAddback(const TBgo* bgo, const std::vector<T>& hits, std::vector<T>& addbacks, std::vector<UShort_t>& nofFragments)
+	{
+		/// This funxtion always(!) re-creates the vectors of suppressed addback hits and number of fragments per suppressed addback hit based on the provided TBgo and vector of hits
+		addbacks.clear();
+		nofFragments.clear();
+		size_t j;
+		for(auto detHit : hits) {
+			TGRSIDetectorHit& hit = static_cast<TGRSIDetectorHit&>(detHit);
+			// check if this hit is suppressed
+			bool suppress = false;
+			for(auto b : bgo->GetHitVector()) {
+				if(SuppressionCriterion(hit, b)) {
+					suppress = true;
+					break;
+				}
+			}
+			//check for each existing addback hit if this hit should be added to it
+			for(j = 0; j < addbacks.size(); ++j) {
+				if(AddbackCriterion(addbacks[j], hit)) {
+					// if this his is suppressed we need to suppress the whole addback event
+					if(suppress) {
+						addbacks.erase(addbacks.begin()+j);
+						nofFragments.erase(nofFragments.begin()+j);
+						break;
+					}
+					addbacks[j].Add(&hit);
+					// copy constructor does not copy the bit field, so we need to set it
+					addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
+					addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
+					++(nofFragments.at(j));
+					break;
+				}
+			}
+			// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
+			// unless this hit was suppressed in which case we don't want to create a new addback
+			// this also covers the case where the last addback hit was just removed
+			if(j == addbacks.size() && !suppress) {
+				addbacks.push_back(detHit);
+				nofFragments.push_back(1);
+			}
+		}
+	}
+
+	/// \cond CLASSIMP
+	ClassDefOverride(TSuppressed, 1)
+	/// \endcond
 };
 /*! @} */
 #endif

--- a/libraries/TGRSIAnalysis/TFipps/TFippsHit.cxx
+++ b/libraries/TGRSIAnalysis/TFipps/TFippsHit.cxx
@@ -74,22 +74,26 @@ bool TFippsHit::CompareEnergy(const TFippsHit* lhs, const TFippsHit* rhs)
 	return (lhs->GetEnergy() > rhs->GetEnergy());
 }
 
-void TFippsHit::Add(const TFippsHit* hit)
+void TFippsHit::Add(const TGRSIDetectorHit* hit)
 {
+	const TFippsHit* fippsHit = dynamic_cast<const TFippsHit*>(hit);
+	if(fippsHit == nullptr) {
+		throw std::runtime_error("trying to add non-fipps hit to fipps hit!");
+	}
 	// add another griffin hit to this one (for addback),
 	// using the time and position information of the one with the higher energy
-	if(!CompareEnergy(this, hit)) {
-		SetCfd(hit->GetCfd());
-		SetTime(hit->GetTime());
-		// SetPosition(hit->GetPosition());
-		SetAddress(hit->GetAddress());
+	if(!CompareEnergy(this, fippsHit)) {
+		SetCfd(fippsHit->GetCfd());
+		SetTime(fippsHit->GetTime());
+		// SetPosition(fippsHit->GetPosition());
+		SetAddress(fippsHit->GetAddress());
 	}
-	SetEnergy(GetEnergy() + hit->GetEnergy());
+	SetEnergy(GetEnergy() + fippsHit->GetEnergy());
 	// this has to be done at the very end, otherwise GetEnergy() might not work
 	SetCharge(0);
 	// KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
-	if(GetKValue() > hit->GetKValue()) {
-		SetKValue(hit->GetKValue());
+	if(GetKValue() > fippsHit->GetKValue()) {
+		SetKValue(fippsHit->GetKValue());
 	}
 }
 

--- a/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TGRSIDetector/TGRSIDetectorHit.cxx
@@ -192,7 +192,6 @@ void TGRSIDetectorHit::Clear(Option_t*)
 
 Int_t TGRSIDetectorHit::GetDetector() const
 {
-
    TChannel* channel = GetChannel();
    if(channel == nullptr) {
       Error("GetDetector", "No TChannel exists for address 0x%08x", GetAddress());

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -25,13 +25,22 @@
 ClassImp(TGriffin)
 /// \endcond
 
-bool DefaultAddback(TGriffinHit& one, TGriffinHit& two)
+bool DefaultAddback(const TGRSIDetectorHit& one, const TGRSIDetectorHit& two)
 {
    return ((one.GetDetector() == two.GetDetector()) &&
            (std::fabs(one.GetTime() - two.GetTime()) < TGRSIOptions::AnalysisOptions()->AddbackWindow()));
 }
 
-std::function<bool(TGriffinHit&, TGriffinHit&)> TGriffin::fAddbackCriterion = DefaultAddback;
+std::function<bool(const TGRSIDetectorHit&, const TGRSIDetectorHit&)> TGriffin::fAddbackCriterion = DefaultAddback;
+
+bool DefaultSuppression(const TGRSIDetectorHit& hit, const TBgoHit& bgoHit)
+{
+	return ((hit.GetDetector() == bgoHit.GetDetector() && hit.GetCrystal() == bgoHit.GetCrystal()) &&
+	(std::fabs(hit.GetTime() - bgoHit.GetTime()) < TGRSIOptions::AnalysisOptions()->SuppressionWindow()) &&
+	(bgoHit.GetEnergy() > TGRSIOptions::AnalysisOptions()->SuppressionEnergy()));
+}
+
+std::function<bool(const TGRSIDetectorHit&, const TBgoHit&)> TGriffin::fSuppressionCriterion = DefaultSuppression;
 
 bool  TGriffin::fSetCoreWave     = false;
 TGriffin::EGainBits TGriffin::fDefaultGainType = TGriffin::EGainBits::kLowGain;
@@ -106,7 +115,7 @@ TVector3 TGriffin::gCloverPosition[17] = {
 
 std::map<int, TSpline*> TGriffin::fEnergyResiduals;
 
-TGriffin::TGriffin() : TGRSIDetector()
+TGriffin::TGriffin() : TSuppressed()
 {
 // Default ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
@@ -115,7 +124,7 @@ TGriffin::TGriffin() : TGRSIDetector()
    Clear();
 }
 
-TGriffin::TGriffin(const TGriffin& rhs) : TGRSIDetector()
+TGriffin::TGriffin(const TGriffin& rhs) : TSuppressed()
 {
 // Copy ctor. Ignores TObjectStreamer in ROOT < 6
 #if MAJOR_ROOT_VERSION < 6
@@ -127,7 +136,7 @@ TGriffin::TGriffin(const TGriffin& rhs) : TGRSIDetector()
 void TGriffin::Copy(TObject& rhs) const
 {
    // Copy function.
-   TGRSIDetector::Copy(rhs);
+   TSuppressed::Copy(rhs);
 
    static_cast<TGriffin&>(rhs).fGriffinLowGainHits   = fGriffinLowGainHits;
    static_cast<TGriffin&>(rhs).fGriffinHighGainHits  = fGriffinHighGainHits;
@@ -149,7 +158,7 @@ void TGriffin::Clear(Option_t* opt)
 {
    // Clears the mother, and all of the hits
    ClearStatus();
-   TGRSIDetector::Clear(opt);
+   TSuppressed::Clear(opt);
    fGriffinLowGainHits.clear();
    fGriffinHighGainHits.clear();
    fAddbackLowGainHits.clear();
@@ -216,7 +225,7 @@ void TGriffin::SetDefaultGainType(const EGainBits& gain_type)
    }
 }
 
-Int_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
+Short_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
 {
    switch(gain_type) {
 		case EGainBits::kLowGain: return fGriffinLowGainHits.size();
@@ -225,37 +234,34 @@ Int_t TGriffin::GetMultiplicity(const EGainBits& gain_type) const
    return 0;
 }
 
-std::vector<TGriffinHit>* TGriffin::GetHitVector(const EGainBits& gain_type)
+std::vector<TGriffinHit>& TGriffin::GetHitVector(const EGainBits& gain_type)
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return &fGriffinLowGainHits;
-		case EGainBits::kHighGain: return &fGriffinHighGainHits;
+		case EGainBits::kLowGain:  return fGriffinLowGainHits;
+		case EGainBits::kHighGain: return fGriffinHighGainHits;
    };
-   return nullptr;
 }
 
-std::vector<TGriffinHit>* TGriffin::GetAddbackVector(const EGainBits& gain_type)
+std::vector<TGriffinHit>& TGriffin::GetAddbackVector(const EGainBits& gain_type)
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return &fAddbackLowGainHits;
-		case EGainBits::kHighGain: return &fAddbackHighGainHits;
+		case EGainBits::kLowGain:  return fAddbackLowGainHits;
+		case EGainBits::kHighGain: return fAddbackHighGainHits;
    };
-   return nullptr;
 }
 
-std::vector<UShort_t>* TGriffin::GetAddbackFragVector(const EGainBits& gain_type)
+std::vector<UShort_t>& TGriffin::GetAddbackFragVector(const EGainBits& gain_type)
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return &fAddbackLowGainFrags;
-		case EGainBits::kHighGain: return &fAddbackHighGainFrags;
+		case EGainBits::kLowGain:  return fAddbackLowGainFrags;
+		case EGainBits::kHighGain: return fAddbackHighGainFrags;
    };
-   return nullptr;
 }
 
 bool TGriffin::IsAddbackSet(const EGainBits& gain_type) const
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainAddbackSet);
+		case EGainBits::kLowGain:  return TestBitNumber(EGriffinBits::kIsLowGainAddbackSet);
 		case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainAddbackSet);
    };
    return false;
@@ -264,7 +270,7 @@ bool TGriffin::IsAddbackSet(const EGainBits& gain_type) const
 bool TGriffin::IsCrossTalkSet(const EGainBits& gain_type) const
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainCrossTalkSet);
+		case EGainBits::kLowGain:  return TestBitNumber(EGriffinBits::kIsLowGainCrossTalkSet);
 		case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainCrossTalkSet);
    };
    return false;
@@ -273,7 +279,7 @@ bool TGriffin::IsCrossTalkSet(const EGainBits& gain_type) const
 void TGriffin::SetAddback(const EGainBits& gain_type, const Bool_t flag) const
 {
    switch(gain_type) {
-		case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainAddbackSet, flag);
+		case EGainBits::kLowGain:  return SetBitNumber(EGriffinBits::kIsLowGainAddbackSet, flag);
 		case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainAddbackSet, flag);
    };
 }
@@ -307,7 +313,7 @@ TGriffinHit* TGriffin::GetGriffinHit(const int& i, const EGainBits& gain_type)
       if(!IsCrossTalkSet(gain_type)) {
          FixCrossTalk(gain_type);
       }
-      return &(GetHitVector(gain_type)->at(i));
+      return &(GetHitVector(gain_type).at(i));
    } catch(const std::out_of_range& oor) {
       std::cerr<<ClassName()<<" Hits are out of range: "<<oor.what()<<std::endl;
       if(!gInterpreter) {
@@ -317,17 +323,17 @@ TGriffinHit* TGriffin::GetGriffinHit(const int& i, const EGainBits& gain_type)
    return nullptr;
 }
 
-Int_t TGriffin::GetAddbackLowGainMultiplicity()
+Short_t TGriffin::GetAddbackLowGainMultiplicity()
 {
    return GetAddbackMultiplicity(EGainBits::kLowGain);
 }
 
-Int_t TGriffin::GetAddbackHighGainMultiplicity()
+Short_t TGriffin::GetAddbackHighGainMultiplicity()
 {
    return GetAddbackMultiplicity(EGainBits::kHighGain);
 }
 
-Int_t TGriffin::GetAddbackMultiplicity(const EGainBits& gain_type)
+Short_t TGriffin::GetAddbackMultiplicity(const EGainBits& gain_type)
 {
    // Automatically builds the addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero)
    // and return the number of addback hits.
@@ -338,41 +344,20 @@ Int_t TGriffin::GetAddbackMultiplicity(const EGainBits& gain_type)
    auto hit_vec  = GetHitVector(gain_type);
    auto ab_vec   = GetAddbackVector(gain_type);
    auto frag_vec = GetAddbackFragVector(gain_type);
-   if(hit_vec->empty()) {
+   if(hit_vec.empty()) {
       return 0;
    }
    // if the addback has been reset, clear the addback hits
    if(!IsAddbackSet(gain_type)) {
-      ab_vec->clear();
-      frag_vec->clear();
+      ab_vec.clear();
+      frag_vec.clear();
    }
-   if(ab_vec->empty()) {
-      // use the first griffin hit as starting point for the addback hits
-      ab_vec->push_back(hit_vec->at(0));
-      frag_vec->push_back(1);
-
-      // loop over remaining griffin hits
-      size_t i, j;
-      for(i = 1; i < hit_vec->size(); ++i) {
-         // check for each existing addback hit if this griffin hit should be added
-         for(j = 0; j < ab_vec->size(); ++j) {
-            if(fAddbackCriterion(ab_vec->at(j), hit_vec->at(i))) {
-               ab_vec->at(j).Add(&(hit_vec->at(i))); // copy constructor does not copy the bit field, so we set it.
-               ab_vec->at(j).SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits.
-               ab_vec->at(j).SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits. pcb.
-               (frag_vec->at(j))++;
-               break;
-            }
-         }
-         if(j == ab_vec->size()) {
-            ab_vec->push_back(hit_vec->at(i));
-            frag_vec->push_back(1);
-         }
-      }
+   if(ab_vec.empty()) {
+		CreateAddback(hit_vec, ab_vec, frag_vec);
       SetAddback(gain_type, true);
    }
 
-   return ab_vec->size();
+   return ab_vec.size();
 }
 
 TGriffinHit* TGriffin::GetAddbackLowGainHit(const int& i)
@@ -388,7 +373,7 @@ TGriffinHit* TGriffin::GetAddbackHighGainHit(const int& i)
 TGriffinHit* TGriffin::GetAddbackHit(const int& i, const EGainBits& gain_type)
 {
    if(i < GetAddbackMultiplicity(gain_type)) {
-      return &GetAddbackVector(gain_type)->at(i);
+      return &(GetAddbackVector(gain_type)[i]);
    }
    std::cerr<<"Addback hits are out of range"<<std::endl;
    throw grsi::exit_exception(1);
@@ -412,10 +397,10 @@ void TGriffin::AddFragment(const std::shared_ptr<const TFragment>& frag, TChanne
 				TGriffinHit geHit(*frag);
 				switch(chan->GetMnemonic()->OutputSensor()) {
 					case TMnemonic::EMnemonic::kA:
-						GetHitVector(EGainBits::kLowGain)->push_back(std::move(geHit));
+						GetHitVector(EGainBits::kLowGain).push_back(std::move(geHit));
 						break;
 					case TMnemonic::EMnemonic::kB:
-						GetHitVector(EGainBits::kHighGain)->push_back(std::move(geHit));
+						GetHitVector(EGainBits::kHighGain).push_back(std::move(geHit));
 						break;
 					default:
 						break;
@@ -481,8 +466,8 @@ void TGriffin::ResetAddback(const EGainBits& gain_type)
 {
    SetAddback(gain_type, false);
    SetCrossTalk(gain_type, false);
-   GetAddbackVector(gain_type)->clear();
-   GetAddbackFragVector(gain_type)->clear();
+   GetAddbackVector(gain_type).clear();
+   GetAddbackFragVector(gain_type).clear();
 }
 
 UShort_t TGriffin::GetNLowGainAddbackFrags(const size_t& idx)
@@ -499,8 +484,8 @@ UShort_t TGriffin::GetNAddbackFrags(const size_t& idx, const EGainBits& gain_typ
 {
    // Get the number of addback "fragments" contributing to the total addback hit
    // with index idx.
-   if(idx < GetAddbackFragVector(gain_type)->size()) {
-      return GetAddbackFragVector(gain_type)->at(idx);
+   if(idx < GetAddbackFragVector(gain_type).size()) {
+      return GetAddbackFragVector(gain_type)[idx];
    }
    return 0;
 }
@@ -569,22 +554,21 @@ void TGriffin::FixHighGainCrossTalk()
 void TGriffin::FixCrossTalk(const EGainBits& gain_type)
 {
    auto hit_vec = GetHitVector(gain_type);
-   if(hit_vec->size() < 2) {
+   if(hit_vec.size() < 2) {
       SetCrossTalk(gain_type, true);
       return;
    }
-   for(auto& i : *hit_vec) {
-      i.ClearEnergy();
+   for(auto& hit : hit_vec) {
+      hit.ClearEnergy();
    }
 
    if(TGRSIOptions::AnalysisOptions()->IsCorrectingCrossTalk()) {
-      size_t i, j;
-      for(i = 0; i < hit_vec->size(); ++i) {
-         for(j = i + 1; j < hit_vec->size(); ++j) {
-            hit_vec->at(i).SetEnergy(TGriffin::CTCorrectedEnergy(&(hit_vec->at(i)), &(hit_vec->at(j))));
-            hit_vec->at(j).SetEnergy(TGriffin::CTCorrectedEnergy(&(hit_vec->at(j)), &(hit_vec->at(i))));
-         }
-      }
+		for(auto one : hit_vec) {
+			for(auto two : hit_vec) {
+				one.SetEnergy(TGriffin::CTCorrectedEnergy(&one, &two));
+				two.SetEnergy(TGriffin::CTCorrectedEnergy(&two, &one));
+			}
+		}
    }
    SetCrossTalk(gain_type, true);
 }
@@ -598,4 +582,243 @@ const char* TGriffin::GetColorFromNumber(Int_t number)
    case(3): return "W";
    };
    return "X";
+}
+
+TGriffinHit* TGriffin::GetSuppressedLowGainHit(const int& i)
+{
+	return GetSuppressedHit(i, EGainBits::kLowGain);
+}
+
+TGriffinHit* TGriffin::GetSuppressedHighGainHit(const int& i)
+{
+	return GetSuppressedHit(i, EGainBits::kHighGain);
+}
+
+Short_t TGriffin::GetSuppressedLowGainMultiplicity(const TBgo* bgo)
+{
+	return GetSuppressedMultiplicity(bgo, EGainBits::kLowGain);
+}
+
+Short_t TGriffin::GetSuppressedHighGainMultiplicity(const TBgo* bgo)
+{
+	return GetSuppressedMultiplicity(bgo, EGainBits::kHighGain);
+}
+
+bool TGriffin::IsSuppressed(const EGainBits& gain_type) const
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain:  return TestBitNumber(EGriffinBits::kIsLowGainSuppressed);
+		case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainSuppressed);
+   };
+	return false;
+}
+
+void TGriffin::ResetLowGainSuppressed()
+{
+	ResetSuppressed(EGainBits::kLowGain);
+}
+
+void TGriffin::ResetHighGainSuppressed()
+{
+	ResetSuppressed(EGainBits::kHighGain);
+}
+
+Short_t TGriffin::GetSuppressedAddbackLowGainMultiplicity(const TBgo* bgo)
+{
+	return GetSuppressedAddbackMultiplicity(bgo, EGainBits::kLowGain);
+}
+
+Short_t TGriffin::GetSuppressedAddbackHighGainMultiplicity(const TBgo* bgo)
+{
+	return GetSuppressedAddbackMultiplicity(bgo, EGainBits::kHighGain);
+}
+
+TGriffinHit* TGriffin::GetSuppressedAddbackLowGainHit(const int& i)
+{
+	return GetSuppressedAddbackHit(i, EGainBits::kLowGain);
+}
+
+TGriffinHit* TGriffin::GetSuppressedAddbackHighGainHit(const int& i)
+{
+	return GetSuppressedAddbackHit(i, EGainBits::kHighGain);
+}
+
+bool TGriffin::IsSuppressedAddbackSet(const EGainBits& gain_type) const
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain: return TestBitNumber(EGriffinBits::kIsLowGainSuppressedAddbackSet);
+		case EGainBits::kHighGain: return TestBitNumber(EGriffinBits::kIsHighGainSuppressedAddbackSet);
+   };
+	return false;
+}
+
+void TGriffin::ResetLowGainSuppressedAddback()
+{
+	ResetSuppressedAddback(EGainBits::kLowGain);
+}
+
+void TGriffin::ResetHighGainSuppressedAddback()
+{
+	ResetSuppressedAddback(EGainBits::kHighGain);
+}
+
+UShort_t TGriffin::GetNLowGainSuppressedAddbackFrags(const size_t& idx)
+{
+	return GetNSuppressedAddbackFrags(idx, EGainBits::kLowGain);
+}
+
+UShort_t TGriffin::GetNHighGainSuppressedAddbackFrags(const size_t& idx)
+{
+	return GetNSuppressedAddbackFrags(idx, EGainBits::kHighGain);
+}
+
+std::vector<TGriffinHit>& TGriffin::GetSuppressedVector(const EGainBits& gain_type)
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain:  return fSuppressedLowGainHits;
+		case EGainBits::kHighGain: return fSuppressedHighGainHits;
+   };
+}
+
+std::vector<TGriffinHit>& TGriffin::GetSuppressedAddbackVector(const EGainBits& gain_type)
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain:  return fSuppressedAddbackLowGainHits;
+		case EGainBits::kHighGain: return fSuppressedAddbackHighGainHits;
+   };
+}
+
+std::vector<UShort_t>& TGriffin::GetSuppressedAddbackFragVector(const EGainBits& gain_type)
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain:  return fSuppressedAddbackLowGainFrags;
+		case EGainBits::kHighGain: return fSuppressedAddbackHighGainFrags;
+   };
+}
+
+TGriffinHit* TGriffin::GetSuppressedHit(const int& i, const EGainBits& gain_type)
+{
+   try {
+      if(!IsCrossTalkSet(gain_type)) {
+         FixCrossTalk(gain_type);
+      }
+      return &(GetSuppressedVector(gain_type).at(i));
+   } catch(const std::out_of_range& oor) {
+      std::cerr<<ClassName()<<" Suppressed hits are out of range: "<<oor.what()<<std::endl;
+      if(!gInterpreter) {
+         throw grsi::exit_exception(1);
+      }
+   }
+   return nullptr;
+}
+
+Short_t TGriffin::GetSuppressedMultiplicity(const TBgo* bgo, const EGainBits& gain_type)
+{
+	/// Automatically builds the suppressed hits using the fSuppressionCriterion and returns the number of suppressed hits
+   if(!IsCrossTalkSet(gain_type)) {
+      // Calculate Cross Talk on each hit
+      FixCrossTalk(gain_type);
+   }
+   auto hit_vec  = GetHitVector(gain_type);
+   auto sup_vec  = GetSuppressedVector(gain_type);
+	if(hit_vec.empty()) {
+		return 0;
+	}
+   // if the suppressed has been reset, clear the suppressed hits
+   if(!IsSuppressed(gain_type)) {
+      sup_vec.clear();
+   }
+   if(sup_vec.empty()) {
+		CreateSuppressed(bgo, hit_vec, sup_vec);
+      SetSuppressed(gain_type, true);
+   }
+
+   return sup_vec.size();
+}
+
+void TGriffin::SetSuppressed(const EGainBits& gain_type, const Bool_t flag) const
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain:  return SetBitNumber(EGriffinBits::kIsLowGainSuppressed, flag);
+		case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainSuppressed, flag);
+   };
+}
+
+void TGriffin::ResetSuppressed(const EGainBits& gain_type)
+{
+   SetSuppressed(gain_type, false);
+   //SetCrossTalk(gain_type, false);
+   GetSuppressedVector(gain_type).clear();
+}
+
+TGriffinHit* TGriffin::GetSuppressedAddbackHit(const int& i, const EGainBits& gain_type)
+{
+   try {
+      if(!IsCrossTalkSet(gain_type)) {
+         FixCrossTalk(gain_type);
+      }
+      return &(GetSuppressedAddbackVector(gain_type).at(i));
+   } catch(const std::out_of_range& oor) {
+      std::cerr<<ClassName()<<" Suppressed addback hits are out of range: "<<oor.what()<<std::endl;
+      if(!gInterpreter) {
+         throw grsi::exit_exception(1);
+      }
+   }
+   return nullptr;
+}
+
+Short_t TGriffin::GetSuppressedAddbackMultiplicity(const TBgo* bgo, const EGainBits& gain_type)
+{
+   /// Automatically builds the suppressed addback hits using the fAddbackCriterion (if the size of the fAddbackHits vector is zero)
+   /// and return the number of suppressed addback hits.
+   if(!IsCrossTalkSet(gain_type)) {
+      // Calculate Cross Talk on each hit
+      FixCrossTalk(gain_type);
+   }
+   auto hit_vec  = GetHitVector(gain_type);
+   auto ab_vec   = GetAddbackVector(gain_type);
+   auto frag_vec = GetAddbackFragVector(gain_type);
+   if(hit_vec.empty()) {
+      return 0;
+   }
+   // if the addback has been reset, clear the addback hits
+   if(!IsSuppressedAddbackSet(gain_type)) {
+      ab_vec.clear();
+      frag_vec.clear();
+   }
+   if(ab_vec.empty()) {
+		CreateSuppressedAddback(bgo, hit_vec, ab_vec, frag_vec);
+      SetSuppressedAddback(gain_type, true);
+   }
+
+   return ab_vec.size();
+}
+
+void TGriffin::SetSuppressedAddback(const EGainBits& gain_type, const Bool_t flag) const
+{
+   switch(gain_type) {
+		case EGainBits::kLowGain: return SetBitNumber(EGriffinBits::kIsLowGainSuppressedAddbackSet, flag);
+		case EGainBits::kHighGain: return SetBitNumber(EGriffinBits::kIsHighGainSuppressedAddbackSet, flag);
+   };
+}
+
+void TGriffin::ResetSuppressedAddback(const EGainBits& gain_type)
+{
+   SetSuppressedAddback(gain_type, false);
+   //SetCrossTalk(gain_type, false);
+   GetSuppressedAddbackVector(gain_type).clear();
+   GetSuppressedAddbackFragVector(gain_type).clear();
+}
+
+UShort_t TGriffin::GetNSuppressedAddbackFrags(const size_t& idx, const EGainBits& gain_type)
+{
+	try {
+		return GetSuppressedAddbackFragVector(gain_type).at(idx);
+	} catch(const std::out_of_range& oor) {
+      std::cerr<<ClassName()<<" Suppressed addback frags are out of range: "<<oor.what()<<std::endl;
+      if(!gInterpreter) {
+         throw grsi::exit_exception(1);
+      }
+   }
+   return 0;
 }

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffinHit.cxx
@@ -96,35 +96,39 @@ bool TGriffinHit::CompareEnergy(const TGriffinHit* lhs, const TGriffinHit* rhs)
    return (lhs->GetEnergy() > rhs->GetEnergy());
 }
 
-void TGriffinHit::Add(const TGriffinHit* hit)
+void TGriffinHit::Add(const TGRSIDetectorHit* hit)
 {
+	const TGriffinHit* griffinHit = dynamic_cast<const TGriffinHit*>(hit);
+	if(griffinHit == nullptr) {
+		throw std::runtime_error("trying to add non-griffin hit to griffin hit!");
+	}
    // add another griffin hit to this one (for addback),
    // using the time and position information of the one with the higher energy
-   if(!CompareEnergy(this, hit)) {
-      SetCfd(hit->GetCfd());
-      SetTime(hit->GetTime());
-      // SetPosition(hit->GetPosition());
-      SetAddress(hit->GetAddress());
+   if(!CompareEnergy(this, griffinHit)) {
+      SetCfd(griffinHit->GetCfd());
+      SetTime(griffinHit->GetTime());
+      // SetPosition(griffinHit->GetPosition());
+      SetAddress(griffinHit->GetAddress());
    } else {
       SetTime(GetTime());
    }
-   SetEnergy(GetEnergy() + hit->GetEnergy());
+   SetEnergy(GetEnergy() + griffinHit->GetEnergy());
    // this has to be done at the very end, otherwise GetEnergy() might not work
    SetCharge(0);
    // Add all of the pileups.This should be changed when the max number of pileups changes
-   if((NPileUps() + hit->NPileUps()) < 4) {
-      SetNPileUps(NPileUps() + hit->NPileUps());
+   if((NPileUps() + griffinHit->NPileUps()) < 4) {
+      SetNPileUps(NPileUps() + griffinHit->NPileUps());
    } else {
       SetNPileUps(3);
    }
-   if((PUHit() + hit->PUHit()) < 4) {
-      SetPUHit(PUHit() + hit->PUHit());
+   if((PUHit() + griffinHit->PUHit()) < 4) {
+      SetPUHit(PUHit() + griffinHit->PUHit());
    } else {
       SetPUHit(3);
    }
-   // KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup hit was added-back RD
-   if(GetKValue() > hit->GetKValue()) {
-      SetKValue(hit->GetKValue());
+   // KValue is somewhate meaningless in addback, so I am using it as an indicator that a piledup griffinHit was added-back RD
+   if(GetKValue() > griffinHit->GetKValue()) {
+      SetKValue(griffinHit->GetKValue());
    }
 }
 

--- a/libraries/TGRSIAnalysis/TSuppressed/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TSuppressed/LinkDef.h
@@ -1,0 +1,12 @@
+//TSuppressed.h
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
+#pragma link C++ class TSuppressed+;
+
+#endif
+

--- a/libraries/TGRSIAnalysis/TSuppressed/TSuppressed.cxx
+++ b/libraries/TGRSIAnalysis/TSuppressed/TSuppressed.cxx
@@ -1,0 +1,88 @@
+#include "TSuppressed.h"
+
+ClassImp(TSuppressed)
+
+void TSuppressed::CreateAddback(const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments)
+{
+	/// This funxtion always(!) re-creates the vectors of addback hits and number of fragments per addback hit based on the provided vector of hits
+	addbacks.clear();
+	nofFragments.clear();
+	size_t j;
+	for(auto hit : hits) {
+		//check for each existing addback hit if this hit should be added to it
+		for(j = 0; j < addbacks.size(); ++j) {
+			if(fAddbackCriterion(addbacks[j], hit) {
+				addbacks[j].Add(&hit);
+				// copy constructor does not copy the bit field, so we need to set it
+				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
+				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
+				++(nofFragments.at(j));
+				break;
+			}
+		}
+		// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
+		if(j == addbacks.size()) {
+			addbacks.push_back(hit);
+			nofFragments.push_back(1);
+		}
+	}
+}
+
+void TSuppressed::CreateSuppressed(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& suppressedHits)
+{
+	/// This function always(!) re-creates the vector of suppressed hits based on the provided TBgo and vector of hits
+	suppressedHits.clear();
+	for(auto hit : hits) {
+		bool suppress = false;
+		for(auto b : bgo->GetHitVector()) {
+			if(fSuppressionCriterion(hit, b)) {
+				suppress = true;
+				break;
+			}
+		}
+		if(!suppress) suppressedHits.push_back(hit);
+	}
+}
+
+void TSuppressed::CreateSuppressedAddback(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments)
+{
+	/// This funxtion always(!) re-creates the vectors of suppressed addback hits and number of fragments per suppressed addback hit based on the provided TBgo and vector of hits
+	addbacks.clear();
+	nofFragments.clear();
+	size_t j;
+	for(auto hit : hits) {
+		// check if this hit is suppressed
+		bool suppress = false;
+		for(auto b : bgo->GetHitVector()) {
+			if(fSuppressionCriterion(hit, b)) {
+				suppress = true;
+				break;
+			}
+		}
+		//check for each existing addback hit if this hit should be added to it
+		for(j = 0; j < addbacks.size(); ++j) {
+			if(fAddbackCriterion(addbacks[j], hit) {
+				// if this his is suppressed we need to suppress the whole addback event
+				if(suppress) {
+					addbacks.erase(addbacks.begin()+j);
+					nofFragments.erase(nofFragments.begin()+j);
+					break;
+				}
+				addbacks[j].Add(&hit);
+				// copy constructor does not copy the bit field, so we need to set it
+				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
+				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
+				++(nofFragments.at(j));
+				break;
+			}
+		}
+		// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
+		// unless this hit was suppressed in which case we don't want to create a new addback
+		// this also covers the case where the last addback hit was just removed
+		if(j == addbacks.size() && !supress) {
+			addbacks.push_back(hit);
+			nofFragments.push_back(1);
+		}
+	}
+}
+

--- a/libraries/TGRSIAnalysis/TSuppressed/TSuppressed.cxx
+++ b/libraries/TGRSIAnalysis/TSuppressed/TSuppressed.cxx
@@ -2,87 +2,14 @@
 
 ClassImp(TSuppressed)
 
-void TSuppressed::CreateAddback(const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments)
+void TSuppressed::Copy(TObject& rhs) const
 {
-	/// This funxtion always(!) re-creates the vectors of addback hits and number of fragments per addback hit based on the provided vector of hits
-	addbacks.clear();
-	nofFragments.clear();
-	size_t j;
-	for(auto hit : hits) {
-		//check for each existing addback hit if this hit should be added to it
-		for(j = 0; j < addbacks.size(); ++j) {
-			if(fAddbackCriterion(addbacks[j], hit) {
-				addbacks[j].Add(&hit);
-				// copy constructor does not copy the bit field, so we need to set it
-				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
-				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
-				++(nofFragments.at(j));
-				break;
-			}
-		}
-		// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
-		if(j == addbacks.size()) {
-			addbacks.push_back(hit);
-			nofFragments.push_back(1);
-		}
-	}
+   // Copy function.
+   TGRSIDetector::Copy(rhs);
 }
 
-void TSuppressed::CreateSuppressed(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& suppressedHits)
+void TSuppressed::Clear(Option_t* opt)
 {
-	/// This function always(!) re-creates the vector of suppressed hits based on the provided TBgo and vector of hits
-	suppressedHits.clear();
-	for(auto hit : hits) {
-		bool suppress = false;
-		for(auto b : bgo->GetHitVector()) {
-			if(fSuppressionCriterion(hit, b)) {
-				suppress = true;
-				break;
-			}
-		}
-		if(!suppress) suppressedHits.push_back(hit);
-	}
+   // Clears the mother, and all of the hits
+   TGRSIDetector::Clear(opt);
 }
-
-void TSuppressed::CreateSuppressedAddback(const TBgo* bgo, const std::vector<TGRSIDetectorHit>& hits, std::vector<TGRSIDetectorHit>& addbacks, std::vector<UShort_t>& nofFragments)
-{
-	/// This funxtion always(!) re-creates the vectors of suppressed addback hits and number of fragments per suppressed addback hit based on the provided TBgo and vector of hits
-	addbacks.clear();
-	nofFragments.clear();
-	size_t j;
-	for(auto hit : hits) {
-		// check if this hit is suppressed
-		bool suppress = false;
-		for(auto b : bgo->GetHitVector()) {
-			if(fSuppressionCriterion(hit, b)) {
-				suppress = true;
-				break;
-			}
-		}
-		//check for each existing addback hit if this hit should be added to it
-		for(j = 0; j < addbacks.size(); ++j) {
-			if(fAddbackCriterion(addbacks[j], hit) {
-				// if this his is suppressed we need to suppress the whole addback event
-				if(suppress) {
-					addbacks.erase(addbacks.begin()+j);
-					nofFragments.erase(nofFragments.begin()+j);
-					break;
-				}
-				addbacks[j].Add(&hit);
-				// copy constructor does not copy the bit field, so we need to set it
-				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsEnergySet); // this must be set for summed hits
-				addbacks[j].SetHitBit(TGRSIDetectorHit::EBitFlag::kIsTimeSet);   // this must be set for summed hits
-				++(nofFragments.at(j));
-				break;
-			}
-		}
-		// if we haven't found an addback hit to add this hit to, or if there are no addback hits yet we create a new addback hit
-		// unless this hit was suppressed in which case we don't want to create a new addback
-		// this also covers the case where the last addback hit was just removed
-		if(j == addbacks.size() && !supress) {
-			addbacks.push_back(hit);
-			nofFragments.push_back(1);
-		}
-	}
-}
-

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -22,6 +22,8 @@ void TAnalysisOptions::Clear(Option_t*)
    /// Clears all of the variables in the TAnalysisOptions
    fBuildWindow           = 200;
    fAddbackWindow         = 300;
+   fSuppressionWindow     = 300.;
+   fSuppressionEnergy     = 0.;
    fStaticWindow          = false;
    fWaveformFitting       = false;
    fIsCorrectingCrossTalk = true;
@@ -32,6 +34,8 @@ void TAnalysisOptions::Print(Option_t*) const
    /// Print the current status of TAnalysisOptions, includes all names, lists and flags
    std::cout<<BLUE<<"fBuildWindow: "<<DCYAN<<fBuildWindow<<std::endl
             <<BLUE<<"fAddbackWindow: "<<DCYAN<<fAddbackWindow<<std::endl
+            <<BLUE<<"fSuppressionWindow: "<<DCYAN<<fSuppressionWindow<<std::endl
+            <<BLUE<<"fSuppressionEnergy: "<<DCYAN<<fSuppressionEnergy<<std::endl
             <<BLUE<<"fStaticWindow: "<<DCYAN<<fStaticWindow<<std::endl
             <<BLUE<<"fWaveformFitting: "<<DCYAN<<fWaveformFitting<<std::endl
             <<BLUE<<"fIsCorrectingCrossTalk: "<<DCYAN<<fIsCorrectingCrossTalk<<std::endl

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -39,7 +39,7 @@ TEventBuildingLoop::TEventBuildingLoop(std::string name, EBuildMode mode)
       fOrdered = decltype(fOrdered)([](std::shared_ptr<const TFragment> a, std::shared_ptr<const TFragment> b) {
          return a->GetTriggerId() < b->GetTriggerId();
       });
-		td::cout<<DYELLOW<<"sorting by trigger ID!"<<RESET_COLOR<<std::endl;
+		std::cout<<DYELLOW<<"sorting by trigger ID!"<<RESET_COLOR<<std::endl;
       break;
    }
 }

--- a/util/Deadtime.cxx
+++ b/util/Deadtime.cxx
@@ -10,13 +10,11 @@
 #include <iostream>
 #include <functional>
 #include <iomanip>
-#include <vector>
 #include <string>
 #include <cmath>
 #include <cstdio>
 #include <cmath> /* round, floor, ceil, trunc */
 #include <ctime>
-using namespace std;
 
 #include "TF1.h"
 #include "TMath.h"
@@ -109,7 +107,7 @@ int main(int argc, char* argv[])
    int         tend      = 0;
    int         runtime   = 0;
    int         nppg      = 0;
-   string      odbline;
+   std::string      odbline;
    //*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
    int line_count = std::count( // read in number of lines(files)
       std::istreambuf_iterator<char>(filelist), std::istreambuf_iterator<char>(), '\n');
@@ -127,7 +125,7 @@ int main(int argc, char* argv[])
    printf(DBLUE "Working, be patient .. " RESET_COLOR "\n");
    printf("\n");
    filelist.clear();
-   filelist.seekg(0, ios::beg);
+   filelist.seekg(0, std::ios::beg);
    //*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
    Printaddress(p); // Credit to to E.Kwan for this part
    p = &addr[0];
@@ -141,10 +139,10 @@ int main(int argc, char* argv[])
          getline(InFile, odbline);
          posa = odbline.find(starttime);
          posb = odbline.find(stoptime);
-         if(posa != string::npos && odbline.size() > static_cast<size_t>(sub)) {
+         if(posa != std::string::npos && odbline.size() > static_cast<size_t>(sub)) {
             odbline = odbline.substr(sub);
             tstart  = std::stoi(odbline, nullptr, 10);
-         } else if(posb != string::npos && odbline.size() > static_cast<size_t>(sub - 1)) {
+         } else if(posb != std::string::npos && odbline.size() > static_cast<size_t>(sub - 1)) {
             odbline = odbline.substr((sub - 1));
             tend    = std::stoi(odbline, nullptr, 10);
          }
@@ -300,7 +298,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
 {
 
    auto*    vs = new TFile(fname, "read");
-   ofstream ofile;
+   std::ofstream ofile;
    ofile.open("diagnostic.txt");
    FILE* random    = fopen(hname, "w");
    FILE* combine   = fopen(iname, "w");
@@ -509,7 +507,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
             dlim = (2 * ((rmax / double(fbin)) + (double(j) * (rmax / double(fbin)))));
          }
       }
-      // std::cout<<"PPG transitions assumed above "<<(dlim*100.)<<" % change in rate.."<<endl;
+      // std::cout<<"PPG transitions assumed above "<<(dlim*100.)<<" % change in rate.."<<std::endl;
       for(int i = 0; i <= xbins; i++) {
          if(abs(trans[i][1]) > dlim) {
             nt += 1;
@@ -517,7 +515,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
                printf(DRED "Warning: Found more PPG transition(s) than expected in spectrum %s (%i/%i)" RESET_COLOR
                            "\n",
                       sname, nt, numpat);
-               // std::cout<<"(see bin number "<<i<<" in spectrum "<<sname<<")"<<endl;
+               // std::cout<<"(see bin number "<<i<<" in spectrum "<<sname<<")"<<std::endl;
                ppgstat[1] += 1;
                break;
             } else {
@@ -552,9 +550,9 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
       // diagnostic only
       if(cnt % nsc == 0) {
          for(int i = 0; i < numpat; i++) {
-            ofile<<ppg[i][0]<<"\t"<<ppg[i][1]<<endl;
+            ofile<<ppg[i][0]<<"\t"<<ppg[i][1]<<std::endl;
          }
-         ofile<<"/"<<endl;
+         ofile<<"/"<<std::endl;
       }
       //*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~**~*~*~*~*~*~*
       // SOURCE ONLY
@@ -606,7 +604,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
          fprintf(random, "/");
          fprintf(random, "\n");
       }
-      // std::cout<<"Mean = "<<rrand<<", standard deviation = "<<sdrand<<endl;
+      // std::cout<<"Mean = "<<rrand<<", standard deviation = "<<sdrand<<std::endl;
       //*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~**~*~*~*~*~*~**~*~*~*~*~*~*
       // SOURCE+PULSER
       for(int i = pref; i < numpat; i += 2) {
@@ -645,7 +643,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
             x = spec[cnt]->GetBinContent(j);
             if(x != 0) {
                maxl = (0.5 * (pow((x - rcmin), 2))) / x;
-               // ofile<<j<<"\t"<<x<<"\t"<<maxl<<endl;
+               // ofile<<j<<"\t"<<x<<"\t"<<maxl<<std::endl;
                if(maxl <= (minl + 0.5) && x < rcmin && x < lbd) { // fixed
                   lbd = x;
                }
@@ -660,7 +658,7 @@ void DoAnalysis(const char*& fname, int& nfile, double* rate, int& nsclr, int& p
       // diagnostic spectrum (dspec) parameters (re-define for source+pulser)
       lim1 = lbd - (2.0 * abs(rcmin - lbd));
       lim2 = ubd + (2.0 * abs(rcmin - ubd));
-      // std::cout<<lim1<<"\t"<<lim2<<"\t"<<rcmin<<endl;
+      // std::cout<<lim1<<"\t"<<lim2<<"\t"<<rcmin<<std::endl;
       dsbin = (lim2 - lim1) / 20; // dspec[dsbin][2]; What was this statement supposed to do? It has no effect; VB
       for(int i = 0; i < dsbin; i++) {
          dspec[i][0] = lim1 + (i * ((lim2 - lim1) / dsbin));

--- a/util/GainMatchGRIFFIN.cxx
+++ b/util/GainMatchGRIFFIN.cxx
@@ -25,27 +25,25 @@
 #include<TLegend.h>
 #include<TSystem.h>
 
-using namespace std;
-
 enum class EType { kMaxBin, kTPeak, kTSpectrum };
 
-void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, vector<int> channelstoskip, int bins, int xmin, int xmax);
+void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, int bins, int xmin, int xmax);
 void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, int bins, int xmin, int xmax);
 TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, int bins, double xmin, double xmax);
-TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, vector<int> channelstoskip, int bins, double xmin, double xmax);
+TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, std::vector<int> channelstoskip, int bins, double xmin, double xmax);
 void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, double largepeak, std::vector<double> peaks, EType type, double mindistance, bool roughenergy, bool twopeaks, double largepeak2);
-void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, vector<int> channelstoskip, double largepeak, std::vector<double> peaks,EType type, double mindistance, bool roughenergy, bool twopeaks, double largepeak2);
+void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, double largepeak, std::vector<double> peaks,EType type, double mindistance, bool roughenergy, bool twopeaks, double largepeak2);
 TGraph* gainmatch_peaks(TH1* hst, std::vector<double> peakvalues, std::vector<double> peaklocations, double windowsize, EType type);
 void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, const char* paramImgName, const char* graphImgName, int order);
-void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, vector<int> channelstoskip, const char* paramImgName, const char* graphImgName, int order);
-void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, vector<int> channelstoskip, int xbins, double xmin, double xmax);
+void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, const char* paramImgName, const char* graphImgName, int order);
+void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, std::vector<int> channelstoskip, int xbins, double xmin, double xmax);
 void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, int xbins, double xmin, double xmax);
 TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, int bins, double xmin, double xmax, const char* calfile);
-TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, vector<int> channelstoskip, int bins, double xmin, double xmax, const char* calfile);
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<int> channelstoskip, vector<double> peaks, EType type, double width, bool UseMyList, const char* fwhmImgName, const char* fwratioImgName);
+TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, std::vector<int> channelstoskip, int bins, double xmin, double xmax, const char* calfile);
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, std::vector<double> peaks, EType type, double width, bool UseMyList, const char* fwhmImgName, const char* fwratioImgName);
 void check_calibration(const char* testFileName, int minchannel, int maxchannel, EType type, double width, const char* fwhmImgName,const char* fwratioImgName);
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<int> channelstoskip, EType type, double width, const char* fwhmImgName,const char* fwratioImgName);
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<double> peaks, EType type, double width, bool UseMyList, const char* fwhmImgName, const char* fwratioImgName);
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, EType type, double width, const char* fwhmImgName,const char* fwratioImgName);
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<double> peaks, EType type, double width, bool UseMyList, const char* fwhmImgName, const char* fwratioImgName);
 double FWXM(TH1* h, double xmin, double xmax, double percent);
 double FWHM(TH1* h, double xmin, double xmax);
 double FWTM(TH1* h, double xmin, double xmax);
@@ -127,15 +125,15 @@ double GetRoughGain(TH1* h, double largepeak, double mindistance, bool twopeaks=
 		} else {
 			posbigb = spec2->GetPositionX()[0];
 		}
-	} else if(twopeaks) {
+	} else {
 		if(spec2->GetNPeaks()!=2) {
 			posbigb = spec2->GetPositionX()[0];
 			std::cout <<"Warning: Two peaks were specified, but not found. Setting only peak found to " <<largepeak <<std::endl;
 		} else {
 			if(std::min(largepeak,largepeak2) == largepeak) {
-				posbigb = min(spec2->GetPositionX()[0],spec2->GetPositionX()[1]);
+				posbigb = std::min(spec2->GetPositionX()[0],spec2->GetPositionX()[1]);
 			} else {
-				posbigb = max(spec2->GetPositionX()[0],spec2->GetPositionX()[1]);
+				posbigb = std::max(spec2->GetPositionX()[0],spec2->GetPositionX()[1]);
 			}
 		}
 	}
@@ -144,7 +142,7 @@ double GetRoughGain(TH1* h, double largepeak, double mindistance, bool twopeaks=
 	return gain;
 }
 
-void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, vector<int> channelstoskip, int bins = 40e3, int xmin = 0, int xmax = 4000)
+void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, std::vector<int> channelstoskip, int bins = 40e3, int xmin = 0, int xmax = 4000)
 {
 	// create histograms
 	TFile* f = new TFile(fragFileName);
@@ -167,11 +165,11 @@ void make_calibration_histograms(const char* fragFileName, const char* histFileN
 
 void make_calibration_histograms(const char* fragFileName, const char* histFileName, int minchannel, int maxchannel, int bins = 40e3, int xmin = 0, int xmax = 4000)
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	make_calibration_histograms(fragFileName,histFileName,minchannel,maxchannel,dummy,bins,xmin,xmax);
 }
 
-TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, vector<int> channelsToSkip, int bins, double xmin, double xmax)
+TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, std::vector<int> channelsToSkip, int bins, double xmin, double xmax)
 {
 	// initialization stuff
 	TList* list = new TList;
@@ -232,12 +230,11 @@ TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, vector
 
 TList* MakeGRIFFINChargeHsts(TTree* tree, int minchannel, int maxchannel, int bins, double xmin, double xmax)
 {
-	vector<int> dummyvector;
-	TList* list = MakeGRIFFINChargeHsts(tree,minchannel,maxchannel,bins,xmin,xmax);
+	TList* list = MakeGRIFFINChargeHsts(tree, minchannel, maxchannel, std::vector<int>(), bins, xmin, xmax);
 	return list;
 }
 
-void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, vector<int> channelsToSkip, double largepeak, vector<double> peaks, EType type = EType::kTSpectrum, double mindistance=20e3, bool roughenergy=kTRUE, bool twopeaks=kFALSE, double largepeak2 = 0.0)
+void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, std::vector<int> channelsToSkip, double largepeak, std::vector<double> peaks, EType type = EType::kTSpectrum, double mindistance=20e3, bool roughenergy=kTRUE, bool twopeaks=kFALSE, double largepeak2 = 0.0)
 {
 	// minchannel and max channel are inclusive values. most loops go from i=min to i<=maxchannel
 
@@ -269,7 +266,7 @@ void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxch
 
 	// create and save the graphs
 	for(int i=minchannel;i<=maxchannel;i++) {
-		cout <<"\t" <<i <<endl;
+		std::cout <<"\t" <<i <<std::endl;
 		bool skipChannel = kFALSE;
 		for(auto skip : channelsToSkip) {
 			if(i == skip) skipChannel = kTRUE;
@@ -284,10 +281,10 @@ void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxch
 
 		// calculate rough gain
 		double gain = GetRoughGain(h,largepeak,mindistance,twopeaks,largepeak2);
-		//		std::cout <<"Rough gain for channel " <<i <<" is " <<gain <<endl;
+		//		std::cout <<"Rough gain for channel " <<i <<" is " <<gain <<std::endl;
 
 		// calculate rough positions of peaks
-		vector<double> peakguesses;
+		std::vector<double> peakguesses;
 		for(auto peak : peaks) {
 			peakguesses.push_back(gain*peak);
 		}
@@ -325,14 +322,14 @@ void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxch
 	f->Close();
 }
 
-void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, double largepeak, vector<double> peaks, EType type = EType::kTSpectrum, double mindistance=20e3, bool roughenergy=kTRUE, bool twopeaks=kFALSE, double largepeak2 = 0.0)
+void create_gainmatch_graphs(const char* histFileName, int minchannel, int maxchannel, double largepeak, std::vector<double> peaks, EType type = EType::kTSpectrum, double mindistance=20e3, bool roughenergy=kTRUE, bool twopeaks=kFALSE, double largepeak2 = 0.0)
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	create_gainmatch_graphs(histFileName,minchannel,maxchannel,dummy,largepeak,peaks,type,mindistance,roughenergy,twopeaks,largepeak2);
 	return;
 }
 
-TGraph* gainmatch_peaks(TH1* hst, vector<double> peakvalues, vector<double> peaklocations, double windowsize, EType type = EType::kTSpectrum)
+TGraph* gainmatch_peaks(TH1* hst, std::vector<double> peakvalues, std::vector<double> peaklocations, double windowsize, EType type = EType::kTSpectrum)
 {
 	size_t n = peakvalues.size();
 	if(peaklocations.size()!=n) {
@@ -342,9 +339,9 @@ TGraph* gainmatch_peaks(TH1* hst, vector<double> peakvalues, vector<double> peak
 
 	TGraph* graph = new TGraph();
 
-	cout <<"Peaks for " <<hst->GetName() <<endl;
+	std::cout <<"Peaks for " <<hst->GetName() <<std::endl;
 	for(size_t i=0;i<n;i++)	{
-		cout<<i<<endl;
+		std::cout<<i<<std::endl;
 		double centroid = GetCentroid(type,hst,peaklocations[i]-windowsize,peaklocations[i]+windowsize);
 
 		// set point in plot
@@ -356,7 +353,7 @@ TGraph* gainmatch_peaks(TH1* hst, vector<double> peakvalues, vector<double> peak
 }
 
 // i imagine a lot of this function could be rewritten with the TGainMatch class
-void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, vector<int> channelsToSkip, const char* paramImgName = "GRIFFIN_fitting_params.png", const char* graphImgName="GRIFFIN_calgraph.png", int order = 1)
+void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, std::vector<int> channelsToSkip, const char* paramImgName = "GRIFFIN_fitting_params.png", const char* graphImgName="GRIFFIN_calgraph.png", int order = 1)
 {
 	TFile* f = new TFile(ROOTFileName);
 	if(f == nullptr) {
@@ -483,7 +480,7 @@ void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int m
 	c3->Print(paramImgName);
 
 	// create output file
-	ofstream outFile;
+	std::ofstream outFile;
 	outFile.open(outFileName);
 	for(int i=minchannel;i<=maxchannel;i++) {
 		bool skipChannel = kFALSE;
@@ -494,9 +491,9 @@ void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int m
 		if(chi2[i] == 0) continue;
 
 		// get name and address
-		string nameaddress = f->Get(Form("graph%i",i))->GetTitle();
-		string name = nameaddress.substr(0,10);
-		string address = nameaddress.substr(11,10);
+		std::string nameaddress = f->Get(Form("graph%i",i))->GetTitle();
+		std::string name = nameaddress.substr(0,10);
+		std::string address = nameaddress.substr(11,10);
 
 		// start printing out calibration file
 		outFile <<name.c_str() <<"\t{" <<std::endl;
@@ -517,11 +514,11 @@ void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int m
 
 void create_GRIFFIN_cal(const char* ROOTFileName, const char* outFileName, int minchannel, int maxchannel, const char* paramImgName = "GRIFFIN_fitting_params.png", const char* graphImgName="GRIFFIN_calgraph.png", int order = 1)
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	create_GRIFFIN_cal(ROOTFileName,outFileName,minchannel,maxchannel,dummy,paramImgName,graphImgName,order);
 }
 
-void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, vector<int> channelsToSkip, int xbins = 40e3, double xmin = 0, double xmax = 4000)
+void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, std::vector<int> channelsToSkip, int xbins = 40e3, double xmin = 0, double xmax = 4000)
 {
 	TFile* fdata = new TFile(fragFile);
 	if(fdata == nullptr) {
@@ -544,11 +541,11 @@ void recalibrate_spectra(const char* fragFile, const char* newFile, const char* 
 
 void recalibrate_spectra(const char* fragFile, const char* newFile, const char* calFile, int minchannel, int maxchannel, int xbins = 40e3, double xmin = 0, double xmax = 4000)
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	recalibrate_spectra(fragFile,newFile,calFile,minchannel,maxchannel,dummy,xbins,xmin,xmax);	
 }
 
-TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, vector<int> channelsToSkip, int bins, double xmin, double xmax, const char* calfile)
+TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, std::vector<int> channelsToSkip, int bins, double xmin, double xmax, const char* calfile)
 {
 	// initialization stuff
 	TList* list = new TList;
@@ -607,12 +604,12 @@ TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, vector
 
 TList* MakeGRIFFINEnergyHsts(TTree* tree, int minchannel, int maxchannel, int bins, double xmin, double xmax, const char* calfile)
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	TList* list = MakeGRIFFINEnergyHsts(tree,minchannel,maxchannel,dummy,bins,xmin,xmax,calfile);
 	return list;
 }
 
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<int> channelsToSkip, vector<double> peaks, EType type = EType::kTSpectrum, double width = 10, bool UseMyList = kFALSE, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png", const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<int> channelsToSkip, std::vector<double> peaks, EType type = EType::kTSpectrum, double width = 10, bool UseMyList = kFALSE, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png", const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
 {
 	TFile* f = new TFile(testFileName,"update");
 	if(f == nullptr) {
@@ -674,7 +671,7 @@ void check_calibration(const char* testFileName, int minchannel, int maxchannel,
 	}
 
 	// get peak values from summed spectrum for residual calculation
-	vector<double> summedpeaks;
+	std::vector<double> summedpeaks;
 	for(auto peak : peaks) {
 		double centroid = GetCentroid(type,hstall,peak-width,peak+width);
 		summedpeaks.push_back(centroid);
@@ -759,20 +756,20 @@ void check_calibration(const char* testFileName, int minchannel, int maxchannel,
 
 void check_calibration(const char* testFileName, int minchannel, int maxchannel, EType type = EType::kTSpectrum, double width = 10, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png",const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
 {
-	vector<double> peaks;
-	vector<int> dummy;
+	std::vector<double> peaks;
+	std::vector<int> dummy;
 	check_calibration(testFileName,minchannel,maxchannel,dummy,peaks,type,width,kFALSE,fwhmImgName,fwratioImgName);
 }
 
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<int> channelsToSkip, EType type = EType::kTSpectrum, double width = 10, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png",const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<int> channelsToSkip, EType type = EType::kTSpectrum, double width = 10, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png",const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
 {
-	vector<double> peaks;
+	std::vector<double> peaks;
 	check_calibration(testFileName,minchannel,maxchannel,channelsToSkip,peaks,type,width,kFALSE,fwhmImgName,fwratioImgName);
 }
 
-void check_calibration(const char* testFileName, int minchannel, int maxchannel, vector<double> peaks, EType type = EType::kTSpectrum, double width = 10, bool UseMyList = kFALSE, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png", const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
+void check_calibration(const char* testFileName, int minchannel, int maxchannel, std::vector<double> peaks, EType type = EType::kTSpectrum, double width = 10, bool UseMyList = kFALSE, const char* fwhmImgName="GRIFFIN_FWHM_diagnostic.png", const char* fwratioImgName="GRIFFIN_FWratio_diagnostic.png")
 {
-	vector<int> dummy;
+	std::vector<int> dummy;
 	check_calibration(testFileName,minchannel,maxchannel,dummy,peaks,type,width,UseMyList,fwhmImgName,fwratioImgName);
 }
 
@@ -856,7 +853,7 @@ int main(int argc, char **argv) {
 	// these are inclusive
 	int minchannel = 1;
 	int maxchannel = 65;
-	vector<int> channelsToSkip;
+	std::vector<int> channelsToSkip;
 	channelsToSkip.push_back(49);
 	channelsToSkip.push_back(50);
 	channelsToSkip.push_back(51);
@@ -871,7 +868,7 @@ int main(int argc, char **argv) {
 	// fitting specifications
 	bool roughenergy = kTRUE;
 	double largepeak = 586;
-	vector<double> fittingpeaks;
+	std::vector<double> fittingpeaks;
 	fittingpeaks.push_back(2013);
 	fittingpeaks.push_back(586);
 	fittingpeaks.push_back(2577);
@@ -893,7 +890,7 @@ int main(int argc, char **argv) {
 
 	// evaluate parameters
 	// peakstocheck does not have to have the same peaks as fitting peaks
-	vector<double> peakstocheck;
+	std::vector<double> peakstocheck;
 	peakstocheck.push_back(2013);
 	peakstocheck.push_back(586);
 	peakstocheck.push_back(566);

--- a/util/tac_calibrator.cxx
+++ b/util/tac_calibrator.cxx
@@ -31,9 +31,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
-
 int main(int argc, char** argv) {
   if(argc == 1) {
     std::cout<<"Usage: "<<argv[0]<<" <analysis tree file(s)>"<<std::endl;


### PR DESCRIPTION
TSuppressed doesn't do much, it just provides the template functions that allow to create addback vectors and suppressed vectors (and suppressed addback vectors) from a provided hit vector.
For now this mainly meant moving the code from TGriffin to TSuppressed. But if there are more detectors that use addback and/or suppression we won't need to copy-paste the code but just derive those classes from TSuppressed as well (e.g. the LaBr detectors).

I've also changed the private functions of TGriffin to access the vectors to return references instead of pointers.

For the suppression two new analysis options were added, one to set the time window between the detector and the BGO, the other to set an energy threshold for the BGO.

I've also cleaned up some code that still used 'using namespace', don't know how that got back in.