### PR TITLE
New detector specific BgoHit classes

### DIFF
--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -28,15 +28,15 @@ public:
 
 public:
    TBgoHit* GetBgoHit(const Int_t& i);
-   TGRSIDetectorHit* GetHit(const Int_t& idx = 0) { return GetBgoHit(idx); }
-   Short_t   GetMultiplicity() const { return fBgoHits.size(); }
+   TGRSIDetectorHit* GetHit(const Int_t& idx = 0) override { return GetBgoHit(idx); }
+   Short_t   GetMultiplicity() const override { return fBgoHits.size(); }
 	const std::vector<TBgoHit>& GetHitVector() const { return fBgoHits; }
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
 #ifndef __CINT__
-   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan); //!<!
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override; //!<!
 #endif
-   void ClearTransients()
+   void ClearTransients() override
    {
       for(auto hit : fBgoHits) hit.ClearTransients();
    }
@@ -44,18 +44,18 @@ public:
 
    TBgo& operator=(const TBgo&); //!<!
 
-private:
+protected:
    std::vector<TBgoHit> fBgoHits; //  The set of crystal hits
-
+private:
    static TVector3 gScintPosition[17];                      //!<! Position of each BGO scintillator
 
 public:
-   virtual void Copy(TObject&) const;            //!<!
-   virtual void Clear(Option_t* opt = "all");    //!<!
-   virtual void Print(Option_t* opt = "") const; //!<!
+   virtual void Copy(TObject&) const override;            //!<!
+   virtual void Clear(Option_t* opt = "all") override;    //!<!
+   virtual void Print(Option_t* opt = "") const override; //!<!
 
    /// \cond CLASSIMP
-   ClassDef(TBgo, 1) // Bgo Physics structure
+   ClassDefOverride(TBgo, 1) // Bgo Physics structure
    /// \endcond
 };
 /*! @} */

--- a/include/TGriffinBgo.h
+++ b/include/TGriffinBgo.h
@@ -10,15 +10,10 @@
 #include <functional>
 //#include <tuple>
 
-#include "TBits.h"
-#include "TVector3.h"
-
 #include "Globals.h"
+#include "TFragment.h"
+#include "TChannel.h"
 #include "TBgo.h"
-#include "TGRSIDetector.h"
-#include "TGRSIRunInfo.h"
-#include "TTransientBits.h"
-#include "TSpline.h"
 
 class TGriffinBgo : public TBgo {
 public:
@@ -26,10 +21,14 @@ public:
    TGriffinBgo(const TGriffinBgo&);
    virtual ~TGriffinBgo();
 
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override; //!<!
+#endif
+
    TGriffinBgo& operator=(const TGriffinBgo&); //!<!
 
    /// \cond CLASSIMP
-   ClassDef(TGriffinBgo, 1) // GriffinBgo Physics structure
+   ClassDefOverride(TGriffinBgo, 1) // GriffinBgo Physics structure
    /// \endcond
 };
 /*! @} */

--- a/include/TGriffinBgoHit.h
+++ b/include/TGriffinBgoHit.h
@@ -1,5 +1,5 @@
-#ifndef TBGOHIT_H
-#define TBGOHIT_H
+#ifndef TGRIFFINBGOHIT_H
+#define TGRIFFINBGOHIT_H
 
 /** \addtogroup Detectors
  *  @{
@@ -19,24 +19,20 @@
 #include "TChannel.h"
 #include "TPulseAnalyzer.h"
 
-#include "TGRSIDetectorHit.h"
+#include "TBgoHit.h"
 
-class TBgoHit : public TGRSIDetectorHit {
+class TGriffinBgoHit : public TBgoHit {
 public:
-   TBgoHit();
-   TBgoHit(const TBgoHit&);
-   TBgoHit(const TFragment& frag) : TGRSIDetectorHit(frag) {}
-   ~TBgoHit() override;
+   TGriffinBgoHit();
+   TGriffinBgoHit(const TGriffinBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TGriffinBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TGriffinBgoHit() override;
 
    /////////////////////////		/////////////////////////////////////
    inline UShort_t GetArrayNumber() const override { return (20 * (GetDetector() - 1) + 5 * GetCrystal() + GetSegment()); } //!<!
 
-   void Clear(Option_t* opt = "") override;       //!<!
-   void Copy(TObject&) const override;            //!<!
-   void Print(Option_t* opt = "") const override; //!<!
-
    /// \cond CLASSIMP
-   ClassDefOverride(TBgoHit, 1)
+   ClassDefOverride(TGriffinBgoHit, 1)
    /// \endcond
 };
 /*! @} */

--- a/include/TLaBrBgo.h
+++ b/include/TLaBrBgo.h
@@ -14,11 +14,9 @@
 #include "TVector3.h"
 
 #include "Globals.h"
+#include "TFragment.h"
+#include "TChannel.h"
 #include "TBgo.h"
-#include "TGRSIDetector.h"
-#include "TGRSIRunInfo.h"
-#include "TTransientBits.h"
-#include "TSpline.h"
 
 class TLaBrBgo : public TBgo {
 public:
@@ -26,10 +24,14 @@ public:
    TLaBrBgo(const TLaBrBgo&);
    virtual ~TLaBrBgo();
 
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override; //!<!
+#endif
+
    TLaBrBgo& operator=(const TLaBrBgo&); //!<!
 
    /// \cond CLASSIMP
-   ClassDef(TLaBrBgo, 1) // LaBrBgo Physics structure
+   ClassDefOverride(TLaBrBgo, 1) // LaBrBgo Physics structure
    /// \endcond
 };
 /*! @} */

--- a/include/TLaBrBgoHit.h
+++ b/include/TLaBrBgoHit.h
@@ -1,0 +1,39 @@
+#ifndef TLABRBGOHIT_H
+#define TLABRBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined(__CINT__) && !defined(__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TBgoHit.h"
+
+class TLaBrBgoHit : public TBgoHit {
+public:
+   TLaBrBgoHit();
+   TLaBrBgoHit(const TLaBrBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TLaBrBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TLaBrBgoHit() override;
+
+   /////////////////////////		/////////////////////////////////////
+   inline UShort_t GetArrayNumber() const override { return (3 * (GetDetector() - 1) + GetSegment()); } //!<! the BGO of each detector has three segments
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TLaBrBgoHit, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTdrCloverBgo.h
+++ b/include/TTdrCloverBgo.h
@@ -14,11 +14,9 @@
 #include "TVector3.h"
 
 #include "Globals.h"
+#include "TFragment.h"
+#include "TChannel.h"
 #include "TBgo.h"
-#include "TGRSIDetector.h"
-#include "TGRSIRunInfo.h"
-#include "TTransientBits.h"
-#include "TSpline.h"
 
 class TTdrCloverBgo : public TBgo {
 public:
@@ -26,10 +24,14 @@ public:
    TTdrCloverBgo(const TTdrCloverBgo&);
    virtual ~TTdrCloverBgo();
 
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override; //!<!
+#endif
+
    TTdrCloverBgo& operator=(const TTdrCloverBgo&); //!<!
 
    /// \cond CLASSIMP
-   ClassDef(TTdrCloverBgo, 1) // TdrCloverBgo Physics structure
+   ClassDefOverride(TTdrCloverBgo, 1) // TdrCloverBgo Physics structure
    /// \endcond
 };
 /*! @} */

--- a/include/TTdrCloverBgoHit.h
+++ b/include/TTdrCloverBgoHit.h
@@ -1,0 +1,39 @@
+#ifndef TTDRCLOVERBGOHIT_H
+#define TTDRCLOVERBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined(__CINT__) && !defined(__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TBgoHit.h"
+
+class TTdrCloverBgoHit : public TBgoHit {
+public:
+   TTdrCloverBgoHit();
+   TTdrCloverBgoHit(const TTdrCloverBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TTdrCloverBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TTdrCloverBgoHit() override;
+
+   /////////////////////////		/////////////////////////////////////
+   inline UShort_t GetArrayNumber() const override { return (4 * (GetDetector() - 1) + GetCrystal() + 1); } //!<! each crystal has one single signal (OR of all segments)
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TTdrCloverBgoHit, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TTdrTigressBgo.h
+++ b/include/TTdrTigressBgo.h
@@ -14,11 +14,9 @@
 #include "TVector3.h"
 
 #include "Globals.h"
+#include "TFragment.h"
+#include "TChannel.h"
 #include "TBgo.h"
-#include "TGRSIDetector.h"
-#include "TGRSIRunInfo.h"
-#include "TTransientBits.h"
-#include "TSpline.h"
 
 class TTdrTigressBgo : public TBgo {
 public:
@@ -26,10 +24,14 @@ public:
    TTdrTigressBgo(const TTdrTigressBgo&);
    virtual ~TTdrTigressBgo();
 
+#ifndef __CINT__
+   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override; //!<!
+#endif
+
    TTdrTigressBgo& operator=(const TTdrTigressBgo&); //!<!
 
    /// \cond CLASSIMP
-   ClassDef(TTdrTigressBgo, 1) // TdrTigressBgo Physics structure
+   ClassDefOverride(TTdrTigressBgo, 1) // TdrTigressBgo Physics structure
    /// \endcond
 };
 /*! @} */

--- a/include/TTdrTigressBgoHit.h
+++ b/include/TTdrTigressBgoHit.h
@@ -1,0 +1,39 @@
+#ifndef TTDRTIGRESSBGOHIT_H
+#define TTDRTIGRESSBGOHIT_H
+
+/** \addtogroup Detectors
+ *  @{
+ */
+
+#include <cstdio>
+#include <cmath>
+#if !defined(__CINT__) && !defined(__CLING__)
+#include <tuple>
+#endif
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TClonesArray.h"
+
+#include "TFragment.h"
+#include "TChannel.h"
+#include "TPulseAnalyzer.h"
+
+#include "TBgoHit.h"
+
+class TTdrTigressBgoHit : public TBgoHit {
+public:
+   TTdrTigressBgoHit();
+   TTdrTigressBgoHit(const TTdrTigressBgoHit& hit) : TBgoHit(static_cast<const TBgoHit&>(hit)) {}
+   TTdrTigressBgoHit(const TFragment& frag) : TBgoHit(frag) {}
+   ~TTdrTigressBgoHit() override;
+
+   /////////////////////////		/////////////////////////////////////
+   inline UShort_t GetArrayNumber() const override { return (4 * (GetDetector() - 1) + GetCrystal() + 1); } //!<! each crystal has one single signal (OR of all segments)
+
+   /// \cond CLASSIMP
+   ClassDefOverride(TTdrTigressBgoHit, 1)
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -1538,15 +1538,11 @@ int TDataParser::CaenToFragment(uint32_t* data, int size)
          }
 			return -w;
 		}
-      //std::cout<<w-1<<": 0x"<<std::hex<<std::setw(8)<<std::setfill('0')<<data[w-1]<<std::dec<<std::setfill(' ')<<" - "<<numWordsBoard<<" words"<<std::endl;
-		uint8_t boardId = data[w]>>27; // GEO address of board (can be set via register 0xef08 for VME)
-		uint16_t pattern = (data[w]>>8) & 0x7fff; // value read from LVDS I/O (VME only)
+		//uint8_t boardId = data[w]>>27; // GEO address of board (can be set via register 0xef08 for VME)
+		//uint16_t pattern = (data[w]>>8) & 0x7fff; // value read from LVDS I/O (VME only)
 		uint8_t channelMask = data[w++]&0xff; // which channels are in this board aggregate
-      //std::cout<<w-1<<": 0x"<<std::hex<<std::setw(8)<<std::setfill('0')<<data[w-1]<<std::dec<<std::setfill(' ')<<" - boardId "<<boardId<<", pattern "<<pattern<<", channelMask "<<channelMask<<std::endl;
-		uint32_t boardCounter = data[w++]&0x7fffff; // ??? "counts the board aggregate"
-      //std::cout<<w-1<<": 0x"<<std::hex<<std::setw(8)<<std::setfill('0')<<data[w-1]<<std::dec<<std::setfill(' ')<<" - boardCounter "<<boardCounter<<std::endl;
+		++w;//uint32_t boardCounter = data[w++]&0x7fffff; // ??? "counts the board aggregate"
 		uint32_t boardTime = data[w++]; // time of creation of aggregate (does not correspond to a physical quantity)
-      //std::cout<<w-1<<": 0x"<<std::hex<<std::setw(8)<<std::setfill('0')<<data[w-1]<<std::dec<<std::setfill(' ')<<" - boardTime "<<boardTime<<std::endl;
 		//if(boardCounter < gBoardCounter) {
 		//	std::cerr<<"current board counter "<<boardCounter<<" is less than previous one "<<gBoardCounter<<", skipping this data"<<std::endl;
 		//	return nofFragments;
@@ -1701,9 +1697,6 @@ int TDataParser::CaenToFragment(uint32_t* data, int size)
 					}
                ++w;
 				}
-				//if(w >= size) {
-				//	std::cerr<<"4 - Missing words, got only "<<w-1<<" words for channel "<<channel<<" (bank size "<<size<<")"<<std::endl;
-				//}
 				eventFrag->SetCcShort(data[w]&0x7fff);
 				eventFrag->SetCcLong((data[w]>>15) & 0x1);//this is actually the over-range bit!
 				eventFrag->SetCharge(static_cast<Int_t>(data[w++]>>16));

--- a/libraries/TGRSIAnalysis/TBgo/LinkDef.h
+++ b/libraries/TGRSIAnalysis/TBgo/LinkDef.h
@@ -1,4 +1,4 @@
-//TBgo.h TBgoHit.h TGriffinBgo.h TLaBrBgo.h TTdrCloverBgo.h TTdrTigressBgo.h
+//TBgo.h TBgoHit.h TGriffinBgo.h TLaBrBgo.h TTdrCloverBgo.h TTdrTigressBgo.h TGriffinBgoHit.h TLaBrBgoHit.h TTdrCloverBgoHit.h TTdrTigressBgoHit.h
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -12,6 +12,10 @@
 #pragma link C++ class TLaBrBgo+;
 #pragma link C++ class TTdrCloverBgo+;
 #pragma link C++ class TTdrTigressBgo+;
+#pragma link C++ class TGriffinBgoHit+;
+#pragma link C++ class TLaBrBgoHit+;
+#pragma link C++ class TTdrCloverBgoHit+;
+#pragma link C++ class TTdrTigressBgoHit+;
 
 #endif
 

--- a/libraries/TGRSIAnalysis/TBgo/TBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TBgoHit.cxx
@@ -41,11 +41,3 @@ void TBgoHit::Print(Option_t* opt) const
    printf("============================\n");
 }
 
-int TBgoHit::GetCrystal() const
-{
-   TChannel* chan = GetChannel();
-   if(chan == nullptr) {
-      return -1;
-   }
-   return chan->GetCrystalNumber();
-}

--- a/libraries/TGRSIAnalysis/TBgo/TGriffinBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TGriffinBgo.cxx
@@ -1,4 +1,5 @@
 #include "TGriffinBgo.h"
+#include "TGriffinBgoHit.h"
 
 #include <sstream>
 #include <iostream>
@@ -47,3 +48,16 @@ TGriffinBgo& TGriffinBgo::operator=(const TGriffinBgo& rhs)
    rhs.Copy(*this);
    return *this;
 }
+
+void TGriffinBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+{
+   // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
+   // observables.
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+	TGriffinBgoHit hit(*frag);
+	fBgoHits.push_back(std::move(hit));
+}
+

--- a/libraries/TGRSIAnalysis/TBgo/TGriffinBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TGriffinBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TGriffinBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TGriffinBgoHit)
+/// \endcond
+
+TGriffinBgoHit::TGriffinBgoHit()
+{
+	Clear();
+}
+
+TGriffinBgoHit::~TGriffinBgoHit() = default;
+

--- a/libraries/TGRSIAnalysis/TBgo/TLaBrBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TLaBrBgo.cxx
@@ -1,4 +1,5 @@
 #include "TLaBrBgo.h"
+#include "TLaBrBgoHit.h"
 
 #include <sstream>
 #include <iostream>
@@ -47,3 +48,16 @@ TLaBrBgo& TLaBrBgo::operator=(const TLaBrBgo& rhs)
    rhs.Copy(*this);
    return *this;
 }
+
+void TLaBrBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+{
+   // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
+   // observables.
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+	TLaBrBgoHit hit(*frag);
+	fBgoHits.push_back(std::move(hit));
+}
+

--- a/libraries/TGRSIAnalysis/TBgo/TLaBrBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TLaBrBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TLaBrBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TLaBrBgoHit)
+/// \endcond
+
+TLaBrBgoHit::TLaBrBgoHit()
+{
+   Clear();
+}
+
+TLaBrBgoHit::~TLaBrBgoHit() = default;
+

--- a/libraries/TGRSIAnalysis/TBgo/TTdrCloverBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TTdrCloverBgo.cxx
@@ -1,4 +1,5 @@
 #include "TTdrCloverBgo.h"
+#include "TTdrCloverBgoHit.h"
 
 #include <sstream>
 #include <iostream>
@@ -47,3 +48,16 @@ TTdrCloverBgo& TTdrCloverBgo::operator=(const TTdrCloverBgo& rhs)
    rhs.Copy(*this);
    return *this;
 }
+
+void TTdrCloverBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+{
+   // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
+   // observables.
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+	TTdrCloverBgoHit hit(*frag);
+	fBgoHits.push_back(std::move(hit));
+}
+

--- a/libraries/TGRSIAnalysis/TBgo/TTdrCloverBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TTdrCloverBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TTdrCloverBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TTdrCloverBgoHit)
+/// \endcond
+
+TTdrCloverBgoHit::TTdrCloverBgoHit()
+{
+   Clear();
+}
+
+TTdrCloverBgoHit::~TTdrCloverBgoHit() = default;
+

--- a/libraries/TGRSIAnalysis/TBgo/TTdrTigressBgo.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TTdrTigressBgo.cxx
@@ -1,4 +1,5 @@
 #include "TTdrTigressBgo.h"
+#include "TTdrTigressBgoHit.h"
 
 #include <sstream>
 #include <iostream>
@@ -47,3 +48,16 @@ TTdrTigressBgo& TTdrTigressBgo::operator=(const TTdrTigressBgo& rhs)
    rhs.Copy(*this);
    return *this;
 }
+
+void TTdrTigressBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+{
+   // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
+   // observables.
+   if(frag == nullptr || chan == nullptr) {
+      return;
+   }
+
+	TTdrTigressBgoHit hit(*frag);
+	fBgoHits.push_back(std::move(hit));
+}
+

--- a/libraries/TGRSIAnalysis/TBgo/TTdrTigressBgoHit.cxx
+++ b/libraries/TGRSIAnalysis/TBgo/TTdrTigressBgoHit.cxx
@@ -1,0 +1,17 @@
+#include "TTdrTigressBgoHit.h"
+
+#include "TClass.h"
+
+#include "GValue.h"
+
+/// \cond CLASSIMP
+ClassImp(TTdrTigressBgoHit)
+/// \endcond
+
+TTdrTigressBgoHit::TTdrTigressBgoHit()
+{
+   Clear();
+}
+
+TTdrTigressBgoHit::~TTdrTigressBgoHit() = default;
+

--- a/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
+++ b/libraries/TGRSIAnalysis/TGriffin/TGriffin.cxx
@@ -241,6 +241,7 @@ std::vector<TGriffinHit>& TGriffin::GetHitVector(const EGainBits& gain_type)
 		case EGainBits::kLowGain:  return fGriffinLowGainHits;
 		case EGainBits::kHighGain: return fGriffinHighGainHits;
    };
+	return fGriffinLowGainHits;
 }
 
 std::vector<TGriffinHit>& TGriffin::GetAddbackVector(const EGainBits& gain_type)
@@ -249,6 +250,7 @@ std::vector<TGriffinHit>& TGriffin::GetAddbackVector(const EGainBits& gain_type)
 		case EGainBits::kLowGain:  return fAddbackLowGainHits;
 		case EGainBits::kHighGain: return fAddbackHighGainHits;
    };
+	return fAddbackLowGainHits;
 }
 
 std::vector<UShort_t>& TGriffin::GetAddbackFragVector(const EGainBits& gain_type)
@@ -257,6 +259,7 @@ std::vector<UShort_t>& TGriffin::GetAddbackFragVector(const EGainBits& gain_type
 		case EGainBits::kLowGain:  return fAddbackLowGainFrags;
 		case EGainBits::kHighGain: return fAddbackHighGainFrags;
    };
+	return fAddbackLowGainFrags;
 }
 
 bool TGriffin::IsAddbackSet(const EGainBits& gain_type) const
@@ -675,6 +678,7 @@ std::vector<TGriffinHit>& TGriffin::GetSuppressedVector(const EGainBits& gain_ty
 		case EGainBits::kLowGain:  return fSuppressedLowGainHits;
 		case EGainBits::kHighGain: return fSuppressedHighGainHits;
    };
+	return fSuppressedLowGainHits;
 }
 
 std::vector<TGriffinHit>& TGriffin::GetSuppressedAddbackVector(const EGainBits& gain_type)
@@ -683,6 +687,7 @@ std::vector<TGriffinHit>& TGriffin::GetSuppressedAddbackVector(const EGainBits& 
 		case EGainBits::kLowGain:  return fSuppressedAddbackLowGainHits;
 		case EGainBits::kHighGain: return fSuppressedAddbackHighGainHits;
    };
+	return fSuppressedAddbackLowGainHits;
 }
 
 std::vector<UShort_t>& TGriffin::GetSuppressedAddbackFragVector(const EGainBits& gain_type)
@@ -691,6 +696,7 @@ std::vector<UShort_t>& TGriffin::GetSuppressedAddbackFragVector(const EGainBits&
 		case EGainBits::kLowGain:  return fSuppressedAddbackLowGainFrags;
 		case EGainBits::kHighGain: return fSuppressedAddbackHighGainFrags;
    };
+	return fSuppressedAddbackLowGainFrags;
 }
 
 TGriffinHit* TGriffin::GetSuppressedHit(const int& i, const EGainBits& gain_type)

--- a/libraries/TMidas/TMidasEvent.cxx
+++ b/libraries/TMidas/TMidasEvent.cxx
@@ -497,13 +497,13 @@ int TMidasEvent::IterateBank32(TMidas_BANK32** pbk, char** pdata) const
       }
    }
 
-   *pdata = reinterpret_cast<char*>((*pbk) + 1);
-
    if(reinterpret_cast<char*>(*pbk) >= (char*)event + event->fDataSize + sizeof(TMidas_BANK_HEADER)) {
       *pbk   = nullptr;
       *pdata = nullptr;
       return 0;
    }
+
+   *pdata = reinterpret_cast<char*>((*pbk) + 1);
 
    return (*pbk)->fDataSize;
 }


### PR DESCRIPTION
New detector specific BgoHit classes overwrite the GetArrayNumber function. The detector specific Bgo classes themselves add new fragments as such hits.

Also fixed some compiler warnings and a potential bug in TMidasEvent::IterateBank32.