### PR TITLE
Setting fLastFit member at end of TPeak::Fit, so that TPeak::GetLastFit() works

### DIFF
--- a/libraries/TAnalysis/TGRSIFit/TPeak.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TPeak.cxx
@@ -428,6 +428,7 @@ Bool_t TPeak::Fit(TH1* fitHist, Option_t* opt)
 	// always print result of the fit even if not verbose
    if(!quiet) Print("+");
    delete tmppeak;
+   fLastFit = this;
    return true;
 }
 


### PR DESCRIPTION
Now one can use ```TPeak::GetLastFit()``` after using 'F' to fit a peak to access the fit function (same as is already implemented in GPeak). This means the background function can now also be accessed (using ```TPeak::GetLastFit()->Background()```).