### PR TITLE
Deep copy & destructor fixed for TDetector

### DIFF
--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -53,7 +53,7 @@ public:
    } //!<!
 #endif
 
-   void Copy(TObject&) const override;                        //!<!
+   virtual void Copy(TObject&) const override;                        //!<!
    void Clear(Option_t* = "") override { fHits.clear(); } //!<!
    virtual void ClearTransients();                            //!<!
    void Print(Option_t* opt = "") const override;             //!<!

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -146,10 +146,12 @@ public:
    const std::vector<Short_t>* GetWaveform() const { return &fWaveform; } //!<!
    TChannel*                   GetChannel() const
    {
-      if(!IsChannelSet()) {
+		// this is a clutch used because the transient bits aren't working
+		// we shouldn't need to check that the channel is a nullptr
+      if(!IsChannelSet() || fChannel == nullptr) {
          fChannel = TChannel::GetChannel(fAddress);
          SetHitBit(EBitFlag::kIsChannelSet, true);
-      }
+		}
       return fChannel;
    } //!<!
 

--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -38,7 +38,9 @@ void TDetector::Copy(TObject& rhs) const
    TObject::Copy(rhs);
 	static_cast<TDetector&>(rhs).fHits.resize(fHits.size());
 	for(size_t i = 0; i < fHits.size(); ++i) {
-		static_cast<TDetector&>(rhs).fHits[i] = new TDetectorHit(*fHits[i]);
+		// we need to use IsA()->New() to make a new hit of whatever derived type this actually is
+		static_cast<TDetector&>(rhs).fHits[i] = static_cast<TDetectorHit*>(fHits[i]->IsA()->New());
+		*static_cast<TDetector&>(rhs).fHits[i] = *fHits[i];
 	}
 }
 

--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -26,6 +26,9 @@ TDetector::TDetector(const TDetector& rhs) : TObject()
 TDetector::~TDetector()
 {
    /// Default Destructor.
+	for(auto hit : fHits) {
+		delete hit;
+	}
 }
 
 void TDetector::Copy(TObject& rhs) const
@@ -33,7 +36,10 @@ void TDetector::Copy(TObject& rhs) const
    // if(!rhs.InheritsFrom("TDetector"))
    //   return;
    TObject::Copy(rhs);
-	static_cast<TDetector&>(rhs).fHits = fHits;
+	static_cast<TDetector&>(rhs).fHits.resize(fHits.size());
+	for(size_t i = 0; i < fHits.size(); ++i) {
+		static_cast<TDetector&>(rhs).fHits[i] = new TDetectorHit(*fHits[i]);
+	}
 }
 
 void TDetector::Print(Option_t*) const

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1016,9 +1016,10 @@ Int_t TChannel::ReadCalFile(const char* filename)
       return -2;
    }
 
-   auto* buffer = new char[length];
+   auto* buffer = new char[length+1];//+1 for the null character to terminate the string
    infile.seekg(0, std::ios::beg);
    infile.read(buffer, length);
+	buffer[length] = '\0';
 
    int channels_found = ParseInputData(const_cast<const char*>(buffer), "", EPriority::kInputFile);
    SaveToSelf(infilename.c_str());

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -27,7 +27,7 @@ void TUnpackedEvent::Build()
          continue;
       }
 
-      GetDetector(detClass, true)->AddFragment(frag, channel);
+		GetDetector(detClass, true)->AddFragment(frag, channel);
    }
 
    BuildHits();
@@ -60,7 +60,6 @@ std::shared_ptr<TDetector> TUnpackedEvent::GetDetector(TClass* cls, bool make_if
    }
 
    if(make_if_not_found) {
-      // std::shared_ptr<TDetector> output = std::make_shared<TDetector>(*static_cast<TDetector*>(cls->New()));
       std::shared_ptr<TDetector> output(static_cast<TDetector*>(cls->New()));
       fDetectors.push_back(output);
       return output;


### PR DESCRIPTION
This also has the (preliminary) fix for issue #1123.