### PR TITLE
Added capability to create cuts and use them in GRSIproof

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -17,6 +17,7 @@
 #include "TStopwatch.h"
 #include "TGRSIMap.h"
 #include "TPPG.h"
+#include "TCutG.h"
 
 #include <iostream>
 #include <vector>
@@ -236,6 +237,10 @@ int main(int argc, char** argv)
    i = 0;
    for(const auto& calFile : gGRSIOpt->CalInputFiles()) {
       gGRSIProof->AddInput(new TNamed(Form("calFile%d", i++), calFile.c_str()));
+   }
+   i = 0;
+   for(const auto& cutFile : gGRSIOpt->InputCutFiles()) {
+      gGRSIProof->AddInput(new TNamed(Form("cutFile%d", i++), cutFile.c_str()));
    }
 	gGRSIProof->AddInput(new TNamed("ParserLibrary", library.c_str()));
 

--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -8,6 +8,7 @@
 
 #include "TH1.h"
 #include "TLine.h"
+#include "TCutG.h"
 
 #include "GH2I.h"
 
@@ -125,6 +126,8 @@ private:
    std::vector<GMarker*>  fMarkers;
    std::vector<GMarker*>  fBackgroundMarkers;
    EBackgroundSubtraction fBackgroundMode;
+	std::vector<TCutG*>    fCuts;
+	char*                  fCutName;
    void AddMarker(int, int, int dim = 1);
    void RemoveMarker(Option_t* opt = "");
    void OrderMarkers();

--- a/include/TGRSISelector.h
+++ b/include/TGRSISelector.h
@@ -15,6 +15,8 @@
 #include "TH1.h"
 #include "TH2.h"
 #include "THnSparse.h"
+#include "TCutG.h"
+
 #include "GHSym.h"
 #include "GCube.h"
 #include "TAnalysisOptions.h"
@@ -64,7 +66,8 @@ protected:
    TGRSIMap<std::string, GHSym*>      fSym; //!<!
    TGRSIMap<std::string, GCube*>      fCube; //!<!
    TGRSIMap<std::string, THnSparseF*> fHSparse; //!<!
-	TPPG*             fPpg{nullptr}; //!<!
+	TPPG*                              fPpg{nullptr}; //!<!
+	std::map<std::string, TCutG*>      fCuts; //!<!
 
 private:
    std::string       fOutputPrefix; //!<!


### PR DESCRIPTION
- GRSIProof reads cuts from all supplied "cut files". The cut files are determined by TGRSIOptions::InputCutFiles which returns all files with extension .cuts provided on the command line.
  Don't know what these files were originally intended for, but now those are just re-named root-files.
- TGRSISelector tries to open all files provided by GRSIProof as "cut files" and reads any TCutG object from them. These are stored in a map, mapping the TCutG pointer to the name of the cut.
- GCanvas now has three more short cuts:
  - i: initialize cut, prompting for a name, using single clicks to add points, and double click to finish/close the cut.
  - c: create the cut, using the previously initialized object "CUTG".
  - s: save cuts, prompting for a file name, default is CutFile.cuts.