### PR TITLE
Fixing #1124

### DIFF
--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -14,166 +14,213 @@
 
 class GMarker : public TObject {
 public:
-   GMarker() : x(-1), y(-1), localx(0.0), localy(0.0), linex(nullptr), liney(nullptr) {}
+   GMarker() : fLineX(nullptr), fLineY(nullptr) {}
+	GMarker(int tmpX, int tmpY, TH1* hist);
    GMarker(const GMarker& m) : TObject(m) { ((GMarker&)m).Copy(*this); }
    ~GMarker() override
    {
-      if(linex) {
-         linex->Delete();
-      }
-      if(liney) {
-         liney->Delete();
-      }
-   }
-   void Draw(Option_t* opt = "") override
-   {
-      if(linex) {
-         linex->Draw(opt);
-      }
-      if(liney) {
-         liney->Draw(opt);
-      }
-   }
+		if(fLineX != nullptr) fLineX->Delete();
+		if(fLineY != nullptr) fLineY->Delete();
+	}
+	void Draw(Option_t* opt = "") override
+	{
+		if(fLineX != nullptr) {
+			fLineX->Draw(opt);
+		}
+		if(fLineY != nullptr) {
+			fLineY->Draw(opt);
+		}
+	}
+	void Print(Option_t* option = "") const override
+	{
+		TObject::Print(option);
+		std::cout<<"fLineX = "<<fLineX<<", fLineY = "<<fLineY<<std::endl;
+		TString opt = option;
+		opt.ToLower();
+		if(opt.Contains("a")) {
+			if(fLineX != nullptr) fLineX->Print();
+			if(fLineY != nullptr) fLineY->Print();
+		}
+	}
 
-   void SetColor(Color_t color)
-   {
-      if(linex) {
-         linex->SetLineColor(color);
-      }
-      if(liney) {
-         liney->SetLineColor(color);
-      }
-   }
+	void SetColor(Color_t color)
+	{
+		if(fLineX != nullptr) {
+			fLineX->SetLineColor(color);
+		}
+		if(fLineY != nullptr) {
+			fLineY->SetLineColor(color);
+		}
+	}
 
-   void SetStyle(Style_t style)
-   {
-      if(linex) {
-         linex->SetLineStyle(style);
-      }
-      if(liney) {
-         liney->SetLineStyle(style);
-      }
-   }
+	void SetStyle(Style_t style)
+	{
+		if(fLineX != nullptr) {
+			fLineX->SetLineStyle(style);
+		}
+		if(fLineY != nullptr) {
+			fLineY->SetLineStyle(style);
+		}
+	}
+	void Update(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax)
+	{
+		if(fLineX != nullptr) {
+			fLineX->SetY1(ymin);
+			fLineX->SetY2(ymax);
+		}
+		if(fLineY != nullptr) {
+			fLineY->SetX1(xmin);
+			fLineY->SetX2(xmax);
+		}
+	}
 
-   // Pixel space
-   int x{0};
-	int y{0};
-   // Coordinate space (SetRangeUser() units)
-   double localx{0.};
-	double localy{0.};
-   // Bin space
-   int    binx{0};
-	int    biny{0};
-   TLine* linex{nullptr};
-   TLine* liney{nullptr};
-   void Copy(TObject& object) const override;
-   bool operator<(const GMarker& rhs) const { return x < rhs.x; }
-   ClassDefOverride(GMarker, 0)
+	void SetLineX(double x1, double x2, double y1, double y2)
+	{
+		if(fLineX == nullptr) fLineX = new TLine(x1, y1, x2, y2);
+		else {
+			fLineX->SetX1(x1);
+			fLineX->SetX2(x2);
+			fLineX->SetY1(y1);
+			fLineX->SetY2(y2);
+		}
+	}
+
+	void SetLineY(double x1, double x2, double y1, double y2)
+	{
+		if(fLineY == nullptr) fLineY = new TLine(x1, y1, x2, y2);
+		else {
+			fLineY->SetX1(x1);
+			fLineY->SetX2(x2);
+			fLineY->SetY1(y1);
+			fLineY->SetY2(y2);
+		}
+	}
+
+	void SetLocalX(const double& val) { if(fLineX != nullptr) { fLineX->SetX1(val); fLineX->SetX2(val); } }
+	void SetLocalY(const double& val) { if(fLineY != nullptr) { fLineY->SetY1(val); fLineY->SetY2(val); } }
+	void SetBinX(const int& val) { SetLineX(fHist->GetXaxis()->GetBinLowEdge(val), gPad->GetUymin(), fHist->GetXaxis()->GetBinLowEdge(val), gPad->GetUymax()); }
+	void SetBinY(const int& val) { SetLineX(gPad->GetUxmin(), fHist->GetYaxis()->GetBinLowEdge(val), gPad->GetUxmax(), fHist->GetYaxis()->GetBinLowEdge(val)); }
+
+	double GetLocalX() const { if(fLineX == nullptr) return 0.; return fLineX->GetX1(); }
+	double GetLocalY() const { if(fLineY == nullptr) return 0.; return fLineY->GetY1(); }
+	int GetBinX() const { if(fLineX == nullptr) return -1; return fHist->GetXaxis()->FindBin(fLineX->GetX1()); }
+	int GetBinY() const { if(fLineY == nullptr) return -1; return fHist->GetYaxis()->FindBin(fLineY->GetY1()); }
+
+	void SetHist(const TH1* val) { fHist = val; }
+
+private:
+	const TH1* fHist;
+	TLine* fLineX{nullptr};
+	TLine* fLineY{nullptr};
+public:
+	void Copy(TObject& object) const override;
+	bool operator<(const GMarker& rhs) const { if(fLineX != nullptr && rhs.fLineX != nullptr) return fLineX->GetX1() < rhs.fLineX->GetX1(); return false; }
+	ClassDefOverride(GMarker, 0)
 };
 
 /*
-class GPopup : public TGTransientFrame  {
-  public:
-    GPopup(const TGWindow *p=0,const TGWindow *m=0);
-    virtual ~GPopup();
-    virtual void CloseWindow();
-    //bool ProcessMessage(Long_t,Long_t,Long_t);
-  private:
-    TGTextButton *fButton1,*fButton2;
-  ClassDefOverride(GPopup,0)
+	class GPopup : public TGTransientFrame  {
+	public:
+	GPopup(const TGWindow *p=0,const TGWindow *m=0);
+	virtual ~GPopup();
+	virtual void CloseWindow();
+//bool ProcessMessage(Long_t,Long_t,Long_t);
+private:
+TGTextButton *fButton1,*fButton2;
+ClassDefOverride(GPopup,0)
 };
 */
 
 class GCanvas : public TCanvas {
 public:
-   GCanvas(Bool_t build = kTRUE);
-   GCanvas(const char* name, const char* title = "", Int_t form = 1);
-   GCanvas(const char* name, const char* title, Int_t ww, Int_t wh);
-   GCanvas(const char* name, Int_t ww, Int_t wh, Int_t winid);
-   GCanvas(const char* name, const char* title, Int_t wtopx, Int_t wtopy, Int_t ww, Int_t wh, bool gui = false);
-   ~GCanvas() override;
+	GCanvas(Bool_t build = kTRUE);
+	GCanvas(const char* name, const char* title = "", Int_t form = 1);
+	GCanvas(const char* name, const char* title, Int_t ww, Int_t wh);
+	GCanvas(const char* name, Int_t ww, Int_t wh, Int_t winid);
+	GCanvas(const char* name, const char* title, Int_t wtopx, Int_t wtopy, Int_t ww, Int_t wh, bool gui = false);
+	~GCanvas() override;
 
-// void ProcessEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
-// void CatchEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
+	// void ProcessEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
+	// void CatchEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-   void HandleInput(int event, Int_t x, Int_t y);
+	void HandleInput(int event, Int_t x, Int_t y);
 #pragma GCC diagnostic pop
-   void Draw(Option_t* opt = "") override;
+	void Draw(Option_t* opt = "") override;
 
-   static GCanvas* MakeDefCanvas();
+	static GCanvas* MakeDefCanvas();
 
-   Int_t GetNMarkers() { return fMarkers.size(); }
-   // Int_t  GetNBG_Markers()            { return fBG_Markers.size(); }
-   void SetMarkerMode(bool flag = true) { fMarkerMode = flag; }
+	Int_t GetNMarkers() { return fMarkers.size(); }
+	// Int_t  GetNBG_Markers()            { return fBG_Markers.size(); }
+	void SetMarkerMode(bool flag = true) { fMarkerMode = flag; }
 
-   // static void SetBackGroundSubtractionType();
+	// static void SetBackGroundSubtractionType();
 
-   TF1* GetLastFit();
+	TF1* GetLastFit();
 
 private:
-   void GCanvasInit();
+	void GCanvasInit();
 
-   void UpdateStatsInfo(int, int);
+	void UpdateStatsInfo(int, int);
 
-   static int lastx;
-   static int lasty;
+	static int lastx;
+	static int lasty;
 
-   bool fGuiEnabled{false};
+	bool fGuiEnabled{false};
 
-   // bool fStatsDisplayed;
-   bool                   fMarkerMode{false};
-   std::vector<GMarker*>  fMarkers;
-   std::vector<GMarker*>  fBackgroundMarkers;
-   EBackgroundSubtraction fBackgroundMode;
+	// bool fStatsDisplayed;
+	bool                   fMarkerMode{false};
+	std::vector<GMarker*>  fMarkers;
+	std::vector<GMarker*>  fBackgroundMarkers;
+	EBackgroundSubtraction fBackgroundMode;
 	std::vector<TCutG*>    fCuts;
 	char*                  fCutName;
-   void AddMarker(int, int, int dim = 1);
-   void RemoveMarker(Option_t* opt = "");
-   void OrderMarkers();
-   void RedrawMarkers();
-   bool SetBackgroundMarkers();
-   bool CycleBackgroundSubtraction();
+	void AddMarker(int, int, TH1* hist);
+	void RemoveMarker(Option_t* opt = "");
+	void OrderMarkers();
+	void RedrawMarkers();
+	bool SetBackgroundMarkers();
+	bool CycleBackgroundSubtraction();
 
-   // std::vector<GMarker*> fBG_Markers;
-   // void AddBGMarker(GMarker *mark);
-   // void RemoveBGMarker();
-   // void ClearBGMarkers();
-   // void OrderBGMarkers();
+	// std::vector<GMarker*> fBG_Markers;
+	// void AddBGMarker(GMarker *mark);
+	// void RemoveBGMarker();
+	// void ClearBGMarkers();
+	// void OrderBGMarkers();
 
-   std::vector<TH1*> FindHists(int dim = 1);
-   std::vector<TH1*> FindAllHists();
+	std::vector<TH1*> FindHists(int dim = 1);
+	std::vector<TH1*> FindAllHists();
 
 public:
-   bool HandleArrowKeyPress(Event_t* event, UInt_t* keysym);
-   bool HandleKeyboardPress(Event_t* event, UInt_t* keysym);
-   bool HandleMousePress(Int_t event, Int_t x, Int_t y);
-   bool HandleMouseShiftPress(Int_t event, Int_t x, Int_t y);
-   bool HandleMouseControlPress(Int_t event, Int_t x, Int_t y);
+	bool HandleArrowKeyPress(Event_t* event, UInt_t* keysym);
+	bool HandleKeyboardPress(Event_t* event, UInt_t* keysym);
+	bool HandleMousePress(Int_t event, Int_t x, Int_t y);
+	bool HandleMouseShiftPress(Int_t event, Int_t x, Int_t y);
+	bool HandleMouseControlPress(Int_t event, Int_t x, Int_t y);
 
 private:
-   bool ProcessNonHistKeyboardPress(Event_t* event, UInt_t* keysym);
-   bool Process1DArrowKeyPress(Event_t* event, UInt_t* keysym);
-   bool Process1DKeyboardPress(Event_t* event, UInt_t* keysym);
-   bool Process1DMousePress(Int_t event, Int_t x, Int_t y);
+	bool ProcessNonHistKeyboardPress(Event_t* event, UInt_t* keysym);
+	bool Process1DArrowKeyPress(Event_t* event, UInt_t* keysym);
+	bool Process1DKeyboardPress(Event_t* event, UInt_t* keysym);
+	bool Process1DMousePress(Int_t event, Int_t x, Int_t y);
 
-   bool Process2DArrowKeyPress(Event_t* event, UInt_t* keysym);
-   bool Process2DKeyboardPress(Event_t* event, UInt_t* keysym);
-   bool Process2DMousePress(Int_t event, Int_t x, Int_t y);
+	bool Process2DArrowKeyPress(Event_t* event, UInt_t* keysym);
+	bool Process2DKeyboardPress(Event_t* event, UInt_t* keysym);
+	bool Process2DMousePress(Int_t event, Int_t x, Int_t y);
 
 private:
-   //Window_t     fCanvasWindowID{};
-   TRootCanvas* fRootCanvas{nullptr};
+	//Window_t     fCanvasWindowID{};
+	TRootCanvas* fRootCanvas{nullptr};
 
-   bool control_key{false};
+	bool control_key{false};
 
-   bool toggle_control()
-   {
-      control_key = !control_key;
-      return control_key;
-   }
+	bool toggle_control()
+	{
+		control_key = !control_key;
+		return control_key;
+	}
 
-   ClassDefOverride(GCanvas, 2);
+	ClassDefOverride(GCanvas, 2);
 };
 
 #endif

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -52,17 +52,34 @@ enum MyArrowPress { kMyArrowLeft = 0x1012, kMyArrowUp = 0x1013, kMyArrowRight = 
 ClassImp(GMarker)
 /// \endcond
 
+GMarker::GMarker(int x, int y, TH1* hist)
+	: fHist(hist)
+{
+   if(fHist->GetDimension() == 1) {
+      double localX = gPad->AbsPixeltoX(x);
+
+      fLineX = new TLine(localX, gPad->GetUymin(), localX, gPad->GetUymax());
+		fLineY = nullptr;
+      SetColor(kRed);
+      Draw();
+   } else if(fHist->GetDimension() == 2) {
+      double localX     = gPad->AbsPixeltoX(x);
+      double localY     = gPad->AbsPixeltoY(y);
+
+      fLineX = new TLine(localX, gPad->GetUymin(), localX, gPad->GetUymax());
+      fLineY = new TLine(gPad->GetUxmin(), localY, gPad->GetUxmax(), localY);
+
+      SetColor(kRed);
+      Draw();
+   }
+}
+
 void GMarker::Copy(TObject& object) const
 {
    TObject::Copy(object);
-   (static_cast<GMarker&>(object)).x      = x;
-   (static_cast<GMarker&>(object)).y      = y;
-   (static_cast<GMarker&>(object)).localx = localx;
-   (static_cast<GMarker&>(object)).localy = localy;
-   (static_cast<GMarker&>(object)).linex  = nullptr;
-   (static_cast<GMarker&>(object)).liney  = nullptr;
-   (static_cast<GMarker&>(object)).binx   = binx;
-   (static_cast<GMarker&>(object)).biny   = biny;
+   (static_cast<GMarker&>(object)).fLineX  = nullptr;
+   (static_cast<GMarker&>(object)).fLineY  = nullptr;
+   (static_cast<GMarker&>(object)).fHist   = fHist;
 }
 
 int GCanvas::lastx = 0;
@@ -124,43 +141,10 @@ void GCanvas::GCanvasInit()
    SetBit(kNotDeleted, false); // root voodoo.
 }
 
-void GCanvas::AddMarker(int x, int y, int dim)
+void GCanvas::AddMarker(int x, int y, TH1* hist)
 {
-   std::vector<TH1*> hists = FindHists(dim);
-   if(hists.empty()) {
-      return;
-   }
-   TH1* hist = hists[0];
-
-   auto* mark = new GMarker();
-   mark->x    = x;
-   mark->y    = y;
-   if(dim == 1) {
-      mark->localx = gPad->AbsPixeltoX(x);
-      mark->localy = gPad->AbsPixeltoY(y);
-      mark->binx   = hist->GetXaxis()->FindBin(mark->localx);
-      mark->biny   = hist->GetYaxis()->FindBin(mark->localy);
-
-      double bin_edge = hist->GetXaxis()->GetBinLowEdge(mark->binx);
-      mark->linex     = new TLine(bin_edge, hist->GetMinimum(), bin_edge, hist->GetMaximum());
-      mark->SetColor(kRed);
-      mark->Draw();
-   } else if(dim == 2) {
-      mark->localx     = gPad->AbsPixeltoX(x);
-      mark->localy     = gPad->AbsPixeltoY(y);
-      mark->binx       = hist->GetXaxis()->FindBin(mark->localx);
-      mark->biny       = hist->GetYaxis()->FindBin(mark->localy);
-      double binx_edge = hist->GetXaxis()->GetBinLowEdge(mark->binx);
-      double biny_edge = hist->GetYaxis()->GetBinLowEdge(mark->biny);
-
-      mark->linex = new TLine(binx_edge, hist->GetYaxis()->GetXmin(), binx_edge, hist->GetYaxis()->GetXmax());
-      mark->liney = new TLine(hist->GetXaxis()->GetXmin(), biny_edge, hist->GetXaxis()->GetXmax(), biny_edge);
-
-      mark->SetColor(kRed);
-      mark->Draw();
-   }
-
-   unsigned int max_number_of_markers = (dim == 1) ? 4 : 2;
+   auto* mark = new GMarker(x, y, hist);
+   unsigned int max_number_of_markers = (hist->GetDimension() == 1) ? 4 : 2;
 
    fMarkers.push_back(mark);
 
@@ -188,11 +172,9 @@ void GCanvas::RemoveMarker(Option_t* opt)
       if(fMarkers.empty()) {
          return;
       }
-      if(fMarkers.at(fMarkers.size() - 1) != nullptr) {
-         delete fMarkers.at(fMarkers.size() - 1);
-      }
+		delete fMarkers.back();
       // printf("Marker %i Removed\n");
-      fMarkers.erase(fMarkers.end() - 1);
+      fMarkers.pop_back();
    }
 }
 
@@ -205,26 +187,12 @@ void GCanvas::RedrawMarkers()
 {
    gPad->Update();
    for(auto marker : fMarkers) {
-      if(marker->linex != nullptr) {
-         marker->linex->SetY1(GetUymin());
-         marker->linex->SetY2(GetUymax());
-      }
-      if(marker->liney != nullptr) {
-         marker->liney->SetX1(GetUxmin());
-         marker->liney->SetX2(GetUxmax());
-      }
-      marker->Draw();
+		marker->Update(GetUxmin(), GetUxmax(), GetUymin(), GetUymax());
+		marker->Draw();
    }
 
    for(auto marker : fBackgroundMarkers) {
-      if(marker->linex != nullptr) {
-         marker->linex->SetY1(GetUymin());
-         marker->linex->SetY2(GetUymax());
-      }
-      if(marker->liney != nullptr) {
-         marker->liney->SetX1(GetUxmin());
-         marker->liney->SetX2(GetUxmax());
-      }
+		marker->Update(GetUxmin(), GetUxmax(), GetUymin(), GetUymax());
       marker->Draw();
    }
 }
@@ -440,7 +408,7 @@ bool GCanvas::HandleMousePress(Int_t event, Int_t x, Int_t y)
    bool used = false;
 
    if(fMarkerMode) {
-      AddMarker(x, y, hist->GetDimension());
+      AddMarker(x, y, hist);
       used = true;
    }
 
@@ -667,15 +635,15 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          break;
       }
       {
-         if(fMarkers.at(fMarkers.size() - 1)->localx < fMarkers.at(fMarkers.size() - 2)->localx) {
+         if(fMarkers.at(fMarkers.size() - 1)->GetLocalX() < fMarkers.at(fMarkers.size() - 2)->GetLocalX()) {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->localx,
-                                              fMarkers.at(fMarkers.size() - 2)->localx);
+               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->GetLocalX(),
+                                              fMarkers.at(fMarkers.size() - 2)->GetLocalX());
             }
          } else {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->localx,
-                                              fMarkers.at(fMarkers.size() - 1)->localx);
+               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalX(),
+                                              fMarkers.at(fMarkers.size() - 1)->GetLocalX());
             }
          }
       }
@@ -712,8 +680,8 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
       break;
    case kKey_f:
       if(!hists.empty() && GetNMarkers() > 1) {
-         // printf("x low = %.1f\t\txhigh = %.1f\n",fMarkers.at(fMarkers.size()-2)->localx,fMarkers.back()->localx);
-         if(PhotoPeakFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->localx, fMarkers.back()->localx) != nullptr) {
+         printf("x low = %.1f\t\txhigh = %.1f\n",fMarkers.at(fMarkers.size()-2)->GetLocalX(),fMarkers.back()->GetLocalX());
+         if(PhotoPeakFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->GetLocalX(), fMarkers.back()->GetLocalX()) != nullptr) {
             edited = true;
          }
       }
@@ -721,8 +689,8 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
 
    case kKey_F:
       if(!hists.empty() && GetNMarkers() > 1) {
-         // printf("x low = %.1f\t\txhigh = %.1f\n",fMarkers.at(fMarkers.size()-2)->localx,fMarkers.back()->localx);
-         if(AltPhotoPeakFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->localx, fMarkers.back()->localx) !=
+         printf("x low = %.1f\t\txhigh = %.1f\n",fMarkers.at(fMarkers.size()-2)->GetLocalX(),fMarkers.back()->GetLocalX());
+         if(AltPhotoPeakFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->GetLocalX(), fMarkers.back()->GetLocalX()) !=
             nullptr) {
             edited = true;
          }
@@ -730,7 +698,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
       break;
 
    case kKey_g:
-      if(GausFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->localx, fMarkers.back()->localx) != nullptr) {
+      if(GausFit(hists.back(), fMarkers.at(fMarkers.size() - 2)->GetLocalX(), fMarkers.back()->GetLocalX()) != nullptr) {
          edited = true;
       }
       break;
@@ -741,8 +709,8 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
 
    case kKey_i:
       if(!hists.empty() && GetNMarkers() > 1) {
-         int binlow  = fMarkers.at(fMarkers.size() - 1)->binx;
-         int binhigh = fMarkers.at(fMarkers.size() - 2)->binx;
+         int binlow  = fMarkers.at(fMarkers.size() - 1)->GetBinX();
+         int binhigh = fMarkers.at(fMarkers.size() - 2)->GetBinX();
          if(binlow > binhigh) {
             std::swap(binlow, binhigh);
          }
@@ -846,8 +814,8 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
       //
       if(ghist != nullptr) {
          GH1D* proj    = nullptr;
-         int   binlow  = fMarkers.at(fMarkers.size() - 1)->binx;
-         int   binhigh = fMarkers.at(fMarkers.size() - 2)->binx;
+         int   binlow  = fMarkers.at(fMarkers.size() - 1)->GetBinX();
+         int   binhigh = fMarkers.at(fMarkers.size() - 2)->GetBinX();
          if(binlow > binhigh) {
             std::swap(binlow, binhigh);
          }
@@ -865,8 +833,8 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          }
 
 			if(fBackgroundMarkers.size() >= 2 && fBackgroundMode != EBackgroundSubtraction::kNoBackground) {
-            int bg_binlow  = fBackgroundMarkers.at(0)->binx;
-            int bg_binhigh = fBackgroundMarkers.at(1)->binx;
+            int bg_binlow  = fBackgroundMarkers.at(0)->GetBinX();
+            int bg_binhigh = fBackgroundMarkers.at(1)->GetBinX();
             if(bg_binlow > bg_binhigh) {
                std::swap(bg_binlow, bg_binhigh);
             }
@@ -904,8 +872,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
    case kKey_q: {
       TH1* ghist = hists.at(0);
       if(GetNMarkers() > 1) {
-
-         edited = (PhotoPeakFit(ghist, fMarkers.at(fMarkers.size() - 2)->localx, fMarkers.back()->localx) != nullptr);
+         edited = (PhotoPeakFit(ghist, fMarkers.at(fMarkers.size() - 2)->GetLocalX(), fMarkers.back()->GetLocalX()) != nullptr);
       }
       if(edited) {
          ghist->Draw("hist");
@@ -926,15 +893,15 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          break;
       }
       {
-         if(fMarkers.at(fMarkers.size() - 1)->localy < fMarkers.at(fMarkers.size() - 2)->localy) {
+         if(fMarkers.at(fMarkers.size() - 1)->GetLocalY() < fMarkers.at(fMarkers.size() - 2)->GetLocalY()) {
             for(auto& hist : hists) {
-               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->localy,
-                                              fMarkers.at(fMarkers.size() - 2)->localy);
+               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->GetLocalY(),
+                                              fMarkers.at(fMarkers.size() - 2)->GetLocalY());
             }
          } else {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->localy,
-                                              fMarkers.at(fMarkers.size() - 1)->localy);
+               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
+                                              fMarkers.at(fMarkers.size() - 1)->GetLocalY());
             }
          }
       }
@@ -976,13 +943,13 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          edited = ShowPeaks(hists.data(), hists.size());
          RemoveMarker("all");
       } else {
-         double x1 = fMarkers.at(fMarkers.size() - 1)->localx;
-         double x2 = fMarkers.at(fMarkers.size() - 2)->localx;
+         double x1 = fMarkers.at(fMarkers.size() - 1)->GetLocalX();
+         double x2 = fMarkers.at(fMarkers.size() - 2)->GetLocalX();
          if(x1 > x2) {
             std::swap(x1, x2);
          }
-         double y1 = fMarkers.at(fMarkers.size() - 1)->localy;
-         double y2 = fMarkers.at(fMarkers.size() - 2)->localy;
+         double y1 = fMarkers.at(fMarkers.size() - 1)->GetLocalY();
+         double y2 = fMarkers.at(fMarkers.size() - 2)->GetLocalY();
          if(y1 > y2) {
             std::swap(y1, y2);
          }
@@ -1003,13 +970,13 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          edited = ShowPeaks(hists.data(), hists.size());
          RemoveMarker("all");
       } else {
-         double x1 = fMarkers.at(fMarkers.size() - 1)->localx;
-         double x2 = fMarkers.at(fMarkers.size() - 2)->localx;
+         double x1 = fMarkers.at(fMarkers.size() - 1)->GetLocalX();
+         double x2 = fMarkers.at(fMarkers.size() - 2)->GetLocalX();
          if(x1 > x2) {
             std::swap(x1, x2);
          }
-         double y1 = fMarkers.at(fMarkers.size() - 1)->localy;
-         double y2 = fMarkers.at(fMarkers.size() - 2)->localy;
+         double y1 = fMarkers.at(fMarkers.size() - 1)->GetLocalY();
+         double y2 = fMarkers.at(fMarkers.size() - 2)->GetLocalY();
          if(y1 > y2) {
             std::swap(y1, y2);
          }
@@ -1176,10 +1143,10 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
          break;
       }
       {
-         double x1 = fMarkers.at(fMarkers.size() - 1)->localx;
-         double y1 = fMarkers.at(fMarkers.size() - 1)->localy;
-         double x2 = fMarkers.at(fMarkers.size() - 2)->localx;
-         double y2 = fMarkers.at(fMarkers.size() - 2)->localy;
+         double x1 = fMarkers.at(fMarkers.size() - 1)->GetLocalX();
+         double y1 = fMarkers.at(fMarkers.size() - 1)->GetLocalY();
+         double x2 = fMarkers.at(fMarkers.size() - 2)->GetLocalX();
+         double y2 = fMarkers.at(fMarkers.size() - 2)->GetLocalY();
          if(x1 > x2) {
             std::swap(x1, x2);
          }
@@ -1234,10 +1201,10 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
          // cut->SetVarX("");
          // cut->SetVarY("");
          //
-         double x1 = fMarkers.at(fMarkers.size() - 1)->localx;
-         double y1 = fMarkers.at(fMarkers.size() - 1)->localy;
-         double x2 = fMarkers.at(fMarkers.size() - 2)->localx;
-         double y2 = fMarkers.at(fMarkers.size() - 2)->localy;
+         double x1 = fMarkers.at(fMarkers.size() - 1)->GetLocalX();
+         double y1 = fMarkers.at(fMarkers.size() - 1)->GetLocalY();
+         double x2 = fMarkers.at(fMarkers.size() - 2)->GetLocalX();
+         double y2 = fMarkers.at(fMarkers.size() - 2)->GetLocalY();
          if(x1 > x2) {
             std::swap(x1, x2);
          }
@@ -1324,15 +1291,15 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
          break;
       }
       {
-         if(fMarkers.at(fMarkers.size() - 1)->localy < fMarkers.at(fMarkers.size() - 2)->localy) {
+         if(fMarkers.at(fMarkers.size() - 1)->GetLocalY() < fMarkers.at(fMarkers.size() - 2)->GetLocalY()) {
             for(auto& hist : hists) {
-               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->localy,
-                                              fMarkers.at(fMarkers.size() - 2)->localy);
+               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 1)->GetLocalY(),
+                                              fMarkers.at(fMarkers.size() - 2)->GetLocalY());
             }
          } else {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->localy,
-                                              fMarkers.at(fMarkers.size() - 1)->localy);
+               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
+                                              fMarkers.at(fMarkers.size() - 1)->GetLocalY());
             }
          }
       }

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -535,56 +535,36 @@ void TBGSubtraction::DrawPeakMarkers()
       fPeakMarker = new GMarker();
    }
    if(fSubtractedHist){
-      fLowPeakMarker->localx  = fPeakLowValue;
-      fHighPeakMarker->localx = fPeakHighValue;
-      fPeakMarker->localx     = fPeakValue;
-      fLowPeakMarker->binx    = fSubtractedHist->GetXaxis()->FindBin(fLowPeakMarker->localx);
-      fHighPeakMarker->binx   = fSubtractedHist->GetXaxis()->FindBin(fHighPeakMarker->localx);
-      fPeakMarker->binx       = fSubtractedHist->GetXaxis()->FindBin(fPeakMarker->localx);
+		fLowPeakMarker->SetHist(fSubtractedHist);
+		fHighPeakMarker->SetHist(fSubtractedHist);
+		fPeakMarker->SetHist(fSubtractedHist);
+
+      fLowPeakMarker->SetLocalX(fPeakLowValue);
+      fHighPeakMarker->SetLocalX(fPeakHighValue);
+      fPeakMarker->SetLocalX(fPeakValue);
+      fLowPeakMarker->SetBinX(fSubtractedHist->GetXaxis()->FindBin(fLowPeakMarker->GetLocalX()));
+      fHighPeakMarker->SetBinX(fSubtractedHist->GetXaxis()->FindBin(fHighPeakMarker->GetLocalX()));
+      fPeakMarker->SetBinX(fSubtractedHist->GetXaxis()->FindBin(fPeakMarker->GetLocalX()));
    
-      double low_peak_bin_edge  = fSubtractedHist->GetXaxis()->GetBinLowEdge(fLowPeakMarker->binx);
-      double high_peak_bin_edge = fSubtractedHist->GetXaxis()->GetBinLowEdge(fHighPeakMarker->binx);
-      double peak_bin_edge       = fSubtractedHist->GetXaxis()->GetBinLowEdge(fPeakMarker->binx);
+      double low_peak_bin_edge  = fSubtractedHist->GetXaxis()->GetBinLowEdge(fLowPeakMarker->GetBinX());
+      double high_peak_bin_edge = fSubtractedHist->GetXaxis()->GetBinLowEdge(fHighPeakMarker->GetBinX());
+      double peak_bin_edge      = fSubtractedHist->GetXaxis()->GetBinLowEdge(fPeakMarker->GetBinX());
   
-      if((fLowPeakMarker->linex) == nullptr) {
-         fLowPeakMarker->linex =
-            new TLine(low_peak_bin_edge, fSubtractedHist->GetMinimum(), low_peak_bin_edge, fSubtractedHist->GetMaximum());
-         fLowPeakMarker->SetColor(kMagenta);
-      }
+		fLowPeakMarker->SetLineX(low_peak_bin_edge, low_peak_bin_edge, fSubtractedHist->GetMinimum(), fSubtractedHist->GetMaximum());
+		fLowPeakMarker->SetColor(kMagenta);
 
-      if((fHighPeakMarker->linex) == nullptr) {
-         fHighPeakMarker->linex =
-            new TLine(high_peak_bin_edge, fSubtractedHist->GetMinimum(), high_peak_bin_edge, fSubtractedHist->GetMaximum());
-         fHighPeakMarker->SetColor(kMagenta);
-      }
-      if((fPeakMarker->linex) == nullptr) {
-         fPeakMarker->linex =
-            new TLine(peak_bin_edge, fSubtractedHist->GetMinimum(), peak_bin_edge, fSubtractedHist->GetMaximum());
-         fPeakMarker->SetColor(kMagenta);
-         fPeakMarker->SetStyle(kDashed);
-      }
+		fHighPeakMarker->SetLineX(high_peak_bin_edge, high_peak_bin_edge, fSubtractedHist->GetMinimum(), fSubtractedHist->GetMaximum());
+		fHighPeakMarker->SetColor(kMagenta);
 
-      fLowPeakMarker->linex->SetX1(low_peak_bin_edge);
-      fLowPeakMarker->linex->SetX2(low_peak_bin_edge);
-      fLowPeakMarker->linex->SetY1(fSubtractedHist->GetMinimum());
-      fLowPeakMarker->linex->SetY2(fSubtractedHist->GetMaximum());
-      
-      fHighPeakMarker->linex->SetX1(high_peak_bin_edge);
-      fHighPeakMarker->linex->SetX2(high_peak_bin_edge);
-      fHighPeakMarker->linex->SetY1(fSubtractedHist->GetMinimum());
-      fHighPeakMarker->linex->SetY2(fSubtractedHist->GetMaximum());
-
-      fPeakMarker->linex->SetX1(peak_bin_edge);
-      fPeakMarker->linex->SetX2(peak_bin_edge);
-      fPeakMarker->linex->SetY1(fSubtractedHist->GetMinimum());
-      fPeakMarker->linex->SetY2(fSubtractedHist->GetMaximum());
+		fPeakMarker->SetLineX(peak_bin_edge, peak_bin_edge, fSubtractedHist->GetMinimum(), fSubtractedHist->GetMaximum());
+		fPeakMarker->SetColor(kMagenta);
+		fPeakMarker->SetStyle(kDashed);
 
       fGateCanvas->GetCanvas()->cd();
-      fLowPeakMarker->linex->Draw();
-      fHighPeakMarker->linex->Draw();
-      fPeakMarker->linex->Draw();
+      fLowPeakMarker->Draw();
+      fHighPeakMarker->Draw();
+      fPeakMarker->Draw();
       fGateCanvas->GetCanvas()->Update();
-
    }
 }
 
@@ -594,41 +574,28 @@ void TBGSubtraction::DrawBGMarkers(TGCheckButton *&check_button, GMarker *&low_m
    if((check_button != nullptr) && check_button->IsDown()) {
       if(low_marker == nullptr) {
          low_marker = new GMarker();
+			low_marker->SetHist(fProjection);
       }
       if(high_marker == nullptr) {
          high_marker = new GMarker();
+			high_marker->SetHist(fProjection);
       }
-      low_marker->localx         = low_entry->GetNumber();
-      high_marker->localx        = high_entry->GetNumber();
-      low_marker->binx           = fProjection->GetXaxis()->FindBin(low_marker->localx);
-      high_marker->binx          = fProjection->GetXaxis()->FindBin(high_marker->localx);
-      double low_bg_bin_edge     = fProjection->GetXaxis()->GetBinLowEdge(low_marker->binx);
-      double high_bg_bin_edge    = fProjection->GetXaxis()->GetBinLowEdge(high_marker->binx);
+      low_marker->SetLocalX(low_entry->GetNumber());
+      high_marker->SetLocalX(high_entry->GetNumber());
+      low_marker->SetBinX(fProjection->GetXaxis()->FindBin(low_marker->GetLocalX()));
+      high_marker->SetBinX(fProjection->GetXaxis()->FindBin(high_marker->GetLocalX()));
+      double low_bg_bin_edge     = fProjection->GetXaxis()->GetBinLowEdge(low_marker->GetBinX());
+      double high_bg_bin_edge    = fProjection->GetXaxis()->GetBinLowEdge(high_marker->GetBinX());
    
-      if((low_marker->linex) == nullptr) {
-         low_marker->linex =
-            new TLine(low_bg_bin_edge, fProjection->GetMinimum(), low_bg_bin_edge, fProjection->GetMaximum());
-         low_marker->SetColor(color);
-      }
+		low_marker->SetLineX(low_bg_bin_edge, low_bg_bin_edge, fProjection->GetMinimum(), fProjection->GetMaximum());
+		low_marker->SetColor(color);
 
-      if((high_marker->linex) == nullptr) {
-         high_marker->linex =
-            new TLine(high_bg_bin_edge, fProjection->GetMinimum(), high_bg_bin_edge, fProjection->GetMaximum());
-         high_marker->SetColor(color);
-      }
-      low_marker->linex->SetX1(low_bg_bin_edge);
-      low_marker->linex->SetX2(low_bg_bin_edge);
-      low_marker->linex->SetY1(fProjection->GetMinimum());
-      low_marker->linex->SetY2(fProjection->GetMaximum());
-
-      high_marker->linex->SetX1(high_bg_bin_edge);
-      high_marker->linex->SetX2(high_bg_bin_edge);
-      high_marker->linex->SetY1(fProjection->GetMinimum());
-      high_marker->linex->SetY2(fProjection->GetMaximum());
+		high_marker->SetLineX(high_bg_bin_edge, high_bg_bin_edge, fProjection->GetMinimum(), fProjection->GetMaximum());
+		high_marker->SetColor(color);
 
       fProjectionCanvas->GetCanvas()->cd();
-      low_marker->linex->Draw();
-      high_marker->linex->Draw();
+      low_marker->Draw();
+      high_marker->Draw();
       fProjectionCanvas->GetCanvas()->Update();
    }
    
@@ -655,43 +622,30 @@ void TBGSubtraction::DrawGateMarkers()
 {
    if(fLowGateMarker == nullptr) {
       fLowGateMarker = new GMarker();
+		fLowGateMarker->SetHist(fProjection);
    }
    if(fHighGateMarker == nullptr) {
       fHighGateMarker = new GMarker();
+		fHighGateMarker->SetHist(fProjection);
    }
 
-   fLowGateMarker->localx  = fGateEntryLow->GetNumber();
-   fHighGateMarker->localx = fGateEntryHigh->GetNumber();
-   fLowGateMarker->binx    = fProjection->GetXaxis()->FindBin(fLowGateMarker->localx);
-   fHighGateMarker->binx   = fProjection->GetXaxis()->FindBin(fHighGateMarker->localx);
+   fLowGateMarker->SetLocalX(fGateEntryLow->GetNumber());
+   fHighGateMarker->SetLocalX(fGateEntryHigh->GetNumber());
+   fLowGateMarker->SetBinX(fProjection->GetXaxis()->FindBin(fLowGateMarker->GetLocalX()));
+   fHighGateMarker->SetBinX(fProjection->GetXaxis()->FindBin(fHighGateMarker->GetLocalX()));
 
-   double low_gate_bin_edge  = fProjection->GetXaxis()->GetBinLowEdge(fLowGateMarker->binx);
-   double high_gate_bin_edge = fProjection->GetXaxis()->GetBinLowEdge(fHighGateMarker->binx);
-   if((fLowGateMarker->linex) == nullptr) {
-      fLowGateMarker->linex =
-         new TLine(low_gate_bin_edge, fProjection->GetMinimum(), low_gate_bin_edge, fProjection->GetMaximum());
-      fLowGateMarker->SetColor(kGreen);
-   }
+   double low_gate_bin_edge  = fProjection->GetXaxis()->GetBinLowEdge(fLowGateMarker->GetBinX());
+   double high_gate_bin_edge = fProjection->GetXaxis()->GetBinLowEdge(fHighGateMarker->GetBinX());
 
-   if((fHighGateMarker->linex) == nullptr) {
-      fHighGateMarker->linex =
-         new TLine(high_gate_bin_edge, fProjection->GetMinimum(), high_gate_bin_edge, fProjection->GetMaximum());
-      fHighGateMarker->SetColor(kGreen);
-   }
+	fLowGateMarker->SetLineX(low_gate_bin_edge, low_gate_bin_edge, fProjection->GetMinimum(), fProjection->GetMaximum());
+	fLowGateMarker->SetColor(kGreen);
 
-   fLowGateMarker->linex->SetX1(low_gate_bin_edge);
-   fLowGateMarker->linex->SetX2(low_gate_bin_edge);
-   fLowGateMarker->linex->SetY1(fProjection->GetMinimum());
-   fLowGateMarker->linex->SetY2(fProjection->GetMaximum());
-
-   fHighGateMarker->linex->SetX1(high_gate_bin_edge);
-   fHighGateMarker->linex->SetX2(high_gate_bin_edge);
-   fHighGateMarker->linex->SetY1(fProjection->GetMinimum());
-   fHighGateMarker->linex->SetY2(fProjection->GetMaximum());
+	fHighGateMarker->SetLineX(high_gate_bin_edge, high_gate_bin_edge, fProjection->GetMinimum(), fProjection->GetMaximum());
+	fHighGateMarker->SetColor(kGreen);
 
    fProjectionCanvas->GetCanvas()->cd();
-   fLowGateMarker->linex->Draw();
-   fHighGateMarker->linex->Draw();
+   fLowGateMarker->Draw();
+   fHighGateMarker->Draw();
 
    fProjectionCanvas->GetCanvas()->Update();
 


### PR DESCRIPTION
Changed GMarker to not store independent x/y coordinates and bins but
use values from the TLines instead.

This means that changing the TLines (by dragging them on the canvas)
changes the GMarker values now, e.g. when fitting a histogram. It also
means that one has to provide the histogram the marker refers to either
via the constructor, or afterwards via the GMarker::SetHist function.
Failure to do so results in a segmentation violation if e.g. asking for
the position of the marker in bins (these functions do not yet check if
the histogram pointer has been set).