### PR TITLE
Added threadsafe streaming operator to detector and detector hit classes

### DIFF
--- a/include/TCalGraph.h
+++ b/include/TCalGraph.h
@@ -35,6 +35,9 @@ public:
 
    TCalGraph(const TCalGraph& copy);
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,24,0)
+	using TGraph::AddPoint;
+#endif
    void AddPoint(const TCalPoint& cal_point);
    Int_t FindClosestPointX(const Double_t& x_val);
    Double_t FindDistToClosestPointX(const Double_t& x_val);

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -57,10 +57,16 @@ public:
    void Clear(Option_t* = "") override { fHits.clear(); } //!<!
    virtual void ClearTransients();                            //!<!
    void Print(Option_t* opt = "") const override;             //!<!
+	virtual void Print(std::ostream& out) const;
 
 	virtual Short_t GetMultiplicity() const { return fHits.size(); }
 	virtual TDetectorHit* GetHit(const int&) const;
 	virtual const std::vector<TDetectorHit*>& GetHitVector() const { return fHits; }
+
+	friend std::ostream& operator<<(std::ostream& out, const TDetector& det) {
+		det.Print(out);
+		return out;
+	}
 
 protected:
 	std::vector<TDetectorHit*> fHits;

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -135,7 +135,7 @@ public:
       return fTime;
    }
 
-   virtual TVector3 GetPosition(Double_t) const { return TVector3(0., 0., 0.); } //!<!
+   virtual TVector3 GetPosition(Double_t) const { return GetPosition(); } //!<!
    virtual TVector3 GetPosition() const { return TVector3(0., 0., 0.); }         //!<!
    virtual double GetEnergy(Option_t* opt = "") const;
 	virtual Double_t GetEnergyNonlinearity(double energy) const;

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -99,6 +99,11 @@ public:
    void Clear(Option_t* opt = "") override;          //!<!
    virtual void ClearTransients() const { fBitFlags = 0; }
    void Print(Option_t* opt = "") const override;                                 //!<!
+	virtual void Print(std::ostream& out) const;
+	friend std::ostream& operator<<(std::ostream& out, const TDetectorHit& hit) {
+		hit.Print(out);
+		return out;
+	}
    virtual bool HasWave() const { return (fWaveform.size() > 0); } //!<!
 
    static bool CompareEnergy(TDetectorHit* lhs, TDetectorHit* rhs);

--- a/include/TEfficiencyCal.h
+++ b/include/TEfficiencyCal.h
@@ -19,6 +19,9 @@ public:
 
 public:
    void Copy(TObject& obj) const override;
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,24,0)
+	using TGraph::AddPoint;
+#endif
    void AddPoint(Double_t energy, Double_t area, Double_t dEnergy = 0.0, Double_t dArea = 0.0);
    void AddPoint(TPeak* peak);
 

--- a/include/TEfficiencyGraph.h
+++ b/include/TEfficiencyGraph.h
@@ -41,7 +41,9 @@ public:
    void Print(Option_t* opt = "") const override;
    void Clear(Option_t* opt = "") override;
 
-   void Scale(const Double_t& scale);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
+	void Scale(const double& scale);
+#endif
    void SetAbsolute(const bool& flag) { fIsAbsolute = flag; }
    bool                         IsAbsolute() const { return fIsAbsolute; }
 

--- a/include/TEnergyCal.h
+++ b/include/TEnergyCal.h
@@ -30,6 +30,9 @@ public:
 	Double_t GetParameter(size_t parameter) const override;
 	void WriteToChannel() const override;
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,24,0)
+	using TGraph::AddPoint;
+#endif
 	void AddPoint(Double_t measured, Double_t accepted, Double_t measuredUncertainty = 0.0,
 			Double_t acceptedUncertainty = 0.0);
 	using TGraphErrors::SetPoint;

--- a/include/TFragment.h
+++ b/include/TFragment.h
@@ -30,7 +30,7 @@ class TFragment : public TDetectorHit {
 public:
    TFragment();
    TFragment(const TFragment&);
-   ~TFragment() override;
+   ~TFragment();
 
 	TFragment& operator=(const TFragment&) = default; // use default assignment operator (to shut up gcc 9.1)
 
@@ -102,6 +102,8 @@ public:
 
    void Clear(Option_t* opt = "") override;
    void Print(Option_t* opt = "") const override;
+
+	virtual void Print(std::ostream& out) const override;
 
    TObject* Clone(const char* name = "") const override;
 

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -44,7 +44,7 @@ public:
 
 	// static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
 
-	static const char* SortName(const char* name);
+	static std::string SortName(const char* name);
 	// void SetName(const char *name) { fName = name; }
 	void SetZ(int);              // Sets the Z (# of protons) of the nucleus
 	void SetN(int);              // Sets the N (# of neutrons) of the nucleus

--- a/libraries/GROOT/GHSym.cxx
+++ b/libraries/GROOT/GHSym.cxx
@@ -1905,7 +1905,6 @@ TProfile* GHSym::Profile(const char* name, Int_t firstbin, Int_t lastbin, Option
 
    // Fill the profile histogram
    // no entries/bin is available so can fill only using bin content as weight
-   Double_t totcont  = 0;
    TArrayD& binSumw2 = *(h1->GetBinSumw2());
 
    // implement filling of projected histogram
@@ -1946,7 +1945,6 @@ TProfile* GHSym::Profile(const char* name, Int_t firstbin, Int_t lastbin, Option
             if(useWeights) {
                binSumw2.fArray[binOut] = tmp + fSumw2.fArray[bin];
             }
-            totcont += cxy;
          }
       }
    }

--- a/libraries/TAnalysis/TCal/TEfficiencyGraph.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyGraph.cxx
@@ -53,6 +53,7 @@ void TEfficiencyGraph::BuildGraph()
    }
 }
 
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,26,0)
 void TEfficiencyGraph::Scale(const Double_t& scale)
 {
    for(auto& it : fCompareMap) {
@@ -64,3 +65,4 @@ void TEfficiencyGraph::Scale(const Double_t& scale)
       GetEY()[i] *= scale;
    }
 }
+#endif

--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -46,8 +46,18 @@ void TDetector::Copy(TObject& rhs) const
 
 void TDetector::Print(Option_t*) const
 {
-   /// Default print statement for TDetector. Currently does
-   /// nothing
+   /// Default print statement for TDetector.
+	Print(std::cout);
+}
+
+void TDetector::Print(std::ostream& out) const
+{
+	/// Print detector to stream out. Iterates over hits and prints them.
+	std::ostringstream str;
+	for(auto hit : fHits) {
+		hit->Print(str);
+	}
+	out<<str.str();
 }
 
 void TDetector::ClearTransients()

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -147,13 +147,20 @@ void TDetectorHit::Copy(TObject& rhs, bool copywave) const
 void TDetectorHit::Print(Option_t*) const
 {
    /// General print statement for a TDetectorHit.
-   /// Currently prints nothing.
-	std::cout<<"==== "<<ClassName()<<" @ "<<this<<" ===="<<std::endl;
-	std::cout<<"\t"<<GetName()<<std::endl;
-	std::cout<<"\tCharge:    "<<Charge()<<std::endl;
-	std::cout<<"\tTime:      "<<GetTime()<<std::endl;
-	std::cout<<"\tTimestamp: "<<GetTimeStamp()<<" in "<<GetTimeStampUnit()<<" ns = "<<GetTimeStampNs()<<std::endl;
-	std::cout<<"============================"<<std::endl;
+	Print(std::cout);
+}
+
+void TDetectorHit::Print(std::ostream& out) const
+{
+	/// Print detector hit to stream out.
+	std::ostringstream str;
+	str<<"==== "<<ClassName()<<" @ "<<this<<" ===="<<std::endl;
+	str<<"\t"<<GetName()<<std::endl;
+	str<<"\tCharge:    "<<Charge()<<std::endl;
+	str<<"\tTime:      "<<GetTime()<<std::endl;
+	str<<"\tTimestamp: "<<GetTimeStamp()<<" in "<<GetTimeStampUnit()<<" ns = "<<GetTimeStampNs()<<std::endl;
+	str<<"============================"<<std::endl;
+	out<<str.str();
 }
 
 const char* TDetectorHit::GetName() const

--- a/libraries/TAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TAnalysis/TNucleus/TNucleus.cxx
@@ -176,7 +176,7 @@ TNucleus::~TNucleus()
 	fTransitionList.Delete();
 }
 
-const char* TNucleus::SortName(const char* name)
+std::string TNucleus::SortName(const char* name)
 {
 	// Names a nucleus based on symbol (ex. 26Na OR Na26). This is to get a nice naming convention.
 	std::string Name = name;
@@ -222,7 +222,7 @@ const char* TNucleus::SortName(const char* name)
 	element.append(std::to_string(static_cast<long long>(Number)));
 	element.append(symbol);
 
-	return element.c_str();
+	return element;
 }
 
 void TNucleus::SetZ(int charge)

--- a/libraries/TFormat/TFragment.cxx
+++ b/libraries/TFormat/TFragment.cxx
@@ -146,36 +146,34 @@ TPPG* TFragment::GetPPG()
 void TFragment::Print(Option_t*) const
 {
    /// Prints out all fields of the TFragment
+	Print(std::cout);
+}
 
-   TChannel* chan = GetChannel();
-   char      buff[20];
-   ctime(&fDaqTimeStamp);
-   struct tm* timeinfo = localtime(&fDaqTimeStamp);
-   strftime(buff, 20, "%b %d %H:%M:%S", timeinfo);
-   std::cout<<"DaqTimeStamp: "<<buff<<std::endl;
-   std::cout<<"DaqId      "<<fDaqId<<std::endl;
-   std::cout<<"\tTriggerId["<<fTriggerId.size()<<"]	"<<std::endl;
-   for(long x : fTriggerId) {
-      std::cout<<"     "<<hex(x,8)<<std::endl;
-   }
-   std::cout<<"\n"<<std::endl;
-   std::cout<<"FragmentId:          "<<fFragmentId<<std::endl;
-   std::cout<<"TriggerBit:          "<<hex(fTriggerBitPattern,8)<<std::endl;
-   std::cout<<"NetworkPacketNumber: "<<fNetworkPacketNumber<<std::endl;
-   if(chan != nullptr) {
-      std::cout<<"Channel: "<<chan->GetNumber()<<"\tName: "<<chan->GetName()<<std::endl;
-      std::cout<<"\tChannel Num:    "<<GetChannelNumber()<<std::endl;
-   }
-   std::cout<<"\tChannel Address:   "<<hex(GetAddress(),8)<<std::endl;
-   std::cout<<"\tCharge:            "<<hex(static_cast<Int_t>(GetCharge()),8)<<std::endl;
-   std::cout<<"\tCFD:               "<<hex(static_cast<Int_t>(GetCfd()),8)<<std::endl;
-   std::cout<<"\tZC:                "<<hex(fZc,8)<<std::endl;
-   std::cout<<"\tTimeStamp:         "<<GetTimeStamp()<<std::endl;
-   if(HasWave()) {
-      std::cout<<"Has a wave form stored."<<std::endl;
-   } else {
-      std::cout<<"Does Not have a wave form stored."<<std::endl;
-   }
+void TFragment::Print(std::ostream& out) const
+{
+	/// Print fragment to stream out in a thread-safe way
+	std::ostringstream str;
+	str<<"DaqTimeStamp:        "<<ctime(&fDaqTimeStamp)<<std::endl
+		<<"DaqId:               "<<fDaqId<<std::endl
+		<<"\tTriggerId["<<fTriggerId.size()<<"]";
+	for(auto id : fTriggerId) {
+		str<<"    0x"<<std::hex<<id<<std::dec;
+	}
+	str<<std::endl
+		<<"FragmentId:           "<<fFragmentId<<std::endl
+		<<"TriggerBit:           0x"<<std::hex<<fTriggerBitPattern<<std::dec<<std::endl
+		<<"NetworkPacketNumber:  "<<fNetworkPacketNumber<<std::endl
+		<<"Channel Address:      0x"<<std::hex<<GetAddress()<<std::dec<<std::endl;
+	TChannel* channel = GetChannel();
+	if(channel != nullptr) {
+		str<<"Channel: "<<channel->GetNumber()<<"\t Name: "<<channel->GetName()<<std::endl;
+	}
+	str<<"Charge:               0x"<<std::hex<<static_cast<Int_t>(GetCharge())<<std::dec<<std::endl
+		<<"Cfd:                  0x"<<std::hex<<static_cast<Int_t>(GetCfd())<<std::dec<<std::endl
+		<<"ZC:                   0x"<<std::hex<<fZc<<std::dec<<std::endl
+		<<"TimeStamp:            "<<GetTimeStamp()<<std::endl
+		<<(HasWave()?"Has a wave form stored":"Doesn't have a wave form stored")<<std::endl;
+	out<<str.str();
 }
 
 bool TFragment::IsDetector(const char* prefix, Option_t* opt) const


### PR DESCRIPTION
The streaming operator calls a Print(std::ostream&) function that does the actual printing. This function can and should be overloaded by each child class. Since the streaming operator does not know about options, the Print function does not take any options either at the moment. If we want to have options again, we could change it so that the streaming operator simply uses an empty options string.


Changes to suppress compilation warnings:
- Removed unused variable in GHSym.
- Added conditions for ROOT versions 6.24 and 6.26 to use TGraph::Scale and TGraph::AddPoint.
- Changed TNucleus::SortName to return std::string instead of const char* as the latter was just a dangling pointer to deleted memory. Doesn't look like this function is used anywhere anyways?

Changed TDetectorHit::GetPosition(Double_t) to simply return TDetectorHit::GetPosition() instead of a copy of the code of that function.