### PR TITLE
updated TChannel to hold an unordered_map rather than map

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -32,7 +32,7 @@
 #include <string>
 #include <cmath>
 #include <utility>
-#include <map>
+#include <unordered_map>
 
 #include "TNamed.h"
 #include "TRandom.h"
@@ -62,8 +62,8 @@ public:
    static void AddChannel(TChannel*, Option_t* opt = "");
    static int UpdateChannel(TChannel*, Option_t* opt = "");
 
-   static std::map<unsigned int, TChannel*>* GetChannelMap() { return fChannelMap; }
-   static std::map<unsigned int, int>* GetMissingChannelMap() { return fMissingChannelMap; }
+   static std::unordered_map<unsigned int, TChannel*>* GetChannelMap() { return fChannelMap; }
+   static std::unordered_map<unsigned int, int>* GetMissingChannelMap() { return fMissingChannelMap; }
    static void DeleteAllChannels();
 
    static bool CompareChannels(const TChannel&, const TChannel&);
@@ -114,9 +114,9 @@ private:
 
    WaveFormShapePar WaveFormShape;
 
-   static std::map<unsigned int, TChannel*>* fChannelMap;       // A map to all of the channels based on address
-   static std::map<unsigned int, int>* fMissingChannelMap;      // A map to all of the missing channels based on address
-   static std::map<int, TChannel*>*          fChannelNumberMap; // A map of TChannels based on channel number
+   static std::unordered_map<unsigned int, TChannel*>* fChannelMap;       // A map to all of the channels based on address
+   static std::unordered_map<unsigned int, int>* fMissingChannelMap;      // A map to all of the missing channels based on address
+   static std::unordered_map<int, TChannel*>*          fChannelNumberMap; // A map of TChannels based on channel number
    static void UpdateChannelNumberMap();
    static void UpdateChannelMap();
    void        OverWriteChannel(TChannel*);

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -19,7 +19,7 @@
 #include <iomanip>
 #include <string>
 #include <vector>
-#include <map>
+#include <unordered_map>
 
 #ifndef __CINT__
 #include <memory>
@@ -42,19 +42,19 @@ public:
 
 private:
    // fragment tree diagnostics (should these all be static?)
-	// detector type maps
-   std::map<Short_t, Long_t> fNumberOfGoodFragments; ///< map of number of good fragments per detector type
-   std::map<Short_t, Long_t> fNumberOfBadFragments;  ///< map of number of bad fragments per detector type
+	// detector type unordered_maps
+   std::unordered_map<Short_t, Long_t> fNumberOfGoodFragments; ///< unordered_map of number of good fragments per detector type
+   std::unordered_map<Short_t, Long_t> fNumberOfBadFragments;  ///< unordered_map of number of bad fragments per detector type
 
-	// channel address maps
-   std::map<UInt_t, UInt_t> fMinChannelId; ///< map of minimum channel id per channel address
-   std::map<UInt_t, UInt_t> fMaxChannelId; ///< map of maximum channel id per channel address
+	// channel address unordered_maps
+   std::unordered_map<UInt_t, UInt_t> fMinChannelId; ///< unordered_map of minimum channel id per channel address
+   std::unordered_map<UInt_t, UInt_t> fMaxChannelId; ///< unordered_map of maximum channel id per channel address
 
-   std::map<UInt_t, Long_t> fNumberOfHits; ///< map of number of hits per channel address
+   std::unordered_map<UInt_t, Long_t> fNumberOfHits; ///< unordered_map of number of hits per channel address
 
-   std::map<UInt_t, long> fDeadTime;     ///< map of deadtime per channel address
-   std::map<UInt_t, long> fMinTimeStamp; ///< map of minimum timestamp per channel address
-   std::map<UInt_t, long> fMaxTimeStamp; ///< map of maximum timestamp per channel address
+   std::unordered_map<UInt_t, long> fDeadTime;     ///< unordered_map of deadtime per channel address
+   std::unordered_map<UInt_t, long> fMinTimeStamp; ///< unordered_map of minimum timestamp per channel address
+   std::unordered_map<UInt_t, long> fMaxTimeStamp; ///< unordered_map of maximum timestamp per channel address
 
    time_t fMinDaqTimeStamp; ///< minimum daq timestamp
    time_t fMaxDaqTimeStamp; ///< maximum daq timestamp

--- a/include/TSortingDiagnostics.h
+++ b/include/TSortingDiagnostics.h
@@ -19,7 +19,7 @@
 #include <iomanip>
 #include <string>
 #include <vector>
-#include <map>
+#include <unordered_map>
 
 #include "TObject.h"
 #include "TH1F.h"
@@ -38,14 +38,14 @@ public:
 
 private:
    // analysis tree diagnostics 
-   std::map<long, std::pair<long, long>> fFragmentsOutOfOrder;
-   std::map<double, std::pair<double, double>> fFragmentsOutOfTimeOrder;
+   std::unordered_map<long, std::pair<long, long>> fFragmentsOutOfOrder;
+   std::unordered_map<double, std::pair<double, double>> fFragmentsOutOfTimeOrder;
    std::vector<Long_t> fPreviousTimeStamps; ///< timestamps of previous fragments, saved every 'BuildWindow' entries
    std::vector<double> fPreviousTimes;      ///< times of previous fragments, saved every 'BuildWindow' entries
    long                fMaxEntryDiff{0};
-	std::map<TClass*, long> fMissingDetectorClasses; ///< counts of missing detector classes
+	std::unordered_map<TClass*, long> fMissingDetectorClasses; ///< counts of missing detector classes
 
-	std::map<TClass*, std::pair<long, long> > fHitsRemoved; ///< removed hits and total hits per detector class
+	std::unordered_map<TClass*, std::pair<long, long> > fHitsRemoved; ///< removed hits and total hits per detector class
 
 public:
    //"setter" functions
@@ -58,9 +58,9 @@ public:
 
    // getter functions
    size_t NumberOfFragmentsOutOfOrder() const { return fFragmentsOutOfOrder.size(); }
-   std::map<long, std::pair<long, long>> FragmentsOutOfOrder() { return fFragmentsOutOfOrder; }
+   std::unordered_map<long, std::pair<long, long>> FragmentsOutOfOrder() { return fFragmentsOutOfOrder; }
    size_t NumberOfFragmentsOutOfTimeOrder() const { return fFragmentsOutOfTimeOrder.size(); }
-   std::map<double, std::pair<double, double>> FragmentsOutOfTimeOrder() { return fFragmentsOutOfTimeOrder; }
+   std::unordered_map<double, std::pair<double, double>> FragmentsOutOfTimeOrder() { return fFragmentsOutOfTimeOrder; }
    long MaxEntryDiff() const { return fMaxEntryDiff; }
 
    // other functions

--- a/libraries/TAnalysis/TCal/TCal.cxx
+++ b/libraries/TAnalysis/TCal/TCal.cxx
@@ -72,8 +72,8 @@ Bool_t TCal::SetChannel(const TChannel* chan)
 void TCal::WriteToAllChannels(const std::string& mnemonic)
 {
    /// Writes this calibration to all channels in the current TChannel Map
-   std::map<unsigned int, TChannel*>::iterator mapIt;
-   std::map<unsigned int, TChannel*>*          chanMap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator mapIt;
+   std::unordered_map<unsigned int, TChannel*>* chanMap = TChannel::GetChannelMap();
    TChannel* origChan = GetChannel();
    for(mapIt = chanMap->begin(); mapIt != chanMap->end(); mapIt++) {
       if(mnemonic.empty() || (strncmp(mapIt->second->GetName(), mnemonic.c_str(), mnemonic.size()) == 0)) {

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <fcntl.h>
 #include <unistd.h>
+#include<unordered_map>
 
 #include <vector>
 #include <sstream>
@@ -25,13 +26,16 @@
  *
  */
 
+
+//NOTE: The fChannelMap is unordered. The easiest way to order it is using std::map<int, int> ordered(unordered.begin(), unordered.end());
+
 /// \cond CLASSIMP
 ClassImp(TChannel)
 /// \endcond
 
-std::map<unsigned int, TChannel*>* TChannel::fChannelMap = new std::map<unsigned int, TChannel*>; // global maps of channels
-std::map<unsigned int, int>* TChannel::fMissingChannelMap = new std::map<unsigned int, int>; // global map of missing channels
-std::map<int, TChannel*>* TChannel::fChannelNumberMap = new std::map<int, TChannel*>;
+std::unordered_map<unsigned int, TChannel*>* TChannel::fChannelMap = new std::unordered_map<unsigned int, TChannel*>; // global maps of channels
+std::unordered_map<unsigned int, int>* TChannel::fMissingChannelMap = new std::unordered_map<unsigned int, int>; // global map of missing channels
+std::unordered_map<int, TChannel*>* TChannel::fChannelNumberMap = new std::unordered_map<int, TChannel*>;
 
 //TClass* TChannel::fMnemonicClass = TMnemonic::Class();
 TClassRef TChannel::fMnemonicClass = TClassRef("TMnemonic");
@@ -625,8 +629,8 @@ void TChannel::SetUseCalFileIntegration(const std::string& mnemonic, bool flag, 
    /// Writes this UseCalFileIntegration to all channels in the current TChannel Map
    /// that starts with the mnemonic. Use "" to write to ALL channels
    /// WARNING: This is case sensitive!
-   std::map<unsigned int, TChannel*>::iterator mapit;
-   std::map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator mapit;
+   std::unordered_map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
    for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++) {
       if(mnemonic.empty() || (strncmp(mapit->second->GetName(), mnemonic.c_str(), mnemonic.size()) == 0)) {
          mapit->second->SetUseCalFileIntegration(TPriorityValue<bool>(flag, pr));
@@ -639,8 +643,8 @@ void TChannel::SetIntegration(const std::string& mnemonic, int tmpint, EPriority
    // Writes this integration to all channels in the current TChannel Map
    // that starts with the mnemonic. Use "" to write to ALL channels
    // WARNING: This is case sensitive!
-   std::map<unsigned int, TChannel*>::iterator mapit;
-   std::map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator mapit;
+   std::unordered_map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
    for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++) {
       if(mnemonic.empty() || (strncmp(mapit->second->GetName(), mnemonic.c_str(), mnemonic.size()) == 0)) {
          mapit->second->SetIntegration(TPriorityValue<int>(tmpint, pr));
@@ -653,8 +657,8 @@ void TChannel::SetDigitizerType(const std::string& mnemonic, const char* tmpstr,
    // Writes this digitizer type to all channels in the current TChannel Map
    // that starts with the mnemonic. Use "" to write to ALL channels
    // WARNING: This is case sensitive!
-   std::map<unsigned int, TChannel*>::iterator mapit;
-   std::map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator mapit;
+   std::unordered_map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
    for(mapit = chanmap->begin(); mapit != chanmap->end(); mapit++) {
       if(mnemonic.empty() || (strncmp(mapit->second->GetName(), mnemonic.c_str(), mnemonic.size()) == 0)) {
          mapit->second->SetDigitizerType(TPriorityValue<std::string>(tmpstr, pr));
@@ -861,6 +865,7 @@ void TChannel::WriteCalFile(const std::string& outfilename)
       }
    }
 
+   //This orders channels nicely
    std::sort(chanVec.begin(), chanVec.end(), TChannel::CompareChannels);
 
    if(outfilename.length() > 0) {
@@ -882,7 +887,6 @@ void TChannel::WriteCalFile(const std::string& outfilename)
 
 void TChannel::WriteCTCorrections(const std::string& outfilename)
 {
-
    std::vector<TChannel*> chanVec;
    for(auto iter : *fChannelMap) {
       if(iter.second != nullptr) {
@@ -890,6 +894,7 @@ void TChannel::WriteCTCorrections(const std::string& outfilename)
       }
    }
 
+   //This ordered channels nicely
    std::sort(chanVec.begin(), chanVec.end(), TChannel::CompareChannels);
 
    if(outfilename.length() > 0) {
@@ -922,6 +927,7 @@ void TChannel::WriteCalBuffer(Option_t*)
       }
    }
 
+	//This ordered channels nicely
    std::sort(chanVec.begin(), chanVec.end(), TChannel::CompareChannels);
 
    std::string data;

--- a/util/AddToChannelNumber.cxx
+++ b/util/AddToChannelNumber.cxx
@@ -1,5 +1,5 @@
 #include "TChannel.h"
-#include <map>
+#include <unordered_map>
 
 int main(int argc, char** argv)
 {
@@ -14,8 +14,8 @@ int main(int argc, char** argv)
 
    // Read Cal file
    TChannel::ReadCalFile(argv[2]);
-   std::map<unsigned int, TChannel*>::iterator it;
-   std::map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator it;
+   std::unordered_map<unsigned int, TChannel*>* chanmap = TChannel::GetChannelMap();
 
    if(chanmap == nullptr) {
       printf("can't find channel map\n");

--- a/util/ScaleCalibration.cxx
+++ b/util/ScaleCalibration.cxx
@@ -1,5 +1,5 @@
 #include "TChannel.h"
-#include <map>
+#include <unordered_map>
 
 int main(int argc, char** argv)
 {
@@ -22,8 +22,8 @@ int main(int argc, char** argv)
 
    // Read Cal file
    TChannel::ReadCalFile(argv[2]);
-   std::map<unsigned int, TChannel*>::iterator it;
-   std::map<unsigned int, TChannel*>*          chanmap = TChannel::GetChannelMap();
+   std::unordered_map<unsigned int, TChannel*>::iterator it;
+   std::unordered_map<unsigned int, TChannel*>* chanmap = TChannel::GetChannelMap();
 
    if(chanmap == nullptr) {
       printf("can't find channel map\n");


### PR DESCRIPTION
- This should speed up first-time channel lookups.
- Impact is likely minor on most data sets, but could be larger when dealing with a couple though thousand BGO channels. 
- map lookup complexity is O(logN), unordered map is optimally O(1) with worst-case O(N). Our use should be close to optimal for hashing.

- **UPGRADING TO THIS VERSION MEANS DETECTOR LIBRARIES MUST BE UPDATED!**

- Quickly tried to implement for TGRSIMap, but failed due to something strange with templating.