### PR TITLE
 Fixed issues with digitizer type

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -75,7 +75,7 @@ private:
    unsigned int fAddress;     // The address of the digitizer
    TPriorityValue<int>          fIntegration; // The charge integration setting
    TPriorityValue<std::string>  fDigitizerTypeString;
-	TPriorityValue<TMnemonic::EDigitizer> fDigitizerType;
+	TPriorityValue<EDigitizer>   fDigitizerType;
    TPriorityValue<int>          fNumber;
    TPriorityValue<int>          fStream;
    TPriorityValue<int>          fUserInfoNumber;
@@ -141,7 +141,8 @@ public:
    inline void SetDigitizerType(TPriorityValue<std::string> tmp)
    {
       fDigitizerTypeString = tmp;
-      fDigitizerType.Set(TMnemonic::EnumerateDigitizer(fDigitizerTypeString.Value()), fDigitizerTypeString.Priority());
+      //fDigitizerType.Set(fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString.Value()), fDigitizerTypeString.Priority());
+      fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType);
    }
    static void SetDigitizerType(const std::string& mnemonic, const char* tmpstr, EPriority pr);
    inline void SetTimeOffset(TPriorityValue<Long64_t> tmp) { fTimeOffset = tmp; }
@@ -163,7 +164,7 @@ public:
    int          GetStream() const { return fStream.Value(); }
    int          GetUserInfoNumber() const { return fUserInfoNumber.Value(); }
    const char*  GetDigitizerTypeString() const { return fDigitizerTypeString.Value().c_str(); }
-	TMnemonic::EDigitizer GetDigitizerType() const { return fDigitizerType.Value(); }
+	EDigitizer   GetDigitizerType() const { return fDigitizerType.Value(); }
    Long64_t     GetTimeOffset() const { return fTimeOffset.Value(); }
    // write the rest of the gettters/setters...
 

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -141,7 +141,6 @@ public:
    inline void SetDigitizerType(TPriorityValue<std::string> tmp)
    {
       fDigitizerTypeString = tmp;
-      //fDigitizerType.Set(fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString.Value()), fDigitizerTypeString.Priority());
       fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType);
    }
    static void SetDigitizerType(const std::string& mnemonic, const char* tmpstr, EPriority pr);

--- a/include/TGRSIint.h
+++ b/include/TGRSIint.h
@@ -99,6 +99,7 @@ private:
 	TRawFile*   (*fCreateRawFile)(const std::string&);
 	void        (*fDestroyRawFile)(TRawFile*);
 	std::string (*fLibraryVersion)();
+	void        (*fInitLibrary)();
 
    /// \cond CLASSIMP
    ClassDefOverride(TGRSIint, 0); // Interpreter for GRSISort

--- a/include/TMnemonic.h
+++ b/include/TMnemonic.h
@@ -2,9 +2,14 @@
 #define MNEMONIC_H
 
 #include <string>
+
 #include "TObject.h"
-#include "Globals.h"
 #include "TClass.h"
+
+#include "Globals.h"
+#include "TPriorityValue.h"
+
+enum class EDigitizer : char;// { kDefault };
 
 class TMnemonic : public TObject {
 public:
@@ -16,7 +21,6 @@ public:
    // EMnemonic or ESystem has no effect on the clashing of enumerated variable names.
    // These separations exist only to easily see the difference when looking at the code here.
    enum class EMnemonic { kA, kB, kC, kD, kE, kF, kG, kH, kI, kJ, kK, kL, kM, kN, kO, kP, kQ, kR, kS, kT, kU, kV, kW, kX, kY, kZ, kClear };
-   enum class EDigitizer { kDefault };
 
    virtual EMnemonic SubSystem() const { return fSubSystem; }
    virtual EMnemonic ArraySubPosition() const { return fArraySubPosition; }
@@ -35,7 +39,7 @@ public:
    virtual void Parse(std::string* name);
    virtual void Parse(const char* name);
 
-   static EDigitizer EnumerateDigitizer(std::string name);
+   virtual void EnumerateDigitizer(TPriorityValue<std::string>&, TPriorityValue<EDigitizer>&) { }
 
    virtual void SetRFMNEMONIC(std::string* name);
 

--- a/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TGRSIAnalysis/TDetector/TDetectorHit.cxx
@@ -59,40 +59,7 @@ Double_t TDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
       return fTime;
    }
 
-   //TChannel* channel = GetChannel();
-   //if(channel == nullptr) {
-   //   Error("GetTime", "No TChannel exists for address 0x%08x", GetAddress());
-      return SetTime(10. * (static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
-   //}
-   //switch(channel->GetDigitizerType()) {
-	//	Double_t dTime;
-	//	case TMnemonic::EDigitizer::kGRF16:
-	//	dTime = (GetTimeStamp() & (~0x3ffff)) * 10. +
-	//	channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
-	//	return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-	//	case TMnemonic::EDigitizer::kGRF4G:
-	//	dTime = GetTimeStamp() * 10. + channel->CalibrateCFD((fCfd >> 22) + ((fCfd & 0x3fffff) + gRandom->Uniform()) / 256.);
-	//	return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-	//	case TMnemonic::EDigitizer::kTIG10:
-	//	dTime = (GetTimeStamp() & (~0x7fffff)) * 10. +
-	//	channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 1.6); // CFD is in 10/16th of a nanosecond
-	//	//channel->CalibrateCFD((GetCfd() & (~0xf) + gRandom->Uniform()) / 1.6); // PBender suggests this.
-	//	return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-   //   case TMnemonic::EDigitizer::kCaen:
-   //   //10 bit CFD for 0-2ns => divide by 512
-   //   dTime = GetTimeStamp() * 10. + channel->CalibrateCFD((GetCfd() + gRandom->Uniform()) / 512.);
-   //   return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-	//	case TMnemonic::EDigitizer::kPixie:
-	//	dTime = GetTimeStamp() * 10. + channel->CalibrateCFD(fCfd/3276.8);// CFD is reported as 15bit interpolation of 10 ns
-	//	return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-	//	case TMnemonic::EDigitizer::kFastPixie:
-	//	dTime = GetTimeStamp() * 10. + channel->CalibrateCFD(fCfd/6553.6);// CFD is reported as 16bit interpolation of 10 ns
-	//	return SetTime(dTime - 10. * (channel->GetTZero(GetEnergy())));
-	//	default:
-	//	dTime = static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform());
-	//	return SetTime(10. * (dTime - channel->GetTZero(GetEnergy())));
-	//}
-   //return 0.;
+	return SetTime(10. * (static_cast<Double_t>((GetTimeStamp()) + gRandom->Uniform())));
 }
 
 Float_t TDetectorHit::GetCharge() const

--- a/libraries/TGRSIFormat/TChannel.cxx
+++ b/libraries/TGRSIFormat/TChannel.cxx
@@ -282,7 +282,7 @@ void TChannel::Clear(Option_t*)
 	fAddress = 0xffffffff;
    fIntegration.Reset(0);
 	fDigitizerTypeString = TPriorityValue<std::string>();
-	fDigitizerType.Reset(TMnemonic::EDigitizer::kDefault);
+	//fDigitizerType.Reset(EDigitizer::kDefault);
    fNumber.Reset(0);
    fStream.Reset(0);
    fUserInfoNumber.Reset(0xffffffff);

--- a/libraries/TGRSIFormat/TMnemonic.cxx
+++ b/libraries/TGRSIFormat/TMnemonic.cxx
@@ -54,11 +54,6 @@ void TMnemonic::EnumerateMnemonic(std::string mnemonic_word, EMnemonic& mnemonic
 	};
 }
 
-TMnemonic::EDigitizer TMnemonic::EnumerateDigitizer(std::string)
-{
-   return EDigitizer::kDefault;
-}
-
 void TMnemonic::Parse(std::string* name)
 {
    if((name == nullptr) || name->length() < 9) {


### PR DESCRIPTION
See also GRIFFINCollaboration/GRSIData#9.

- Added LibraryInit function that sets the mnemonic class for the
  TChannel to the appropriate choice for the library. This function is
  called immediately after opeing the library.
- The parser libraries EnumerateDigitizer now produces warning message
  if string is not recognized.
- Instead of taking a string and returning the digitizer enum class
  EnumerateDigitizer now takes the name and type of the digitizer as
  TPriorityValue references as arguments (return value is void).
- EDigitizer is not part of the TMnemonic namespace anymore and is
  defined only within the data parser library.