### PR TITLE
Fixing issue #1101

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -1,3 +1,4 @@
+#include "TEnv.h"
 #include "TFile.h"
 #include "TTree.h"
 #include "TChain.h"
@@ -143,10 +144,22 @@ static void CatchSignals()
 	sigaction(SIGTERM, &action, NULL);
 }
 
+void SetGRSIEnv()
+{
+   std::string grsi_path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
+   if(grsi_path.length() > 0) {
+      grsi_path += "/";
+   }
+   // Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
+   grsi_path += ".grsirc";
+   gEnv->ReadFile(grsi_path.c_str(), kEnvChange);
+}
+
 int main(int argc, char** argv)
 {
 	gStopwatch = new TStopwatch;
 	try {
+      SetGRSIEnv();
 		gGRSIOpt = TGRSIOptions::Get(argc, argv);
 		if(gGRSIOpt->ShouldExit()) {
 			return 0;


### PR DESCRIPTION
GRSIProof now also uses the .grsirc file to determine the parser library to use.