### PR TITLE
Fixing #1098

### DIFF
--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -45,11 +45,11 @@ void TABPeak::InitializeParameters(TH1* fit_hist)
 	}
 	if(!ParameterSetByUser(3)) {
 		fTotalFunction->SetParLimits(3, 0.000001, 1.0);
-		fTotalFunction->SetParameter("rel_sigma", 2.);
+		fTotalFunction->SetParameter("rel_height", 0.25);
 	}
 	if(!ParameterSetByUser(4)) {
 		fTotalFunction->SetParLimits(4, 1.0, 100); 
-		fTotalFunction->SetParameter("rel_height", 0.25);
+		fTotalFunction->SetParameter("rel_sigma", 2.);
 	}
 	if(!ParameterSetByUser(5)) {
 		// Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0

--- a/thisgrsi.csh
+++ b/thisgrsi.csh
@@ -67,6 +67,13 @@ if ($?old_grsisys) then
                                  -e "s;:$old_grsisys/lib;;g"   \
                                  -e "s;$old_grsisys/lib:;;g"   \
                                  -e "s;$old_grsisys/lib;;g"`
+		if ( -e $GRSISYS/GRSIData ) then
+			setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | \
+											sed -e "s;:$old_grsisys/GRSIData/lib:;:;g" \
+												 -e "s;:$old_grsisys/GRSIData/lib;;g"   \
+												 -e "s;$old_grsisys/GRSIData/lib:;;g"   \
+												 -e "s;$old_grsisys/GRSIData/lib;;g"`
+		endif
    endif
    if ($?DYLD_LIBRARY_PATH) then
       setenv DYLD_LIBRARY_PATH `echo $DYLD_LIBRARY_PATH | \
@@ -74,6 +81,13 @@ if ($?old_grsisys) then
                                  -e "s;:$old_grsisys/lib;;g"   \
                                  -e "s;$old_grsisys/lib:;;g"   \
                                  -e "s;$old_grsisys/lib;;g"`
+		if ( -e $GRSISYS/ILLData ) then
+			setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | \
+											sed -e "s;:$old_grsisys/ILLData/lib:;:;g" \
+												 -e "s;:$old_grsisys/ILLData/lib;;g"   \
+												 -e "s;$old_grsisys/ILLData/lib:;;g"   \
+												 -e "s;$old_grsisys/ILLData/lib;;g"`
+		endif
    endif
    if ($?MANPATH) then
       setenv MANPATH `echo $MANPATH | \
@@ -81,6 +95,13 @@ if ($?old_grsisys) then
                                  -e "s;:$old_grsisys/man;;g"   \
                                  -e "s;$old_grsisys/man:;;g"   \
                                  -e "s;$old_grsisys/man;;g"`
+		if ( -e $GRSISYS/iThembaData ) then
+			setenv LD_LIBRARY_PATH `echo $LD_LIBRARY_PATH | \
+											sed -e "s;:$old_grsisys/iThembaData/lib:;:;g" \
+												 -e "s;:$old_grsisys/iThembaData/lib;;g"   \
+												 -e "s;$old_grsisys/iThembaData/lib:;;g"   \
+												 -e "s;$old_grsisys/iThembaData/lib;;g"`
+		endif
    endif
 endif
 
@@ -102,6 +123,18 @@ if ($?LD_LIBRARY_PATH) then
    setenv LD_LIBRARY_PATH $GRSISYS/lib:$LD_LIBRARY_PATH      # Linux, ELF HP-UX
 else
    setenv LD_LIBRARY_PATH $GRSISYS/lib
+endif
+
+if ($?GRSIDATA) then
+	setenv LD_LIBRARY_PATH $GRSIDATA/lib:$LD_LIBRARY_PATH
+endif
+
+if ($?ILLDATA) then
+	setenv LD_LIBRARY_PATH $ILLDATA/lib:$LD_LIBRARY_PATH
+endif
+
+if ($?ITHEMBADATA) then
+	setenv LD_LIBRARY_PATH $ITHEMBADATA/lib:$LD_LIBRARY_PATH
 endif
 
 if ($?DYLD_LIBRARY_PATH) then

--- a/thisgrsi.sh
+++ b/thisgrsi.sh
@@ -60,6 +60,18 @@ if [ -n "${old_grsisys}" ] ; then
    if [ -n "${LD_LIBRARY_PATH}" ]; then
       drop_from_path $LD_LIBRARY_PATH ${old_grsisys}/lib
       LD_LIBRARY_PATH=$newpath
+		if [ -e ${old_grsisys}/GRSIData ]; then
+			drop_from_path $LD_LIBRARY_PATH ${old_grsisys}/GRSIData/lib
+		fi
+      LD_LIBRARY_PATH=$newpath
+		if [ -e ${old_grsisys}/ILLData ]; then
+			drop_from_path $LD_LIBRARY_PATH ${old_grsisys}/ILLData/lib
+		fi
+      LD_LIBRARY_PATH=$newpath
+		if [ -e ${old_grsisys}/iThembaData ]; then
+			drop_from_path $LD_LIBRARY_PATH ${old_grsisys}/iThembaData/lib
+		fi
+      LD_LIBRARY_PATH=$newpath
    fi
    if [ -n "${DYLD_LIBRARY_PATH}" ]; then
       drop_from_path $DYLD_LIBRARY_PATH ${old_grsisys}/lib
@@ -87,10 +99,20 @@ else
 fi
 
 if [ -z "${LD_LIBRARY_PATH}" ]; then
-   LD_LIBRARY_PATH=$GRSISYS/lib; export LD_LIBRARY_PATH       # Linux, ELF HP-UX
+   LD_LIBRARY_PATH=$GRSISYS/lib;
 else
-   LD_LIBRARY_PATH=$GRSISYS/lib:$LD_LIBRARY_PATH; export LD_LIBRARY_PATH
+   LD_LIBRARY_PATH=$GRSISYS/lib:$LD_LIBRARY_PATH;
 fi
+if [ ! -z "${GRSIDATA}" ]; then
+	LD_LIBRARY_PATH=$GRSIDATA/lib:$LD_LIBRARY_PATH;
+fi
+if [ ! -z "${ILLDATA}" ]; then
+	LD_LIBRARY_PATH=$ILLDATA/lib:$LD_LIBRARY_PATH;
+fi
+if [ ! -z "${ITHEMBADATA}" ]; then
+	LD_LIBRARY_PATH=$ITHEMBADATA/lib:$LD_LIBRARY_PATH;
+fi
+export LD_LIBRARY_PATH       # Linux, ELF HP-UX
 
 if [ -z "${DYLD_LIBRARY_PATH}" ]; then
    DYLD_LIBRARY_PATH=$GRSISYS/lib; export DYLD_LIBRARY_PATH   # Mac OS X


### PR DESCRIPTION
- TPeakFitter::Fit stores the current zoom of the histogram, then
  changes the zoom to its own range, fits the histogram, and zooms back
  to the original zoom at the end. Also added a check if the fit result
  is good to prevent seg faults.
- Fixed mistake in TABPeak where parameters were initialized wrong
  (introduced in PR #1097).
- Also changed thisgrsi.sh and thisgrsi.csh to automatically add detector libraries to LD_LIBRARY_PATH (thisgrsi.csh not tested!).