### PR TITLE
Changes from S1602 and simple gaussian peak

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -206,11 +206,6 @@ int main(int argc, char** argv)
    std::cout<<DCYAN<<"************************* END COMPILATION ******************************"<<RESET_COLOR
             <<std::endl;
 
-   if(!gGRSIOpt->CalInputFiles().empty()) {
-      std::cout<<DRED<<"Cal Files are currently ignored in GRSIProof, please write calibration to tree"
-               <<RESET_COLOR<<std::endl;
-   }
-
    if(!gGRSIOpt->InputFiles().empty()) {
       std::cout<<DRED<<"Can't Proof a Midas file..."<<RESET_COLOR<<std::endl;
    }

--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -1,0 +1,55 @@
+#ifndef TGAUSS_H
+#define TGAUSS_H
+
+/** \addtogroup Fitting Fitting & Analysis
+ *  @{
+ */
+
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cstdarg>
+
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
+#include "TGraph.h"
+
+#include "TGRSIFunctions.h"
+#include "TGRSIFit.h"
+#include "TSinglePeak.h"
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TGauss
+///
+///  This class is used to fit simple gaussian peaks in data
+///
+/////////////////////////////////////////////////////////////////
+
+class TGauss : public TSinglePeak {
+public:
+   // ctors and dtors
+   ~TGauss() override {};
+   TGauss();
+   TGauss(Double_t centroid, Double_t relativeLimit = -1.);
+
+   void InitParNames() override;
+   void InitializeParameters(TH1* hist) override;
+
+   Double_t Centroid() const override;
+   Double_t CentroidErr() const override;
+   Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }
+
+   void Print(Option_t *opt = "") const override;
+
+protected:
+   Double_t PeakFunction(Double_t *dim, Double_t *par) override;
+
+public:
+   /// \cond CLASSIMP
+   ClassDefOverride(TGauss, 1);
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -740,6 +740,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
       }
       break;
    case kKey_l:
+   case kKey_y:
       if(GetLogy() != 0) {
          // Show full y range, not restricted to positive values.
          for(auto& hist : hists) {
@@ -1449,9 +1450,9 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
    case kKey_l:
    case kKey_z:
       if(GetLogz() != 0) {
-         // Show full y range, not restricted to positive values.
+         // Show full z range, not restricted to positive values.
          for(auto& hist : hists) {
-            hist->GetYaxis()->UnZoom();
+            hist->GetZaxis()->UnZoom();
          }
          TVirtualPad* cpad = gPad;
          cd();
@@ -1460,8 +1461,8 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
       } else {
          // Only show plot from 0 up when in log scale.
          for(auto& hist : hists) {
-            if(hist->GetYaxis()->GetXmin() < 0) {
-               hist->GetYaxis()->SetRangeUser(0, hist->GetYaxis()->GetXmax());
+            if(hist->GetZaxis()->GetXmin() < 0) {
+               hist->GetZaxis()->SetRangeUser(0, hist->GetYaxis()->GetXmax());
             }
          }
          TVirtualPad* cpad = gPad;

--- a/libraries/TAnalysis/TPeakFitting/LinkDef.h
+++ b/libraries/TAnalysis/TPeakFitting/LinkDef.h
@@ -1,4 +1,4 @@
-//TSinglePeak.h TRWPeak.h TPeakFitter.h TABPeak.h TAB3Peak.h
+//TSinglePeak.h TRWPeak.h TPeakFitter.h TABPeak.h TAB3Peak.h TGauss.h
 
 #ifdef __CINT__
 
@@ -13,6 +13,7 @@
 #pragma link C++ class TABPeak+;
 #pragma link C++ class TAB3Peak+;
 #pragma link C++ class TRWPeak+;
+#pragma link C++ class TGauss+;
 #pragma link C++ class TPeakFitter+;
 
 #endif

--- a/libraries/TAnalysis/TPeakFitting/TGauss.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TGauss.cxx
@@ -1,0 +1,74 @@
+#include "TGauss.h"
+
+/// \cond CLASSIMP
+ClassImp(TGauss)
+/// \endcond
+
+TGauss::TGauss() : TSinglePeak() { }
+
+TGauss::TGauss(Double_t centroid, Double_t relativeLimit) : TSinglePeak()
+{
+   fTotalFunction = new TF1("gauss_total",this,&TGauss::TotalFunction,0,1,3,"TGauss","TotalFunction");
+   InitParNames();
+   fTotalFunction->SetParameter(1,centroid);
+	if(relativeLimit >= 0) {
+		fTotalFunction->SetParLimits(1, (1.-relativeLimit)*centroid, (1.+relativeLimit)*centroid);
+	}
+   SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
+   fTotalFunction->SetLineColor(kMagenta);
+}
+
+void TGauss::InitParNames()
+{
+   fTotalFunction->SetParName(0, "height");
+   fTotalFunction->SetParName(1, "centroid");
+   fTotalFunction->SetParName(2, "sigma");
+}
+
+void TGauss::InitializeParameters(TH1* fit_hist)
+{
+   /// Makes initial guesses at parameters for the fit base on the histogram.
+   // Make initial guesses
+   // Actually set the parameters in the photopeak function
+   // Fixing has to come after setting
+   // Might have to include bin widths eventually
+   // The centroid should already be set by this point in the ctor
+   Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
+   if(!ParameterSetByUser(0)) {
+		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*2.);
+		fTotalFunction->SetParameter("height", fit_hist->GetBinContent(bin));
+	}
+	if(!ParameterSetByUser(2)) {
+		fTotalFunction->SetParLimits(2, 0.01, 10.);
+		fTotalFunction->SetParameter("sigma", TMath::Sqrt(5 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+	}
+}
+
+Double_t TGauss::Centroid() const
+{
+   return fTotalFunction->GetParameter("centroid");
+}
+
+Double_t TGauss::CentroidErr() const
+{
+   return fTotalFunction->GetParError(1);
+}
+
+Double_t TGauss::PeakFunction(Double_t *dim, Double_t *par)
+{
+   Double_t x      = dim[0]; // channel number used for fitting
+   Double_t height = par[0]; // height of photopeak
+   Double_t c      = par[1]; // centroid of gaussian
+   Double_t sigma  = par[2]; // standard deviation of gaussian
+
+   Double_t gauss      = height * TMath::Gaus(x, c, sigma);
+   
+	return gauss;
+}
+
+void TGauss::Print(Option_t * opt) const
+{
+   std::cout << "gaussian peak:" << std::endl;
+   TSinglePeak::Print(opt);
+}
+

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1320,7 +1320,8 @@ int TChannel::WriteToRoot(TFile* fileptr)
 	TDirectory* savdir = gDirectory;
 
 	if(c == nullptr) {
-		printf("No TChannels found to write.\n");
+		std::cout<<"No TChannels found to write."<<std::endl;
+		return 0;
 	}
 	if(fileptr == nullptr) {
 		fileptr = gDirectory->GetFile();

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -189,8 +189,6 @@ Bool_t TGRSISelector::Process(Long64_t entry)
 		current_file = fChain->GetCurrentFile();
 		std::cout<<"Starting to sort: "<<current_file->GetName()<<std::endl;
 		TChannel::ReadCalFromFile(current_file);
-		//TRunInfo::Get()->ReadInfoFromFile(current_file);
-		//   TChannel::WriteCalFile();
 	}
 
 	fChain->GetEntry(entry);
@@ -263,6 +261,7 @@ void TGRSISelector::Terminate()
 		std::cerr<<"failed to find TPPG, can't write it!"<<std::endl;
 	}
 	options->AnalysisOptions()->WriteToFile(outputFile);
+	TChannel::WriteToRoot();
 	outputFile->Close();
 }
 

--- a/libraries/TLoops/TAnalysisWriteLoopClient.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoopClient.cxx
@@ -20,6 +20,8 @@ TAnalysisWriteLoopClient::TAnalysisWriteLoopClient(std::string name, std::string
 	}
    fOutputFile->Write();
 
+	fOutputFile->cd();
+
 	fEventTree  = new TTree("AnalysisTree", "AnalysisTree");
 	if(TGRSIOptions::Get()->SeparateOutOfOrder()) {
 		fOutOfOrderTree = new TTree("OutOfOrderTree", "OutOfOrderTree");

--- a/util/Spe2TBrowser/load_spe.C
+++ b/util/Spe2TBrowser/load_spe.C
@@ -1,7 +1,8 @@
-
-
+#include <iostream>
 #include<stdio.h>
 #include<string.h>
+
+#include "TH1.h"
 
 /* ======================================================================= */
 void swapb8(char *buf)
@@ -69,11 +70,11 @@ int get_file_rec(FILE *fd, void *data, int maxbytes, int swap_bytes)
   //warn("ERROR: record is too big for get_file_rec\n"
   //    "       max size = %d, record size = %d.\n",
   //     maxbytes, reclen);
-	cout<<"ERR1 \n";
+	std::cout<<"ERR1"<<std::endl;
   return 0;
  ERR2:
   //warn("ERROR during read in get_file_rec.\n");
-	cout<<"ERR2 \n";  
+	std::cout<<"ERR2"<<std::endl;
 	return 0;
 
 return 0;
@@ -81,7 +82,7 @@ return 0;
 /* ====================================================================== */
 
 
-int load_spe(char *filename,TH1F* histo)
+int load_spe(const char *filename,TH1F* histo)
 {
 	int idim1,idim2,j,rl;
 	int swap = -1;
@@ -115,15 +116,15 @@ int load_spe(char *filename,TH1F* histo)
 
 	for(j=0;j<numch;j++)
 	{
-		//if(sp[j]>0){cout<<j<<"\t"<<sp[j]<<endl;	}
+		//if(sp[j]>0){std::cout<<j<<"\t"<<sp[j]<<endl;	}
 		//histo->SetBinContent(j,sp[j]);
 		temp->Fill(j,sp[j]);
 	}	
 
-	*histo = (TH1F*)temp->Clone();
+	histo = (TH1F*)temp->Clone();
 	histo->SetName(filename);
 
-	cout<<"loaded\n";
+	std::cout<<"loaded"<<std::endl;
 	return 0;
 }
 


### PR DESCRIPTION
- Removed obsolete warning from grsiproof that cal-files can't be used.
- Fixed a bug in GCanvas where toggling the z-axis to or from logscale
  would change the range of the y-axis.
  1D-histograms can now be toggled to logscale using the y key as well
  (and not just the l key).
- TChannel::WriteToRoot returns 0 if no channels are found instead of
  trying to write them (and crashing).
- TGRSISelector writes TChannel to the output file (not working yet!).
- Fixed some bugs in load_spe.C script.
- Added simple gaussian peak.