### PR TITLE
Fixing issue #1197

### DIFF
--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -4,7 +4,6 @@
 #include "TROOT.h"
 #include "TCanvas.h"
 #include "TRootCanvas.h"
-//#include "TPeak.h"
 
 #include "TH1.h"
 #include "TLine.h"
@@ -118,19 +117,6 @@ public:
 	ClassDefOverride(GMarker, 0)
 };
 
-/*
-	class GPopup : public TGTransientFrame  {
-	public:
-	GPopup(const TGWindow *p=0,const TGWindow *m=0);
-	virtual ~GPopup();
-	virtual void CloseWindow();
-//bool ProcessMessage(Long_t,Long_t,Long_t);
-private:
-TGTextButton *fButton1,*fButton2;
-ClassDefOverride(GPopup,0)
-};
-*/
-
 class GCanvas : public TCanvas {
 public:
 	GCanvas(Bool_t build = kTRUE);
@@ -140,8 +126,6 @@ public:
 	GCanvas(const char* name, const char* title, Int_t wtopx, Int_t wtopy, Int_t ww, Int_t wh, bool gui = false);
 	~GCanvas() override;
 
-	// void ProcessEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
-	// void CatchEvent(Int_t event,Int_t x,Int_t y,TObject *obj);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 	void HandleInput(int event, Int_t x, Int_t y);
@@ -151,10 +135,7 @@ public:
 	static GCanvas* MakeDefCanvas();
 
 	Int_t GetNMarkers() { return fMarkers.size(); }
-	// Int_t  GetNBG_Markers()            { return fBG_Markers.size(); }
 	void SetMarkerMode(bool flag = true) { fMarkerMode = flag; }
-
-	// static void SetBackGroundSubtractionType();
 
 	TF1* GetLastFit();
 
@@ -168,7 +149,6 @@ private:
 
 	bool fGuiEnabled{false};
 
-	// bool fStatsDisplayed;
 	bool                   fMarkerMode{false};
 	std::vector<GMarker*>  fMarkers;
 	std::vector<GMarker*>  fBackgroundMarkers;
@@ -181,12 +161,6 @@ private:
 	void RedrawMarkers();
 	bool SetBackgroundMarkers();
 	bool CycleBackgroundSubtraction();
-
-	// std::vector<GMarker*> fBG_Markers;
-	// void AddBGMarker(GMarker *mark);
-	// void RemoveBGMarker();
-	// void ClearBGMarkers();
-	// void OrderBGMarkers();
 
 	std::vector<TH1*> FindHists(int dim = 1);
 	std::vector<TH1*> FindAllHists();
@@ -209,7 +183,6 @@ private:
 	bool Process2DMousePress(Int_t event, Int_t x, Int_t y);
 
 private:
-	//Window_t     fCanvasWindowID{};
 	TRootCanvas* fRootCanvas{nullptr};
 
 	bool control_key{false};

--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -185,14 +185,6 @@ private:
 private:
 	TRootCanvas* fRootCanvas{nullptr};
 
-	bool control_key{false};
-
-	bool toggle_control()
-	{
-		control_key = !control_key;
-		return control_key;
-	}
-
 	ClassDefOverride(GCanvas, 2);
 };
 

--- a/include/GPeak.h
+++ b/include/GPeak.h
@@ -1,7 +1,9 @@
 #ifndef GPEAK_H
 #define GPEAK_H
 
-#include <TF1.h>
+#include "TF1.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
 
 #include <string>
 #include <algorithm>

--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -12,48 +12,55 @@
 
 #include "TMath.h"
 #include "TROOT.h"
+#include "TFitResultPtr.h"
+#include "TFitResult.h"
 
 #ifdef HAS_MATHMORE
 #include "Math/SpecFuncMathMore.h"
 #endif
 
+#include "Globals.h"
+
 namespace TGRSIFunctions {
 
-// Fitting Functions
-Double_t PolyBg(Double_t* x, Double_t* par, Int_t order);
-Double_t StepBG(Double_t* dim, Double_t* par);
-Double_t StepFunction(Double_t* dim, Double_t* par);
-Double_t PhotoPeak(Double_t* dim, Double_t* par);
-Double_t PhotoPeakBG(Double_t* dim, Double_t* par);
-Double_t MultiPhotoPeakBG(Double_t* dim, Double_t* par);
-Double_t Gaus(Double_t* dim, Double_t* par);
-Double_t SkewedGaus(Double_t* dim, Double_t* par);
-Double_t MultiSkewedGausWithBG(Double_t* dim, Double_t* par);
-Double_t Bateman(std::vector<Double_t>& dim, std::vector<Double_t>& par, UInt_t nChain = 1, Double_t SecondsPerBin = 1.0);
-Double_t PhotoEfficiency(Double_t* dim, Double_t* par);
+	// Function to check parameter erros to see if any parameter is near its limit
+	bool CheckParameterErrors(const TFitResultPtr& fit_res, std::string opt = "");
 
-// STEFFEN ADDED THESE
-Double_t LanGausHighRes(Double_t* x, Double_t* pars);
-Double_t LanGaus(Double_t* x, Double_t* pars);
-Double_t MultiGausWithBG(Double_t* dim, Double_t* par);
-// Double_t TripleAlphaGausWithBG(Double_t *x,Double_t *pars);
-Double_t SkewedGaus2(Double_t* x, Double_t* par);
-Double_t MultiSkewedGausWithBG2(Double_t* dim, Double_t* par);
+	// Fitting Functions
+	Double_t PolyBg(Double_t* x, Double_t* par, Int_t order);
+	Double_t StepBG(Double_t* dim, Double_t* par);
+	Double_t StepFunction(Double_t* dim, Double_t* par);
+	Double_t PhotoPeak(Double_t* dim, Double_t* par);
+	Double_t PhotoPeakBG(Double_t* dim, Double_t* par);
+	Double_t MultiPhotoPeakBG(Double_t* dim, Double_t* par);
+	Double_t Gaus(Double_t* dim, Double_t* par);
+	Double_t SkewedGaus(Double_t* dim, Double_t* par);
+	Double_t MultiSkewedGausWithBG(Double_t* dim, Double_t* par);
+	Double_t Bateman(std::vector<Double_t>& dim, std::vector<Double_t>& par, UInt_t nChain = 1, Double_t SecondsPerBin = 1.0);
+	Double_t PhotoEfficiency(Double_t* dim, Double_t* par);
 
-// CSI FIT FUNCTION
-Double_t CsIFitFunction(Double_t* i, Double_t* p);
+	// STEFFEN ADDED THESE
+	Double_t LanGausHighRes(Double_t* x, Double_t* pars);
+	Double_t LanGaus(Double_t* x, Double_t* pars);
+	Double_t MultiGausWithBG(Double_t* dim, Double_t* par);
+	// Double_t TripleAlphaGausWithBG(Double_t *x,Double_t *pars);
+	Double_t SkewedGaus2(Double_t* x, Double_t* par);
+	Double_t MultiSkewedGausWithBG2(Double_t* dim, Double_t* par);
 
-// Common corrections
-Double_t DeadTimeCorrect(Double_t* dim, Double_t deadtime, Double_t binWidth = 1.0);
-Double_t DeadTimeAffect(Double_t function, Double_t deadtime, Double_t binWidth = 1.0);
+	// CSI FIT FUNCTION
+	Double_t CsIFitFunction(Double_t* i, Double_t* p);
 
-// Timing functions
- Double_t ConvolutedDecay(Double_t *x, Double_t *par);
- Double_t ConvolutedDecay2(Double_t *x, Double_t *par);
+	// Common corrections
+	Double_t DeadTimeCorrect(Double_t* dim, Double_t deadtime, Double_t binWidth = 1.0);
+	Double_t DeadTimeAffect(Double_t function, Double_t deadtime, Double_t binWidth = 1.0);
+
+	// Timing functions
+	Double_t ConvolutedDecay(Double_t *x, Double_t *par);
+	Double_t ConvolutedDecay2(Double_t *x, Double_t *par);
 
 #ifdef HAS_MATHMORE
-// Angular correlation fitting
-Double_t LegendrePolynomial(Double_t* x, Double_t* p);
+	// Angular correlation fitting
+	Double_t LegendrePolynomial(Double_t* x, Double_t* p);
 #endif
 }
 /*! @} */

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -48,26 +48,26 @@ public:
 
    TF1* GetBackground() { return fBGToFit; }
    TF1* GetFitFunction() { return fTotalFitFunction; }
-   void SetRange(const Double_t &low, const Double_t &high);
+   void SetRange(const Double_t& low, const Double_t& high);
    Int_t GetNParameters() const;
    void Fit(TH1* fit_hist,Option_t* opt="");
    void DrawPeaks(Option_t* = "") const;
 
 	void ResetInitFlag() { fInitFlag = false; }
 
+	void SetIndex(const int& index) { fIndex = index; }
+
 private:
    void UpdateFitterParameters();
    void UpdatePeakParameters(const TFitResultPtr& fit_res,TH1* fit_hist);
-	bool CheckParameterErrors(const TFitResultPtr& fit_res);
    Double_t DefaultBackgroundFunction(Double_t* dim, Double_t* par);
-
 
 private:
 //   TMultiplePeak* fPeaksToFit{nullptr};
    MultiplePeak_t fPeaksToFit;
    TF1* fBGToFit{nullptr};
 
-   TF1* fTotalFitFunction;
+   TF1* fTotalFitFunction{nullptr};
 
    Double_t fRangeLow;
    Double_t fRangeHigh;
@@ -79,6 +79,7 @@ private:
 
 	TH1* fLastHistFit{nullptr};
 
+	int fIndex{0}; ///< this index is added to the colors kRed for the total function and kMagenta for the individual peaks
    /// \cond CLASSIMP
    ClassDefOverride(TPeakFitter, 2);
    /// \endcond

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -130,7 +130,6 @@ void GCanvas::GCanvasInit()
    // default gui's (canvas,browser,etc).
    // fStatsDisplayed = true;
    fMarkerMode     = true;
-   control_key     = false;
    fGuiEnabled     = false;
    fBackgroundMode = EBackgroundSubtraction::kNoBackground;
 	fCutName = new char[256];
@@ -603,7 +602,10 @@ bool GCanvas::ProcessNonHistKeyboardPress(Event_t*, UInt_t* keysym)
       GetCanvasImp()->ShowEditor(!GetCanvasImp()->HasEditor());
       edited = true;
       break;
-   case kKey_F9: SetCrosshair(static_cast<Int_t>(!HasCrosshair())); edited = true;
+   case kKey_F9: 
+		SetCrosshair(static_cast<Int_t>(!HasCrosshair()));
+		edited = true;
+		break;
    }
 
    return edited;
@@ -618,16 +620,12 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
    }
 
    switch(*keysym) {
-   case kKey_Control: toggle_control(); break;
-
    case kKey_b: edited = SetBackgroundMarkers(); break;
 
    case kKey_B: edited = CycleBackgroundSubtraction(); break;
 
    case kKey_d: {
-      printf("i am here.\n");
       new GPopup(gClient->GetDefaultRoot(), gClient->GetDefaultRoot(), 500, 200);
-
    } break;
 
    case kKey_e:
@@ -702,10 +700,6 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
          edited = true;
       }
       break;
-
-   // case kKey_G:
-   //   edited = GausBGFit();
-   //   break;
 
    case kKey_i:
       if(!hists.empty() && GetNMarkers() > 1) {
@@ -901,7 +895,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, UInt_t* keysym)
             }
          } else {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
+               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
                                               fMarkers.at(fMarkers.size() - 1)->GetLocalY());
             }
          }
@@ -1265,14 +1259,6 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
       RemoveMarker("all");
       edited = true;
       break;
-   case kKey_p:
-      if(hists.empty()) {
-         break;
-      }
-      printf("you hit the p key.\n");
-
-      break;
-
    case kKey_P: {
       GH2D* ghist = nullptr;
       for(auto hist : hists) {
@@ -1299,7 +1285,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
             }
          } else {
             for(auto& hist : hists) {
-               hist->GetXaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
+               hist->GetYaxis()->SetRangeUser(fMarkers.at(fMarkers.size() - 2)->GetLocalY(),
                                               fMarkers.at(fMarkers.size() - 1)->GetLocalY());
             }
          }

--- a/libraries/GROOT/GGaus.cxx
+++ b/libraries/GROOT/GGaus.cxx
@@ -10,7 +10,7 @@
 
 ClassImp(GGaus)
 
-   GGaus::GGaus(Double_t xlow, Double_t xhigh, Option_t*)
+GGaus::GGaus(Double_t xlow, Double_t xhigh, Option_t*)
    : TF1("gausbg", "gaus(0)+pol1(3)", xlow, xhigh), fBGFit("background", "pol1", xlow, xhigh)
 {
    Clear("");
@@ -55,7 +55,6 @@ GGaus::GGaus(Double_t xlow, Double_t xhigh, TF1* bg, Option_t*) : TF1("gausbg", 
 
 GGaus::GGaus() : TF1("gausbg", "gaus(0)+pol1(3)", 0, 1000), fBGFit("background", "pol1", 0, 1000)
 {
-
    Clear();
    InitNames();
    fBGFit.SetNpx(1000);

--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -12,6 +12,38 @@ NamespaceImp(TGRSIFunctions)
 //
 ///////////////////////////////////////////////////////////////////////
 
+bool TGRSIFunctions::CheckParameterErrors(const TFitResultPtr& fitres, std::string opt)
+{
+	/// This function compares the parameter error with the square root of the corresponding
+	/// diagonal entry of the covariance matrix. If the difference between the two is larger
+	/// than 0.1 (arbitrarily chosen cutoff), the check fails.
+	/// Implemented options are "q" to be quiet (prints nothing), or "v" to be verbose
+	/// (prints message not just for failed parameters but also ones that pass the test).
+
+   // if we do not have a fit result, we have to assume everything is okay for now
+   if(fitres.Get() == nullptr) return true;
+   std::transform(opt.begin(), opt.end(), opt.begin(), [](unsigned char c){ return std::tolower(c); });
+   bool quiet = (opt.find('q') != std::string::npos);
+   bool verbose = (opt.find('v') != std::string::npos);
+   bool result = true;
+   // loop over all parameters and compare the parameter error with the square root 
+   // of the diagonal element of the covariance matrix
+   auto covarianceMatrix = fitres->GetCovarianceMatrix();
+   for(unsigned int i = 0; i < fitres->NPar(); ++i) {
+      if(std::fabs(fitres->ParError(i) - TMath::Sqrt(covarianceMatrix[i][i])) > 0.1) {
+         if(!quiet) {
+            std::cout<<RED<<"Parameter "<<i<<" = "<<fitres->GetParameterName(i)<<" is at or close to the limit, error is "<<fitres->ParError(i)<<", and square root of diagonal is "<<TMath::Sqrt(covarianceMatrix[i][i])<<RESET_COLOR<<std::endl;
+         }
+         result = false;
+         // we don't break here even though we could, because we want to print out
+         // all parameters with issues
+      } else if(verbose) {
+         std::cout<<GREEN<<"Parameter "<<i<<" = "<<fitres->GetParameterName(i)<<" is not close to the limit, error is "<<fitres->ParError(i)<<", and square root of diagonal is "<<TMath::Sqrt(covarianceMatrix[i][i])<<RESET_COLOR<<std::endl;
+      } 
+   }
+   return result;
+}  
+
 Double_t TGRSIFunctions::CsIFitFunction(Double_t* i, Double_t* p)
 {
    Double_t x, s, e;


### PR DESCRIPTION
TPeakFitter, TPeak, GPeak, and GGaus now all check if any parameter got close to its limits by comparing the parameter error with the square root of the corresponding diagonal element of the covariance matrix. If a parameter is close, the peak will be fit again using the "E" option to use the minos technique for error estimation. If this also fails and the option "retryfit" has been passed along, the fit will be repeated again without any parameter limits.

I also updated the wiki page about fitting to reflect these changes.

Went over the wiki page about interactive analysis and updated the list of GCanvas hotkeys and cleaned up the GCanvas code a bit.