### PR TITLE
Fixed issue with AnalysisOptions not being written to file

### DIFF
--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -9,7 +9,7 @@ TDetector::TDetector()
    : TObject()
 {
    /// Default constructor.
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 }
@@ -17,7 +17,7 @@ TDetector::TDetector()
 TDetector::TDetector(const TDetector& rhs) : TObject()
 {
    /// Default Copy constructor.
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    rhs.Copy(*this);

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -18,7 +18,7 @@ TDetectorHit::TDetectorHit(const int& Address) : TObject()
    Clear();
    fAddress = Address;
 
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 }
@@ -32,7 +32,7 @@ TDetectorHit::TDetectorHit(const TDetectorHit& rhs, bool copywave) : TObject(rhs
    }
    ClearTransients();
 
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 }

--- a/libraries/TAnalysis/TNucleus/TGRSITransition.cxx
+++ b/libraries/TAnalysis/TNucleus/TGRSITransition.cxx
@@ -7,7 +7,7 @@ ClassImp(TGRSITransition)
 TGRSITransition::TGRSITransition()
 {
 	// Default constructor for TGRSITransition
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 	Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
 	Clear();

--- a/libraries/TFormat/TBadFragment.cxx
+++ b/libraries/TFormat/TBadFragment.cxx
@@ -5,7 +5,7 @@ ClassImp(TBadFragment)
 TBadFragment::TBadFragment() : TFragment()
 {
 	/// Default constructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();

--- a/libraries/TFormat/TFragment.cxx
+++ b/libraries/TFormat/TFragment.cxx
@@ -15,7 +15,7 @@ Long64_t TFragment::fNumberOfFragments = 0;
 TFragment::TFragment() : TDetectorHit()
 {
 /// Default constructor
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
    Class()->IgnoreTObjectStreamer(kTRUE);
 #endif
    Clear();

--- a/libraries/TGRSIint/TAnalysisOptions.cxx
+++ b/libraries/TGRSIint/TAnalysisOptions.cxx
@@ -78,7 +78,11 @@ bool TAnalysisOptions::WriteToFile(TFile* file)
    }
 
 	// check again that we have a directory to write to
-   if(gDirectory) { // we don't compare to nullptr here, as ROOT >= 6.24.00 uses the TDirectoryAtomicAdapter structure with a bool() operator
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,24,0)
+	if(gDirectory == nullptr) {
+#else
+   if(!gDirectory) { // we don't compare to nullptr here, as ROOT >= 6.24.00 uses the TDirectoryAtomicAdapter structure with a bool() operator
+#endif
 		std::cout<<"No file opened to write to."<<std::endl;
       return !success;
    }

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -343,7 +343,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
 					// gFragment->SetNotify(GrutNotifier::Get());
 				}
 				printf("file %s added to gFragment.\n", file->GetName());
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 				gFragment->AddFile(file->GetName(), TChain::kBigNumber, "FragmentTree");
 #else
 				gFragment->AddFile(file->GetName(), TTree::kMaxEntries, "FragmentTree");
@@ -358,7 +358,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
 					// gAnalysis->SetNotify(GrutNotifier::Get());
 				}
 				printf("file %s added to gAnalysis.\n", file->GetName());
-#if MAJOR_ROOT_VERSION < 6
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
 				gAnalysis->AddFile(file->GetName(), TChain::kBigNumber, "AnalysisTree");
 #else
 				gAnalysis->AddFile(file->GetName(), TTree::kMaxEntries, "AnalysisTree");

--- a/makefile
+++ b/makefile
@@ -20,14 +20,11 @@ SRC_SUFFIX = cxx
 
 # EVERYTHING PAST HERE SHOULD WORK AUTOMATICALLY
 
-MAJOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f1)
-MINOR_ROOT_VERSION:=$(shell root-config --version | cut -d '.' -f2 | cut -d '/' -f1)
 ROOT_PYTHON_VERSION=$(shell root-config --python-version)
 
 MATHMORE_INSTALLED:=$(shell root-config --has-mathmore)
 XML_INSTALLED:=$(shell root-config --has-xml)
 
-CFLAGS += -DMAJOR_ROOT_VERSION=${MAJOR_ROOT_VERSION} -DMINOR_ROOT_VERSION=${MINOR_ROOT_VERSION}
 ifeq ($(ROOT_PYTHON_VERSION),2.7)
   CFLAGS += -DHAS_CORRECT_PYTHON_VERSION
 endif


### PR DESCRIPTION
This bug was introduced when ROOT version 6.24.00 changed how gDirectory behaves. I added a check for the ROOT version with two different checks, either ```gDirectory == nullptr``` (older versions) or ```!gDirectory``` (newer versions). This now allows the analysis options to be written to file again.

Also changed all uses of MAJOR_ROOT_VERSION to use standard ROOT_VERSION_CODE instead.