### PR TITLE
Added check of objects sizes to TGRSISelector

### DIFF
--- a/include/TGRSISelector.h
+++ b/include/TGRSISelector.h
@@ -28,6 +28,9 @@
 
 // Fixed size dimensions of array or collections stored in the TTree if any.
 
+// 1 GB size limit for objects in ROOT
+#define SIZE_LIMIT 1073741822
+
 class TGRSISelector : public TSelector {
 public:
    TTree* fChain; //! pointer to the analyzed TTree or TChain
@@ -50,7 +53,7 @@ public:
    void SetOption(const char* option) override { fOption = option; }
    void SetObject(TObject* obj) override { fObject = obj; }
    // void    SetInputList(TList *input) { fInput = input; }
-   TList* GetOutputList() const override { return fOutput; }
+   TList* GetOutputList() const override { return fOutput; } ///< this does the same as TSelector::GetOutputList()
    void   SlaveTerminate() override;
    void   Terminate() override;
 
@@ -74,6 +77,7 @@ protected:
 	int64_t				fEntry; //!<! entry number currently being processed
 
 private:
+	void CheckSizes(const char* usage); ///< Function to check size of objects in output list
    std::string       fOutputPrefix; //!<! pre-fix for output files
    TAnalysisOptions* fAnalysisOptions{nullptr}; //!<! pointer to analysis options
 	Int_t             fFirstRunNumber; //!<! run number of first file

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -27,6 +27,7 @@
 #include "TGRSISelector.h"
 #include "GValue.h"
 #include "TParserLibrary.h"
+#include "TBufferFile.h"
 
 #include "TSystem.h"
 #include "TH2.h"
@@ -162,6 +163,7 @@ void TGRSISelector::SlaveBegin(TTree* /*tree*/)
 	}
 
 	CreateHistograms();
+	CheckSizes("use");
 }
 
 Bool_t TGRSISelector::Process(Long64_t entry)
@@ -210,7 +212,9 @@ void TGRSISelector::SlaveTerminate()
 	/// have been processed. When running with PROOF SlaveTerminate() is called
 	/// on each slave server.
 
+	// check size of each object in the output list
 	EndOfSort();
+	CheckSizes("send to server");
 	fOutput->Add(new TChannel(TChannel::GetChannelMap()->begin()->second));
 }
 
@@ -219,6 +223,9 @@ void TGRSISelector::Terminate()
 	/// The Terminate() function is the last function to be called during
 	/// a query. It always runs on the client, it can be used to present
 	/// the results graphically or save the results to file.
+
+	CheckSizes("write");
+
 	TGRSIOptions* options = TGRSIOptions::Get();
 	if(fRunInfo == nullptr) {
 		fRunInfo = TRunInfo::Get();
@@ -295,4 +302,21 @@ Bool_t TGRSISelector::Notify()
 	/// user if needed. The return value is currently not used.
 
 	return kTRUE;
+}
+
+void TGRSISelector::CheckSizes(const char* usage)
+{
+	// check size of each object in the output list
+	for(const auto&& obj : *fOutput) {
+		TBufferFile b(TBuffer::kWrite, 10000);
+		TClass::GetClass(obj->ClassName())->WriteBuffer(b, obj);
+		if(b.Length() > SIZE_LIMIT) {
+			std::cout<<DRED<<obj->ClassName()<<" '"<<obj->GetName()<<"' too large to "<<usage<<": "<<b.Length()<<" bytes = "<<b.Length()/1024./1024./1024.<<" GB, removing it!"<<RESET_COLOR<<std::endl;
+			// we only remove it from the output list, not deleting the object itself
+			// this way the selector will still work and fill that histogram, it just won't get written to file
+			fOutput->Remove(obj);
+		//} else {
+			//std::cout<<GREEN<<obj->ClassName()<<" '"<<obj->GetName()<<"' okay to "<<usage<<": "<<b.Length()<<" bytes = "<<b.Length()/1024./1024./1024.<<" GB"<<RESET_COLOR<<std::endl;
+		}
+	}
 }


### PR DESCRIPTION
This issue came up again in #1252. We now check the size of objects after they have been created (this aims mostly for histograms), after the worker is done (first check for trees), and before trying to write them (final check for trees).
Objects that are too big are removed from the output list (and then no longer processed for sending and writing them), but not deleted. This means the selector will continue to fill the large histogram without issues (and use the memory for it!), the histogram will just not be written.