### PR TITLE
Fixing issue with copying detector hits

### DIFF
--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -40,7 +40,7 @@ void TDetector::Copy(TObject& rhs) const
 	for(size_t i = 0; i < fHits.size(); ++i) {
 		// we need to use IsA()->New() to make a new hit of whatever derived type this actually is
 		static_cast<TDetector&>(rhs).fHits[i] = static_cast<TDetectorHit*>(fHits[i]->IsA()->New());
-		*static_cast<TDetector&>(rhs).fHits[i] = *fHits[i];
+		fHits[i]->Copy(*(static_cast<TDetector&>(rhs).fHits[i]));
 	}
 }
 


### PR DESCRIPTION
This bug was found because TDescantHits read from file would have fCcShort set to zero even though non-zero values should have been written to file. The issue was traced back down to the way we copied the hits of a detector in the TDetector::Copy function. Using the virtual TDetectorHit::Copy function instead of the assignment operator solved this issue.

This might also solve issue #1142, but I still have to test that.

