### PR TITLE
Speeds up Analysis tree writing.

### DIFF
--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -132,6 +132,7 @@ public:
 
 private:
    static std::map<std::string, TRuntimeObjects*> fRuntimeMap;
+	TDirectory * FindDirectory(const char*);
 #ifndef __CINT__
    std::shared_ptr<TUnpackedEvent>  fDetectors;
    std::shared_ptr<const TFragment> fFrag;

--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -132,7 +132,7 @@ public:
 
 private:
    static std::map<std::string, TRuntimeObjects*> fRuntimeMap;
-	TDirectory * FindDirectory(const char*);
+   TDirectory * FindDirectory(const char*);
 #ifndef __CINT__
    std::shared_ptr<TUnpackedEvent>  fDetectors;
    std::shared_ptr<const TFragment> fFrag;

--- a/libraries/THistogramming/TCompiledHistograms.cxx
+++ b/libraries/THistogramming/TCompiledHistograms.cxx
@@ -89,7 +89,8 @@ Int_t TCompiledHistograms::Write(const char*, Int_t, Int_t)
    TObject* obj;
    while((obj = next()) != nullptr) {
       if(obj->InheritsFrom(TDirectory::Class())) {
-         TPreserveGDirectory preserve;
+         //WATCH OUT: THIS DOESN'T SEEM THREAD-SAFE DUE TO gDIRECTORY BEING USED.
+			TPreserveGDirectory preserve;
          TDirectory*         dir = static_cast<TDirectory*>(obj);
          gDirectory->mkdir(dir->GetName())->cd();
          TIter    dir_next(dir->GetList());

--- a/libraries/THistogramming/TCompiledHistograms.cxx
+++ b/libraries/THistogramming/TCompiledHistograms.cxx
@@ -90,7 +90,7 @@ Int_t TCompiledHistograms::Write(const char*, Int_t, Int_t)
    while((obj = next()) != nullptr) {
       if(obj->InheritsFrom(TDirectory::Class())) {
          //WATCH OUT: THIS DOESN'T SEEM THREAD-SAFE DUE TO gDIRECTORY BEING USED.
-			TPreserveGDirectory preserve;
+         TPreserveGDirectory preserve;
          TDirectory*         dir = static_cast<TDirectory*>(obj);
          gDirectory->mkdir(dir->GetName())->cd();
          TIter    dir_next(dir->GetList());

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -25,6 +25,7 @@ TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* o
 {
    SetName(name);
    fRuntimeMap.insert(std::make_pair(name, this));
+
 }
 
 // TRuntimeObjects::TRuntimeObjects(TUnpackedEvent *detectors, TList* objects, TList *gates,
@@ -48,89 +49,39 @@ TRuntimeObjects::TRuntimeObjects(TList* objects, TList* gates, std::vector<TFile
 
 TH1* TRuntimeObjects::FillHistogram(const char* name, int bins, double low, double high, double value, double weight)
 {
-   TH1* hist = dynamic_cast<TH1*>(GetObjects().FindObject(name));
-   if(hist == nullptr) {
-      hist = new TH1D(name, name, bins, low, high);
-      if(fDirectory != nullptr) {
-         hist->SetDirectory(fDirectory);
-      }
-      GetObjects().Add(hist);
-   }
-   if(!(std::isnan(value))) {
-      hist->Fill(value, weight);
-   }
-   return hist;
+	FillHistogram("General",name,bins,low,high,value,weight);
+	return nullptr;
 }
 
 TH2* TRuntimeObjects::FillHistogram(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue, int Ybins,
                                     double Ylow, double Yhigh, double Yvalue, double weight)
 {
-   TH2* hist = dynamic_cast<TH2*>(GetObjects().FindObject(name));
-   if(hist == nullptr) {
-      hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
-      if(fDirectory != nullptr) {
-         hist->SetDirectory(fDirectory);
-      }
-      GetObjects().Add(hist);
-   }
-   if(!std::isnan(Xvalue) && !std::isnan(Yvalue)) {
-      hist->Fill(Xvalue, Yvalue, weight);
-   }
-   return hist;
+	FillHistogram("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue,weight);
+	return nullptr;
 }
 
 TProfile* TRuntimeObjects::FillProfileHist(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue,
                                            double Yvalue)
 {
-   TProfile* prof = dynamic_cast<TProfile*>(GetObjects().FindObject(name));
-   if(prof == nullptr) {
-      prof = new TProfile(name, name, Xbins, Xlow, Xhigh);
-      if(fDirectory != nullptr) {
-         prof->SetDirectory(fDirectory);
-      }
-      GetObjects().Add(prof);
-   }
-   if(!(std::isnan(Xvalue))) {
-      if(!(std::isnan(Yvalue))) {
-         prof->Fill(Xvalue, Yvalue);
-      }
-   }
-   return prof;
+   FillProfileHist("General",name,Xbins,Xlow,Xhigh,Xvalue,Yvalue);
+   return nullptr;
 }
 
 TH2* TRuntimeObjects::FillHistogramSym(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue, int Ybins,
                                        double Ylow, double Yhigh, double Yvalue)
 {
-   TH2* hist = dynamic_cast<TH2*>(GetObjects().FindObject(name));
-   if(hist == nullptr) {
-      hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
-      if(fDirectory != nullptr) {
-         hist->SetDirectory(fDirectory);
-      }
-      GetObjects().Add(hist);
-   }
-
-   if(!(std::isnan(Xvalue))) {
-      if(!(std::isnan(Yvalue))) {
-         hist->Fill(Xvalue, Yvalue);
-         hist->Fill(Yvalue, Xvalue);
-      }
-   }
-   return hist;
+	FillHistogramSym("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue);
+   return nullptr;
 }
 
 //-------------------------------------------------------------------------
 TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name, int bins, double low, double high,
                                            double value, double weight)
 {
+	
+	TDirectory * dir = FindDirectory(dirname);
 
-   TDirectory* dir = dynamic_cast<TDirectory*>(GetObjects().FindObject(dirname));
-   if(dir == nullptr) {
-      dir = new TDirectory(dirname, dirname);
-      GetObjects().Add(dir);
-   }
-   dir->cd();
-   TH1* hist = dynamic_cast<TH1*>(dir->FindObject(name));
+   TH1* hist = static_cast<TH1*>(dir->FindObject(name));
    if(hist == nullptr) {
       hist = new TH1D(name, name, bins, low, high);
       hist->SetDirectory(dir);
@@ -140,50 +91,15 @@ TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name
    if(!std::isnan(value)) {
       hist->Fill(value, weight);
    }
-   dir->cd("../");
-   // return hist;
    return dir;
-
-   /*
-      std::cout<<"1"<<std::endl;
-      if(!(gDirectory->cd(dirname))){
-      gDirectory->mkdir(dirname);
-      std::cout<<"2"<<std::endl;
-      }
-      std::cout<<"3"<<std::endl;
-      TDirectory *dir = gDirectory->GetDirectory(dirname);
-   //gDirectory->pwd()
-   std::cout<<"4"<<std::endl;
-   TH1* hist = (TH1*)dir->FindObject(name);
-   std::cout<<"4a"<<std::endl;
-   if(!hist){
-   std::cout<<"4b"<<std::endl;
-   hist = new TH1I(name,name,bins,low,high);
-   //    GetObjects().Add(hist);
-   std::cout<<"5"<<std::endl;
-   dir->Add(hist);
-   std::cout<<"6"<<std::endl;
-   }
-   std::cout<<"7"<<std::endl;
-   hist->Fill(value);
-   std::cout<<"8"<<std::endl;
-   gDirectory->cd("../");
-   std::cout<<"9"<<std::endl;
-   return dir;
-   //return hist;*/
 }
 
 TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name, int Xbins, double Xlow, double Xhigh,
                                            double Xvalue, int Ybins, double Ylow, double Yhigh, double Yvalue,
                                            double weight)
 {
-   TDirectory* dir = dynamic_cast<TDirectory*>(GetObjects().FindObject(dirname));
-   if(dir == nullptr) {
-      dir = new TDirectory(dirname, dirname);
-      GetObjects().Add(dir);
-   }
-   dir->cd();
-   TH2* hist = dynamic_cast<TH2*>(dir->FindObject(name));
+	TDirectory * dir = FindDirectory(dirname);
+   TH2* hist = static_cast<TH2*>(dir->FindObject(name));
    if(hist == nullptr) {
       hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
       hist->SetDirectory(dir);
@@ -193,31 +109,15 @@ TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name
    if(!std::isnan(Xvalue) && !std::isnan(Yvalue)) {
       hist->Fill(Xvalue, Yvalue, weight);
    }
-   dir->cd("../");
-   // return hist;
-   return dir; /*
-                  TH2* hist = (TH2*) GetObjects().FindObject(name);
-                  if(!hist){
-                  hist = new TH2D(name.c_str(),name.c_str(),
-                  Xbins, Xlow, Xhigh,
-                  Ybins, Ylow, Yhigh);
-                  GetObjects().Add(hist);
-                  }
-                  hist->Fill(Xvalue, Yvalue);
-                  return hist;*/
+   return dir; 
 }
 
 TDirectory* TRuntimeObjects::FillProfileHist(const char* dirname, const char* name, int Xbins, double Xlow,
                                              double Xhigh, double Xvalue, double Yvalue)
 {
 
-   TDirectory* dir = dynamic_cast<TDirectory*>(GetObjects().FindObject(dirname));
-   if(dir == nullptr) {
-      dir = new TDirectory(dirname, dirname);
-      GetObjects().Add(dir);
-   }
-   dir->cd();
-   TProfile* prof = dynamic_cast<TProfile*>(dir->FindObject(name));
+   TDirectory *dir = FindDirectory(dirname);
+	TProfile* prof = dynamic_cast<TProfile*>(dir->FindObject(name));
    if(prof == nullptr) {
       prof = new TProfile(name, name, Xbins, Xlow, Xhigh);
       prof->SetDirectory(dir);
@@ -229,7 +129,6 @@ TDirectory* TRuntimeObjects::FillProfileHist(const char* dirname, const char* na
          prof->Fill(Xvalue, Yvalue);
       }
    }
-   dir->cd("../");
    return dir;
 }
 
@@ -237,12 +136,7 @@ TDirectory* TRuntimeObjects::FillHistogramSym(const char* dirname, const char* n
                                               double Xhigh, double Xvalue, int Ybins, double Ylow, double Yhigh,
                                               double Yvalue)
 {
-   TDirectory* dir = dynamic_cast<TDirectory*>(GetObjects().FindObject(dirname));
-   if(dir == nullptr) {
-      dir = new TDirectory(dirname, dirname);
-      GetObjects().Add(dir);
-   }
-   dir->cd();
+   TDirectory *dir = FindDirectory(dirname);
    TH2* hist = dynamic_cast<TH2*>(dir->FindObject(name));
    if(hist == nullptr) {
       hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
@@ -255,18 +149,7 @@ TDirectory* TRuntimeObjects::FillHistogramSym(const char* dirname, const char* n
          hist->Fill(Yvalue, Xvalue);
       }
    }
-   dir->cd("../");
-   // return hist;
-   return dir; /*
-                  TH2* hist = (TH2*) GetObjects().FindObject(name);
-                  if(!hist){
-                  hist = new TH2D(name.c_str(),name.c_str(),
-                  Xbins, Xlow, Xhigh,
-                  Ybins, Ylow, Yhigh);
-                  GetObjects().Add(hist);
-                  }
-                  hist->Fill(Xvalue, Yvalue);
-                  return hist;*/
+   return dir; 
 }
 //-------------------------------------------------------------------------
 
@@ -297,4 +180,24 @@ TCutG* TRuntimeObjects::GetCut(const std::string& name)
 double TRuntimeObjects::GetVariable(const char* name)
 {
    return GValue::Value(name);
+}
+
+TDirectory * TRuntimeObjects::FindDirectory(const char* dirname)
+{
+	/*static bool found_default = false;
+	if(!strcmp(dirname,"")){
+		if(!found_default && !GetObjects().FindObject(fDirectory)){
+			found_default = true;
+			GetObjects().Add(fDirectory);
+		}	
+		return fDirectory;
+	}*/
+
+   TDirectory* dir = static_cast<TDirectory*>(GetObjects().FindObject(dirname));
+   if(dir == nullptr) {
+      dir = new TDirectory(dirname, dirname);
+      GetObjects().Add(dir);
+   }
+	return dir;
+
 }

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -115,7 +115,7 @@ TDirectory* TRuntimeObjects::FillProfileHist(const char* dirname, const char* na
 {
 
    TDirectory *dir = FindDirectory(dirname);
-   TProfile* prof = dynamic_cast<TProfile*>(dir->FindObject(name));
+   TProfile* prof = static_cast<TProfile*>(dir->FindObject(name));
    if(prof == nullptr) {
       prof = new TProfile(name, name, Xbins, Xlow, Xhigh);
       prof->SetDirectory(dir);
@@ -135,7 +135,7 @@ TDirectory* TRuntimeObjects::FillHistogramSym(const char* dirname, const char* n
                                               double Yvalue)
 {
    TDirectory *dir = FindDirectory(dirname);
-   TH2* hist = dynamic_cast<TH2*>(dir->FindObject(name));
+   TH2* hist = static_cast<TH2*>(dir->FindObject(name));
    if(hist == nullptr) {
       hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
       hist->SetDirectory(dir);
@@ -166,7 +166,7 @@ TCutG* TRuntimeObjects::GetCut(const std::string& name)
    for(auto& tfile : fCut_files) {
       TObject* obj = tfile->Get(name.c_str());
       if(obj != nullptr) {
-         TCutG* cut = dynamic_cast<TCutG*>(obj);
+         TCutG* cut = static_cast<TCutG*>(obj);
          if(cut != nullptr) {
             return cut;
          }

--- a/libraries/THistogramming/TRuntimeObjects.cxx
+++ b/libraries/THistogramming/TRuntimeObjects.cxx
@@ -25,7 +25,6 @@ TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* o
 {
    SetName(name);
    fRuntimeMap.insert(std::make_pair(name, this));
-
 }
 
 // TRuntimeObjects::TRuntimeObjects(TUnpackedEvent *detectors, TList* objects, TList *gates,
@@ -49,15 +48,15 @@ TRuntimeObjects::TRuntimeObjects(TList* objects, TList* gates, std::vector<TFile
 
 TH1* TRuntimeObjects::FillHistogram(const char* name, int bins, double low, double high, double value, double weight)
 {
-	FillHistogram("General",name,bins,low,high,value,weight);
-	return nullptr;
+   FillHistogram("General",name,bins,low,high,value,weight);
+   return nullptr;
 }
 
 TH2* TRuntimeObjects::FillHistogram(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue, int Ybins,
                                     double Ylow, double Yhigh, double Yvalue, double weight)
 {
-	FillHistogram("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue,weight);
-	return nullptr;
+   FillHistogram("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue,weight);
+   return nullptr;
 }
 
 TProfile* TRuntimeObjects::FillProfileHist(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue,
@@ -70,7 +69,7 @@ TProfile* TRuntimeObjects::FillProfileHist(const char* name, int Xbins, double X
 TH2* TRuntimeObjects::FillHistogramSym(const char* name, int Xbins, double Xlow, double Xhigh, double Xvalue, int Ybins,
                                        double Ylow, double Yhigh, double Yvalue)
 {
-	FillHistogramSym("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue);
+   FillHistogramSym("General",name,Xbins,Xlow,Xhigh,Xvalue,Ybins,Ylow,Yhigh,Yvalue);
    return nullptr;
 }
 
@@ -78,8 +77,7 @@ TH2* TRuntimeObjects::FillHistogramSym(const char* name, int Xbins, double Xlow,
 TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name, int bins, double low, double high,
                                            double value, double weight)
 {
-	
-	TDirectory * dir = FindDirectory(dirname);
+   TDirectory * dir = FindDirectory(dirname);
 
    TH1* hist = static_cast<TH1*>(dir->FindObject(name));
    if(hist == nullptr) {
@@ -98,7 +96,7 @@ TDirectory* TRuntimeObjects::FillHistogram(const char* dirname, const char* name
                                            double Xvalue, int Ybins, double Ylow, double Yhigh, double Yvalue,
                                            double weight)
 {
-	TDirectory * dir = FindDirectory(dirname);
+   TDirectory * dir = FindDirectory(dirname);
    TH2* hist = static_cast<TH2*>(dir->FindObject(name));
    if(hist == nullptr) {
       hist = new TH2D(name, name, Xbins, Xlow, Xhigh, Ybins, Ylow, Yhigh);
@@ -117,7 +115,7 @@ TDirectory* TRuntimeObjects::FillProfileHist(const char* dirname, const char* na
 {
 
    TDirectory *dir = FindDirectory(dirname);
-	TProfile* prof = dynamic_cast<TProfile*>(dir->FindObject(name));
+   TProfile* prof = dynamic_cast<TProfile*>(dir->FindObject(name));
    if(prof == nullptr) {
       prof = new TProfile(name, name, Xbins, Xlow, Xhigh);
       prof->SetDirectory(dir);
@@ -184,20 +182,20 @@ double TRuntimeObjects::GetVariable(const char* name)
 
 TDirectory * TRuntimeObjects::FindDirectory(const char* dirname)
 {
-	/*static bool found_default = false;
-	if(!strcmp(dirname,"")){
-		if(!found_default && !GetObjects().FindObject(fDirectory)){
-			found_default = true;
-			GetObjects().Add(fDirectory);
-		}	
-		return fDirectory;
-	}*/
+   /*static bool found_default = false;
+   if(!strcmp(dirname,"")){
+      if(!found_default && !GetObjects().FindObject(fDirectory)){
+         found_default = true;
+         GetObjects().Add(fDirectory);
+      }	
+      return fDirectory;
+   }*/
 
    TDirectory* dir = static_cast<TDirectory*>(GetObjects().FindObject(dirname));
    if(dir == nullptr) {
       dir = new TDirectory(dirname, dirname);
       GetObjects().Add(dir);
    }
-	return dir;
+   return dir;
 
 }

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -99,6 +99,7 @@ bool TAnalysisWriteLoop::Iteration()
    fInputSize = fInputQueue->Pop(event);
    if(fInputSize < 0) {
       fInputSize = 0;
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
    } else {
 		++fItemsPopped;
 	}
@@ -124,7 +125,6 @@ bool TAnalysisWriteLoop::Iteration()
 	if(fInputQueue->IsFinished()) {
 		return false;
 	}
-	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	return true;
 }
 

--- a/libraries/TLoops/TAnalysisWriteLoopClient.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoopClient.cxx
@@ -50,6 +50,7 @@ bool TAnalysisWriteLoopClient::Iteration()
    fInputSize = fInputQueue->Pop(event);
    if(fInputSize < 0) {
       fInputSize = 0;
+   	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
    }
    ++fItemsPopped;
 
@@ -73,7 +74,6 @@ bool TAnalysisWriteLoopClient::Iteration()
 		//fEventTree->GetUserInfo()->Add(TChannel::GetMnemonicClass());
       return false;
    }
-   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
    return true;
 }
 
@@ -178,11 +178,12 @@ void TAnalysisWriteLoopClient::WriteEvent(std::shared_ptr<TUnpackedEvent>& event
 		}
 
 		// Fill
-		std::lock_guard<std::mutex> lock(ttree_fill_mutex);
+	//	std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 		fEventTree->Fill();
 
 		// write file every 100000 popped events (this sends the events to the server)
 		if(fItemsPopped%100000 == 0) {
+			std::lock_guard<std::mutex> lock(ttree_fill_mutex);
 			fOutputFile->Write();
 		}
 	}


### PR DESCRIPTION
- Removed dynamic casting by only letting the fObjects list get filled with directory names. The histograms are then found by searches within a TDirectory. In principle, a crash can occur if you fill a directory with a TH1 and TH2 of the same name. However, as of right now, I'd prefer the crash (maybe add a warning?) compared to the alternative of quietly doing the wrong thing that a dynamic cast may allow for. The removal of dynamic casts significanlty improved the performance of the code.
-Removed directory cd'ing. Not sure what it did other than take up a lot of time.