### PR TITLE
 Changed names of objects written to file not to be class names

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -48,6 +48,7 @@ public:
    static TChannel* GetChannel(unsigned int temp_address);
    static TChannel* GetChannelByNumber(int temp_num);
    static TChannel* FindChannelByName(const char* ccName);
+   static std::vector<TChannel*> FindChannelByRegEx(const char* ccName);
 
    TChannel();
    TChannel(const char*);

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -153,7 +153,7 @@ public:
    virtual Int_t    GetSegment() const;       //!<!
    virtual Int_t    GetCrystal() const;       //!<!
    const char*      GetName() const override; //!<!
-   virtual UShort_t GetArrayNumber() const;   //!<!
+   virtual UShort_t GetArrayNumber() const { return GetDetector(); } //!<! Simply returns the detector number, overwritten for detectors that have crystals/segments
 
    // virtual void GetSegment() const;
 

--- a/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
@@ -234,15 +234,6 @@ Int_t TDetectorHit::GetCrystal() const
 	return -1;
 }
 
-UShort_t TDetectorHit::GetArrayNumber() const
-{
-	TChannel* channel = GetChannel();
-	if(channel != nullptr) {
-		return (GetDetector() - 1) * 4 + GetCrystal();
-	}
-	return -1;
-}
-
 bool TDetectorHit::CompareEnergy(TDetectorHit* lhs, TDetectorHit* rhs)
 {
 	return (lhs->GetEnergy() > rhs->GetEnergy());

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -1299,7 +1299,7 @@ int TChannel::WriteToRoot(TFile* fileptr)
    TIter iter(gDirectory->GetListOfKeys());
 
    bool        found         = false;
-   std::string mastername    = "TChannel";
+   std::string mastername    = "Channel";
    std::string mastertitle   = "TChannel";
    std::string channelbuffer = fFileData; //fFileData is the old TChannel information read from file
    WriteCalBuffer(); //replaces fFileData with the current channels
@@ -1332,7 +1332,7 @@ int TChannel::WriteToRoot(TFile* fileptr)
    TChannel::ParseInputData(channelbuffer.c_str(), "q", EPriority::kRootFile);
    c = TChannel::GetDefaultChannel();
    c->SetNameTitle(mastername.c_str(), mastertitle.c_str());
-   c->Write("", TObject::kOverwrite);
+   c->Write("Channel", TObject::kOverwrite);
 
    ParseInputData(savedata.c_str(), "q", EPriority::kRootFile);
    SaveToSelf(savedata.c_str());

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -10,6 +10,7 @@
 #include <vector>
 #include <sstream>
 #include <algorithm>
+#include <regex>
 
 #include "TFile.h"
 #include "TKey.h"
@@ -358,13 +359,33 @@ TChannel* TChannel::FindChannelByName(const char* ccName)
       chan                    = iter.second;
       std::string channelName = chan->GetName();
       if(channelName.compare(0, name.length(), name) == 0) {
-         break;
+         return chan;
       }
-      chan = nullptr;
    }
-   // either comes out normally as null or breaks out with some TChannel [SC]
 
-   return chan;
+   return nullptr;
+}
+
+std::vector<TChannel*> TChannel::FindChannelByRegEx(const char* ccName)
+{
+   /// Finds the TChannel by the name of the channel
+	std::vector<TChannel*> result;
+   if(ccName == nullptr) {
+      return result;
+   }
+
+   std::regex regex(ccName);
+
+	TChannel* chan;
+   for(auto iter : *fChannelMap) {
+      chan                    = iter.second;
+      std::string channelName = chan->GetName();
+		if(std::regex_match(channelName, regex)) {
+         result.push_back(chan);
+      }
+   }
+
+   return result;
 }
 
 void TChannel::UpdateChannelNumberMap()

--- a/libraries/TGRSIFormat/TRunInfo.cxx
+++ b/libraries/TGRSIFormat/TRunInfo.cxx
@@ -334,8 +334,8 @@ bool TRunInfo::WriteToRoot(TFile* fileptr)
       printf("No file opened to write to.\n");
       bool2return = false;
    } else {
-      runInfo->Write();
-		runInfo->fDetectorInformation->Write();
+      runInfo->Write("RunInfo", TObject::kOverwrite);
+		runInfo->fDetectorInformation->Write("DetectorInformation", TObject::kOverwrite);
    }
 
    printf("Writing TRunInfo to %s\n", gDirectory->GetFile()->GetName());

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -61,7 +61,7 @@ bool TAnalysisOptions::WriteToFile(TFile* file)
       printf("No file opened to write to.\n");
       success = false;
    } else {
-      Write();
+      Write("AnalysisOptions",TObject::kOverwrite);
    }
 
    printf("Writing TAnalysisOptions to %s\n", gDirectory->GetFile()->GetName());

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -548,8 +548,8 @@ bool TGRSIOptions::WriteToFile(TFile* file)
       printf("No file opened to write to.\n");
       success = false;
    } else {
-      Get()->Write();
-		fAnalysisOptions->Write();
+      Get()->Write("GRSIOptions", TObject::kOverwrite);
+		fAnalysisOptions->WriteToFile(file);
    }
 
    printf("Writing TGRSIOptions to %s\n", gDirectory->GetFile()->GetName());

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -354,8 +354,8 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
 #endif
          }
 
-         if(file->FindObjectAny("TChannel") != nullptr) {
-            file->Get("TChannel"); // this calls TChannel::Streamer
+         if(file->FindObjectAny("Channel") != nullptr) {
+            file->Get("Channel"); // this calls TChannel::Streamer
          }
          if(file->FindObjectAny("GValue") != nullptr) {
             file->Get("GValue");

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -141,17 +141,17 @@ void TAnalysisWriteLoop::Write()
 		outputFile->cd();
 
 		if(GValue::Size() != 0) {
-			GValue::Get()->Write();
+			GValue::Get()->Write("Values", TObject::kOverwrite);
 		}
 		if(TChannel::GetNumberOfChannels() != 0) {
 			TChannel::WriteToRoot();
 		}
 		runInfo->WriteToRoot(outputFile);
 		options->AnalysisOptions()->WriteToFile(outputFile);
-		ppg->Write();
+		ppg->Write("PPG", TObject::kOverwrite);
 
 		if(options->WriteDiagnostics()) {
-			diag->Write();
+			diag->Write("SortingDiagnostics", TObject::kOverwrite);
 		}
 
 		outputFile->Close();

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -146,21 +146,20 @@ void TFragWriteLoop::Write()
       fBadEventTree->Write(fBadEventTree->GetName(), TObject::kOverwrite);
       fScalerTree->Write(fScalerTree->GetName(), TObject::kOverwrite);
       if(GValue::Size() != 0) {
-         gValues->Write();
+         gValues->Write("Values", TObject::kOverwrite);
       }
 
       if(TChannel::GetNumberOfChannels() != 0) {
-         // TChannel::GetDefaultChannel()->Write();
          TChannel::WriteToRoot();
       }
 
       runInfo->WriteToRoot(fOutputFile);
       options->WriteToFile(fOutputFile);
-      ppg->Write();
+      ppg->Write("PPG", TObject::kOverwrite);
 
       if(options->WriteDiagnostics()) {
          parsingDiagnostics->ReadPPG(ppg);
-         parsingDiagnostics->Write();
+         parsingDiagnostics->Write("ParsingDiagnostics", TObject::kOverwrite);
       }
 
       fOutputFile->Close();


### PR DESCRIPTION
- new function TChannel::FindChannelByRegEx returns vector of channels
  that match the supplied regular expression (see #1051)
- changed default GetArrayNumber function to return detector number.
  This function is overwritten by detectors that have cyrstals/segments.