### PR TITLE
 Added TGRSIint::OpenLibrary and calling it at start of grsisort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ GRSIProof/*.?
 __pycache__
 grsi_logon.C
 *.pcm
+*Data

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -95,7 +95,7 @@ public:
    virtual void Copy(TObject&, bool copywave) const; //!<!
    virtual void CopyWave(TObject&) const;            //!<!
    void Clear(Option_t* opt = "") override;          //!<!
-   virtual void ClearTransients() const { fBitflags = 0; }
+   virtual void ClearTransients() const { fBitFlags = 0; }
    void Print(Option_t* opt = "") const override;                                 //!<!
    virtual bool HasWave() const { return (fWaveform.size() > 0) ? true : false; } //!<!
 
@@ -183,14 +183,14 @@ private:
    //     TVector3(0., 0., 0.); }
 
 protected:
-   Bool_t IsEnergySet() const { return (fBitflags.TestBit(EBitFlag::kIsEnergySet)); }
-   Bool_t IsChannelSet() const { return (fBitflags.TestBit(EBitFlag::kIsChannelSet)); }
-   Bool_t IsTimeSet() const { return (fBitflags.TestBit(EBitFlag::kIsTimeSet)); }
-   Bool_t IsPPGSet() const { return (fBitflags.TestBit(EBitFlag::kIsPPGSet)); }
+   Bool_t IsEnergySet() const { return (fBitFlags.TestBit(EBitFlag::kIsEnergySet)); }
+   Bool_t IsChannelSet() const { return (fBitFlags.TestBit(EBitFlag::kIsChannelSet)); }
+   Bool_t IsTimeSet() const { return (fBitFlags.TestBit(EBitFlag::kIsTimeSet)); }
+   Bool_t IsPPGSet() const { return (fBitFlags.TestBit(EBitFlag::kIsPPGSet)); }
 
 public:
    void SetHitBit(EBitFlag, Bool_t set = true) const; // const here is dirty
-   bool TestHitBit(EBitFlag flag) const { return fBitflags.TestBit(flag); }
+   bool TestHitBit(EBitFlag flag) const { return fBitFlags.TestBit(flag); }
 
 protected:
    UInt_t               fAddress{0};   ///< address of the the channel in the DAQ.
@@ -210,10 +210,8 @@ private:
 
 protected:
    static TPPG* fPPG;
-
-private:
    // flags
-   mutable TTransientBits<UChar_t> fBitflags;
+   mutable TTransientBits<UChar_t> fBitFlags;
    static TVector3                 fBeamDirection; //!
 
    /// \cond CLASSIMP

--- a/include/TGRSIint.h
+++ b/include/TGRSIint.h
@@ -77,6 +77,7 @@ private:
    void DrawLogo();
    void LoadGROOTGraphics();
    void LoadExtraClasses();
+	void OpenLibrary();
 
    Long_t DelayedProcessLine(std::string command);
 

--- a/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
@@ -48,7 +48,7 @@ void TDetectorHit::Streamer(TBuffer& R__b)
    if(R__b.IsReading()) {
       R__b.ReadClassBuffer(TDetectorHit::Class(), this);
    } else {
-      fBitflags = 0;
+      fBitFlags = 0;
       R__b.WriteClassBuffer(TDetectorHit::Class(), this);
    }
 }
@@ -147,7 +147,7 @@ void TDetectorHit::Copy(TObject& rhs) const
    static_cast<TDetectorHit&>(rhs).fTime      = fTime;
    static_cast<TDetectorHit&>(rhs).fChannel   = fChannel;
 
-   static_cast<TDetectorHit&>(rhs).fBitflags       = 0;
+   static_cast<TDetectorHit&>(rhs).fBitFlags       = 0;
    static_cast<TDetectorHit&>(rhs).fPPGStatus      = fPPGStatus;
    static_cast<TDetectorHit&>(rhs).fCycleTimeStamp = fCycleTimeStamp;
 }
@@ -199,7 +199,7 @@ void TDetectorHit::Clear(Option_t*)
 	// fDetector       = -1;
 	// fSegment        = -1;
 	fEnergy         = 0.;
-	fBitflags       = 0;
+	fBitFlags       = 0;
 	fPPGStatus      = EPpgPattern::kJunk;
 	fCycleTimeStamp = 0;
 	fChannel        = nullptr;
@@ -298,5 +298,5 @@ double TDetectorHit::GetTimeSinceTapeMove() const
 // const here is rather dirty
 void TDetectorHit::SetHitBit(enum EBitFlag flag, Bool_t set) const
 {
-	fBitflags.SetBit(flag, set);
+	fBitFlags.SetBit(flag, set);
 }

--- a/libraries/THistogramming/DynamicLibrary.cxx
+++ b/libraries/THistogramming/DynamicLibrary.cxx
@@ -49,8 +49,7 @@ DynamicLibrary::DynamicLibrary(std::string libname_param, bool unique_name) : fL
    }
 
    if(fLibrary == nullptr) {
-      return;
-      // throw RuntimeFileNotFound(dlerror());
+      throw std::runtime_error(dlerror());
    }
 }
 


### PR DESCRIPTION
Now the path and version of the library get printed whenever grsisort is started with a library provided via command line argument or .grsirc (whether raw data files are processed or not).