### PR TITLE
TDetectorHit::GetTime now uses TChannel::GetTime

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -44,6 +44,9 @@
 #include "Globals.h"
 #include "TPriorityValue.h"
 
+enum class EDigitizer : char;
+class TMnemonic;
+
 class TChannel : public TNamed {
 public:
    static TChannel* GetChannel(unsigned int temp_address, bool warn = true);
@@ -141,11 +144,7 @@ public:
    static void SetIntegration(const std::string& mnemonic, int tmpint, EPriority pr);
    inline void SetStream(TPriorityValue<int> tmp) { fStream = tmp; }
    inline void SetUserInfoNumber(TPriorityValue<int> tmp) { fUserInfoNumber = tmp; }
-   inline void SetDigitizerType(TPriorityValue<std::string> tmp)
-   {
-      fDigitizerTypeString = tmp;
-      fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType, fTimeStampUnit);
-   }
+   inline void SetDigitizerType(TPriorityValue<std::string> tmp);
    static void SetDigitizerType(const std::string& mnemonic, const char* tmpstr, EPriority pr);
    inline void SetTimeOffset(TPriorityValue<Long64_t> tmp) { fTimeOffset = tmp; }
 
@@ -153,12 +152,13 @@ public:
    void SetSegmentNumber(int tempint) { fSegmentNumber = tempint; }
    void SetCrystalNumber(int tempint) { fCrystalNumber = tempint; }
 
+	double            GetTime(Long64_t timestamp, Float_t cfd) const;
    int               GetDetectorNumber() const;
    int               GetSegmentNumber() const;
    int               GetCrystalNumber() const;
-   const TMnemonic*  GetMnemonic() const { return fMnemonic.Value(); }
-   TClass*           GetClassType() const { return fMnemonic.Value()->GetClassType(); }
-   void              SetClassType(TClass* cl_type) { fMnemonic.Value()->SetClassType(cl_type); }
+   const TMnemonic*  GetMnemonic() const;
+   TClass*           GetClassType() const;
+   void              SetClassType(TClass* cl_type);
 
    int          GetNumber() const { return fNumber.Value(); }
    unsigned int GetAddress() const { return fAddress; }

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -144,7 +144,7 @@ public:
    static void SetIntegration(const std::string& mnemonic, int tmpint, EPriority pr);
    inline void SetStream(TPriorityValue<int> tmp) { fStream = tmp; }
    inline void SetUserInfoNumber(TPriorityValue<int> tmp) { fUserInfoNumber = tmp; }
-   inline void SetDigitizerType(TPriorityValue<std::string> tmp);
+   void SetDigitizerType(TPriorityValue<std::string> tmp);
    static void SetDigitizerType(const std::string& mnemonic, const char* tmpstr, EPriority pr);
    inline void SetTimeOffset(TPriorityValue<Long64_t> tmp) { fTimeOffset = tmp; }
 
@@ -152,7 +152,7 @@ public:
    void SetSegmentNumber(int tempint) { fSegmentNumber = tempint; }
    void SetCrystalNumber(int tempint) { fCrystalNumber = tempint; }
 
-	double            GetTime(Long64_t timestamp, Float_t cfd) const;
+	double            GetTime(Long64_t timestamp, Float_t cfd, double energy) const;
    int               GetDetectorNumber() const;
    int               GetSegmentNumber() const;
    int               GetCrystalNumber() const;
@@ -237,22 +237,22 @@ public:
    bool             UseWaveParam() const { return WaveFormShape.InUse; }
    WaveFormShapePar GetWaveParam() const { return WaveFormShape; }
 
-   double CalibrateENG(double);
-   double CalibrateENG(double, int temp_int);
-   double CalibrateENG(int, int temp_int = 0);
+   double CalibrateENG(double) const;
+   double CalibrateENG(double, int temp_int) const;
+   double CalibrateENG(int, int temp_int = 0) const;
 
-   double CalibrateCFD(double);
-   double CalibrateCFD(int);
+   double CalibrateCFD(double) const;
+   double CalibrateCFD(int) const;
 
-   double CalibrateLED(double);
-   double CalibrateLED(int);
+   double CalibrateLED(double) const;
+   double CalibrateLED(int) const;
 
-   double        CalibrateTIME(double);
-   double        CalibrateTIME(int);
-   inline double GetTZero(double tempd) { return CalibrateTIME(tempd); }
-   inline double GetTZero(int tempi) { return CalibrateTIME(tempi); }
+   double        CalibrateTIME(double) const;
+   double        CalibrateTIME(int) const;
+   inline double GetTZero(double tempd) const { return CalibrateTIME(tempd); }
+   inline double GetTZero(int tempi) const { return CalibrateTIME(tempi); }
 
-   double CalibrateEFF(double);
+   double CalibrateEFF(double) const;
 
    void DestroyCalibrations();
 

--- a/include/TMnemonic.h
+++ b/include/TMnemonic.h
@@ -9,8 +9,11 @@
 
 #include "Globals.h"
 #include "TPriorityValue.h"
+#include "TChannel.h"
 
-enum class EDigitizer : char;// { kDefault };
+enum class EDigitizer : char;
+
+class TChannel;
 
 class TMnemonic : public TObject {
 public:
@@ -47,6 +50,8 @@ public:
    virtual void SetClassType(TClass* classType) { fClassType = classType; }
    virtual TClass*                   GetClassType() const;
 
+	virtual double GetTime(Long64_t timestamp, Float_t, const TChannel* channel) const;
+	
    virtual void Print(Option_t* opt = "") const override;
    virtual void Clear(Option_t* opt = "") override;
 

--- a/include/TMnemonic.h
+++ b/include/TMnemonic.h
@@ -50,7 +50,7 @@ public:
    virtual void SetClassType(TClass* classType) { fClassType = classType; }
    virtual TClass*                   GetClassType() const;
 
-	virtual double GetTime(Long64_t timestamp, Float_t, const TChannel* channel) const;
+	virtual double GetTime(Long64_t timestamp, Float_t cfd, double energy, const TChannel* channel) const;
 	
    virtual void Print(Option_t* opt = "") const override;
    virtual void Clear(Option_t* opt = "") override;

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -63,7 +63,7 @@ Double_t TDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
 		return SetTime(static_cast<Double_t>(GetTimeStamp() + gRandom->Uniform()));
 	}
 
-	return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd()));
+	return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd(), GetEnergy()));
 }
 
 Float_t TDetectorHit::GetCharge() const

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -60,10 +60,10 @@ Double_t TDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
    }
 	TChannel* tmpChan = GetChannel();
 	if(tmpChan == nullptr) {
-		return SetTime(static_cast<Double_t>(((GetTimeStamp()) + gRandom->Uniform()) * GetTimeStampUnit()));
+		return SetTime(static_cast<Double_t>(GetTimeStamp() + gRandom->Uniform()));
 	}
 
-	return SetTime(static_cast<Double_t>(((GetTimeStamp()) + gRandom->Uniform()) * GetTimeStampUnit() - tmpChan->GetTimeOffset()));
+	return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd()));
 }
 
 Float_t TDetectorHit::GetCharge() const

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1404,3 +1404,29 @@ void TChannel::ReadEnergyNonlinearities(TFile* file, const char* graphName, bool
 		}
 	}
 }
+
+void TChannel::SetDigitizerType(TPriorityValue<std::string> tmp)
+{
+	fDigitizerTypeString = tmp;
+	fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType, fTimeStampUnit);
+}
+
+double TChannel::GetTime(Long64_t timestamp, Float_t cfd) const
+{
+	return fMnemonic.Value()->GetTime(timestamp, cfd, this);
+}
+
+const TMnemonic* TChannel::GetMnemonic() const
+{
+	return fMnemonic.Value();
+}
+
+TClass* TChannel::GetClassType() const
+{
+	return fMnemonic.Value()->GetClassType();
+}
+
+void TChannel::SetClassType(TClass* cl_type)
+{
+	fMnemonic.Value()->SetClassType(cl_type);
+}

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -481,7 +481,7 @@ void TChannel::DestroyCalibrations()
    DestroyCTCal();
 }
 
-double TChannel::CalibrateENG(int charge, int temp_int)
+double TChannel::CalibrateENG(int charge, int temp_int) const
 {
    /// Returns the calibrated energy of the channel when a charge is passed to it.
    /// This is done by first adding a random number between 0 and 1 to the charge
@@ -497,7 +497,7 @@ double TChannel::CalibrateENG(int charge, int temp_int)
    return CalibrateENG(static_cast<double>(charge) + gRandom->Uniform(), temp_int);
 }
 
-double TChannel::CalibrateENG(double charge, int temp_int)
+double TChannel::CalibrateENG(double charge, int temp_int) const
 {
    /// Returns the calibrated energy of the channel when a charge is passed to it.
    /// This is divided by the integration parameter. The
@@ -519,7 +519,7 @@ double TChannel::CalibrateENG(double charge, int temp_int)
    return CalibrateENG((charge) / static_cast<double>(temp_int));
 }
 
-double TChannel::CalibrateENG(double charge)
+double TChannel::CalibrateENG(double charge) const
 {
    /// Returns the calibrated energy. The polynomial energy calibration formula is
    /// applied to get the calibrated energy. This function does not use the
@@ -534,13 +534,13 @@ double TChannel::CalibrateENG(double charge)
    return cal_chg;
 }
 
-double TChannel::CalibrateCFD(int cfd)
+double TChannel::CalibrateCFD(int cfd) const
 {
    /// Calibrates the CFD properly.
    return CalibrateCFD(static_cast<double>(cfd) + gRandom->Uniform());
 }
 
-double TChannel::CalibrateCFD(double cfd)
+double TChannel::CalibrateCFD(double cfd) const
 {
    /// Returns the calibrated CFD. The polynomial CFD calibration formula is
    /// applied to get the calibrated CFD.
@@ -559,13 +559,13 @@ double TChannel::CalibrateCFD(double cfd)
    return cal_cfd;
 }
 
-double TChannel::CalibrateLED(int led)
+double TChannel::CalibrateLED(int led) const
 {
    /// Calibrates the LED
    return CalibrateLED(static_cast<double>(led) + gRandom->Uniform());
 }
 
-double TChannel::CalibrateLED(double led)
+double TChannel::CalibrateLED(double led) const
 {
    /// Returns the calibrated LED. The polynomial LED calibration formula is
    /// applied to get the calibrated LED.
@@ -580,7 +580,7 @@ double TChannel::CalibrateLED(double led)
    return cal_led;
 }
 
-double TChannel::CalibrateTIME(int chg)
+double TChannel::CalibrateTIME(int chg) const
 {
    /// Calibrates the time spectrum
    if(fTIMECoefficients.size() != 3 || (chg < 1)) {
@@ -589,7 +589,7 @@ double TChannel::CalibrateTIME(int chg)
    return CalibrateTIME((CalibrateENG(chg)));
 }
 
-double TChannel::CalibrateTIME(double energy)
+double TChannel::CalibrateTIME(double energy) const
 {
    /// uses the values stored in TIMECOefficients to calculate a
    /// "walk correction" factor.  This function returns the correction
@@ -605,7 +605,7 @@ double TChannel::CalibrateTIME(double energy)
    return timeCorrection;
 }
 
-double TChannel::CalibrateEFF(double)
+double TChannel::CalibrateEFF(double) const
 {
    /// This needs to be added
    return 1.0;
@@ -1405,15 +1405,15 @@ void TChannel::ReadEnergyNonlinearities(TFile* file, const char* graphName, bool
 	}
 }
 
-void TChannel::SetDigitizerType(TPriorityValue<std::string> tmp)
+inline void TChannel::SetDigitizerType(TPriorityValue<std::string> tmp)
 {
 	fDigitizerTypeString = tmp;
 	fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType, fTimeStampUnit);
 }
 
-double TChannel::GetTime(Long64_t timestamp, Float_t cfd) const
+double TChannel::GetTime(Long64_t timestamp, Float_t cfd, double energy) const
 {
-	return fMnemonic.Value()->GetTime(timestamp, cfd, this);
+	return fMnemonic.Value()->GetTime(timestamp, cfd, energy, this);
 }
 
 const TMnemonic* TChannel::GetMnemonic() const

--- a/libraries/TFormat/TMnemonic.cxx
+++ b/libraries/TFormat/TMnemonic.cxx
@@ -146,7 +146,7 @@ TClass* TMnemonic::GetClassType() const
 	return fClassType;
 }
 
-double TMnemonic::GetTime(Long64_t timestamp, Float_t, const TChannel* channel) const
+double TMnemonic::GetTime(Long64_t timestamp, Float_t, double, const TChannel* channel) const
 { 
 	return static_cast<double>((timestamp + gRandom->Uniform()) * channel->GetTimeStampUnit());
 }

--- a/libraries/TFormat/TMnemonic.cxx
+++ b/libraries/TFormat/TMnemonic.cxx
@@ -145,3 +145,8 @@ TClass* TMnemonic::GetClassType() const
 {
 	return fClassType;
 }
+
+double TMnemonic::GetTime(Long64_t timestamp, Float_t, const TChannel* channel) const
+{ 
+	return static_cast<double>((timestamp + gRandom->Uniform()) * channel->GetTimeStampUnit());
+}


### PR DESCRIPTION
TChannel::GetTime in turn calls the GetTime function of the fMnemonicClass. This way the TDetectorHit class can apply the CFD algorithm the right way for the type of digitizer this channel belongs to without knowing anything about the digitizers. This together with the corresponding changes in the parser libraries solves issue #1209.

ATTENTION: Using this commit means that the parser libraries have to be updated as well!