### PR TITLE
Updates to grsiproof and fixed cross-talk selector

### DIFF
--- a/GRSIProof/CrossTalk.C
+++ b/GRSIProof/CrossTalk.C
@@ -15,13 +15,13 @@ const double gb_time_high = 350.;
 
 bool Addback(TGriffinHit& one, TGriffinHit& two)
 {
-   return ((one.GetDetector() == two.GetDetector()) && (std::fabs(one.GetTime() - two.GetTime()) < 300.));
+	return ((one.GetDetector() == two.GetDetector()) && (std::fabs(one.GetTime() - two.GetTime()) < 300.));
 }
 
 bool PromptCoincidence(TGriffinHit* one, TGriffinHit* two)
 {
 
-   return ((two->GetTime() - one->GetTime()) >= gg_time_low) && ((two->GetTime() - one->GetTime()) <= gg_time_high);
+	return ((two->GetTime() - one->GetTime()) >= gg_time_low) && ((two->GetTime() - one->GetTime()) <= gg_time_high);
 }
 
 void CrossTalk::CreateHistograms() {
@@ -36,7 +36,7 @@ void CrossTalk::CreateHistograms() {
 		for(int crys_1=0; crys_1 <4; ++crys_1){
 			for(int crys_2=crys_1+1;crys_2<4;++crys_2){
 				std::string name_str = Form("det_%d_%d_%d",det_num,crys_1,crys_2);
-			 	const char* hist_name = name_str.c_str();
+				const char* hist_name = name_str.c_str();
 				std::cout << "Creating histogram: " << hist_name;
 				fH2[name_str] = new TH2I(hist_name,hist_name,1500,0,1500,1500,0,1500); 
 				std::cout << " at address: " << fH2[hist_name] << std::endl;
@@ -49,6 +49,7 @@ void CrossTalk::CreateHistograms() {
 	fH1["aE"] = new TH1D("aE", "Summed Addback", 1500,0,1500);
 	fH1["gE"] = new TH1D("gE", "Summed Singles", 1500,0,1500);
 	fH1["gEnoCT"] = new TH1D("gEnoCT", "Singles, no CT correction", 1500,0,1500);
+
 	for(auto it : fH1) {
 		GetOutputList()->Add(it.second);
 	}
@@ -62,21 +63,22 @@ void CrossTalk::CreateHistograms() {
 
 void CrossTalk::FillHistograms() {
 	//find the multiplicity in each clover over the entire event
-   //we do this because we want to force a multiplicity of 2
+	//we do this because we want to force a multiplicity of 2
 	Int_t det_multiplicity[17] = {0};
-	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedMultiplicity(); ++gr1){
+	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedMultiplicity(fGriffinBgo); ++gr1){
 		++(det_multiplicity[fGrif->GetSuppressedHit(gr1)->GetDetector()]);
 	}
-   for(auto gr1 = 0; gr1 < fGrif->GetSuppressedMultiplicity(); ++gr1){
+
+	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedMultiplicity(fGriffinBgo); ++gr1){
 		if(pileup_reject && (fGrif->GetSuppressedHit(gr1)->GetKValue() != 700)) continue; //This pileup number might have to change for other expmnts
 		fH1[Form("gEdet%d",fGrif->GetSuppressedHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH2["gE_chan"]->Fill(fGrif->GetSuppressedHit(gr1)->GetArrayNumber(),fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH1["gE"]->Fill(fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH1["gEnoCT"]->Fill(fGrif->GetSuppressedHit(gr1)->GetNoCTEnergy());
-		for(auto gr2 = gr1 + 1; gr2 < fGrif->GetMultiplicity(); ++gr2){
+		for(auto gr2 = gr1 + 1; gr2 < fGrif->GetSuppressedMultiplicity(fGriffinBgo); ++gr2){
 			if(pileup_reject && fGrif->GetSuppressedHit(gr2)->GetKValue() != 700) continue; //This pileup number might have to change for other expmnts
 			if((det_multiplicity[fGrif->GetSuppressedHit(gr1)->GetDetector()] == 2) && Addback(*(fGrif->GetSuppressedHit(gr1)), *(fGrif->GetSuppressedHit(gr2)))){
-				TSuppressedHit *low_crys_hit, *high_crys_hit;
+				TGriffinHit *low_crys_hit, *high_crys_hit;
 				if(fGrif->GetSuppressedHit(gr1)->GetCrystal() < fGrif->GetSuppressedHit(gr2)->GetCrystal()){
 					low_crys_hit = fGrif->GetSuppressedHit(gr1);
 					high_crys_hit = fGrif->GetSuppressedHit(gr2);
@@ -92,13 +94,13 @@ void CrossTalk::FillHistograms() {
 		}
 	}
 
-   for(auto gr1 = 0; gr1 < fGrif->GetSuppressedAddbackMultiplicity(); ++gr1) {
-      if(pileup_reject && (fGrif->GetSuppressedAddbackHit(gr1)->GetKValue() != 700))
-         continue; // This pileup number might have to change for other expmnts
-      fH1["aE"]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
-      fH1[Form("aEdet%d", fGrif->GetSuppressedAddbackHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
-      fH1["aMult"]->Fill(fGrif->GetNSuppressedAddbackFrags(gr1));
-      if(fGrif->GetNSuppressedAddbackFrags(gr1) == 2)
-         fH1[Form("aE2det%d", fGrif->GetSuppressedAddbackHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
-   }
+	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedAddbackMultiplicity(fGriffinBgo); ++gr1) {
+		if(pileup_reject && (fGrif->GetSuppressedAddbackHit(gr1)->GetKValue() != 700))
+			continue; // This pileup number might have to change for other expmnts
+		fH1["aE"]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
+		fH1[Form("aEdet%d", fGrif->GetSuppressedAddbackHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
+		fH1["aMult"]->Fill(fGrif->GetNSuppressedAddbackFrags(gr1));
+		if(fGrif->GetNSuppressedAddbackFrags(gr1) == 2)
+			fH1[Form("aE2det%d", fGrif->GetSuppressedAddbackHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
+	}
 }

--- a/GRSIProof/CrossTalk.h
+++ b/GRSIProof/CrossTalk.h
@@ -19,7 +19,7 @@
 #include "TGriffin.h"
 #include "TSceptar.h"
 #include "TGRSISelector.h"
-
+#include "TGriffinBgo.h"
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
 class CrossTalk : public TGRSISelector {
@@ -27,15 +27,16 @@ class CrossTalk : public TGRSISelector {
 public:
    TGriffin* fGrif;
    TSceptar* fScep;
+	TGriffinBgo* fGriffinBgo;
 
-   CrossTalk(TTree* /*tree*/ = 0) : TGRSISelector(), fGrif(0), fScep(0) { SetOutputPrefix("Crosstalk"); }
-   virtual ~CrossTalk() {}
-   virtual Int_t Version() const { return 2; }
-   void          CreateHistograms();
-   void          FillHistograms();
-   void InitializeBranches(TTree* tree);
+	CrossTalk(TTree* /*tree*/ = 0) : TGRSISelector(), fGrif(0), fScep(0), fGriffinBgo(0) { SetOutputPrefix("Crosstalk"); }
+	virtual ~CrossTalk() {}
+	virtual Int_t Version() const { return 2; }
+	void          CreateHistograms();
+	void          FillHistograms();
+	void InitializeBranches(TTree* tree);
 
-   ClassDef(CrossTalk, 2);
+	ClassDef(CrossTalk, 2);
 };
 
 #endif
@@ -43,9 +44,16 @@ public:
 #ifdef CrossTalk_cxx
 void CrossTalk::InitializeBranches(TTree* tree)
 {
-   if(!tree) return;
-   tree->SetBranchAddress("TGriffin", &fGrif);
-  // tree->SetBranchAddress("TSceptar", &fScep);
+	if(!tree) return;
+	if(tree->SetBranchAddress("TGriffin", &fGrif) == TTree::kMissingBranch) {
+		fGrif = new TGriffin;
+	}
+	if(tree->SetBranchAddress("TSceptar", &fScep) == TTree::kMissingBranch) {
+		fScep = new TSceptar;
+	}
+	if(tree->SetBranchAddress("TGriffinBgo", &fGriffinBgo) == TTree::kMissingBranch) {
+		fGriffinBgo = new TGriffinBgo;
+	}
 }
 
 #endif // #ifdef CrossTalk_cxx

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -85,6 +85,7 @@ void Analyze(const char* tree_type)
 			std::cout<<DRED<<"Exception when processing chain: "<<e.detail()<<RESET_COLOR<<std::endl;
 			throw e;
 		}
+      std::cout<<"Done with "<<(Form("%s", macro_it.c_str()))<<std::endl;
    }
 
    // Delete the proof chain now that we are done with it.
@@ -222,7 +223,20 @@ int main(int argc, char** argv)
    }
 
    if(gGRSIProof == nullptr) {
-      std::cout<<"Can't connect to proof"<<std::endl;
+      std::cout<<"Couldn't connect to proof on first attempt, trying again"<<std::endl;
+		if(gGRSIOpt->GetMaxWorkers() >= 0) {
+			std::cout<<"Opening proof with '"<<Form("workers=%d", gGRSIOpt->GetMaxWorkers())<<"'"<<std::endl;
+			gGRSIProof = TGRSIProof::Open(Form("workers=%d", gGRSIOpt->GetMaxWorkers()));
+		} else if(gGRSIOpt->SelectorOnly()) {
+			std::cout<<"Opening proof with one worker (selector-only)"<<std::endl;
+			gGRSIProof = TGRSIProof::Open("workers=1");
+		} else {
+			gGRSIProof = TGRSIProof::Open("");
+		}
+   }
+
+   if(gGRSIProof == nullptr) {
+      std::cout<<"Still can't connect to proof, try running it again?"<<std::endl;
       return 0;
    }
 

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -60,10 +60,13 @@ typedef char int8_t;
 #include <cstdint>
 #endif
 
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <cstdio>
 #include <cstdlib>
+#include <execinfo.h>
+#include <cxxabi.h>
 //#include <stdint.h>
 const std::string& ProgramName();
 
@@ -81,4 +84,78 @@ public:
    const char* message;
 };
 }
+
+// print a demangled stack backtrace of the caller function (copied from https://panthema.net/2008/0901-stacktrace-demangled/)
+static inline void PrintStacktrace(std::ostream& out = std::cout, unsigned int maxFrames = 63)
+{
+	out<<"stack trace:"<<std::endl;
+
+	// storage array for stack trace address data
+	void** addrlist = new void*[maxFrames+1];
+
+	// retrieve current stack addresses
+	int addrlen = backtrace(addrlist, maxFrames+1);
+
+	if(addrlen == 0) {
+		out<<"  <empty, possibly corrupt>"<<std::endl;
+		return;
+	}
+
+	// resolve addresses into strings containing "filename(function+address)",
+	// this array must be free()-ed
+	char** symbollist = backtrace_symbols(addrlist, addrlen);
+
+	// allocate string which will be filled with the demangled function name
+	size_t funcnamesize = 256;
+	char* funcname = new char[funcnamesize];
+
+	// iterate over the returned symbol lines. skip the first, it is the
+	// address of this function.
+	for(int i = 2; i < addrlen; i++) {
+		char* begin_name = nullptr;
+		char* begin_offset = nullptr;
+		char* end_offset = nullptr;
+
+		// find parentheses and +address offset surrounding the mangled name:
+		// ./module(function+0x15c) [0x8048a6d]
+		for(char* p = symbollist[i]; *p; ++p) {
+			if(*p == '(') {
+				begin_name = p;
+			} else if (*p == '+') {
+				begin_offset = p;
+			} else if(*p == ')' && begin_offset) {
+				end_offset = p;
+				break;
+			}
+		}
+
+		if(begin_name && begin_offset && end_offset && begin_name < begin_offset) {
+			*begin_name++ = '\0';
+			*begin_offset++ = '\0';
+			*end_offset = '\0';
+
+			// mangled name is now in [begin_name, begin_offset) and caller
+			// offset in [begin_offset, end_offset). now apply
+			// __cxa_demangle():
+
+			int status;
+			char* ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+			if(status == 0) {
+				funcname = ret; // use possibly realloc()-ed string
+				std::cout<<"  "<<symbollist[i]<<" : "<<funcname<<"+"<<begin_offset<<std::endl;
+			} else {
+				// demangling failed. Output function name as a C function with
+				// no arguments.
+				std::cout<<"  "<<symbollist[i]<<" : "<<begin_name<<"()+"<<begin_offset<<std::endl;
+			}
+		} else {
+			// couldn't parse the line? print the whole line.
+			std::cout<<"  "<<symbollist[i]<<std::endl;
+		}
+	}
+
+	free(funcname);
+	free(symbollist);
+}
+
 #endif

--- a/include/TGRSIMap.h
+++ b/include/TGRSIMap.h
@@ -18,9 +18,6 @@
 /// This class re-implements std::map with more explicit
 /// expections replacing out-of-range exceptions.
 ///
-/// all constructors were copied from http://www.cplusplus.com/reference/map/map/map/ (c++11 tab)
-/// and from bits/stl_map.h of gcc 4.9.1
-///
 ////////////////////////////////////////////////////////////
 
 template <typename key_type>
@@ -28,41 +25,46 @@ class TGRSIMapException;
 
 template <typename key_type, typename mapped_type, typename key_compare = std::less<key_type>,
 			typename allocator_type = std::allocator<std::pair<const key_type, mapped_type> > >
-class TGRSIMap : public std::map<key_type, mapped_type, key_compare, allocator_type>
+class TGRSIMap
 {
 public:
-	TGRSIMap(const key_compare& comp = key_compare(), const allocator_type& alloc = allocator_type()) : std::map<key_type, mapped_type, key_compare, allocator_type>(comp, alloc) {}
-	TGRSIMap(const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(alloc) {}
-	template <class InputIterator>
-		TGRSIMap(InputIterator first, InputIterator last,
-				const key_compare& comp = key_compare(),
-				const allocator_type& alloc = allocator_type()) : std::map<key_type, mapped_type, key_compare, allocator_type>(first, last, comp, alloc) {}
-	TGRSIMap(const TGRSIMap& x) : std::map<key_type, mapped_type, key_compare, allocator_type>(x) {}
-	TGRSIMap(const TGRSIMap& x, const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(x, alloc) {}
-	TGRSIMap(TGRSIMap&& x) : std::map<key_type, mapped_type, key_compare, allocator_type>(x) {}
-	TGRSIMap(TGRSIMap&& x, const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(x, alloc) {}
+	TGRSIMap() {}
 	~TGRSIMap() {}
 
 	void Print() {
-		for(auto it : *this) {
+		for(auto it : fMap) {
 			std::cout<<it.first<<" - "<<it.second<<std::endl;
 		}
 	}
 
 	mapped_type& at(const key_type& k) { 
 		try {
-			return std::map<key_type, mapped_type, key_compare, allocator_type>::at(k);
+			return fMap.at(k);
 		} catch(std::exception& e) {
-			throw TGRSIMapException<key_type>(k, *this);
+			throw TGRSIMapException<key_type>(k, fMap);
 		}
 	}
 	const mapped_type& at(const key_type& k) const {
 		try {
-			return std::map<key_type, mapped_type, key_compare, allocator_type>::at(k);
+			return fMap.at(k);
 		} catch(std::exception& e) {
-			throw TGRSIMapException<key_type>(k, *this);
+			throw TGRSIMapException<key_type>(k, fMap);
 		}
 	}
+
+	      mapped_type& operator[](const key_type& k)       { return at(k); }
+	const mapped_type& operator[](const key_type& k) const { return at(k); }
+
+	typedef std::map<key_type, mapped_type, key_compare, allocator_type> map_t;
+	typename map_t::iterator begin()       { return fMap.begin(); }
+	typename map_t::const_iterator begin() const { return fMap.begin(); }
+	typename map_t::iterator end()       { return fMap.end(); }
+	typename map_t::const_iterator end() const { return fMap.end(); }
+
+	typename map_t::size_type count(const key_type* k) const { return fMap.count(); }
+
+private:
+	std::map<key_type, mapped_type, key_compare, allocator_type> fMap;
 };
 
 template <typename key_type>
@@ -70,7 +72,7 @@ class TGRSIMapException : public std::exception
 {
 public:
 	template<typename mapped_type, typename key_compare, typename allocator_type>
-	TGRSIMapException(const key_type key, const TGRSIMap<key_type, mapped_type, key_compare, allocator_type>& map)
+	TGRSIMapException(const key_type key, const std::map<key_type, mapped_type, key_compare, allocator_type>& map)
 		: std::exception(), fKey(key)
 		{
 			for(auto it : map) {

--- a/include/TGRSIMap.h
+++ b/include/TGRSIMap.h
@@ -31,7 +31,6 @@ template <typename key_type, typename mapped_type, typename key_compare = std::l
 class TGRSIMap : public std::map<key_type, mapped_type, key_compare, allocator_type>
 {
 public:
-	//TGRSIMap() : std::map<key_type, mapped_type, key_compare, allocator_type>() {}
 	TGRSIMap(const key_compare& comp = key_compare(), const allocator_type& alloc = allocator_type()) : std::map<key_type, mapped_type, key_compare, allocator_type>(comp, alloc) {}
 	TGRSIMap(const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(alloc) {}
 	template <class InputIterator>
@@ -42,10 +41,13 @@ public:
 	TGRSIMap(const TGRSIMap& x, const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(x, alloc) {}
 	TGRSIMap(TGRSIMap&& x) : std::map<key_type, mapped_type, key_compare, allocator_type>(x) {}
 	TGRSIMap(TGRSIMap&& x, const allocator_type& alloc) : std::map<key_type, mapped_type, key_compare, allocator_type>(x, alloc) {}
-	//TGRSIMap(initializer_list<value_type> il,
-	//		const key_compare& comp = key_compare(),
-	//		const allocator_type& alloc = allocator_type()) : std::map<key_type, mapped_type, key_compare, allocator_type>(il, comp, alloc) {}
 	~TGRSIMap() {}
+
+	void Print() {
+		for(auto it : *this) {
+			std::cout<<it.first<<" - "<<it.second<<std::endl;
+		}
+	}
 
 	mapped_type& at(const key_type& k) { 
 		try {

--- a/include/TGRSIProof.h
+++ b/include/TGRSIProof.h
@@ -50,7 +50,7 @@ public:
    static TGRSIProof* Open(const char* worker = "")
    {
       TGRSIProof* p = static_cast<TGRSIProof*>(TProof::Open(worker));
-      p->LoadLibsIntoProof();
+		if(p != nullptr) p->LoadLibsIntoProof();
       return p;
    }
    void LoadLibsIntoProof()

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -136,7 +136,11 @@ void TChannel::SetName(const char* tmpName)
 void TChannel::InitChannelInput()
 {
    int channels_found = ParseInputData(fFileData.c_str(), "q", EPriority::kRootFile);
-   printf("Successfully read %i TChannels from" CYAN " %s" RESET_COLOR "\n", channels_found, gFile->GetName());
+	if(gFile != nullptr) {
+		std::cout<<"Successfully read "<<channels_found<<" TChannels from "<<CYAN<<gFile->GetName()<<RESET_COLOR<<std::endl;
+	} else {
+		std::cout<<"Successfully read "<<channels_found<<" TChannels"<<std::endl;
+	}
 }
 
 bool TChannel::CompareChannels(const TChannel& chana, const TChannel& chanb)


### PR DESCRIPTION
- @AndrewMac1 fixed the cross talk selector, it hadn't been tested after changing it to use suppressed hits.
- Added checks in grsiproof to avoid some crashes or at least give a clearer message instead.
- Changed TGRSIMap to use std::map instead of inheriting from it (apparently STL containers do not have virtual destructors, so inheriting from them is a bad idea). Might want to change this to an unordered_map?
- Added a global function PrintBacktrace to do just that. It takes an ostream and number of frames as arguments, default are std::cout and 63.