### PR TITLE
Added selection of peak shape to TBGSubtraction (#1197)

### DIFF
--- a/include/TAB3Peak.h
+++ b/include/TAB3Peak.h
@@ -34,6 +34,7 @@ public:
    void InitParNames() override;
    void InitializeParameters(TH1* hist) override;
 
+	void Centroid(const Double_t& centroid) override;
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override;

--- a/include/TAB3Peak.h
+++ b/include/TAB3Peak.h
@@ -35,6 +35,7 @@ public:
    void InitializeParameters(TH1* hist) override;
 
 	void Centroid(const Double_t& centroid) override;
+
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override;
@@ -61,7 +62,7 @@ private:
 
 public:
    /// \cond CLASSIMP
-   ClassDefOverride(TAB3Peak, 1);
+   ClassDefOverride(TAB3Peak, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -34,6 +34,8 @@ public:
    void InitParNames() override;
    void InitializeParameters(TH1* hist) override;
 
+	void Centroid(const Double_t& centroid) override;
+
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override;

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -59,7 +59,7 @@ private:
 
 public:
    /// \cond CLASSIMP
-   ClassDefOverride(TABPeak, 1);
+   ClassDefOverride(TABPeak, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -18,7 +18,8 @@
 #include "TRootEmbeddedCanvas.h"
 #include "RQ_OBJECT.h"
 
-#include "TPeak.h"
+#include "TPeakFitter.h"
+#include "TSinglePeak.h"
 
 #include "TH1.h"
 #include "TH2.h"
@@ -62,11 +63,17 @@ class TBGSubtraction : public TGMainFrame {
       kWrite2FileNameEntry,
       kHistogramDescriptionEntry,
       kComboAxisEntry,
+      kComboPeakEntry,
       kBGCheckButton1,
       kBGCheckButton2,
-      kPeakSkewCheckButton,
       kAutoUpdateCheckButton
    };
+	enum EPeaks {
+		kGauss = 0,
+		kRWPeak = 1,
+		kABPeak = 2,
+		kAB3Peak = 3
+	};
 
    //  RQ_OBJECT("TBGSubtraction")
 private:
@@ -93,7 +100,6 @@ private:
    TGLabel*             fBGParamLabel{nullptr};
    TGCheckButton*       fBGCheckButton1;
    TGCheckButton*       fBGCheckButton2;
-   TGCheckButton*       fPeakSkewCheckButton;
    TGCheckButton*       fAutoUpdateCheckButton;
 
    TGLayoutHints* fBly;
@@ -123,6 +129,7 @@ private:
 
    // Combo box
    TGComboBox* fAxisCombo;
+   TGComboBox* fPeakCombo;
 
    // Markers
    GMarker* fLowGateMarker;
@@ -140,18 +147,21 @@ private:
    Int_t fGateAxis;
 
    Bool_t fForceUpdate;
-   Double_t fPeakLowLimit;
-   Double_t fPeakHighLimit;
-   Double_t fPeakLowValue;
-   Double_t fPeakHighValue;
-   Double_t fPeakValue;
+   Double_t fPeakLowLimit; ///< lower limit for peak slider range
+   Double_t fPeakHighLimit; ///< upper limit for peak slider range
+   Double_t fPeakLowValue; ///< low range for fit
+   Double_t fPeakHighValue; ///< high range for fit
+   Double_t fPeakValue; ///< centroid for fit
 
-   TPeak* fPeakFit;
+   TSinglePeak* fPeak; ///< the peak to be fit (will be a class that inherits from TSinglePeak)
+	TPeakFitter* fPeakFitter; ///< the peak fitter that fPeak is added to
+	Int_t fPeakId; ///< the current ID of the peak
 
 public:
    TBGSubtraction(TH2* mat, const char* gate_axis = "x");
    ~TBGSubtraction() override;
    void AxisComboSelected();
+   void PeakComboSelected();
    void ClickedBGButton1();
    void ClickedBGButton2();
  //  void ClickedBG2Button();

--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -206,7 +206,7 @@ private:
    void UpdateBGSlider2();
 
    /// \cond CLASSIMP
-   ClassDefOverride(TBGSubtraction, 6); // Background subtractor GUI
+   ClassDefOverride(TBGSubtraction, 7); // Background subtractor GUI
    /// \endcond
 };
 /*! @} */

--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -37,6 +37,8 @@ public:
    void InitParNames() override;
    void InitializeParameters(TH1* hist) override;
 
+	void Centroid(const Double_t& centroid) override;
+
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }

--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -50,7 +50,7 @@ protected:
 
 public:
    /// \cond CLASSIMP
-   ClassDefOverride(TGauss, 1);
+   ClassDefOverride(TGauss, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -44,6 +44,7 @@ public:
    void InitializeBackgroundParameters(TH1* fit_hist);
 
    virtual void Print(Option_t* opt = "") const override;
+	void PrintParameters() const;
 
    TF1* GetBackground() { return fBGToFit; }
    TF1* GetFitFunction() { return fTotalFitFunction; }
@@ -51,6 +52,8 @@ public:
    Int_t GetNParameters() const;
    void Fit(TH1* fit_hist,Option_t* opt="");
    void DrawPeaks(Option_t* = "") const;
+
+	void ResetInitFlag() { fInitFlag = false; }
 
 private:
    void UpdateFitterParameters();

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -79,7 +79,7 @@ private:
 	TH1* fLastHistFit{nullptr};
 
    /// \cond CLASSIMP
-   ClassDefOverride(TPeakFitter, 1);
+   ClassDefOverride(TPeakFitter, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -37,6 +37,8 @@ public:
    void InitParNames() override;
    void InitializeParameters(TH1* hist) override;
 
+	void Centroid(const Double_t& centroid) override;
+
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -51,7 +51,7 @@ protected:
 
 public:
    /// \cond CLASSIMP
-   ClassDefOverride(TRWPeak, 1);
+   ClassDefOverride(TRWPeak, 2);
    /// \endcond
 };
 /*! @} */

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -48,6 +48,7 @@ public:
    Double_t Area() const { return fArea; }
    Double_t AreaErr() const { return fAreaErr; }
 
+	virtual void Centroid(const Double_t& centroid) = 0;
    virtual Double_t Centroid() const = 0;
    virtual Double_t CentroidErr() const = 0;
    virtual Double_t Width() const = 0;
@@ -56,6 +57,7 @@ public:
    virtual void Draw(Option_t * opt = "") override;
    virtual void DrawBackground(Option_t * opt = "") { if(fGlobalBackground) fGlobalBackground->Draw(opt);}
    virtual void DrawComponents(Option_t* opt = "");
+	virtual void PrintParameters() const;
 
    TF1* GetFitFunction() { return fTotalFunction; }
    TF1* GetBackgroundFunction();

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -95,7 +95,7 @@ protected:
 
 public:
    /// \cond CLASSIMP
-   ClassDefOverride(TSinglePeak, 1);
+   ClassDefOverride(TSinglePeak, 2);
    /// \endcond
 };
 /*! @} */

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -9,9 +9,14 @@ TAB3Peak::TAB3Peak() : TSinglePeak() {}
 
 TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak()
 {
+	Centroid(centroid);
+}
+
+void TAB3Peak::Centroid(const Double_t& centroid)
+{
    fTotalFunction = new TF1("ab_fit",this,&TAB3Peak::TotalFunction,0,1,8,"TAB3Peak","TotalFunction");
    InitParNames();
-   fTotalFunction->SetParameter(1,centroid);
+   fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,0,0,1});
    fTotalFunction->SetLineColor(kMagenta);
 }

--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -9,9 +9,14 @@ TABPeak::TABPeak() : TSinglePeak() {}
 
 TABPeak::TABPeak(Double_t centroid) : TSinglePeak()
 {
+	Centroid(centroid);
+}
+
+void TABPeak::Centroid(const Double_t& centroid)
+{
    fTotalFunction = new TF1("ab_fit",this,&TABPeak::TotalFunction,0,1,6,"TABPeak","TotalFunction");
    InitParNames();
-   fTotalFunction->SetParameter(1,centroid);
+   fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
    fTotalFunction->SetLineColor(kMagenta);
 }

--- a/libraries/TAnalysis/TPeakFitting/TGauss.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TGauss.cxx
@@ -8,12 +8,17 @@ TGauss::TGauss() : TSinglePeak() { }
 
 TGauss::TGauss(Double_t centroid, Double_t relativeLimit) : TSinglePeak()
 {
-   fTotalFunction = new TF1("gauss_total",this,&TGauss::TotalFunction,0,1,3,"TGauss","TotalFunction");
-   InitParNames();
-   fTotalFunction->SetParameter(1,centroid);
+	Centroid(centroid);
 	if(relativeLimit >= 0) {
 		fTotalFunction->SetParLimits(1, (1.-relativeLimit)*centroid, (1.+relativeLimit)*centroid);
 	}
+}
+
+void TGauss::Centroid(const Double_t& centroid)
+{
+   fTotalFunction = new TF1("gauss_total",this,&TGauss::TotalFunction,0,1,3,"TGauss","TotalFunction");
+   InitParNames();
+   fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
    fTotalFunction->SetLineColor(kMagenta);
 }
@@ -71,4 +76,3 @@ void TGauss::Print(Option_t * opt) const
    std::cout << "gaussian peak:" << std::endl;
    TSinglePeak::Print(opt);
 }
-

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -20,7 +20,8 @@ TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) 
    fRangeHigh = range_high;
 }
 
-void TPeakFitter::Print(Option_t * opt) const{
+void TPeakFitter::Print(Option_t * opt) const
+{
 	std::cout << "Range: " << fRangeLow << " to " << fRangeHigh << std::endl;
 	Int_t counter = 0;
 	if(!fPeaksToFit.empty()) {
@@ -41,7 +42,19 @@ void TPeakFitter::Print(Option_t * opt) const{
 	}
 }
 
-Int_t TPeakFitter::GetNParameters() const{
+void TPeakFitter::PrintParameters() const
+{
+	std::cout<<"Range: "<<fRangeLow<<" to "<<fRangeHigh<<" - ";
+	int i = 0;
+	for(auto peak : fPeaksToFit) {
+		std::cout<<peak->IsA()->GetName()<<" #"<<i++<<" ";
+		peak->PrintParameters();
+	}
+	std::cout<<std::endl;
+}
+
+Int_t TPeakFitter::GetNParameters() const
+{
 	Int_t n_par = 0;
 	for(auto i : fPeaksToFit)
 		n_par += i->GetNParameters();
@@ -85,6 +98,7 @@ void TPeakFitter::Fit(TH1* fit_hist,Option_t *opt)
 		fLastHistFit = fit_hist;
 	}
 	UpdateFitterParameters();
+	PrintParameters();
 	//Do a first fit to get closer on the parameters
 	fit_hist->Fit(fTotalFitFunction,"RNQ0");
 	//Now try the fit with the options provided

--- a/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
@@ -8,10 +8,14 @@ TRWPeak::TRWPeak() : TSinglePeak() { }
 
 TRWPeak::TRWPeak(Double_t centroid) : TSinglePeak()
 {
+	Centroid(centroid);
+}
 
+void TRWPeak::Centroid(const Double_t& centroid)
+{
    fTotalFunction = new TF1("rw_total",this,&TRWPeak::TotalFunction,0,1,6,"TRWPeak","TotalFunction");
    InitParNames();
-   fTotalFunction->SetParameter(1,centroid);
+   fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});
    fTotalFunction->SetLineColor(kMagenta);
 }

--- a/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -51,6 +51,16 @@ void TSinglePeak::Print(Option_t *) const{
 
 }
 
+void TSinglePeak::PrintParameters() const {
+	if(fTotalFunction != nullptr) {
+		for(int i = 0; i < fTotalFunction->GetNpar(); ++i) {
+			std::cout<<i<<"/"<<fTotalFunction->GetParName(i)<<" = "<<fTotalFunction->GetParameter(i)<<" ";
+		}
+	} else {
+		std::cout<<"no total function ";
+	}
+}
+
 Double_t TSinglePeak::TotalFunction(Double_t *dim, Double_t *par){
    return PeakFunction(dim,par) + BackgroundFunction(dim,par);
 }


### PR DESCRIPTION
The user can now select between TGauss, TRWPeak, TABPeak, or TAB3Peak
for fitting in TBGSubtraction. These classes give a better estimate of
the uncertainty in the area of the fit.

- **TBGSubtraction**: Changed from TPeak to TSinglePeak plus TPeakFitter and
  added combo box to select peak type (defaults to TGauss).
- **TPeakFitter**: Added function to reset the init flag (called
whenever the peak type is changed), and a function to print all
parameters on a single line, this function is now being called before
each fit to show the starting parameters.
- **TSinglePeak**: Added function to print all parameters (without
newline), and function to set the centroid (in case the constructor
without the centroid provided has been used).
- **Peak Classes**: Added function to set the centroid. This function is
now used if the centroid is provided in the constructor, but the default
constructor needs this function to be called separately. This is
necessary because the ROOT way of creating new object with runtime
dependent type uses the default constructor without arguments only.

Also incremented the version number of all involved classes.