### PR TITLE
Bug fix for fitting in TBGSubtraction (see #1223) and other small changes

### DIFF
--- a/GRSIProof/CrossTalk.C
+++ b/GRSIProof/CrossTalk.C
@@ -13,6 +13,9 @@ const double gg_time_high = 300.;
 const double gb_time_low  = -250.;
 const double gb_time_high = 350.;
 
+// default k-value this might have to be adjusted for each experiment!!!
+const Short_t defaultKValue = 379;
+
 bool Addback(TGriffinHit& one, TGriffinHit& two)
 {
 	return ((one.GetDetector() == two.GetDetector()) && (std::fabs(one.GetTime() - two.GetTime()) < 300.));
@@ -70,13 +73,13 @@ void CrossTalk::FillHistograms() {
 	}
 
 	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedMultiplicity(fGriffinBgo); ++gr1){
-		if(pileup_reject && (fGrif->GetSuppressedHit(gr1)->GetKValue() != 700)) continue; //This pileup number might have to change for other expmnts
+		if(pileup_reject && (fGrif->GetSuppressedHit(gr1)->GetKValue() != defaultKValue)) continue; //This pileup number might have to change for other expmnts
 		fH1[Form("gEdet%d",fGrif->GetSuppressedHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH2["gE_chan"]->Fill(fGrif->GetSuppressedHit(gr1)->GetArrayNumber(),fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH1["gE"]->Fill(fGrif->GetSuppressedHit(gr1)->GetEnergy());
 		fH1["gEnoCT"]->Fill(fGrif->GetSuppressedHit(gr1)->GetNoCTEnergy());
 		for(auto gr2 = gr1 + 1; gr2 < fGrif->GetSuppressedMultiplicity(fGriffinBgo); ++gr2){
-			if(pileup_reject && fGrif->GetSuppressedHit(gr2)->GetKValue() != 700) continue; //This pileup number might have to change for other expmnts
+			if(pileup_reject && fGrif->GetSuppressedHit(gr2)->GetKValue() != defaultKValue) continue; //This pileup number might have to change for other expmnts
 			if((det_multiplicity[fGrif->GetSuppressedHit(gr1)->GetDetector()] == 2) && Addback(*(fGrif->GetSuppressedHit(gr1)), *(fGrif->GetSuppressedHit(gr2)))){
 				TGriffinHit *low_crys_hit, *high_crys_hit;
 				if(fGrif->GetSuppressedHit(gr1)->GetCrystal() < fGrif->GetSuppressedHit(gr2)->GetCrystal()){
@@ -95,7 +98,7 @@ void CrossTalk::FillHistograms() {
 	}
 
 	for(auto gr1 = 0; gr1 < fGrif->GetSuppressedAddbackMultiplicity(fGriffinBgo); ++gr1) {
-		if(pileup_reject && (fGrif->GetSuppressedAddbackHit(gr1)->GetKValue() != 700))
+		if(pileup_reject && (fGrif->GetSuppressedAddbackHit(gr1)->GetKValue() != defaultKValue))
 			continue; // This pileup number might have to change for other expmnts
 		fH1["aE"]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());
 		fH1[Form("aEdet%d", fGrif->GetSuppressedAddbackHit(gr1)->GetDetector())]->Fill(fGrif->GetSuppressedAddbackHit(gr1)->GetEnergy());

--- a/libraries/GROOT/GGaus.cxx
+++ b/libraries/GROOT/GGaus.cxx
@@ -27,7 +27,6 @@ GGaus::GGaus(Double_t xlow, Double_t xhigh, Option_t*)
    // Changing the name here causes an infinite loop when starting the FitEditor
    // SetName(Form("gaus_%d_to_%d",(Int_t)(xlow),(Int_t)(xhigh)));
    InitNames();
-   // TF1::SetParameter("centroid",cent);
 }
 
 GGaus::GGaus(Double_t xlow, Double_t xhigh, TF1* bg, Option_t*) : TF1("gausbg", "gaus(0)+pol1(3)", xlow, xhigh)
@@ -69,22 +68,7 @@ GGaus::GGaus(const GGaus& peak) : TF1(peak)
 
 GGaus::~GGaus()
 {
-   // if(background)
-   //  delete background;
 }
-
-// void GGaus::Fcn(Int_t &npar,Double_t *gin,Double_T &f,Double_t *par,Int_t iflag) {
-// chisquared calculator
-//
-//  int i=0;
-//  double chisq = 0;
-//  double delta = 0;
-//  for(i=0;i<nbins;i++) {
-//    delta = (data[i] - GRootFunctions::PhotoPeakBG((x+i),par))/error[i];
-//    chisq += delta*delta;
-//  }
-//  f=chisq;
-//}
 
 void GGaus::InitNames()
 {
@@ -97,11 +81,6 @@ void GGaus::InitNames()
 
 void GGaus::Copy(TObject& obj) const
 {
-   // printf("0x%08x\n",&obj);
-   // fflush(stdout);
-   // printf("%s\n",obj.GetName());
-   // fflush(stdout);
-
    TF1::Copy(obj);
    (static_cast<GGaus&>(obj)).init_flag = init_flag;
    (static_cast<GGaus&>(obj)).fArea     = fArea;
@@ -120,7 +99,6 @@ bool GGaus::InitParams(TH1* fithist)
       printf("No histogram is associated yet, no initial guesses made\n");
       return false;
    }
-   // printf("%s called.\n",__PRETTY_FUNCTION__); fflush(stdout);
    // Makes initial guesses at parameters for the fit. Uses the histogram to
    Double_t xlow, xhigh;
    GetRange(xlow, xhigh);
@@ -161,23 +139,15 @@ bool GGaus::InitParams(TH1* fithist)
    TF1::SetParLimits(0, 0, largesty * 2);
    TF1::SetParLimits(1, xlow, xhigh);
    TF1::SetParLimits(2, 0, xhigh - xlow);
-   // TF1::SetParLimits(3,0.0,40);
-   // TF1::SetParLimits(4,0.01,5);
 
    // Make initial guesses
    TF1::SetParameter(0, largesty);                // fithist->GetBinContent(bin));
    TF1::SetParameter(1, largestx);                // GetParameter("centroid"));
    TF1::SetParameter(2, (largestx * .01) / 2.35); // 2,(xhigh-xlow));     //2.0/binWidth); //
-   // TF1::SetParameter(3,5.);
-   // TF1::SetParameter(4,1.);
 
    TF1::SetParError(0, 0.10 * largesty);
    TF1::SetParError(1, 0.25);
    TF1::SetParError(2, 0.10 * ((largestx * .01) / 2.35));
-   // TF1::SetParError(3,5);
-   // TF1::SetParError(4,0.5);
-
-   // TF1::Print();
 
    SetInitialized();
    return true;
@@ -206,14 +176,10 @@ Bool_t GGaus::Fit(TH1* fithist, Option_t* opt)
 
    TFitResultPtr fitres = fithist->Fit(this, Form("%sRSME", options.Data()));
 
-   // fitres.Get()->Print();
    if(!fitres.Get()->IsValid()) {
       if(!verbose) {
          printf(RED "fit has failed, trying refit... " RESET_COLOR);
       }
-      // SetParameter(3,0.1);
-      // SetParameter(4,0.01);
-      // SetParameter(5,0.0);
       fithist->GetListOfFunctions()->Last()->Delete();
       fitres = fithist->Fit(this, Form("%sRSME", options.Data())); //,Form("%sRSM",options.Data()))
       if(fitres.Get()->IsValid()) {
@@ -227,51 +193,14 @@ Bool_t GGaus::Fit(TH1* fithist, Option_t* opt)
       }
    }
 
-   // if(fitres->ParError(2) != fitres->ParError(2)) { // checks if nan.
-   //  if(fitres->Parameter(3)<1) {
-   //    FixParameter(4,0);
-   //    FixParameter(3,1);
-   // printf("Beta may have broken the fit, retrying with R=0);
-   //    fithist->GetListOfFunctions()->Last()->Delete();
-   //    fitres = fithist->Fit(this,Form("%sRSM",options.Data()));
-   //  }
-   //}
-
-   // TF1::Print();
-
-   // Double_t binwidth = fithist->GetBinWidth(GetParameter("centroid"));
-   // Double_t width    = TF1::GetParameter("sigma");
    Double_t xlow, xhigh;
-   // Double_t int_low,int_high;
    TF1::GetRange(xlow, xhigh);
-   // int_low  = xlow - 5.*width;
-   // int_high = xhigh +5.*width;
-
-   // Make a function that does not include the background
-   // Intgrate the background.
-   // GGaus *tmppeak = new GGaus;
-   // Copy(*tmppeak);
-
-   // tmppeak->SetParameter("bg_offset",0.0);
-   // tmppeak->SetRange(int_low,int_high);//This will help get the true area of the gaussian 200 ~ infinity in a gaus
-   // tmppeak->SetName("tmppeak");
-
-   // fArea = (tmppeak->Integral(int_low,int_high))/binwidth;
-   //  TMatrixDSym CovMat = fitres->GetCovarianceMatrix();
-   //  CovMat(6,6) = 0.0;
-   //  CovMat(7,7) = 0.0;
-   //  CovMat(8,8) = 0.0;
-   //  CovMat(9,9) = 0.0;
-
-   //  fDArea = (tmppeak->IntegralError(int_low,int_high,tmppeak->GetParameters(),CovMat.GetMatrixArray()))/binwidth;
 
    double bgpars[2];
    bgpars[0] = TF1::GetParameters()[3];
    bgpars[1] = TF1::GetParameters()[4];
-   // bgpars[5] = TF1::GetParameters()[7];
 
    fBGFit.SetParameters(bgpars);
-   // fithist->GetListOfFunctions()->Print();
 
    fArea         = Integral(xlow, xhigh) / fithist->GetBinWidth(1);
    double bgArea = fBGFit.Integral(xlow, xhigh) / fithist->GetBinWidth(1);
@@ -289,18 +218,12 @@ Bool_t GGaus::Fit(TH1* fithist, Option_t* opt)
    printf("sum after subtraction: %02f\n", fSum);
 
    if(!verbose && !noprint) {
-      Print(); /*
-       printf("BG Area:         %.02f\n",bgArea);
-       printf("GetChisquared(): %.4f\n", TF1::GetChisquare());
-       printf("GetNDF():        %i\n",   TF1::GetNDF());
-       printf("GetProb():       %.4f\n", TF1::GetProb());*/
-      // TF1::Print();
+      Print();
    }
 
    Copy(*fithist->GetListOfFunctions()->FindObject(GetName()));
    fithist->GetListOfFunctions()->Add(fBGFit.Clone());
 
-   // delete tmppeak;
    return true;
 }
 

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -218,7 +218,7 @@ Long64_t TDetectorHit::GetTimeStampNs(Option_t*) const
 {
 	TChannel* tmpChan = GetChannel();
 	if(tmpChan == nullptr) {
-		return fTimeStamp * 1; // GetTimeStampUnit returns 1 of there is no channel
+		return fTimeStamp; // GetTimeStampUnit returns 1 of there is no channel
 	}
 	return fTimeStamp * GetTimeStampUnit() - tmpChan->GetTimeOffset();
 }

--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -33,6 +33,8 @@ bool TGRSIFunctions::CheckParameterErrors(const TFitResultPtr& fitres, std::stri
    // loop over all parameters and compare the parameter error with the square root 
    // of the diagonal element of the covariance matrix
    auto covarianceMatrix = fitres->GetCovarianceMatrix();
+	// if we fail to get a covariance matrix we assume there was a problem in the fit
+	if(covarianceMatrix.GetNrows() != static_cast<Int_t>(fitres->NPar()) || covarianceMatrix.GetNcols() != static_cast<Int_t>(fitres->NPar())) return false;
    for(unsigned int i = 0; i < fitres->NPar(); ++i) {
       if(std::fabs(fitres->ParError(i) - TMath::Sqrt(covarianceMatrix[i][i])) > 0.1) {
          if(!quiet) {

--- a/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -244,7 +244,6 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
    // After performing this fit I want to put something here that takes the fit result (good,bad,etc)
    // for printing out. RD
 
-   // Int_t fitStatus = fitres; //This returns a fit status from the TFitResult Ptr
    // This removes the background parts of the fit form the integral error, while maintaining the covariance between the
    // fits and the background.
    TMatrixDSym CovMat = fitres->GetCovarianceMatrix();
@@ -253,7 +252,6 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
    CovMat(2, 2) = 0.0;
    CovMat(3, 3) = 0.0;
    CovMat(4, 4) = 0.0;
-   //   printf("covmat ");CovMat.Print();
 
    // This copies the parameters background but the background function doesn't have peaks
    CopyParameters(fBackground);
@@ -271,31 +269,6 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
       //  printf("empt covmat ");emptyCovMat.Print();
    }
 
-   /*
-      if(fitres->ParError(2) != fitres->ParError(2)){ //Check to see if nan
-         if(fitres->Parameter(3) < 1){
-            InitParams(fithist);
-            FixParameter(4,0);
-            FixParameter(3,1);
-            std::cout<<"Beta may have broken the fit, retrying with R=0"<<std::endl;
-          // Leaving the log-likelihood argument out so users are not constrained to just using that. - JKS
-            fithist->GetListOfFunctions()->Last()->Delete();
-            if(GetLogLikelihoodFlag()){
-               fitres = fithist->Fit(this,Form("%sLRS",opt));//The RS needs to always be there
-            }
-            else{
-               fitres = fithist->Fit(this,Form("%sRS",opt));
-            }
-         }
-      }*/
-   /*   if(fitres->Parameter(5) < 0.0){
-         FixParameter(5,0);
-         std::cout<<"Step < 0. Retrying fit with stp = 0"<<std::endl;
-         fitres = fithist->Fit(this,Form("%sRSML",opt));
-      }
-   */
-   /*
-*/
    if(print_flag) {
       printf("Chi^2/NDF = %lf\n", fitres->Chi2() / fitres->Ndf());
    }
@@ -318,8 +291,6 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
       peak->SetParameter("bg_offset", 0.0);
       peak->SetChi2(fitres->Chi2());
       peak->SetNdf(fitres->Ndf());
-
-      // printf("tmp cov mat: ");tmpCovMat.Print();
 
       // Set the important diagonals for the integral of the covariance matrix
       tmpCovMat(6 * i + 5, 6 * i + 5) = CovMat(6 * i + 5, 6 * i + 5);
@@ -360,15 +331,6 @@ Bool_t TMultiPeak::Fit(TH1* fithist, Option_t* opt)
       }
    }
 
-   // Set the background for drawing later
-   //  background->SetParameters(GetParameters());
-   // To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix
-   // Copy(*fithist->GetListOfFunctions()->Last());
-   // if(optstr.Contains("+"))
-   //    Copy(*fithist->GetListOfFunctions()->Before(fithist->GetListOfFunctions()->Last()));
-
-   //     peak->SetParameter("step",GetParameter(Form("Step_%i",i)));
-   //   delete tmppeak;
    return true;
 }
 
@@ -409,9 +371,6 @@ Double_t TMultiPeak::MultiPhotoPeakBG(Double_t* dim, Double_t* par)
       tmp_par[0] = par[6 * i + 5];  // height of photopeak
       tmp_par[1] = par[6 * i + 6];  // Peak Centroid of non skew gaus
       tmp_par[2] = par[6 * i + 7];  // standard deviation  of gaussian
-      //This is where I link up the widths of the gaussians if they are within 5 keV. 
-   //  for(int j = 0; j < npeaks; ++j){
-      //}
       tmp_par[3] = par[6 * i + 8];  //"skewedness" of the skewed gaussian
       tmp_par[4] = par[6 * i + 9];  // relative height of skewed gaussian
       tmp_par[5] = par[6 * i + 10]; // Size of step in background
@@ -513,7 +472,6 @@ void TMultiPeak::DrawPeaks()
       sum->SetLineStyle(2);
       sum->SetLineColor(kMagenta);
 
-      //  peak->DrawF1(Form("%s + %s",peak->GetName(),Background()->GetName()),centroid-range,centroid+range,"same");
       sum->SetRange(centroid - range, centroid + range);
       sum->DrawCopy("SAME");
       delete sum;

--- a/libraries/TAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TPeak.cxx
@@ -220,7 +220,6 @@ Bool_t TPeak::InitParams(TH1* fitHist)
    Int_t bin     = fitHist->FindBin(GetParameter("centroid"));
    Int_t binlow  = fitHist->GetXaxis()->FindBin(xlow);
    Int_t binhigh = fitHist->GetXaxis()->FindBin(xhigh);
-   // Double_t binWidth = fitHist->GetBinWidth(bin);
    SetParLimits(0, 0, fitHist->GetMaximum());
    GetParLimits(1, low, high);
    if(low == high && low == 0.) {
@@ -252,8 +251,6 @@ Bool_t TPeak::InitParams(TH1* fitHist)
    // The centroid should already be set by this point in the ctor
    SetParameter("Height", fitHist->GetBinContent(bin));
    SetParameter("centroid", GetParameter("centroid"));
-   //  SetParameter("sigma",(xhigh-xlow)*0.5); // slightly more robust starting value for sigma -JKS
-   //  SetParameter("sigma",1.0/binWidth); // slightly more robust starting value for sigma -JKS
    SetParameter("sigma", TMath::Sqrt(9.0 + 4. * GetParameter("centroid") / 1000.) / 2.35);
    SetParameter("beta", GetParameter("sigma") / 2.0);
    SetParameter("R", 0.001);
@@ -303,16 +300,6 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    // Now that it is initialized, let's fit it.
    // Just in case the range changed, we should reset the centroid and bg energy limits
    // check first if the parameter has been fixed!
-   /////////////////// TODO: this should be done in SetRange !!!!!!!!!!
-   // double parmin, parmax;
-   // GetParLimits(1,parmin,parmax);
-   // if(parmin < parmax) {
-   //	SetParLimits(1,GetXmin(),GetXmax());
-   //}
-   // GetParLimits(9,parmin,parmax);
-   // if(parmin < parmax) {
-   //	SetParLimits(9,GetXmin(),GetXmax());
-   //}
    std::vector<double> lowerLimit(GetNpar());
    std::vector<double> upperLimit(GetNpar());
    for(int i = 0; i < GetNpar(); ++i) {
@@ -349,8 +336,6 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
 
    // After performing this fit I want to put something here that takes the fit result (good,bad,etc)
    // for printing out. RD
-
-   // Int_t fitStatus = fitres; //This returns a fit status from the TFitResult Ptr
 
    if(fitres->ParError(2) != fitres->ParError(2)) { // Check to see if nan
       if(fitres->Parameter(3) < 1) {
@@ -439,8 +424,6 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
    fBackground->SetParameters(GetParameters());
    // To DO: put a flag in signalling that the errors are not to be trusted if we have a bad cov matrix
    Copy(*fitHist->GetListOfFunctions()->Last());
-   //  if(optstr.Contains("+"))
-   //    Copy(*fitHist->GetListOfFunctions()->Before(fitHist->GetListOfFunctions()->Last()));
 
 	// always print result of the fit even if not verbose
    if(!quiet) Print("+");

--- a/libraries/TGUI/TBGSubtraction.cxx
+++ b/libraries/TGUI/TBGSubtraction.cxx
@@ -459,6 +459,7 @@ void TBGSubtraction::DoPeakFit()
 		std::cerr<<"Something went wrong and the peak is a nullptr?"<<std::endl;
 		return;
 	}
+	fPeakFitter->ResetInitFlag();
 	fPeak->Centroid(fPeakValue);
 	fPeakFitter->SetRange(fPeakLowValue, fPeakHighValue);
    fGateCanvas->GetCanvas()->cd();
@@ -469,7 +470,7 @@ void TBGSubtraction::DoPeakFit()
 
 void TBGSubtraction::DrawPeak()
 {
-   if(fPeak) fPeak->Draw("same");
+   if(fPeak != nullptr) fPeak->Draw("same");
 }
 
 void TBGSubtraction::ClickedBGButton1()


### PR DESCRIPTION
- Added a reset of the peak parameters before fitting a peak in TBGSubtraction, should fix the problems @bolaizol reported at the end of #1223.
- Added checks that the covariance matrix is good for TPeakFitter and TGRSIFunctions::CheckParameterErrors.
- Removed an unnecessary ```*  1``` in TDetectorHit::GetTimeStampNs.
- Removed commented out code.
- The default k-value in CrossTalk.C selector is now set via a single global variable instead of being hard-coded in two places.