### PR TITLE
Number of small improvements

### DIFF
--- a/GRSIProof/GriffinKValueSelector.C
+++ b/GRSIProof/GriffinKValueSelector.C
@@ -1,0 +1,68 @@
+#define GriffinKValueSelector_cxx
+// The class definition in GriffinKValueSelector.h has been generated automatically
+#include "GriffinKValueSelector.h"
+
+int maxKValue = 720;
+
+void GriffinKValueSelector::CreateHistograms()
+{
+	// 1D spectra of energy
+   fH1["hE"] =      new TH1D("hE", "Energy of all hits;energy [keV];counts/0.5 keV", 4000, 0., 2000.);
+   fH1["hE_noPU"] = new TH1D("hE_noPU", "Energy (no pileup);energy [keV];counts/0.5 keV", 4000, 0., 2000.);
+   fH1["hE_2h"] =   new TH1D("hE_2h", "Energy (pileup of 2 hits);energy [keV];counts/0.5 keV", 4000, 0., 2000.);
+   fH1["hE_3h"] =   new TH1D("hE_3h", "Energy (pileup of 3 hits);energy [keV];counts/0.5 keV", 4000, 0., 2000.);
+   fH1["hE_2hc"] =  new TH1D("hE_2hc", "Energy (pileup of 2 hits with only 2 integration windows);energy [keV];counts/0.5 keV", 4000, 0., 2000.);
+	// 2D spectra of energy vs. k-value
+   fH2["hKP"] =       new TH2D("hKP", "K-value vs. # of pileups;# of pileups;k-value", 50, -32.5, 17.5, maxKValue, 0., maxKValue);
+   fH2["hEK_noPU"] =  new TH2D("hEK_noPU", "Energy vs. k-value (no pileup);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_1h2"] =   new TH2D("hEK_1h2", "Energy vs. k-value (first of two piled-up hits);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_2h2"] =   new TH2D("hEK_2h2", "Energy vs. k-value (second of two piled-up hits);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_1h3"] =   new TH2D("hEK_1h3", "Energy vs. k-value (first of three piled-up hits);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_2h3"] =   new TH2D("hEK_2h3", "Energy vs. k-value (second of three piled-up hits);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_3h3"] =   new TH2D("hEK_3h3", "Energy vs. k-value (third of three piled-up hits);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_1h2c"] =  new TH2D("hEK_1h2c", "Energy vs. k-value (first of two piled-up hits with only 2 integration windows);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+   fH2["hEK_2h2c"] =  new TH2D("hEK_2h2c", "Energy vs. k-value (second of two piled-up hits with only 2 integration windows);k-value;energy [keV]", maxKValue, 0., maxKValue, 2000, 0., 2000.);
+
+   for(auto it : fH1) {
+      GetOutputList()->Add(it.second);
+   }
+   for(auto it : fH2) {
+      GetOutputList()->Add(it.second);
+   }
+   for(auto it : fHSparse) {
+      GetOutputList()->Add(it.second);
+   }
+}
+
+void GriffinKValueSelector::FillHistograms()
+{
+	if(fFragment->GetDetectorType() == 0) { //GRIFFIN detector
+		fH1.at("hE")->Fill(fFragment->GetEnergy());
+		fH2.at("hKP")->Fill(fFragment->GetNumberOfPileups(), fFragment->GetKValue());
+		if(fFragment->GetNumberOfPileups() > 0) {
+			fH1.at("hE_noPU")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_noPU")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -20) {
+			fH1.at("hE_2h")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_1h2")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -21) {
+			fH1.at("hE_2h")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_2h2")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -30) {
+			fH1.at("hE_3h")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_1h3")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -31) {
+			fH1.at("hE_3h")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_2h3")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -32) {
+			fH1.at("hE_3h")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_3h3")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -200) {
+			fH1.at("hE_2hc")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_1h2c")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		} else if(fFragment->GetNumberOfPileups() == -201) {
+			fH1.at("hE_2hc")->Fill(fFragment->GetEnergy());
+			fH2.at("hEK_2h2c")->Fill(fFragment->GetKValue(), fFragment->GetEnergy());
+		}
+	}
+}

--- a/GRSIProof/GriffinKValueSelector.h
+++ b/GRSIProof/GriffinKValueSelector.h
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////
+// This class has been automatically generated on
+// Tue Oct 25 13:18:27 2016 by ROOT version 5.34/24
+// from TTree FragmentTree/FragmentTree
+// found on file: fragment07844_000.root
+//////////////////////////////////////////////////////////
+
+#ifndef GriffinKValueSelector_h
+#define GriffinKValueSelector_h
+
+#include "TChain.h"
+#include "TFile.h"
+
+// Header file for the classes stored in the TTree if any.
+#include "TFragment.h"
+#include "TGRSISelector.h"
+
+// Fixed size dimensions of array or collections stored in the TTree if any.
+
+class GriffinKValueSelector : public TGRSISelector {
+
+public:
+   TFragment* fFragment;
+
+   GriffinKValueSelector(TTree* /*tree*/ = 0) : TGRSISelector(), fFragment(0) { SetOutputPrefix("GriffinKValue"); }
+   virtual ~GriffinKValueSelector() {}
+   virtual Int_t Version() const { return 2; }
+   void          CreateHistograms();
+   void          FillHistograms();
+   void InitializeBranches(TTree* tree);
+
+   ClassDef(GriffinKValueSelector, 2);
+};
+
+#endif
+
+#ifdef GriffinKValueSelector_cxx
+void GriffinKValueSelector::InitializeBranches(TTree* tree)
+{
+   if(!tree) return;
+   tree->SetBranchAddress("TFragment", &fFragment);
+}
+
+#endif // #ifdef GriffinKValueSelector_cxx

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -265,5 +265,7 @@ int main(int argc, char** argv)
    Analyze("AnalysisTree");
    Analyze("Lst2RootTree");
 
+	AtExitHandler();
+
 	return 0;
 }

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -146,9 +146,7 @@ public:
    const std::vector<Short_t>* GetWaveform() const { return &fWaveform; } //!<!
    TChannel*                   GetChannel() const
    {
-		// this is a clutch used because the transient bits aren't working
-		// we shouldn't need to check that the channel is a nullptr
-      if(!IsChannelSet() || fChannel == nullptr) {
+      if(!IsChannelSet()) {
          fChannel = TChannel::GetChannel(fAddress);
          SetHitBit(EBitFlag::kIsChannelSet, true);
 		}

--- a/include/TGRSIMap.h
+++ b/include/TGRSIMap.h
@@ -59,7 +59,27 @@ public:
 	typename map_t::iterator end()       { return fMap.end(); }
 	typename map_t::const_iterator end() const { return fMap.end(); }
 
-	typename map_t::size_type count(const key_type* k) const { return fMap.count(); }
+	// capacity functions of std::map
+	bool empty() const noexcept { return fMap.empty(); }
+	size_t size() const noexcept { return fMap.size(); }
+	size_t max_size() const noexcept { return fMap.max_size(); }
+	// modifier functions of std::map
+	void clear() noexcept { fMap.clear(); }
+	//insert
+	//insert_or_assign
+	//emplace
+	//emplace_hint
+	//try_emplace
+	void erase(typename map_t::iterator pos) { fMap.erase(pos); }
+	void erase(typename map_t::iterator first, typename map_t::iterator last) { fMap.erase(first, last); }
+	void swap(map_t& other) { fMap.swap(other); }
+	// lookup functions of std::map
+	typename map_t::size_type count(const key_type* key) const { return fMap.count(key); }
+	typename map_t::iterator find(const key_type& key) { return fMap.find(key); }
+	typename map_t::const_iterator find(const key_type& key) const { return fMap.find(key); }
+	//equal_range
+	//lower_bound
+	//upper_bound
 
 private:
 	std::map<key_type, mapped_type, key_compare, allocator_type> fMap;

--- a/util/PlotGriffinKValue.C
+++ b/util/PlotGriffinKValue.C
@@ -1,0 +1,109 @@
+void PlotGriffinKValue(const char* filename, double eLow = 0., double eHigh = 0.)
+{
+	TFile* file = new TFile(filename);
+
+	gStyle->SetOptTitle(0);
+	gStyle->SetOptStat(0);
+
+	TCanvas* canv1 = new TCanvas;
+
+	canv1->SetLogz();
+	static_cast<TH2D*>(file->Get("hKP"))->Draw("colz");
+
+	TCanvas* canv2 = new TCanvas;
+
+	canv2->SetLogy();
+	TH1D* hE = static_cast<TH1D*>(file->Get("hE"));
+	hE->GetXaxis()->CenterTitle();
+	hE->GetYaxis()->CenterTitle();
+	hE->GetXaxis()->SetRangeUser(1., hE->GetYaxis()->GetBinUpEdge(hE->GetYaxis()->GetLast()));
+	hE->SetLineColor(kBlack);
+	if(eLow < eHigh) {
+		hE->GetXaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hE->Draw();
+
+	TH1D* hE_noPU = static_cast<TH1D*>(file->Get("hE_noPU"));
+	hE_noPU->SetLineColor(kBlue);
+	hE_noPU->Draw("same");
+
+	TH1D* hE_2h = static_cast<TH1D*>(file->Get("hE_2h"));
+	hE_2h->SetLineColor(kRed);
+	hE_2h->Draw("same");
+
+	TH1D* hE_3h = static_cast<TH1D*>(file->Get("hE_3h"));
+	hE_3h->SetLineColor(kOrange);
+	hE_3h->Draw("same");
+
+	TH1D* hE_2hc = static_cast<TH1D*>(file->Get("hE_2hc"));
+	hE_2hc->SetLineColor(kBlack);
+	hE_2hc->Draw("same");
+
+	hE->SetTitle("all hits");
+	hE_noPU->SetTitle("no pile-up");
+	hE_2h->SetTitle("two piled-up hits");
+	hE_3h->SetTitle("three piled-up hits");
+	hE_2hc->SetTitle("two piled-up hits with two integrations");
+	canv2->BuildLegend();
+
+	TCanvas* canv3 = new TCanvas("canv3", "Energy vs k-value plots", 700, 2000);
+
+	canv3->Divide(2,4);
+	canv3->SetLogz();
+
+	canv3->cd(1);
+	TH2D* hEK_1h2 = static_cast<TH2D*>(file->Get("hEK_1h2"));
+	if(eLow < eHigh) {
+		hEK_1h2->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_1h2->Draw("colz");
+
+	canv3->cd(2);
+	TH2D* hEK_2h2 = static_cast<TH2D*>(file->Get("hEK_2h2"));
+	if(eLow < eHigh) {
+		hEK_2h2->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_2h2->Draw("colz");
+
+	canv3->cd(3);
+	TH2D* hEK_1h2c = static_cast<TH2D*>(file->Get("hEK_1h2c"));
+	if(eLow < eHigh) {
+		hEK_1h2c->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_1h2c->Draw("colz");
+
+	canv3->cd(4);
+	TH2D* hEK_2h2c = static_cast<TH2D*>(file->Get("hEK_2h2c"));
+	if(eLow < eHigh) {
+		hEK_2h2c->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_2h2c->Draw("colz");
+
+	canv3->cd(5);
+	TH2D* hEK_1h3 = static_cast<TH2D*>(file->Get("hEK_1h3"));
+	if(eLow < eHigh) {
+		hEK_1h3->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_1h3->Draw("colz");
+
+	canv3->cd(6);
+	TH2D* hEK_2h3 = static_cast<TH2D*>(file->Get("hEK_2h3"));
+	if(eLow < eHigh) {
+		hEK_2h3->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_2h3->Draw("colz");
+
+	canv3->cd(7);
+	TH2D* hEK_3h3 = static_cast<TH2D*>(file->Get("hEK_3h3"));
+	if(eLow < eHigh) {
+		hEK_3h3->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_3h3->Draw("colz");
+
+	canv3->cd(8);
+	TH2D* hEK_noPU = static_cast<TH2D*>(file->Get("hEK_noPU"));
+	if(eLow < eHigh) {
+		hEK_noPU->GetYaxis()->SetRangeUser(eLow, eHigh);
+	}
+	hEK_noPU->Draw("colz");
+}


### PR DESCRIPTION
- Calling AtExitHandler at the end of grsiproof explicitly in case the program crashes on exiting.
- Added ability to traverse directories in root-files to Root2Rad.
- Removed the fix to check for nullptr channels from TDetectorHit since it's not necessary anymore after #1182.
- TFragmentMap now uses the k-values for minimized pile-up charges (first one for the first hit, second one for the second hit, and so on) as discussed in #973. Also added selector and a simple plot script to check the k-values as discussed in that thread.