### PR TITLE
Fixed bug in TPeakFitter when changing range after fitting

### DIFF
--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -43,8 +43,6 @@ public:
    Double_t CentroidErr() const override;
    Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }
 
-   void Print(Option_t *opt = "") const override;
-
 protected:
    Double_t PeakFunction(Double_t *dim, Double_t *par) override;
 

--- a/libraries/TAnalysis/TPeakFitting/TGauss.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TGauss.cxx
@@ -70,9 +70,3 @@ Double_t TGauss::PeakFunction(Double_t *dim, Double_t *par)
    
 	return gauss;
 }
-
-void TGauss::Print(Option_t * opt) const
-{
-   std::cout << "gaussian peak:" << std::endl;
-   TSinglePeak::Print(opt);
-}

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -26,10 +26,16 @@ TPeakFitter::TPeakFitter(const Double_t &range_low, const Double_t &range_high) 
 void TPeakFitter::Print(Option_t * opt) const
 {
 	/// Print information from the fit, opt is passed along to each individual peaks Print function.
-	std::cout<<"Range: "<<fRangeLow<<" to "<<fRangeHigh<<std::endl;
+	if(fTotalFitFunction != nullptr) {
+		double xMin, xMax;
+		fTotalFitFunction->GetRange(xMin, xMax);
+		std::cout<<"Fitting range: "<<xMin<<" to "<<xMax<<std::endl;
+	} else {
+		std::cout<<"Range: "<<fRangeLow<<" to "<<fRangeHigh<<std::endl;
+	}
 	Int_t counter = 0;
 	if(!fPeaksToFit.empty()) {
-		std::cout<<"Peaks: "<<std::endl<<std::endl;
+		std::cout<<"Peaks: "<<std::endl;
 		for(auto i : fPeaksToFit) {
 			std::cout<<"Peak #"<<counter++ <<std::endl;
 			i->Print(opt);
@@ -109,6 +115,7 @@ void TPeakFitter::Fit(TH1* fit_hist, Option_t *opt)
 		fTotalFitFunction = new TF1("total_fit",this,&TPeakFitter::FitFunction,fRangeLow,fRangeHigh,GetNParameters(),"TPeakFitter","FitFunction");
 	}
 	fTotalFitFunction->SetLineColor(kMagenta+fIndex);
+	fTotalFitFunction->SetRange(fRangeLow, fRangeHigh);
 	//We need to initialize all of the parameters based on the peak parameters
 	if(fit_hist != nullptr && (!fInitFlag || fit_hist != fLastHistFit)) {
 		if(verbose) std::cout<<"Initializing Fit...."<<std::endl;

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -334,7 +334,7 @@ void TGRSIOptions::Load(int argc, char** argv)
 	}
 
 	parser.option("max-events", &fNumberOfEvents, true)
-		.description("Maximum number of events, fragments, etc. processed").default_value(0);
+		.description("Maximum number of (midas, lst, or tdr) events read").default_value(0);
 
    // look for any arguments ending with .info, pass to parser.
    for(int i = 0; i < argc; i++) {


### PR DESCRIPTION
After fitting a peak in a sub-range of the histogram, changing that range to fit another peak would give an error
```
Warning in <ROOT::Fit::FillData>: fit range is outside histogram range, no fit data for xaxis
Warning in <Fit>: Fit data is empty
```
This was because the fit function was created with a specific range (the first sub-range to be fitted), so trying to fit anything outside that range would fail. This was solved by simply always setting the range of the fit function to the current sub-range of the histogram.

Also removed the overwriting of the TSinglePeak::Print function in TGauss and improved the description of ```--max-events``` option.