### PR TITLE
Fix for issue #1223

### DIFF
--- a/include/TBGSubtraction.h
+++ b/include/TBGSubtraction.h
@@ -79,21 +79,21 @@ class TBGSubtraction : public TGMainFrame {
    //  RQ_OBJECT("TBGSubtraction")
 private:
    TGMainFrame*         fMain{nullptr};
-   TRootEmbeddedCanvas* fProjectionCanvas;
-   TRootEmbeddedCanvas* fGateCanvas;
-   TH2*                 fMatrix;
-   TH1*                 fProjection;
-   TH1*                 fGateHist;
-   TH1*                 fBGHist1;
-   TH1*                 fBGHist2;
-   TH1*                 fSubtractedHist;
-   TH1*                 fSubtractedBinHist;
-   TGDoubleHSlider*     fGateSlider;
-   TGDoubleHSlider*     fBGSlider1;
-   TGDoubleHSlider*     fBGSlider2;
-   TGTripleHSlider*     fPeakSlider;
-	TGHSlider*				fBinningSlider;
-   TGNumberEntry*       fBGParamEntry;
+   TRootEmbeddedCanvas* fProjectionCanvas{nullptr};
+   TRootEmbeddedCanvas* fGateCanvas{nullptr};
+   TH2*                 fMatrix{nullptr};
+   TH1*                 fProjection{nullptr};
+   TH1*                 fGateHist{nullptr};
+   TH1*                 fBGHist1{nullptr};
+   TH1*                 fBGHist2{nullptr};
+   TH1*                 fSubtractedHist{nullptr};
+   TH1*                 fSubtractedBinHist{nullptr};
+   TGDoubleHSlider*     fGateSlider{nullptr};
+   TGDoubleHSlider*     fBGSlider1{nullptr};
+   TGDoubleHSlider*     fBGSlider2{nullptr};
+   TGTripleHSlider*     fPeakSlider{nullptr};
+	TGHSlider*				fBinningSlider{nullptr};
+   TGNumberEntry*       fBGParamEntry{nullptr};
    TGNumberEntry*       fBGEntryLow1{nullptr};
    TGNumberEntry*       fBGEntryHigh1{nullptr};
    TGNumberEntry*       fBGEntryLow2{nullptr};
@@ -102,18 +102,17 @@ private:
    TGNumberEntry*       fGateEntryHigh{nullptr};
    TGLabel*             fBGParamLabel{nullptr};
    TGLabel*             fBinningLabel{nullptr};
-   TGCheckButton*       fBGCheckButton1;
-   TGCheckButton*       fBGCheckButton2;
-   TGCheckButton*       fAutoUpdateCheckButton;
+   TGCheckButton*       fBGCheckButton1{nullptr};
+   TGCheckButton*       fBGCheckButton2{nullptr};
+   TGCheckButton*       fAutoUpdateCheckButton{nullptr};
 
-   TGLayoutHints* fBly;
-   TGLayoutHints* fBly1;
+   TGLayoutHints* fBly{nullptr};
+   TGLayoutHints* fBly1{nullptr};
    TGLayoutHints* fLayoutCanvases{nullptr};
    TGLayoutHints* fLayoutParam{nullptr};
 
    TGTextEntry* fWrite2FileName{nullptr};
    TGTextEntry* fHistogramDescription{nullptr};
-   //      TGTextButton         *fDrawCanvasButton;
    TGTextButton* fWrite2FileButton{nullptr};
    TGTextButton* fPeakFitButton{nullptr};
 
@@ -121,8 +120,8 @@ private:
    TGStatusBar* fProjectionStatus{nullptr};
 
    // Frames
-   TGVerticalFrame*   fGateFrame;
-   TGVerticalFrame*   fProjectionFrame;
+   TGVerticalFrame*   fGateFrame{nullptr};
+   TGVerticalFrame*   fProjectionFrame{nullptr};
    TGHorizontalFrame* fPeakFitFrame{nullptr};
    TGHorizontalFrame* fBinningFrame{nullptr};
    TGHorizontalFrame* fBGParamFrame{nullptr};
@@ -133,21 +132,21 @@ private:
    TGHorizontalFrame* fButtonFrame{nullptr};
 
    // Combo box
-   TGComboBox* fAxisCombo;
-   TGComboBox* fPeakCombo;
+   TGComboBox* fAxisCombo{nullptr};
+   TGComboBox* fPeakCombo{nullptr};
 
    // Markers
-   GMarker* fLowGateMarker;
-   GMarker* fHighGateMarker;
-   GMarker* fLowBGMarker1;
-   GMarker* fHighBGMarker1;
-   GMarker* fLowBGMarker2;
-   GMarker* fHighBGMarker2;
-   GMarker* fLowPeakMarker;
-   GMarker* fHighPeakMarker;
-   GMarker* fPeakMarker;
+   GMarker* fLowGateMarker{nullptr};
+   GMarker* fHighGateMarker{nullptr};
+   GMarker* fLowBGMarker1{nullptr};
+   GMarker* fHighBGMarker1{nullptr};
+   GMarker* fLowBGMarker2{nullptr};
+   GMarker* fHighBGMarker2{nullptr};
+   GMarker* fLowPeakMarker{nullptr};
+   GMarker* fHighPeakMarker{nullptr};
+   GMarker* fPeakMarker{nullptr};
 
-   TFile* fCurrentFile;
+   TFile* fCurrentFile{nullptr};
 
    Int_t fGateAxis;
 
@@ -158,14 +157,14 @@ private:
    Double_t fPeakHighValue; ///< high range for fit
    Double_t fPeakValue; ///< centroid for fit
 
-   TSinglePeak* fPeak; ///< the peak to be fit (will be a class that inherits from TSinglePeak)
-	TPeakFitter* fPeakFitter; ///< the peak fitter that fPeak is added to
+   TSinglePeak* fPeak{nullptr}; ///< the peak to be fit (will be a class that inherits from TSinglePeak)
+	TPeakFitter* fPeakFitter{nullptr}; ///< the peak fitter that fPeak is added to
 	Int_t fPeakId; ///< the current ID of the peak
 
-	Int_t fMaxBinning{10}; ///< maximum binning possible with binning slider (hard-coded, for now?)
+	Int_t fMaxBinning{20}; ///< maximum binning possible with binning slider (hard-coded, for now?)
 
 public:
-   TBGSubtraction(TH2* mat, const char* gate_axis = "x");
+   TBGSubtraction(TH2* mat, const char* gate_axis = "x", int maxBinning = 20);
    ~TBGSubtraction() override;
    void AxisComboSelected();
    void PeakComboSelected();

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -13,14 +13,14 @@
 ClassImp(TBGSubtraction)
 /// \endcond
 
-TBGSubtraction::TBGSubtraction(TH2* mat, const char* gate_axis)
+TBGSubtraction::TBGSubtraction(TH2* mat, const char* gate_axis, int maxBinning)
    : TGMainFrame(nullptr, 10, 10, kHorizontalFrame), fProjectionCanvas(nullptr), fGateCanvas(nullptr), fMatrix(mat),
      fProjection(nullptr), fGateHist(nullptr), fBGHist1(nullptr), fBGHist2(nullptr), fSubtractedHist(nullptr), fSubtractedBinHist(nullptr), fGateSlider(nullptr),
      fBGSlider1(nullptr), fBGSlider2(nullptr), fPeakSlider(nullptr), fBinningSlider(nullptr), fBGParamEntry(nullptr), fBGCheckButton1(nullptr), fBGCheckButton2(nullptr), 
      fAutoUpdateCheckButton(nullptr), fBly(nullptr), fBly1(nullptr), fGateFrame(nullptr), 
      fProjectionFrame(nullptr), fAxisCombo(nullptr), fPeakCombo(nullptr), fLowGateMarker(nullptr), fHighGateMarker(nullptr), fLowBGMarker1(nullptr),  
      fHighBGMarker1(nullptr), fLowBGMarker2(nullptr), fHighBGMarker2(nullptr), fLowPeakMarker(nullptr), fHighPeakMarker(nullptr), 
-     fPeakMarker(nullptr), fGateAxis(0), fForceUpdate(true), fPeak(nullptr), fPeakFitter(new TPeakFitter())
+     fPeakMarker(nullptr), fGateAxis(0), fForceUpdate(true), fPeak(nullptr), fPeakFitter(new TPeakFitter()), fMaxBinning(maxBinning)
 {
    TString tmp_gate_word(gate_axis);
    tmp_gate_word.ToUpper();
@@ -1212,6 +1212,7 @@ void TBGSubtraction::RebinProjection()
 	fSubtractedBinHist->SetDirectory(nullptr);
    fGateCanvas->GetCanvas()->cd();
 	fSubtractedBinHist->GetXaxis()->SetRangeUser(fGateCanvas->GetCanvas()->GetUxmin(), fGateCanvas->GetCanvas()->GetUxmax());
+	fSubtractedBinHist->GetYaxis()->SetRangeUser(fGateCanvas->GetCanvas()->GetUymin(), fGateCanvas->GetCanvas()->GetUymax());
 	fSubtractedBinHist->Draw("hist");
    DrawPeakMarkers();
    fGateCanvas->GetCanvas()->Update();


### PR DESCRIPTION
- Increased default maximum range for binning slider from 10 to 20 and added it as an input parameter to the constructor.
- Now also fixing the y-axis range when rebinning, using the range the old histogram was zoomed into relative to it's maximum values. This ensures that the changing bin values when re-binning are taken into account.