### PR TITLE
Several small bug fixes

### DIFF
--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -45,7 +45,7 @@ public:
 	const std::vector<std::string>& ValInputFiles() { return fInputValFiles; }
 	const std::vector<std::string>& InputOdbFiles() { return fInputOdbFiles; }
 	const std::vector<std::string>& ExternalRunInfo() { return fExternalRunInfo; }
-	const std::vector<std::string>& InputCutFiles() { return fInputCutsFiles; }
+	const std::vector<std::string>& InputCutFiles() { return fInputCutFiles; }
 	const std::vector<std::string>& WinInputFiles() { return fInputWinFiles; }
 	const std::vector<std::string>& MacroInputFiles() { return fMacroFiles; }
 
@@ -148,7 +148,7 @@ private:
 	std::vector<std::string> fExternalRunInfo; ///< A list of the input run info files
 	std::vector<std::string> fMacroFiles;      ///< A list of the input macro (.C) files
 
-	std::vector<std::string> fInputCutsFiles; ///< A list of input cut files
+	std::vector<std::string> fInputCutFiles;  ///< A list of input cut files
 	std::vector<std::string> fInputValFiles;  ///< A list of the input GValue files
 	std::vector<std::string> fInputWinFiles;  ///< A list of the input window files
 	std::string              fInputRing;      ///< The name of hte input ring

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -36,39 +36,39 @@ public:
    TPeakFitter(const Double_t& range_low, const Double_t& range_high);
 
 public:
-   void AddPeak(TSinglePeak *p)     { fPeaksToFit.push_back(p); }
-   void RemovePeak(TSinglePeak *p)  { fPeaksToFit.remove(p); }
-//   void SetPeakToFit(TMultiplePeak * peaks_to_fit) { fPeaksToFit = peaks_to_fit; }
+   void AddPeak(TSinglePeak* p)     { fPeaksToFit.push_back(p); }
+   void RemovePeak(TSinglePeak* p)  { fPeaksToFit.remove(p); }
+//   void SetPeakToFit(TMultiplePeak*  peaks_to_fit) { fPeaksToFit = peaks_to_fit; }
    void SetBackground(TF1* bg_to_fit)                 { fBGToFit = bg_to_fit; }
    void InitializeParameters(TH1* fit_hist);
    void InitializeBackgroundParameters(TH1* fit_hist);
 
-   virtual void Print(Option_t * opt = "") const override;
+   virtual void Print(Option_t* opt = "") const override;
 
-   TF1 * GetBackground() { return fBGToFit; }
+   TF1* GetBackground() { return fBGToFit; }
    void SetRange(const Double_t &low, const Double_t &high);
    Int_t GetNParameters() const;
-   void Fit(TH1* fit_hist,Option_t *opt="");
-   void DrawPeaks(Option_t * = "") const;
+   void Fit(TH1* fit_hist,Option_t* opt="");
+   void DrawPeaks(Option_t* = "") const;
 
 private:
    void UpdateFitterParameters();
    void UpdatePeakParameters(TFitResultPtr fit_res,TH1* fit_hist);
-   Double_t DefaultBackgroundFunction(Double_t *dim, Double_t *par);
+   Double_t DefaultBackgroundFunction(Double_t* dim, Double_t* par);
 
 
 private:
-//   TMultiplePeak *fPeaksToFit{nullptr};
+//   TMultiplePeak* fPeaksToFit{nullptr};
    MultiplePeak_t fPeaksToFit;
-   TF1 *fBGToFit{nullptr};
+   TF1* fBGToFit{nullptr};
 
    TF1* fTotalFitFunction;
 
    Double_t fRangeLow;
    Double_t fRangeHigh;
    
-   Double_t FitFunction(Double_t *dim, Double_t *par);
-   Double_t BackgroundFunction(Double_t *dim, Double_t *par);
+   Double_t FitFunction(Double_t* dim, Double_t* par);
+   Double_t BackgroundFunction(Double_t* dim, Double_t* par);
 
    bool fInitFlag{false};
 

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -68,6 +68,7 @@ public:
    Double_t GetNDF() const { return fNDF; }
    Double_t GetReducedChi2() const { return fChi2/fNDF; }
 
+	bool ParameterSetByUser(int par);
 
 protected:
    Double_t TotalFunction(Double_t* dim, Double_t* par);

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -1369,13 +1369,14 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
 
 	case kKey_s: 
 		{
+			TDirectory* oldDir = gDirectory;
 			TString defaultName = "CutFile.cuts";
 			char* fileName = new char[256];
 			new TGInputDialog(nullptr, static_cast<TRootCanvas*>(GetCanvasImp()), "Enter file name to save cuts to", defaultName, fileName);
 			if(strlen(fileName) == 0) {
 				break;
 			}
-			TFile f(fileName, "recreate");
+			TFile f(fileName, "update");
 			if(!f.IsOpen()) {
 				std::cout<<RESET_COLOR<<"Failed to open file '"<<fileName<<"', not saving cuts!"<<std::endl;
 				break;
@@ -1387,6 +1388,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
 			}
 			f.Close();
 			delete fileName;
+			oldDir->cd();
 		}
 		break;
 

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -36,20 +36,13 @@ void TAB3Peak::InitializeParameters(TH1* fit_hist)
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   Double_t xlow, xhigh, low, high;
-   fTotalFunction->GetRange(xlow, xhigh);
    Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
 	if(!ParameterSetByUser(0)) {
 		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
 		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
 	}
-	if(!ParameterSetByUser(1)) {
-		fTotalFunction->GetParLimits(1, low, high);
-		fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-	}
 	if(!ParameterSetByUser(2)) {
-		fTotalFunction->GetParLimits(2, low, high);
-		fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+		fTotalFunction->SetParLimits(2, 0.1, 8);
 		fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
 	}
 	if(!ParameterSetByUser(3)) {

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -5,10 +5,10 @@
 ClassImp(TAB3Peak)
 /// \endcond
 
-TAB3Peak::TAB3Peak() : TSinglePeak(){ }
+TAB3Peak::TAB3Peak() : TSinglePeak() {}
 
-TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak() {
-
+TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak()
+{
    fTotalFunction = new TF1("ab_fit",this,&TAB3Peak::TotalFunction,0,1,8,"TAB3Peak","TotalFunction");
    InitParNames();
    fTotalFunction->SetParameter(1,centroid);
@@ -16,7 +16,8 @@ TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak() {
    fTotalFunction->SetLineColor(kMagenta);
 }
 
-void TAB3Peak::InitParNames(){
+void TAB3Peak::InitParNames()
+{
    fTotalFunction->SetParName(0, "Height");
    fTotalFunction->SetParName(1, "centroid");
    fTotalFunction->SetParName(2, "sigma");
@@ -27,55 +28,75 @@ void TAB3Peak::InitParNames(){
    fTotalFunction->SetParName(7, "step");
 }
 
-void TAB3Peak::InitializeParameters(TH1* fit_hist){
-   // Makes initial guesses at parameters for the fit. Uses the histogram to
-   Double_t xlow, xhigh, low, high;
-   fTotalFunction->GetRange(xlow, xhigh);
-   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
-   fTotalFunction->GetParLimits(1, low, high);
-   fTotalFunction->GetParLimits(2, low, high);
-   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
-   fTotalFunction->SetParLimits(3, 0.000001, 1.0);
-   fTotalFunction->SetParLimits(4, 1.0, 100); 
-   fTotalFunction->SetParLimits(5, 0.000001, 1.0);
-   fTotalFunction->SetParLimits(6, 1.0, 100); 
-   // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
-   fTotalFunction->SetParLimits(7, 0.0, 1.0E2);
-   
+void TAB3Peak::InitializeParameters(TH1* fit_hist)
+{
+   /// Makes initial guesses at parameters for the fit base on the histogram.
    // Make initial guesses
    // Actually set the parameters in the photopeak function
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
-   fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
-   fTotalFunction->SetParameter("rel_sigma1", 2.);
-   fTotalFunction->SetParameter("rel_sigma2", 6.);
-   fTotalFunction->SetParameter("rel_height1", 0.25);
-   fTotalFunction->SetParameter("rel_height2", 0.25);
-   fTotalFunction->SetParameter("step", 1.0);
+   Double_t xlow, xhigh, low, high;
+   fTotalFunction->GetRange(xlow, xhigh);
+   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+	if(!ParameterSetByUser(0)) {
+		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+	}
+	if(!ParameterSetByUser(1)) {
+		fTotalFunction->GetParLimits(1, low, high);
+		fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
+	}
+	if(!ParameterSetByUser(2)) {
+		fTotalFunction->GetParLimits(2, low, high);
+		fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+		fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+	}
+	if(!ParameterSetByUser(3)) {
+		fTotalFunction->SetParLimits(3, 0.000001, 1.0);
+		fTotalFunction->SetParameter("rel_height1", 0.25);
+	}
+	if(!ParameterSetByUser(4)) {
+		fTotalFunction->SetParLimits(4, 1.0, 100); 
+		fTotalFunction->SetParameter("rel_sigma1", 2.);
+	}
+	if(!ParameterSetByUser(5)) {
+		fTotalFunction->SetParLimits(5, 0.000001, 1.0);
+		fTotalFunction->SetParameter("rel_height2", 0.25);
+	}
+	if(!ParameterSetByUser(6)) {
+		fTotalFunction->SetParLimits(6, 1.0, 100); 
+		fTotalFunction->SetParameter("rel_sigma2", 6.);
+	}
+	if(!ParameterSetByUser(7)) {
+		// Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+		fTotalFunction->SetParLimits(7, 0.0, 1.0E2);
+		fTotalFunction->SetParameter("step", 1.0);
+	}
 }
 
-Double_t TAB3Peak::Centroid() const{
+Double_t TAB3Peak::Centroid() const
+{
    return fTotalFunction->GetParameter("centroid");
 }
 
-Double_t TAB3Peak::CentroidErr() const{
+Double_t TAB3Peak::CentroidErr() const
+{
    return fTotalFunction->GetParError(1);
 }
 
-Double_t TAB3Peak::Width() const{
+Double_t TAB3Peak::Width() const
+{
    return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma2");
 }
 
-Double_t TAB3Peak::PeakFunction(Double_t *dim, Double_t *par){
+Double_t TAB3Peak::PeakFunction(Double_t *dim, Double_t *par)
+{
    return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par) + ThreeHitPeakFunction(dim,par);
 }
 
-Double_t TAB3Peak::OneHitPeakFunction(Double_t *dim, Double_t *par){
-   
+Double_t TAB3Peak::OneHitPeakFunction(Double_t *dim, Double_t *par)
+{
    Double_t x           = dim[0]; // channel number used for fitting
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
@@ -84,8 +105,8 @@ Double_t TAB3Peak::OneHitPeakFunction(Double_t *dim, Double_t *par){
    return height * TMath::Gaus(x, c, sigma);
 }
 
-Double_t TAB3Peak::TwoHitPeakFunction(Double_t *dim, Double_t *par){
-   
+Double_t TAB3Peak::TwoHitPeakFunction(Double_t *dim, Double_t *par)
+{
    Double_t x           = dim[0]; // channel number used for fitting
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
@@ -96,8 +117,8 @@ Double_t TAB3Peak::TwoHitPeakFunction(Double_t *dim, Double_t *par){
    return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
 }
 
-Double_t TAB3Peak::ThreeHitPeakFunction(Double_t *dim, Double_t *par){
-   
+Double_t TAB3Peak::ThreeHitPeakFunction(Double_t *dim, Double_t *par)
+{
    Double_t x           = dim[0]; // channel number used for fitting
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
@@ -109,20 +130,23 @@ Double_t TAB3Peak::ThreeHitPeakFunction(Double_t *dim, Double_t *par){
 }
 
 
-Double_t TAB3Peak::OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+Double_t TAB3Peak::OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par)
+{
    return OneHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
 }
 
-Double_t TAB3Peak::TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+Double_t TAB3Peak::TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par)
+{
    return TwoHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
 }
 
-Double_t TAB3Peak::ThreeHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
+Double_t TAB3Peak::ThreeHitPeakOnGlobalFunction(Double_t *dim, Double_t *par)
+{
    return ThreeHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
 }
 
-Double_t TAB3Peak::BackgroundFunction(Double_t *dim, Double_t *par){
-   
+Double_t TAB3Peak::BackgroundFunction(Double_t *dim, Double_t *par)
+{
    Double_t x           = dim[0]; // channel number used for fitting
    Double_t height      = par[0]; // height of photopeak
    Double_t c           = par[1]; // Peak Centroid of non skew gaus
@@ -134,12 +158,14 @@ Double_t TAB3Peak::BackgroundFunction(Double_t *dim, Double_t *par){
    return step_func;
 }
 
-void TAB3Peak::Print(Option_t * opt) const{
+void TAB3Peak::Print(Option_t * opt) const
+{
    std::cout << "Addback-like peak:" << std::endl;
    TSinglePeak::Print(opt);
 }
 
-void TAB3Peak::DrawComponents(Option_t * opt){
+void TAB3Peak::DrawComponents(Option_t * opt)
+{
    //We need to draw this on top of the global background. Probably easiest to make another temporary TF1?
    if(!fGlobalBackground)
       return;
@@ -153,12 +179,12 @@ void TAB3Peak::DrawComponents(Option_t * opt){
    fOneHitOnGlobal = new TF1("draw_component1", this, &TAB3Peak::OneHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","OneHitPeakOnGlobalFunction");
    fTwoHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::TwoHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","TwoHitPeakOnGlobalFunction");
    fThreeHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::ThreeHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TAB3Peak","ThreeHitPeakOnGlobalFunction");
-   for(int i = 0; i < fTotalFunction->GetNpar(); ++i){
+   for(int i = 0; i < fTotalFunction->GetNpar(); ++i) {
       fOneHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
       fTwoHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
       fThreeHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
    }
-   for(int i = 0; i < fGlobalBackground->GetNpar(); ++i){
+   for(int i = 0; i < fGlobalBackground->GetNpar(); ++i) {
       fOneHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
       fTwoHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
       fThreeHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
@@ -173,7 +199,5 @@ void TAB3Peak::DrawComponents(Option_t * opt){
    fOneHitOnGlobal->Draw(opt);
    fTwoHitOnGlobal->Draw(opt);
    fThreeHitOnGlobal->Draw(opt);
-
 }
-
 

--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -34,20 +34,13 @@ void TABPeak::InitializeParameters(TH1* fit_hist)
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-	Double_t xlow, xhigh, low, high;
-	fTotalFunction->GetRange(xlow, xhigh);
 	Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
 	if(!ParameterSetByUser(0)) {
 		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
 		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
 	}
-	if(!ParameterSetByUser(1)) {
-		fTotalFunction->GetParLimits(1, low, high);
-		fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-	}
 	if(!ParameterSetByUser(2)) {
-		fTotalFunction->GetParLimits(2, low, high);
-		fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+		fTotalFunction->SetParLimits(2, 0.1, 8);
 		fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
 	}
 	if(!ParameterSetByUser(3)) {

--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -5,10 +5,10 @@
 ClassImp(TABPeak)
 /// \endcond
 
-TABPeak::TABPeak() : TSinglePeak(){ }
+TABPeak::TABPeak() : TSinglePeak() {}
 
-TABPeak::TABPeak(Double_t centroid) : TSinglePeak() {
-
+TABPeak::TABPeak(Double_t centroid) : TSinglePeak()
+{
    fTotalFunction = new TF1("ab_fit",this,&TABPeak::TotalFunction,0,1,6,"TABPeak","TotalFunction");
    InitParNames();
    fTotalFunction->SetParameter(1,centroid);
@@ -16,7 +16,8 @@ TABPeak::TABPeak(Double_t centroid) : TSinglePeak() {
    fTotalFunction->SetLineColor(kMagenta);
 }
 
-void TABPeak::InitParNames(){
+void TABPeak::InitParNames()
+{
    fTotalFunction->SetParName(0, "Height");
    fTotalFunction->SetParName(1, "centroid");
    fTotalFunction->SetParName(2, "sigma");
@@ -25,125 +26,142 @@ void TABPeak::InitParNames(){
    fTotalFunction->SetParName(5, "step");
 }
 
-void TABPeak::InitializeParameters(TH1* fit_hist){
-   // Makes initial guesses at parameters for the fit. Uses the histogram to
-   Double_t xlow, xhigh, low, high;
-   fTotalFunction->GetRange(xlow, xhigh);
-   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
-   fTotalFunction->GetParLimits(1, low, high);
-   fTotalFunction->GetParLimits(2, low, high);
-   fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
-   fTotalFunction->SetParLimits(3, 0.000001, 1.0);
-   fTotalFunction->SetParLimits(4, 1.0, 100); 
-   // Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
-   fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
-   
+void TABPeak::InitializeParameters(TH1* fit_hist)
+{
+   /// Makes initial guesses at parameters for the fit base on the histogram.
    // Make initial guesses
    // Actually set the parameters in the photopeak function
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
-   fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-   fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
-   fTotalFunction->SetParameter("rel_sigma", 2.);
-   fTotalFunction->SetParameter("rel_height", 0.25);
-   fTotalFunction->SetParameter("step", 1.0);
+	Double_t xlow, xhigh, low, high;
+	fTotalFunction->GetRange(xlow, xhigh);
+	Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+	if(!ParameterSetByUser(0)) {
+		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
+		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+	}
+	if(!ParameterSetByUser(1)) {
+		fTotalFunction->GetParLimits(1, low, high);
+		fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
+	}
+	if(!ParameterSetByUser(2)) {
+		fTotalFunction->GetParLimits(2, low, high);
+		fTotalFunction->SetParLimits(2, 0.1, 8); // sigma should be less than the window width - JKS
+		fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+	}
+	if(!ParameterSetByUser(3)) {
+		fTotalFunction->SetParLimits(3, 0.000001, 1.0);
+		fTotalFunction->SetParameter("rel_sigma", 2.);
+	}
+	if(!ParameterSetByUser(4)) {
+		fTotalFunction->SetParLimits(4, 1.0, 100); 
+		fTotalFunction->SetParameter("rel_height", 0.25);
+	}
+	if(!ParameterSetByUser(5)) {
+		// Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
+		fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
+		fTotalFunction->SetParameter("step", 1.0);
+	}
 }
 
-Double_t TABPeak::Centroid() const{
-   return fTotalFunction->GetParameter("centroid");
+Double_t TABPeak::Centroid() const
+{
+	return fTotalFunction->GetParameter("centroid");
 }
 
-Double_t TABPeak::CentroidErr() const{
-   return fTotalFunction->GetParError(1);
+Double_t TABPeak::CentroidErr() const
+{
+	return fTotalFunction->GetParError(1);
 }
 
-Double_t TABPeak::Width() const{
-   return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma");
+Double_t TABPeak::Width() const
+{
+	return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma");
 }
 
-Double_t TABPeak::PeakFunction(Double_t *dim, Double_t *par){
-   return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par);
+Double_t TABPeak::PeakFunction(Double_t *dim, Double_t *par)
+{
+	return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par);
 }
 
-Double_t TABPeak::OneHitPeakFunction(Double_t *dim, Double_t *par){
-   
-   Double_t x           = dim[0]; // channel number used for fitting
-   Double_t height      = par[0]; // height of photopeak
-   Double_t c           = par[1]; // Peak Centroid of non skew gaus
-   Double_t sigma       = par[2]; // standard deviation of gaussian
+Double_t TABPeak::OneHitPeakFunction(Double_t *dim, Double_t *par)
+{
+	Double_t x           = dim[0]; // channel number used for fitting
+	Double_t height      = par[0]; // height of photopeak
+	Double_t c           = par[1]; // Peak Centroid of non skew gaus
+	Double_t sigma       = par[2]; // standard deviation of gaussian
 
-   return height * TMath::Gaus(x, c, sigma);
+	return height * TMath::Gaus(x, c, sigma);
 }
 
-Double_t TABPeak::TwoHitPeakFunction(Double_t *dim, Double_t *par){
-   
-   Double_t x           = dim[0]; // channel number used for fitting
-   Double_t height      = par[0]; // height of photopeak
-   Double_t c           = par[1]; // Peak Centroid of non skew gaus
-   Double_t sigma       = par[2]; // standard deviation of gaussian
-   Double_t rel_height  = par[3]; // relative height of 2-hit peak
-   Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
-   
-   return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
+Double_t TABPeak::TwoHitPeakFunction(Double_t *dim, Double_t *par)
+{
+	Double_t x           = dim[0]; // channel number used for fitting
+	Double_t height      = par[0]; // height of photopeak
+	Double_t c           = par[1]; // Peak Centroid of non skew gaus
+	Double_t sigma       = par[2]; // standard deviation of gaussian
+	Double_t rel_height  = par[3]; // relative height of 2-hit peak
+	Double_t rel_sigma   = par[4]; // relative sigma of 2-hit peak
+
+	return height * rel_height * TMath::Gaus(x,c,rel_sigma*sigma);
 }
 
-Double_t TABPeak::OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
-   return OneHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
+Double_t TABPeak::OneHitPeakOnGlobalFunction(Double_t *dim, Double_t *par)
+{
+	return OneHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
 }
 
-Double_t TABPeak::TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par){
-   return TwoHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
+Double_t TABPeak::TwoHitPeakOnGlobalFunction(Double_t *dim, Double_t *par)
+{
+	return TwoHitPeakFunction(dim,par) + fGlobalBackground->EvalPar(dim, &par[fTotalFunction->GetNpar()]);
 }
 
-Double_t TABPeak::BackgroundFunction(Double_t *dim, Double_t *par){
-   
-   Double_t x           = dim[0]; // channel number used for fitting
-   Double_t height      = par[0]; // height of photopeak
-   Double_t c           = par[1]; // Peak Centroid of non skew gaus
-   Double_t sigma       = par[2]; // standard deviation of gaussian
-   Double_t step        = par[5]; // Size of the step function;
+Double_t TABPeak::BackgroundFunction(Double_t *dim, Double_t *par)
+{
+	Double_t x           = dim[0]; // channel number used for fitting
+	Double_t height      = par[0]; // height of photopeak
+	Double_t c           = par[1]; // Peak Centroid of non skew gaus
+	Double_t sigma       = par[2]; // standard deviation of gaussian
+	Double_t step        = par[5]; // Size of the step function;
 
-   Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
-   
-   return step_func;
+	Double_t step_func   = TMath::Abs(step) * height / 100.0 * TMath::Erfc((x - c) / (TMath::Sqrt(2.0) * sigma));
+
+	return step_func;
 }
 
-void TABPeak::Print(Option_t * opt) const{
-   std::cout << "Addback-like peak:" << std::endl;
-   TSinglePeak::Print(opt);
+void TABPeak::Print(Option_t * opt) const
+{
+	std::cout << "Addback-like peak:" << std::endl;
+	TSinglePeak::Print(opt);
 }
 
-void TABPeak::DrawComponents(Option_t * opt){
-   //We need to draw this on top of the global background. Probably easiest to make another temporary TF1?
-   if(!fGlobalBackground)
-      return;
+void TABPeak::DrawComponents(Option_t * opt)
+{
+	//We need to draw this on top of the global background. Probably easiest to make another temporary TF1?
+	if(!fGlobalBackground) return;
 
-   Double_t low, high;
-   fGlobalBackground->GetRange(low,high);
-   if(fOneHitOnGlobal) fOneHitOnGlobal->Delete();
-   if(fTwoHitOnGlobal) fTwoHitOnGlobal->Delete();
-   //Make a copy of the total function, and then tack on the global background parameters.
-   fOneHitOnGlobal = new TF1("draw_component1", this, &TABPeak::OneHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TABPeak","OneHitPeakOnGlobalFunction");
-   fTwoHitOnGlobal = new TF1("draw_component2", this, &TABPeak::TwoHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TABPeak","TwoHitPeakOnGlobalFunction");
-   for(int i = 0; i < fTotalFunction->GetNpar(); ++i){
-      fOneHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
-      fTwoHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
-   }
-   for(int i = 0; i < fGlobalBackground->GetNpar(); ++i){
-      fOneHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
-      fTwoHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
-   }
-   //Draw a copy of this function
-   fOneHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
-   fTwoHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
-   fOneHitOnGlobal->SetLineStyle(8);
-   fTwoHitOnGlobal->SetLineStyle(3);
-   fOneHitOnGlobal->Draw(opt);
-   fTwoHitOnGlobal->Draw(opt);
-
+	Double_t low, high;
+	fGlobalBackground->GetRange(low,high);
+	if(fOneHitOnGlobal) fOneHitOnGlobal->Delete();
+	if(fTwoHitOnGlobal) fTwoHitOnGlobal->Delete();
+	//Make a copy of the total function, and then tack on the global background parameters.
+	fOneHitOnGlobal = new TF1("draw_component1", this, &TABPeak::OneHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TABPeak","OneHitPeakOnGlobalFunction");
+	fTwoHitOnGlobal = new TF1("draw_component2", this, &TABPeak::TwoHitPeakOnGlobalFunction,low,high,fTotalFunction->GetNpar()+fGlobalBackground->GetNpar(),"TABPeak","TwoHitPeakOnGlobalFunction");
+	for(int i = 0; i < fTotalFunction->GetNpar(); ++i) {
+		fOneHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
+		fTwoHitOnGlobal->SetParameter(i,fTotalFunction->GetParameter(i));
+	}
+	for(int i = 0; i < fGlobalBackground->GetNpar(); ++i) {
+		fOneHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+		fTwoHitOnGlobal->SetParameter(i+fTotalFunction->GetNpar(),fGlobalBackground->GetParameter(i));
+	}
+	//Draw a copy of this function
+	fOneHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+	fTwoHitOnGlobal->SetLineColor(fTotalFunction->GetLineColor());
+	fOneHitOnGlobal->SetLineStyle(8);
+	fTwoHitOnGlobal->SetLineStyle(3);
+	fOneHitOnGlobal->Draw(opt);
+	fTwoHitOnGlobal->Draw(opt);
 }
-
 

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -6,14 +6,16 @@
 ClassImp(TPeakFitter)
 /// \endcond
 
-TPeakFitter::TPeakFitter() : TObject(){
+TPeakFitter::TPeakFitter() : TObject()
+{
    fBGToFit = new TF1("fbg",this, &TPeakFitter::DefaultBackgroundFunction,fRangeLow,fRangeHigh,4,"TPeakFitter","DefaultBackgroundFunction"); 
    fBGToFit->FixParameter(3,0);
    fTotalFitFunction = nullptr;
    fBGToFit->SetLineColor(kRed);
 }
 
-TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) : TPeakFitter(){
+TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) : TPeakFitter()
+{
    fRangeLow = range_low;
    fRangeHigh = range_high;
 }
@@ -21,22 +23,20 @@ TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) 
 void TPeakFitter::Print(Option_t * opt) const{
 	std::cout << "Range: " << fRangeLow << " to " << fRangeHigh << std::endl;
 	Int_t counter = 0;
-	if(!fPeaksToFit.empty()){
+	if(!fPeaksToFit.empty()) {
 		std::cout << "Peaks: " << std::endl<<std::endl;
-		for(auto i : fPeaksToFit){
+		for(auto i : fPeaksToFit) {
 			std::cout << "Peak #" << counter++ <<std::endl;
 			i->Print(opt);
 		}
 		std::cout << "Chi2/Ndf = " << fPeaksToFit.front()->GetChi2() << "/"<<fPeaksToFit.front()->GetNDF()<< " = " << fPeaksToFit.front()->GetReducedChi2() << std::endl;
-	}
-	else{
+	} else {
 		std::cout << "Could not find peak to print" << std::endl;
 	}
-	if(fBGToFit){
+	if(fBGToFit) {
 		std::cout << "BG: " << std::endl;
 		fBGToFit->Print(opt);
-	}
-	else{
+	} else {
 		std::cout << "Could not find a BG to print" << std::endl;
 	}
 }
@@ -51,12 +51,14 @@ Int_t TPeakFitter::GetNParameters() const{
 	return n_par;
 }
 
-void TPeakFitter::SetRange(const Double_t &low, const Double_t &high){
+void TPeakFitter::SetRange(const Double_t &low, const Double_t &high)
+{
 	fRangeLow = low;
 	fRangeHigh = high;
 }
 
-void TPeakFitter::Fit(TH1* fit_hist,Option_t *opt){
+void TPeakFitter::Fit(TH1* fit_hist,Option_t *opt)
+{
 	if(fPeaksToFit.empty()) {
 		std::cout<<"No peaks provided!"<<std::endl;
 		return;
@@ -65,7 +67,7 @@ void TPeakFitter::Fit(TH1* fit_hist,Option_t *opt){
 	ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2", "Combination");
 	TVirtualFitter::SetMaxIterations(100000);
 	TVirtualFitter::SetPrecision(1e-4);
-	if(!fTotalFitFunction){
+	if(!fTotalFitFunction) {
 		fTotalFitFunction = new TF1("total_fit",this,&TPeakFitter::FitFunction,fRangeLow,fRangeHigh,GetNParameters(),"TPeakFitter","FitFunction");
 	}
 	//We need to initialize all of the parameters based on the peak parameters
@@ -105,7 +107,7 @@ void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
 	global_bg->SetParameters(fTotalFitFunction->GetParameters());
 
 	//Start by looping through all of the peaks in the fitter.
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		TF1* peak_func = p_it->GetFitFunction();
 		//We need to make a clone of the main fit function, and set all of the non-peak parameters to 0.
 		//This will allow us to do the proper integrals. We have to do the same with the covariance matrix
@@ -116,16 +118,15 @@ void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
 		//This would be the diagonals of the background, and all of the other peaks.
 		Int_t param_to_zero_counter = 0;
 		std::vector<Int_t> param_to_zero_list;
-		for(auto other_p_it : fPeaksToFit){
-			if(other_p_it != p_it){
-				for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i){
+		for(auto other_p_it : fPeaksToFit) {
+			if(other_p_it != p_it) {
+				for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i) {
 					param_to_zero_list.push_back(param_to_zero_counter);
 					++param_to_zero_counter;
 				}
-			}
-			else{
-				for(int i = 0; i < peak_func->GetNpar(); ++i){
-					if(p_it->IsBackgroundParameter(i)){
+			} else {
+				for(int i = 0; i < peak_func->GetNpar(); ++i) {
+					if(p_it->IsBackgroundParameter(i)) {
 						param_to_zero_list.push_back(param_to_zero_counter);
 					}
 					++param_to_zero_counter;
@@ -136,21 +137,21 @@ void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
 			}
 		}
 		//We have no taken care to zero all of the non-peak parameters in the peak list, so we want to remove the total background contribution
-		for(int i = param_to_zero_counter; i < fTotalFitFunction->GetNpar(); ++i){
+		for(int i = param_to_zero_counter; i < fTotalFitFunction->GetNpar(); ++i) {
 			param_to_zero_list.push_back(i);
 		}
 
 		//zero other non-peak portions of matrix
-		for(auto i : param_to_zero_list){
-			for(auto j : param_to_zero_list){
+		for(auto i : param_to_zero_list) {
+			for(auto j : param_to_zero_list) {
 				//    std::cout << "Zeroing : " << i << " " << j << std::endl;
 				covariance_matrix(i,j) = 0.0;
 			}
 			total_function_copy->SetParameter(i,0.0);
 		}
 		//     covariance_matrix.Print();
-		if(peak_func){
-			for(int i = 0;i < peak_func->GetNpar(); ++i){
+		if(peak_func) {
+			for(int i = 0;i < peak_func->GetNpar(); ++i) {
 				peak_func->SetParameter(i,fTotalFitFunction->GetParameter(param_counter));
 				peak_func->SetParError(i,fTotalFitFunction->GetParError(param_counter));
 				Double_t low, high;
@@ -166,15 +167,15 @@ void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
 		}
 		total_function_copy->Delete();
 	}
-	if(fBGToFit){
-		for(int i = 0;i < fBGToFit->GetNpar(); ++i){
+	if(fBGToFit) {
+		for(int i = 0;i < fBGToFit->GetNpar(); ++i) {
 			fBGToFit->SetParameter(i,fTotalFitFunction->GetParameter(param_counter));
 			fBGToFit->SetParError(i,fTotalFitFunction->GetParError(param_counter));
 			++param_counter;
 		}
 	}
 	//We now have a copy of the global background. Copy and send to every peak
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		p_it->SetGlobalBackground(new TF1(*global_bg));
 		p_it->SetChi2(fTotalFitFunction->GetChisquare());
 		p_it->SetNDF(fTotalFitFunction->GetNDF());
@@ -182,19 +183,21 @@ void TPeakFitter::UpdatePeakParameters(TFitResultPtr fit_res, TH1* fit_hist) {
 	global_bg->Delete();
 }
 
-void TPeakFitter::InitializeParameters(TH1* fit_hist){
-	for(auto p_it : fPeaksToFit){
+void TPeakFitter::InitializeParameters(TH1* fit_hist)
+{
+	for(auto p_it : fPeaksToFit) {
 		p_it->InitializeParameters(fit_hist);
 	}
 }
 
-void TPeakFitter::UpdateFitterParameters() {
+void TPeakFitter::UpdateFitterParameters()
+{
 	Int_t param_counter = 0;
 	Int_t peak_counter = 0;
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		TF1* peak_func = p_it->GetFitFunction();
-		if(peak_func){
-			for(int i = 0;i < peak_func->GetNpar(); ++i){
+		if(peak_func) {
+			for(int i = 0;i < peak_func->GetNpar(); ++i) {
 				fTotalFitFunction->SetParName(param_counter, Form("%s_%i",peak_func->GetParName(i),peak_counter));
 				fTotalFitFunction->SetParameter(param_counter,peak_func->GetParameter(i));
 				fTotalFitFunction->SetParError(param_counter,peak_func->GetParError(i));
@@ -206,8 +209,8 @@ void TPeakFitter::UpdateFitterParameters() {
 			++peak_counter;
 		}
 	}
-	if(fBGToFit){
-		for(int i = 0;i < fBGToFit->GetNpar(); ++i){
+	if(fBGToFit) {
+		for(int i = 0;i < fBGToFit->GetNpar(); ++i) {
 			fTotalFitFunction->SetParName(param_counter,fBGToFit->GetParName(i));
 			fTotalFitFunction->SetParameter(param_counter,fBGToFit->GetParameter(i));
 			fTotalFitFunction->SetParError(param_counter,fBGToFit->GetParError(i));
@@ -220,11 +223,12 @@ void TPeakFitter::UpdateFitterParameters() {
 }
 
 
-Double_t TPeakFitter::FitFunction(Double_t *dim, Double_t *par){
+Double_t TPeakFitter::FitFunction(Double_t *dim, Double_t *par)
+{
 	//I want to use the EvalPar command here in order to ge the individual peaks
 	Double_t sum = 0;
 	Int_t params_so_far = 0;
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		TF1* peak_func = p_it->GetFitFunction();
 		sum+=peak_func->EvalPar(dim,&par[params_so_far]);
 		params_so_far += peak_func->GetNpar();
@@ -235,10 +239,11 @@ Double_t TPeakFitter::FitFunction(Double_t *dim, Double_t *par){
 
 }
 
-Double_t TPeakFitter::BackgroundFunction(Double_t *dim, Double_t *par){
+Double_t TPeakFitter::BackgroundFunction(Double_t *dim, Double_t *par)
+{
 	Double_t sum = 0;
 	Int_t params_so_far = 0;
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		TF1* peak_func = p_it->GetBackgroundFunction();
 		sum+=peak_func->EvalPar(dim,&par[params_so_far]);
 		params_so_far += peak_func->GetNpar();
@@ -249,25 +254,48 @@ Double_t TPeakFitter::BackgroundFunction(Double_t *dim, Double_t *par){
 
 }
 
-void TPeakFitter::InitializeBackgroundParameters(TH1* fit_hist){
+void TPeakFitter::InitializeBackgroundParameters(TH1* fit_hist)
+{
+	Double_t lowLimit;
+	Double_t highLimit;
+	double value;
+
 	fBGToFit->SetParName(0, "A");
 	fBGToFit->SetParName(1, "B");
 	fBGToFit->SetParName(2, "C");
 	fBGToFit->SetParName(3, "bg_offset");
-	fBGToFit->SetParLimits(0, 0.0, fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)) * 100.);
-	fBGToFit->SetParLimits(3, fRangeLow, fRangeHigh);
-	fBGToFit->SetParameter("A", fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)));
-	fBGToFit->SetParameter("B", fit_hist->GetBinWidth(1)*((fit_hist->GetBinContent(fit_hist->FindBin(fRangeLow)) - fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh))) / (fRangeLow - fRangeHigh)) );
-	fBGToFit->SetParameter("C", 0.0000);
-	if(!fPeaksToFit.empty())
-		fBGToFit->SetParameter("bg_offset", fPeaksToFit.front()->Centroid());
-	else
-		fBGToFit->SetParameter("bg_offset", (fRangeHigh + fRangeLow)/2.);
 
-	fBGToFit->FixParameter(2, 0.00);
+	fBGToFit->GetParLimits(0, lowLimit, highLimit);
+	value = fBGToFit->GetParameter(0);
+	if(value == 0 && lowLimit == 0 && highLimit == 0) {
+		fBGToFit->SetParLimits(0, 0.0, fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)) * 100.);
+		fBGToFit->SetParameter("A", fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh)));
+	}
+	fBGToFit->GetParLimits(1, lowLimit, highLimit);
+	value = fBGToFit->GetParameter(1);
+	if(value == 0 && lowLimit == 0 && highLimit == 0) {
+		fBGToFit->SetParameter("B", fit_hist->GetBinWidth(1)*((fit_hist->GetBinContent(fit_hist->FindBin(fRangeLow)) - fit_hist->GetBinContent(fit_hist->FindBin(fRangeHigh))) / (fRangeLow - fRangeHigh)) );
+	}
+	fBGToFit->GetParLimits(2, lowLimit, highLimit);
+	value = fBGToFit->GetParameter(2);
+	if(value == 0 && lowLimit == 0 && highLimit == 0) {
+		fBGToFit->SetParameter("C", 0.0000);
+		fBGToFit->FixParameter(2, 0.00);
+	}
+	fBGToFit->GetParLimits(3, lowLimit, highLimit);
+	value = fBGToFit->GetParameter(3);
+	if(value == 0 && lowLimit == 0 && highLimit == 0) {
+		fBGToFit->SetParLimits(3, fRangeLow, fRangeHigh);
+		if(!fPeaksToFit.empty()) {
+			fBGToFit->SetParameter("bg_offset", fPeaksToFit.front()->Centroid());
+		} else {
+			fBGToFit->SetParameter("bg_offset", (fRangeHigh + fRangeLow)/2.);
+		}
+	}
 }
 
-Double_t TPeakFitter::DefaultBackgroundFunction(Double_t *dim, Double_t *par){
+Double_t TPeakFitter::DefaultBackgroundFunction(Double_t *dim, Double_t *par)
+{
 	Double_t x = dim[0];
 	Double_t A = par[0];
 	Double_t B = par[1];
@@ -284,7 +312,7 @@ void TPeakFitter::DrawPeaks(Option_t *) const{
 	fTotalFitFunction->Copy(*bg_to_draw);
 	bg_to_draw->SetLineColor(kRed);
 
-	for(auto p_it : fPeaksToFit){
+	for(auto p_it : fPeaksToFit) {
 		TF1* peak_func = p_it->GetFitFunction();
 		TF1* total_function_copy = new TF1;
 		fTotalFitFunction->Copy(*total_function_copy);
@@ -292,16 +320,15 @@ void TPeakFitter::DrawPeaks(Option_t *) const{
 		//Now we need to remove all of the parts of the covariance peak that has nothing to do with this particular peak
 		//This would be the diagonals of the background, and all of the other peaks.
 		Int_t param_to_zero_counter = 0;
-		for(auto other_p_it : fPeaksToFit){
-			if(other_p_it != p_it){
-				for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i){
+		for(auto other_p_it : fPeaksToFit) {
+			if(other_p_it != p_it) {
+				for(int i = 0; i < other_p_it->GetFitFunction()->GetNpar(); ++i) {
 					total_function_copy->SetParameter(param_to_zero_counter,0.0);
 					++param_to_zero_counter;
 				}
-			}
-			else{
-				for(int i = 0; i < peak_func->GetNpar(); ++i){
-					if(!p_it->IsBackgroundParameter(i)){
+			} else {
+				for(int i = 0; i < peak_func->GetNpar(); ++i) {
+					if(!p_it->IsBackgroundParameter(i)) {
 						bg_to_draw->SetParameter(param_to_zero_counter,0.0);
 					}
 					++param_to_zero_counter;

--- a/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
@@ -34,21 +34,13 @@ void TRWPeak::InitializeParameters(TH1* fit_hist)
    // Fixing has to come after setting
    // Might have to include bin widths eventually
    // The centroid should already be set by this point in the ctor
-   Double_t xlow, xhigh, low, high;
-   fTotalFunction->GetRange(xlow, xhigh);
    Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
    if(!ParameterSetByUser(0)) {
 		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*2.);
 		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
 	}
-	if(!ParameterSetByUser(1)) {
-		fTotalFunction->GetParLimits(1, low, high);
-		fTotalFunction->SetParameter("centroid", fTotalFunction->GetParameter(1));
-	}
 	if(!ParameterSetByUser(2)) {
-		fTotalFunction->GetParLimits(2, low, high);
-		fTotalFunction->SetParLimits(2, 0.01, 10.); // sigma should be less than the window width - JKS
-		//  fTotalFunction->SetParameter("sigma", TMath::Sqrt(9.0 + 2. * fTotalFunction->GetParameter("centroid") / 1000.) / 2.35);
+		fTotalFunction->SetParLimits(2, 0.01, 10.);
 		fTotalFunction->SetParameter("sigma", TMath::Sqrt(5 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
 	}
 	if(!ParameterSetByUser(3)) {

--- a/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -94,3 +94,16 @@ void TSinglePeak::Draw(Option_t *opt){
    fPeakOnGlobal->Draw(opt);
 }
 
+bool TSinglePeak::ParameterSetByUser(int par)
+{
+	/// This function checks if a parameter or its limits have been set to a non-zero value.
+	/// In case that the user fixed a parameter to be zero, the limits are non-zero, so this case is covered as well.
+	Double_t lowLimit;
+	Double_t highLimit;
+
+	fTotalFunction->GetParLimits(par, lowLimit, highLimit);
+	double value = fTotalFunction->GetParameter(par);
+
+	// if either one of the three has been set, we return true
+	return (value != 0 || lowLimit != 0 || highLimit != 0);
+}

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -686,14 +686,14 @@ void TChannel::Print(Option_t*) const
    std::cout<<std::setfill(' ');
    std::cout<<"Digitizer: "<<fDigitizerTypeString<<std::endl;
    std::cout<<"TimeOffset: "<<fTimeOffset<<std::endl;
-   std::cout<<"EngCoeff:  ";
+   std::cout<<"ENGCoeff:  ";
    for(float fENGCoefficient : fENGCoefficients.Value()) {
       std::cout<<fENGCoefficient<<"\t";
    }
    std::cout<<std::endl;
    std::cout<<"Integration: "<<fIntegration<<std::endl;
    std::cout<<"ENGChi2:   "<<fENGChi2<<std::endl;
-   std::cout<<"EffCoeff:  ";
+   std::cout<<"EFFCoeff:  ";
    for(double fEFFCoefficient : fEFFCoefficients.Value()) {
       std::cout<<fEFFCoefficient<<"\t";
    }
@@ -776,16 +776,16 @@ std::string TChannel::PrintToString(Option_t*)
    buffer.append(Form("Number:    %d\n", fNumber.Value()));
    buffer.append(Form("Address:   0x%08x\n", fAddress));
    buffer.append(Form("Digitizer: %s\n", fDigitizerTypeString.Value().c_str()));
-   buffer.append("EngCoeff:  ");
+   buffer.append("ENGCoeff:  ");
    for(float fENGCoefficient : fENGCoefficients.Value()) {
-      if(fENGCoefficient<0.001)buffer.append(Form("%e\t", fENGCoefficient));
+      if(std::fabs(fENGCoefficient)<0.001)buffer.append(Form("%e\t", fENGCoefficient));
       else buffer.append(Form("%f\t", fENGCoefficient));
    }
    buffer.append("\n");
 	if(!fCFDCoefficients.Value().empty()) {
-		buffer.append("CfdCoeff:  ");
+		buffer.append("CFDCoeff:  ");
 		for(float fCFDCoefficient : fCFDCoefficients.Value()) {
-			if(fCFDCoefficient<0.001)buffer.append(Form("%e\t", fCFDCoefficient));
+			if(std::fabs(fCFDCoefficient)<0.001)buffer.append(Form("%e\t", fCFDCoefficient));
 			else buffer.append(Form("%f\t", fCFDCoefficient));
 		}
 		buffer.append("\n");
@@ -793,7 +793,7 @@ std::string TChannel::PrintToString(Option_t*)
    buffer.append(Form("Integration: %d\n", fIntegration.Value()));
    buffer.append(Form("TimeOffset: %lld\n", fTimeOffset.Value()));
    buffer.append(Form("ENGChi2:     %f\n", fENGChi2.Value()));
-   buffer.append("EffCoeff:  ");
+   buffer.append("EFFCoeff:  ");
    for(double fEFFCoefficient : fEFFCoefficients.Value()) {
       buffer.append(Form("%f\t", fEFFCoefficient));
    }
@@ -813,13 +813,6 @@ std::string TChannel::PrintToString(Option_t*)
       }
       buffer.append("\n");
    }
-   if(!fCFDCoefficients.Value().empty()) {
-      buffer.append("CFDCoeff:  ");
-      for(double fCFDCoefficient : fCFDCoefficients.Value()) {
-         buffer.append(Form("%f\t", fCFDCoefficient));
-      }
-      buffer.append("\n");
-	}
    buffer.append(Form("FileInt: %d\n", static_cast<int>(fUseCalFileInt.Value())));
    if(UseWaveParam()) {
       buffer.append(Form("RiseTime: %f\n", WaveFormShape.TauRise));

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -45,7 +45,7 @@ void TGRSIOptions::Clear(Option_t*)
    fExternalRunInfo.clear();
    fMacroFiles.clear();
 
-   fInputCutsFiles.clear();
+   fInputCutFiles.clear();
    fInputValFiles.clear();
    fInputWinFiles.clear();
    fInputRing = "";
@@ -520,7 +520,7 @@ bool TGRSIOptions::FileAutoDetect(const std::string& filename)
 
    case kFileType::PRESETWINDOW: fInputWinFiles.push_back(filename); return true;
 
-   case kFileType::CUTS_FILE: fInputCutsFiles.push_back(filename); return true;
+   case kFileType::CUTS_FILE: fInputCutFiles.push_back(filename); return true;
 
    case kFileType::CONFIG_FILE: return false;
 


### PR DESCRIPTION
- Saving cuts updates the file instead of overwriting and preserves the directory root is in.
- Removed double printing of cfd parameters in TChannel.
- TChannel now uses %e instead of %f only for parameters with small absolute values instead of all negative values.
- Added check to peaks if parameters were set by user, should fix #1096.
- Renamed fInputCutsFiles to fInputCutFiles in TGRSIOptions.