### PR TITLE
Small improvements

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -38,6 +38,7 @@
 #include "TRandom.h"
 #include "TList.h"
 #include "TTree.h"
+#include "TGraph.h"
 #include "TMnemonic.h"
 #include "TClassRef.h"
 #include "Globals.h"
@@ -102,6 +103,7 @@ private:
    TPriorityValue<std::vector<double> >  fEFFCoefficients;  // Efficiency calibration coeffs (low to high order)
    TPriorityValue<double>                fEFFChi2;          // Chi2 of Efficiency calibration
    TPriorityValue<std::vector<double> >  fCTCoefficients;   // Cross talk coefficients
+	TPriorityValue<TGraph>                fEnergyNonlinearity; // Energy nonlinearity as spline
 
    struct WaveFormShapePar {
       bool   InUse;
@@ -126,6 +128,9 @@ private:
    void SetTIMECoefficients(TPriorityValue<std::vector<double> > tmp) { fTIMECoefficients = tmp; }
    void SetEFFCoefficients(TPriorityValue<std::vector<double> > tmp) { fEFFCoefficients = tmp; }
    void SetCTCoefficients(TPriorityValue<std::vector<double> > tmp) { fCTCoefficients = tmp; }
+	void SetEnergyNonlinearity(TPriorityValue<TGraph> tmp) { fEnergyNonlinearity = tmp; }
+
+	void SetupEnergyNonlinearity(); // sort energy nonlinearity graph and set name/title
 
    static void trim(std::string*, const std::string& trimChars = " \f\n\r\t\v");
 
@@ -187,6 +192,8 @@ public:
    std::vector<double>  GetTIMECoeff() const { return fTIMECoefficients.Value(); }
    std::vector<double>  GetEFFCoeff() const { return fEFFCoefficients.Value(); }
    std::vector<double>  GetCTCoeff() const { return fCTCoefficients.Value(); }
+	TGraph               GetEnergyNonlinearity() const { return fEnergyNonlinearity.Value(); }
+	double               GetEnergyNonlinearity(double en) const;
 
    inline void AddENGCoefficient(Float_t temp) { fENGCoefficients.Address()->push_back(temp); }
    inline void AddCFDCoefficient(double temp) { fCFDCoefficients.Address()->push_back(temp); }
@@ -194,6 +201,7 @@ public:
    inline void AddTIMECoefficient(double temp) { fTIMECoefficients.Address()->push_back(temp); }
    inline void AddEFFCoefficient(double temp) { fEFFCoefficients.Address()->push_back(temp); }
    inline void AddCTCoefficient(double temp) { fCTCoefficients.Address()->push_back(temp); }
+	void AddEnergyNonlinearityPoint(double x, double y) { fEnergyNonlinearity.Address()->SetPoint(fEnergyNonlinearity.Address()->GetN(), x, y); }
 
    inline void SetENGChi2(TPriorityValue<double> tmp) { fENGChi2 = tmp; }
    inline void SetCFDChi2(TPriorityValue<double> tmp) { fCFDChi2 = tmp; }
@@ -251,6 +259,7 @@ public:
    void DestroyTIMECal();
    void DestroyEFFCal();
    void DestroyCTCal();
+	void DestroyEnergyNonlinearity();
 
    static Int_t ReadCalFromCurrentFile(Option_t* opt = "overwrite");
    static Int_t ReadCalFromTree(TTree*, Option_t* opt = "overwrite");

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -131,6 +131,7 @@ public:
    virtual TVector3 GetPosition(Double_t) const { return TVector3(0., 0., 0.); } //!<!
    virtual TVector3 GetPosition() const { return TVector3(0., 0., 0.); }         //!<!
    virtual double GetEnergy(Option_t* opt = "") const;
+	virtual Double_t GetEnergyNonlinearity(double energy) const;
    virtual Long64_t GetTimeStamp(Option_t* = "") const { return fTimeStamp; }
    virtual Long64_t GetTimeStampNs(Option_t* opt = "") const;
    virtual Double_t GetTime(const ETimeFlag& correct_flag = ETimeFlag::kAll,
@@ -157,10 +158,6 @@ public:
    const char*      GetName() const override; //!<!
    virtual UShort_t GetArrayNumber() const { return GetDetector(); } //!<! Simply returns the detector number, overwritten for detectors that have crystals/segments
 	virtual Int_t    GetTimeStampUnit() const; //!<!
-
-   // virtual void GetSegment() const;
-
-   virtual Double_t GetEnergyNonlinearity(double) const { return 0.0; }
 
    // The PPG is only stored in events that come out of the GRIFFIN DAQ
 	EPpgPattern GetPPGStatus() const;

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -104,6 +104,15 @@ double TDetectorHit::GetEnergy(Option_t*) const
    return SetEnergy(energy + GetEnergyNonlinearity(energy));
 }
 
+Double_t TDetectorHit::GetEnergyNonlinearity(double energy) const
+{
+	TChannel* channel = GetChannel();
+	if(channel == nullptr) {
+		return 0.;
+	}
+	return -(channel->GetEnergyNonlinearity(energy));
+}
+
 void TDetectorHit::Copy(TObject& rhs) const
 {
    TObject::Copy(rhs);

--- a/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -15,6 +15,7 @@ Bool_t TMultiPeak::fLogLikelihoodFlag = false;
 TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t>& centroids, Option_t*)
    : TGRSIFit("multipeakbg",this, &TMultiPeak::MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5,"TMultiPeak","MultiPhotoPeakBG")
 {
+	std::cout<<"Warning, the class TMultiPeak is deprecated!"<<std::endl;
    Clear();
    // We make the background first so we can send it to the TPeaks.
    fBackground = new TF1(Form("MPbackground_%d_to_%d", static_cast<Int_t>(xlow), static_cast<Int_t>(xhigh)),this,&TMultiPeak::MultiStepBG, xlow, xhigh, centroids.size() * 6 + 5,"TMuliPeak","MultiStepBG");
@@ -50,6 +51,7 @@ TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t
 
 TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, 0, 1000, 10, "TMultiPeak","MultiPhotoPeakBG")
 {
+	std::cout<<"Warning, the class TMultiPeak is deprecated!"<<std::endl;
    // I don't think this constructor should be used, RD.
    InitNames();
    fBackground = new TF1("background",this, &TMultiPeak::MultiStepBG, 1000, 10,10,"TMultiPeak","MultiStepBG"); // This is a weird nonsense line.

--- a/util/html_generator.C
+++ b/util/html_generator.C
@@ -165,6 +165,7 @@ void html_generator() {
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TAngularCorrelation");
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TCSM");
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TDescant");
+	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TEmma");
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TGenericDetector");
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TGriffin");
 	html.AddLibraryPath("GRSIData/libraries/TGRSIAnalysis/TGRSIDetector");


### PR DESCRIPTION
- Added TEmma to html generator.
- Added message that TMultiPeak is deprecated.
- Moved energy nonlinearity to TChannel (see #874 and GRIFFINCollaboration/GRSIData#25).
  - Nonlinearity is now stored as TGraph in the TChannel and written as a single line with alternating x and y values to the cal-file.
  - Uses linear interpolation for points between minimum and maximum x-value, otherwise (or if no points were provided) returns zero.