### PR TITLE
Fixed issue with cross talk correction in grsiproof

### DIFF
--- a/include/TAnalysisOptions.h
+++ b/include/TAnalysisOptions.h
@@ -29,8 +29,10 @@ public:
    void Clear(Option_t* opt = "") override;
    void Print(Option_t* opt = "") const override;
 
+   bool WriteToFile(const std::string& file);
    bool WriteToFile(TFile* file = nullptr);
    void ReadFromFile(const std::string& file);
+   void ReadFromFile(TFile* file = nullptr);
 
    // sorting options
    inline void SetBuildWindow(const long int t_bw) { fBuildWindow = t_bw; }

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1252,13 +1252,18 @@ int TChannel::WriteToRoot(TFile* fileptr)
 		fileptr = gDirectory->GetFile();
 	}
 
+	// check if we got a file
+   if(fileptr == nullptr) {
+		std::cout<<"Error, no file provided and no file open (gDirectory = "<<gDirectory->GetName()<<")!"<<std::endl;
+		return 0;
+	}
 	fileptr->cd();
 	std::string oldoption = std::string(fileptr->GetOption());
 	if(oldoption == "READ") {
 		fileptr->ReOpen("UPDATE");
 	}
 	if(gDirectory == nullptr) {
-		printf("No file opened to write to.\n");
+		std::cout<<"No file opened to write to."<<std::endl;
 	}
 	TIter iter(gDirectory->GetListOfKeys());
 
@@ -1301,9 +1306,9 @@ int TChannel::WriteToRoot(TFile* fileptr)
 	ParseInputData(savedata.c_str(), "q", EPriority::kRootFile);
 	SaveToSelf(savedata.c_str());
 
-	printf("  %i TChannels saved to %s.\n", GetNumberOfChannels(), gDirectory->GetFile()->GetName());
+	std::cout<<"  "<<GetNumberOfChannels()<<" TChannels saved to "<<gDirectory->GetFile()->GetName()<<std::endl;
 	if(oldoption == "READ") {
-		printf("  Returning %s to \"%s\" mode.\n", gDirectory->GetFile()->GetName(), oldoption.c_str());
+		std::cout<<"  Returning "<<gDirectory->GetFile()->GetName()<<" to \"READ\" mode."<<std::endl;
 		fileptr->ReOpen("READ");
 	}
 	savdir->cd(); // Go back to original gDirectory

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -189,6 +189,7 @@ Bool_t TGRSISelector::Process(Long64_t entry)
 		current_file = fChain->GetCurrentFile();
 		std::cout<<"Starting to sort: "<<current_file->GetName()<<std::endl;
 		TChannel::ReadCalFromFile(current_file);
+		TGRSIOptions::AnalysisOptions()->ReadFromFile(current_file);
 	}
 
 	fChain->GetEntry(entry);

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -44,6 +44,16 @@ void TAnalysisOptions::Print(Option_t*) const
             <<RESET_COLOR<<std::endl;
 }
 
+bool TAnalysisOptions::WriteToFile(const std::string& file)
+{
+	TFile f(file.c_str(), "update");
+	if(f.IsOpen()) {
+		return WriteToFile(&f);
+	}
+	std::cout<<R"(Failed to open file ")"<<file<<R"(" in update mode!)"<<std::endl;
+	return false;
+}
+
 bool TAnalysisOptions::WriteToFile(TFile* file)
 {
    /// Writes options information to the root file
@@ -90,10 +100,18 @@ bool TAnalysisOptions::WriteToFile(TFile* file)
 
 void TAnalysisOptions::ReadFromFile(const std::string& file)
 {
+	TFile f(file.c_str(), "read");
+	if(f.IsOpen()) {
+		return ReadFromFile(&f);
+	}
+	std::cout<<R"(Failed to open file ")"<<file<<R"(" in read mode!)"<<std::endl;
+}
+
+void TAnalysisOptions::ReadFromFile(TFile* file)
+{
    TDirectory* oldDir = gDirectory;
-   auto        f      = new TFile(file.c_str());
-   if(f != nullptr && f->IsOpen()) {
-      TList* list = f->GetListOfKeys();
+   if(file != nullptr && file->IsOpen()) {
+      TList* list = file->GetListOfKeys();
       TIter  iter(list);
       while(TKey* key = static_cast<TKey*>(iter.Next())) {
          if((key == nullptr) || (strcmp(key->GetClassName(), "TAnalysisOptions") != 0)) {
@@ -101,14 +119,12 @@ void TAnalysisOptions::ReadFromFile(const std::string& file)
          }
 
          *this = *static_cast<TAnalysisOptions*>(key->ReadObj());
-         f->Close();
          oldDir->cd();
          return;
       }
-		std::cout<<R"(Failed to find analysis options in file ")"<<CYAN<<f->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
-		f->Close();
+		std::cout<<R"(Failed to find analysis options in file ")"<<CYAN<<file->GetName()<<RESET_COLOR<<R"(":)"<<std::endl;
    } else {
-      std::cout<<R"(Failed to open file ")"<<file<<R"(")"<<std::endl;
+      std::cout<<R"(File ")"<<file<<R"(" is null or not open)"<<std::endl;
    }
    oldDir->cd();
 }

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -51,27 +51,39 @@ bool TAnalysisOptions::WriteToFile(TFile* file)
    bool        success = true;
    TDirectory* oldDir  = gDirectory;
 
+	// if no file was provided, try to use the current file
    if(file == nullptr) {
       file = gDirectory->GetFile();
    }
+	// check if we got a file
+   if(file == nullptr) {
+		std::cout<<"Error, no file provided and no file open (gDirectory = "<<gDirectory->GetName()<<")!"<<std::endl;
+		return !success;
+	}
+
    file->cd();
    std::string oldoption = std::string(file->GetOption());
    if(oldoption == "READ") {
       file->ReOpen("UPDATE");
    }
-   if(!gDirectory) {
-      printf("No file opened to write to.\n");
-      success = false;
-   } else {
-      Write("AnalysisOptions",TObject::kOverwrite);
-   }
 
-   printf("Writing TAnalysisOptions to %s\n", gDirectory->GetFile()->GetName());
+	// check again that we have a directory to write to
+   if(gDirectory == nullptr) {
+		std::cout<<"No file opened to write to."<<std::endl;
+      return !success;
+   }
+	// write analysis options
+	std::cout<<"Writing TAnalysisOptions to "<<gDirectory->GetFile()->GetName()<<std::endl;
+	Write("AnalysisOptions",TObject::kOverwrite);
+
+	// check if we need to change back to read mode
    if(oldoption == "READ") {
-      printf("  Returning %s to \"%s\" mode.\n", gDirectory->GetFile()->GetName(), oldoption.c_str());
+		std::cout<<"  Returning "<<gDirectory->GetFile()->GetName()<<" to \""<<oldoption.c_str()<<"\" mode."<<std::endl;
       file->ReOpen("READ");
    }
-   oldDir->cd(); // Go back to original gDirectory
+
+	// go back to original gDirectory
+   oldDir->cd();
 
    return success;
 }

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -281,8 +281,8 @@ void TGRSIOptions::Load(int argc, char** argv)
 		parser.option("write-diagnostics", &fWriteDiagnostics, true).description("Write Parsing/SortingDiagnostics to root-file")
 			.colour(DGREEN);
 		parser.option("word-count-offset", &fWordOffset, true)
-			.description("Offset to the word count in the GRIFFIN header word, default is 1.")
-			.default_value(1);
+			.description("Offset to the word count in the GRIFFIN header word, default is -1 (disabled).")
+			.default_value(1).colour(DGREEN);
 		parser.option("log-errors", &fLogErrors, true);
 		parser.option("reading-material", &fReadingMaterial, true);
 		parser.option("write-fragment-tree write-frag-tree", &fWriteFragmentTree, true)
@@ -406,6 +406,7 @@ void TGRSIOptions::Load(int argc, char** argv)
 		fSeparateOutOfOrder = true;
 		fSuppressErrors = true;
 		fReconstructTimeStamp = true;
+		fWordOffset = -1;
 	}
 }
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: clean all extras docs doxygen grsirc
+.PHONY: clean all extras docs doxygen grsirc complete parsers GRSIData ILLData iThembaData
 .SECONDARY:
 .SECONDEXPANSION:
 
@@ -108,6 +108,8 @@ EXECUTABLES     := $(patsubst %.o,bin/%,$(notdir $(EXE_O_FILES))) bin/grsisort
 
 HISTOGRAM_SO    := $(patsubst histos/%.$(SRC_SUFFIX),lib/lib%.so,$(wildcard histos/*.$(SRC_SUFFIX)))
 FILTER_SO    := $(patsubst filters/%.$(SRC_SUFFIX),lib/lib%.so,$(wildcard filters/*.$(SRC_SUFFIX)))
+
+PARSER_LIBRARIES := $(shell ls -d GRSIData ILLData iThembaData 2> /dev/null)
 
 ifdef VERBOSE
 run_and_test = @echo $(1) && $(1);
@@ -223,6 +225,20 @@ html: all
 	@grsisort -q -l --work_harder util/html_generator.C #>/dev/null
 	@$(RM) -r grsisort
 	@$(RM) tempfile.out
+
+complete: all parsers
+
+parsers: all
+	@$(foreach parser,$(PARSER_LIBRARIES),$(MAKE) -C $(parser);)
+
+GRSIData: all
+	@$(MAKE) -C GRSIData
+
+ILLData: all
+	@$(MAKE) -C ILLData
+
+iThembaData: all
+	@$(MAKE) -C iThembaData
 
 clean:
 	@printf "\n$(WARN_COLOR)Cleaning up$(NO_COLOR)\n\n"


### PR DESCRIPTION
- This should fix issue #1154.
- Also added targets to makefile which compile single or all present parser libraries from the $GRSIYS directory (need update to the library makefiles!).
- Disabling of word count check (```--word-count-offset=-1```) is now part of the ```--recommended``` flag.
- Updated the TAnalysisOptions::WriteToFile and TChannel::WriteToRoot functions. No functional change (I hope), just adding a few checks and changing printf to std::cout.