### PR TITLE
S3 comments and modifications to TIGRESS position

### DIFF
--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -129,10 +129,10 @@ private:
    static double fRadialOffset; //!<!
    
    // Vectors constructed from segment array and manual adjustments once at start of sort
-   static TVector3 PostionVectors[2][17][4][9];     //!<!
+   static TVector3 fPositionVectors[2][17][4][9];     //!<!
    
-   static TVector3 CloverRadial[17];      	//!<!  clover direction vectors
-   static TVector3 CloverCross[17][2];      	//!<!  clover perpendicular vectors, for smearing
+   static TVector3 fCloverRadial[17];      	//!<!  clover direction vectors
+   static TVector3 fCloverCross[17][2];      	//!<!  clover perpendicular vectors, for smearing
 
    // These array contain the original data that is used
    static double GeBluePosition[17][9][3];      //!<!  detector segment XYZ

--- a/include/TTigress.h
+++ b/include/TTigress.h
@@ -41,7 +41,8 @@ public:
       kSetSegWave   = BIT(2),
       kSetBGOHits   = BIT(3),
       kForceCrystal = BIT(4),
-      kArrayBackPos = BIT(5) // 110 or 145
+      kArrayBackPos = BIT(5),
+      kVectorsBuilt = BIT(6) // 110 or 145
    };
 
 //std::underlying_type<ETigressGlobalBits>::type operator |(ETigressGlobalBits lhs, ETigressGlobalBits rhs)  
@@ -125,7 +126,15 @@ private:
    std::vector<TTigressHit> fTigressHits;
 
    static double fTargetOffset; //!<!
+   static double fRadialOffset; //!<!
+   
+   // Vectors constructed from segment array and manual adjustments once at start of sort
+   static TVector3 PostionVectors[2][17][4][9];     //!<!
+   
+   static TVector3 CloverRadial[17];      	//!<!  clover direction vectors
+   static TVector3 CloverCross[17][2];      	//!<!  clover perpendicular vectors, for smearing
 
+   // These array contain the original data that is used
    static double GeBluePosition[17][9][3];      //!<!  detector segment XYZ
    static double GeGreenPosition[17][9][3];     //!<!
    static double GeRedPosition[17][9][3];       //!<!
@@ -143,6 +152,8 @@ private:
    std::vector<TTigressHit> fAddbackHits;  //!<! Used to create addback hits on the fly
    std::vector<UShort_t>    fAddbackFrags; //!<! Number of crystals involved in creating in the addback hit
 
+   static void BuildVectors();  //!<!
+   
 public:
    // Naming convention was off, couldnt find anything that used them in grsisort
    // Left them as return bool to not break external code
@@ -169,6 +180,7 @@ public:
    static bool SetArrayBackPos(bool set = true)
    {
       SetGlobalBit(ETigressGlobalBits::kArrayBackPos, set);
+      BuildVectors();
       return set;
    } //!<!
 
@@ -177,10 +189,18 @@ public:
    static bool GetBGOWave() { return TestGlobalBit(ETigressGlobalBits::kSetBGOWave); }        //!<!
    static bool GetForceCrystal() { return TestGlobalBit(ETigressGlobalBits::kForceCrystal); } //!<!
    static bool GetArrayBackPos() { return TestGlobalBit(ETigressGlobalBits::kArrayBackPos); } //!<!
+   static bool GetVectorsBuilt() { return TestGlobalBit(ETigressGlobalBits::kVectorsBuilt); } //!<!
 
    static bool BGOSuppression[4][4][5]; //!<!
 
-   static void SetTargetOffset(double offset) { fTargetOffset = offset; } //!<!
+   static void SetTargetOffset(double offset) {
+	   fTargetOffset = offset; 
+	   BuildVectors();
+   } //!<!
+   static void SetRadialOffset(double offset) { 
+	   fRadialOffset = offset;
+	   BuildVectors();
+   } //!<!
 
    static double GetFaceDistance()
    {

--- a/libraries/TGRSIAnalysis/TS3/TS3.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3.cxx
@@ -15,7 +15,7 @@ int TS3::fSectorNumber  = 32;
 
 double TS3::fOffsetPhiCon = 0.5 * TMath::Pi(); // Offset between connector and sector 0 (viewed from sector side)
 double TS3::fOffsetPhiSet =
-   -22.5 * TMath::Pi() / 180.; // Phi rotation of connector in setup // -90 for bambino -22.5 for SPICE
+   -22.5 * TMath::Pi() / 180.; // Phi rotation of connector in setup // -112.5 for bambino -22.5 for SPICE
 double TS3::fOuterDiameter  = 70.;
 double TS3::fInnerDiameter  = 22.;
 double TS3::fTargetDistance = 31.;
@@ -343,12 +343,15 @@ TVector3 TS3::GetPosition(int ring, int sector, double offsetphi, double offsetZ
    phi += fOffsetPhiCon;
    // The above calculates the position on the S3
 
-   // This orients the detector relative to the beam
+   // This sets orientation of the detector face relative to the beam
    if(sectorsdownstream) {
       phi = -phi;
    }
+   
+   //This rotates the detector around the beam-axis into the correct lab position
    phi += offsetphi;
 
+   //This produces a uniform distribution over the area of a pixel
    if(smear) {
       double sep = ring_width * 0.025;
       double r1 = radius - ring_width * 0.5 + sep, r2 = radius + ring_width * 0.5 - sep;

--- a/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
+++ b/libraries/TGRSIAnalysis/TS3/TS3Hit.cxx
@@ -63,7 +63,8 @@ void TS3Hit::SetWavefit(const TFragment& frag)
 
 
 Bool_t TS3Hit::SectorsDownstream() const
-{
+{	//Do not confuse with fIsDownstream which relates to detector position relative to target, NOT orientation.
+	
 	if(GetChannel()->GetMnemonic()->System() == TMnemonic::ESystem::kSiLiS3){
 		if(GetArrayPosition() == 0) return true;
 		return false;
@@ -96,8 +97,8 @@ void TS3Hit::Print(Option_t*) const
 }
 
 Double_t TS3Hit::GetDefaultPhiOffset() const
-{
-   double deg = -90-21;//~22.5 should be bambino rotation
+{	//Phi rotation of connector in setup
+   double deg = -90-21;// -22.5 should be bambino chamber rotation -90 rotation of detector in chamber
    if(GetChannel()->GetMnemonic()->System() == TMnemonic::ESystem::kSiLiS3) {
       deg = -22.5;
       if(GetChannel()->GetMnemonic()->ArrayPosition() == 2) {

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -348,10 +348,10 @@ TVector3 TTigress::GetPosition(int DetNbr, int CryNbr, int SegNbr, double dist, 
 	if(smear && SegNbr==0){
 		double   x, y, r = sqrt(gRandom->Uniform(0, 400));
 		gRandom->Circle(x, y, r);
-		return PostionVectors[BackPos][DetNbr][CryNbr][SegNbr] + CloverCross[DetNbr][0]*x + CloverCross[DetNbr][1]*y;
+		return fPositionVectors[BackPos][DetNbr][CryNbr][SegNbr] + fCloverCross[DetNbr][0]*x + fCloverCross[DetNbr][1]*y;
 	}
 
-	return PostionVectors[BackPos][DetNbr][CryNbr][SegNbr];
+	return fPositionVectors[BackPos][DetNbr][CryNbr][SegNbr];
 }	
 	
  
@@ -422,10 +422,10 @@ void TTigress::BuildVectors(){
 	det_pos.SetXYZ(xx, yy, zz - fTargetOffset);
 
 	if(fRadialOffset){
-		det_pos+=CloverRadial[DetNbr].Unit()*fRadialOffset;
+		det_pos+=fCloverRadial[DetNbr].Unit()*fRadialOffset;
 	}
 	
-	PostionVectors[Back][DetNbr][CryNbr][SegNbr]=det_pos;
+	fPositionVectors[Back][DetNbr][CryNbr][SegNbr]=det_pos;
     }
    }
   }
@@ -433,20 +433,20 @@ void TTigress::BuildVectors(){
 
 
   for(int DetNbr=0;DetNbr<17;DetNbr++){
-	TVector3 a(-CloverRadial[DetNbr].Y(),CloverRadial[DetNbr].X(), 0);
-	TVector3 b = CloverRadial[DetNbr].Cross(a);	  
-	CloverCross[DetNbr][0]=a.Unit();
-	CloverCross[DetNbr][1]=b.Unit();
+	TVector3 a(-fCloverRadial[DetNbr].Y(),fCloverRadial[DetNbr].X(), 0);
+	TVector3 b = fCloverRadial[DetNbr].Cross(a);	  
+	fCloverCross[DetNbr][0]=a.Unit();
+	fCloverCross[DetNbr][1]=b.Unit();
   }
 
   SetGlobalBit(ETigressGlobalBits::kVectorsBuilt, true);
 }
 
-TVector3 TTigress::PostionVectors[2][17][4][9];
-TVector3 TTigress::CloverCross[17][2];
+TVector3 TTigress::fPositionVectors[2][17][4][9];
+TVector3 TTigress::fCloverCross[17][2];
 
 
-TVector3 TTigress::CloverRadial[17]={TVector3(0., 0., 0.),
+TVector3 TTigress::fCloverRadial[17]={TVector3(0., 0., 0.),
 				     TVector3( 0.9239, 0.3827, 1.),
 				     TVector3(-0.3827, 0.9239, 1.),
 				     TVector3(-0.9239, -0.3827, 1.),

--- a/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
+++ b/libraries/TGRSIAnalysis/TTigress/TTigress.cxx
@@ -14,6 +14,7 @@ ClassImp(TTigress)
 /// \endcond
 
 double TTigress::fTargetOffset = 0.;
+double TTigress::fRadialOffset = 0.;
 
 // Default tigress unpacking settings
 TTransientBits<UShort_t> TTigress::fgTigressBits(ETigressGlobalBits::kSetCoreWave | ETigressGlobalBits::kSetBGOHits);
@@ -331,79 +332,137 @@ TVector3 TTigress::GetPosition(const TTigressHit& hit, double dist, bool smear)
 
 TVector3 TTigress::GetPosition(int DetNbr, int CryNbr, int SegNbr, double dist, bool smear)
 {
-   TVector3 det_pos;
-   double   xx = 0;
-   double   yy = 0;
-   double   zz = 0;
+	if(!GetVectorsBuilt){
+		BuildVectors();
+	}
+	
+	int BackPos=0;
+	
+	// Would be good to get rid of "dist" and just use SetArrayBackPos, but leaving in for old codes.
+	if(dist>0){
+		if(dist > 140.)BackPos=1;
+	}else if(GetArrayBackPos()){
+		BackPos=1;
+	}
+		
+	if(smear && SegNbr==0){
+		double   x, y, r = sqrt(gRandom->Uniform(0, 400));
+		gRandom->Circle(x, y, r);
+		return PostionVectors[BackPos][DetNbr][CryNbr][SegNbr] + CloverCross[DetNbr][0]*x + CloverCross[DetNbr][1]*y;
+	}
 
-   if(dist > 140. || (GetArrayBackPos() && dist < 100.)) { // 145.0
+	return PostionVectors[BackPos][DetNbr][CryNbr][SegNbr];
+}	
+	
+ 
 
-      switch(CryNbr) {
-      case -1: break;
-      case 0:
-         xx = GeBluePositionBack[DetNbr][SegNbr][0];
-         yy = GeBluePositionBack[DetNbr][SegNbr][1];
-         zz = GeBluePositionBack[DetNbr][SegNbr][2];
-         break;
-      case 1:
-         xx = GeGreenPositionBack[DetNbr][SegNbr][0];
-         yy = GeGreenPositionBack[DetNbr][SegNbr][1];
-         zz = GeGreenPositionBack[DetNbr][SegNbr][2];
-         break;
-      case 2:
-         xx = GeRedPositionBack[DetNbr][SegNbr][0];
-         yy = GeRedPositionBack[DetNbr][SegNbr][1];
-         zz = GeRedPositionBack[DetNbr][SegNbr][2];
-         break;
-      case 3:
-         xx = GeWhitePositionBack[DetNbr][SegNbr][0];
-         yy = GeWhitePositionBack[DetNbr][SegNbr][1];
-         zz = GeWhitePositionBack[DetNbr][SegNbr][2];
-         break;
-      };
-      det_pos.SetXYZ(xx, yy, zz);
-   } else {
-      switch(CryNbr) {
-      case -1: break;
-      case 0:
-         xx = GeBluePosition[DetNbr][SegNbr][0];
-         yy = GeBluePosition[DetNbr][SegNbr][1];
-         zz = GeBluePosition[DetNbr][SegNbr][2];
-         break;
-      case 1:
-         xx = GeGreenPosition[DetNbr][SegNbr][0];
-         yy = GeGreenPosition[DetNbr][SegNbr][1];
-         zz = GeGreenPosition[DetNbr][SegNbr][2];
-         break;
-      case 2:
-         xx = GeRedPosition[DetNbr][SegNbr][0];
-         yy = GeRedPosition[DetNbr][SegNbr][1];
-         zz = GeRedPosition[DetNbr][SegNbr][2];
-         break;
-      case 3:
-         xx = GeWhitePosition[DetNbr][SegNbr][0];
-         yy = GeWhitePosition[DetNbr][SegNbr][1];
-         zz = GeWhitePosition[DetNbr][SegNbr][2];
-         break;
-      };
+void TTigress::BuildVectors(){
+
+ for(int Back=0;Back<2;Back++){
+  for(int DetNbr=0;DetNbr<17;DetNbr++){
+   for(int CryNbr=0;CryNbr<4;CryNbr++){
+    for(int SegNbr=0;SegNbr<9;SegNbr++){
+
+	    
+	TVector3 det_pos;
+	double   xx = 0;
+	double   yy = 0;
+	double   zz = 0;
+   
+	if(Back==1) { // distance=145.0
+	switch(CryNbr) {
+		case -1: break;
+		case 0:
+			xx = GeBluePositionBack[DetNbr][SegNbr][0];
+			yy = GeBluePositionBack[DetNbr][SegNbr][1];
+			zz = GeBluePositionBack[DetNbr][SegNbr][2];
+			break;
+		case 1:
+			xx = GeGreenPositionBack[DetNbr][SegNbr][0];
+			yy = GeGreenPositionBack[DetNbr][SegNbr][1];
+			zz = GeGreenPositionBack[DetNbr][SegNbr][2];
+			break;
+		case 2:
+			xx = GeRedPositionBack[DetNbr][SegNbr][0];
+			yy = GeRedPositionBack[DetNbr][SegNbr][1];
+			zz = GeRedPositionBack[DetNbr][SegNbr][2];
+			break;
+		case 3:
+			xx = GeWhitePositionBack[DetNbr][SegNbr][0];
+			yy = GeWhitePositionBack[DetNbr][SegNbr][1];
+			zz = GeWhitePositionBack[DetNbr][SegNbr][2];
+			break;
+		};
+	} else {
+		switch(CryNbr) {
+		case -1: break;
+		case 0:
+			xx = GeBluePosition[DetNbr][SegNbr][0];
+			yy = GeBluePosition[DetNbr][SegNbr][1];
+			zz = GeBluePosition[DetNbr][SegNbr][2];
+			break;
+		case 1:
+			xx = GeGreenPosition[DetNbr][SegNbr][0];
+			yy = GeGreenPosition[DetNbr][SegNbr][1];
+			zz = GeGreenPosition[DetNbr][SegNbr][2];
+			break;
+		case 2:
+			xx = GeRedPosition[DetNbr][SegNbr][0];
+			yy = GeRedPosition[DetNbr][SegNbr][1];
+			zz = GeRedPosition[DetNbr][SegNbr][2];
+			break;
+		case 3:
+			xx = GeWhitePosition[DetNbr][SegNbr][0];
+			yy = GeWhitePosition[DetNbr][SegNbr][1];
+			zz = GeWhitePosition[DetNbr][SegNbr][2];
+			break;
+		};
+	}
+
+	det_pos.SetXYZ(xx, yy, zz - fTargetOffset);
+
+	if(fRadialOffset){
+		det_pos+=CloverRadial[DetNbr].Unit()*fRadialOffset;
+	}
+	
+	PostionVectors[Back][DetNbr][CryNbr][SegNbr]=det_pos;
+    }
    }
+  }
+ }
 
-   det_pos.SetXYZ(xx, yy, zz - fTargetOffset);
 
-   if(smear) {
-      if(SegNbr == 0) {
-         // Not perfect as it takes the perpendicular core vector, not the clover vector, but good enough for my
-         // purposes
-         TVector3 a(-yy, xx, 0);
-         TVector3 b = TVector3(xx, yy, zz).Cross(a);
-         double   x, y, r = sqrt(gRandom->Uniform(0, 400));
-         gRandom->Circle(x, y, r);
-         det_pos += a.Unit() * x + b.Unit() * y;
-      }
-   }
+  for(int DetNbr=0;DetNbr<17;DetNbr++){
+	TVector3 a(-CloverRadial[DetNbr].Y(),CloverRadial[DetNbr].X(), 0);
+	TVector3 b = CloverRadial[DetNbr].Cross(a);	  
+	CloverCross[DetNbr][0]=a.Unit();
+	CloverCross[DetNbr][1]=b.Unit();
+  }
 
-   return det_pos;
+  SetGlobalBit(ETigressGlobalBits::kVectorsBuilt, true);
 }
+
+TVector3 TTigress::PostionVectors[2][17][4][9];
+TVector3 TTigress::CloverCross[17][2];
+
+
+TVector3 TTigress::CloverRadial[17]={TVector3(0., 0., 0.),
+				     TVector3( 0.9239, 0.3827, 1.),
+				     TVector3(-0.3827, 0.9239, 1.),
+				     TVector3(-0.9239, -0.3827, 1.),
+				     TVector3(0.3827, -0.9239, 1.),
+				     TVector3( 0.9239, 0.3827, 0.),
+				     TVector3(0.3827, 0.9239, 0.),
+				     TVector3(-0.3827, 0.9239, 0.),
+				     TVector3(-0.9239, 0.3827, 0.),
+				     TVector3(-0.9239, -0.3827, 0.),
+				     TVector3(-0.3827, -0.9239, 0.),
+				     TVector3(0.3827, -0.9239, 0.),
+				     TVector3(0.9239, -0.3827, 0.),
+				     TVector3( 0.9239, 0.3827, -1.),
+				     TVector3(-0.3827, 0.9239, -1.),
+				     TVector3(-0.9239, -0.3827, -1.),
+				     TVector3(0.3827, -0.9239, -1.)};
 
 double TTigress::GeBluePosition[17][9][3] = {{{0., 0., 0.},
                                               {0., 0., 0.},


### PR DESCRIPTION
There was some confusion during the setting up for the upcoming TIGRESS experiment regarding the S3 position codes, this caused some delays while double checking detector mapping problems.
I've added some additional comments which should hopefully reduce the problem in the future.

I've also changed the way the TIGRESS position function works in order to add some extra debugging functionality (which turned out not to be needed ...)
I'm doubt there is any computational advantage to having the vectors built once rather than every time they are called as I have it done now, but it seemed neat at the time.