### PR TITLE
Bug fixes and small improvements

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -111,6 +111,8 @@ void AtExitHandler()
 
 			std::string firstMacro;
 			if(!gGRSIOpt->MacroInputFiles().empty()) firstMacro = gGRSIOpt->MacroInputFiles().at(0);
+			firstMacro = basename(firstMacro.c_str()); // remove path
+			firstMacro = firstMacro.substr(0, firstMacro.find_last_of('.')); // remove extension
 
 			if(runNumber != 0 && subRunNumber != -1) {
 				// both run and subrun number set => single file processed
@@ -202,7 +204,7 @@ int main(int argc, char** argv)
 		} else {
 			std::cout<<"Warning, expected dataparser/detector library location to be of form <path>/lib/lib<name>.so, but it is "<<library<<". Won't be able to add include path!"<<std::endl;
 		}
-		gSystem->Load(library.c_str());
+		// no need to load the parser library, that is already taken care of by TGRSIProof class
 	} else {
 		std::cout<<"Warning, no dataparser/detector library provided, won't be able to add include path!"<<std::endl;
 	}
@@ -214,7 +216,7 @@ int main(int argc, char** argv)
 	std::cout<<DCYAN<<"************************* MACRO COMPILATION ****************************"<<RESET_COLOR
 		<<std::endl;
 	for(const auto& i : gGRSIOpt->MacroInputFiles()) {
-		Int_t error_code = gSystem->CompileMacro(i.c_str(), "kgO"); // k - keep shared library after session ends, g - add debuging symbols, O - optimize the code, v - verbose output
+		Int_t error_code = gSystem->CompileMacro(i.c_str(), "kgOs"); // k - keep shared library after session ends, g - add debuging symbols, O - optimize the code, s - silent, v - verbose output
 		if(error_code == 0) {
 			std::cout<<DRED<<i<<" failed to compile properly.. ABORT!"<<RESET_COLOR<<std::endl;
 			return 1;

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -105,8 +105,26 @@ void AtExitHandler()
 		std::cout<<"getting session logs ..."<<std::endl;
 		TProofLog* pl = TProof::Mgr("proof://__lite__")->GetSessionLogs();
 		if(pl != nullptr) {
-			pl->Save("*", gGRSIOpt->LogFile().c_str());
-			std::cout<<"Wrote logs to '"<<gGRSIOpt->LogFile()<<"'"<<std::endl;
+			TRunInfo* runInfo = TRunInfo::Get();
+			Int_t runNumber    = runInfo->RunNumber();
+			Int_t subRunNumber = runInfo->SubRunNumber();
+
+			std::string firstMacro;
+			if(!gGRSIOpt->MacroInputFiles().empty()) firstMacro = gGRSIOpt->MacroInputFiles().at(0);
+
+			if(runNumber != 0 && subRunNumber != -1) {
+				// both run and subrun number set => single file processed
+				pl->Save("*", Form("%s%05d_%03d.log", firstMacro.c_str(), runNumber, subRunNumber));
+				std::cout<<"Wrote logs to '"<<Form("%s%05d_%03d.log", firstMacro.c_str(), runNumber, subRunNumber)<<"'"<<std::endl;
+			} else if(runNumber != 0) {
+				// multiple subruns of a single run
+				pl->Save("*", Form("%s%05d_%03d-%03d.log", firstMacro.c_str(), runNumber, runInfo->FirstSubRunNumber(), runInfo->LastSubRunNumber()));
+				std::cout<<"Wrote logs to '"<<Form("%s%05d_%03d-%03d.log", firstMacro.c_str(), runNumber, runInfo->FirstSubRunNumber(), runInfo->LastSubRunNumber())<<"'"<<std::endl;
+			} else {
+				// multiple runs
+				pl->Save("*", Form("%s%05d-%05d.log", firstMacro.c_str(), runInfo->FirstRunNumber(), runInfo->LastRunNumber()));
+				std::cout<<"Wrote logs to '"<<Form("%s%05d-%05d.log", firstMacro.c_str(), runInfo->FirstRunNumber(), runInfo->LastRunNumber())<<"'"<<std::endl;
+			}
 		} else {
 			std::cout<<"Failed to get logs!"<<std::endl;
 		}
@@ -114,17 +132,17 @@ void AtExitHandler()
 		std::cout<<"stopping all workers ..."<<std::endl;
 		gGRSIProof->StopProcess(true);
 	}
-	
+
 	// print time it took to run grsiproof
-   double realTime = gStopwatch->RealTime();
-   int    hour     = static_cast<int>(realTime / 3600);
-   realTime -= hour * 3600;
-   int min = static_cast<int>(realTime / 60);
-   realTime -= min * 60;
-   std::cout<<DMAGENTA<<std::endl
-            <<"Done after "<<hour<<":"<<std::setfill('0')<<std::setw(2)<<min<<":"
-				<<std::setprecision(3)<<std::fixed<<realTime<<" h:m:s"
-				<<RESET_COLOR<<std::endl;
+	double realTime = gStopwatch->RealTime();
+	int    hour     = static_cast<int>(realTime / 3600);
+	realTime -= hour * 3600;
+	int min = static_cast<int>(realTime / 60);
+	realTime -= min * 60;
+	std::cout<<DMAGENTA<<std::endl
+		<<"Done after "<<hour<<":"<<std::setfill('0')<<std::setw(2)<<min<<":"
+		<<std::setprecision(3)<<std::fixed<<realTime<<" h:m:s"
+		<<RESET_COLOR<<std::endl;
 }
 
 void HandleSignal(int)
@@ -146,20 +164,20 @@ static void CatchSignals()
 
 void SetGRSIEnv()
 {
-   std::string grsi_path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
-   if(grsi_path.length() > 0) {
-      grsi_path += "/";
-   }
-   // Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
-   grsi_path += ".grsirc";
-   gEnv->ReadFile(grsi_path.c_str(), kEnvChange);
+	std::string grsi_path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
+	if(grsi_path.length() > 0) {
+		grsi_path += "/";
+	}
+	// Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
+	grsi_path += ".grsirc";
+	gEnv->ReadFile(grsi_path.c_str(), kEnvChange);
 }
 
 int main(int argc, char** argv)
 {
 	gStopwatch = new TStopwatch;
 	try {
-      SetGRSIEnv();
+		SetGRSIEnv();
 		gGRSIOpt = TGRSIOptions::Get(argc, argv);
 		if(gGRSIOpt->ShouldExit()) {
 			return 0;
@@ -172,9 +190,9 @@ int main(int argc, char** argv)
 	std::atexit(AtExitHandler);
 	CatchSignals();
 
-   // Add the path were we store headers for GRSIProof macros to see
-   const char* pPath = getenv("GRSISYS");
-   gInterpreter->AddIncludePath(Form("%s/include", pPath));
+	// Add the path were we store headers for GRSIProof macros to see
+	const char* pPath = getenv("GRSISYS");
+	gInterpreter->AddIncludePath(Form("%s/include", pPath));
 	// if we have a data parser/detector library, add it's include path as well
 	std::string library = gGRSIOpt->ParserLibrary();
 	if(!library.empty()) {
@@ -188,40 +206,40 @@ int main(int argc, char** argv)
 	} else {
 		std::cout<<"Warning, no dataparser/detector library provided, won't be able to add include path!"<<std::endl;
 	}
-   // The first thing we want to do is see if we can compile the macros that are passed to us
-   if(gGRSIOpt->MacroInputFiles().empty()) {
-      std::cout<<DRED<<"Can't PROOF if there is no MACRO"<<RESET_COLOR<<std::endl;
-      return 1;
-   }
-   std::cout<<DCYAN<<"************************* MACRO COMPILATION ****************************"<<RESET_COLOR
-            <<std::endl;
-   for(const auto& i : gGRSIOpt->MacroInputFiles()) {
-      Int_t error_code = gSystem->CompileMacro(i.c_str(), "kgO"); // k - keep shared library after session ends, g - add debuging symbols, O - optimize the code, v - verbose output
-      if(error_code == 0) {
-         std::cout<<DRED<<i<<" failed to compile properly.. ABORT!"<<RESET_COLOR<<std::endl;
-         return 1;
-      }
-   }
-   std::cout<<DCYAN<<"************************* END COMPILATION ******************************"<<RESET_COLOR
-            <<std::endl;
+	// The first thing we want to do is see if we can compile the macros that are passed to us
+	if(gGRSIOpt->MacroInputFiles().empty()) {
+		std::cout<<DRED<<"Can't PROOF if there is no MACRO"<<RESET_COLOR<<std::endl;
+		return 1;
+	}
+	std::cout<<DCYAN<<"************************* MACRO COMPILATION ****************************"<<RESET_COLOR
+		<<std::endl;
+	for(const auto& i : gGRSIOpt->MacroInputFiles()) {
+		Int_t error_code = gSystem->CompileMacro(i.c_str(), "kgO"); // k - keep shared library after session ends, g - add debuging symbols, O - optimize the code, v - verbose output
+		if(error_code == 0) {
+			std::cout<<DRED<<i<<" failed to compile properly.. ABORT!"<<RESET_COLOR<<std::endl;
+			return 1;
+		}
+	}
+	std::cout<<DCYAN<<"************************* END COMPILATION ******************************"<<RESET_COLOR
+		<<std::endl;
 
-   if(!gGRSIOpt->InputFiles().empty()) {
-      std::cout<<DRED<<"Can't Proof a Midas file..."<<RESET_COLOR<<std::endl;
-   }
+	if(!gGRSIOpt->InputFiles().empty()) {
+		std::cout<<DRED<<"Can't Proof a Midas file..."<<RESET_COLOR<<std::endl;
+	}
 
-   // The first thing we do is get the PROOF Lite instance to run
-   if(gGRSIOpt->GetMaxWorkers() >= 0) {
-      std::cout<<"Opening proof with '"<<Form("workers=%d", gGRSIOpt->GetMaxWorkers())<<"'"<<std::endl;
-      gGRSIProof = TGRSIProof::Open(Form("workers=%d", gGRSIOpt->GetMaxWorkers()));
-   } else if(gGRSIOpt->SelectorOnly()) {
-      std::cout<<"Opening proof with one worker (selector-only)"<<std::endl;
-      gGRSIProof = TGRSIProof::Open("workers=1");
-   } else {
-      gGRSIProof = TGRSIProof::Open("");
-   }
+	// The first thing we do is get the PROOF Lite instance to run
+	if(gGRSIOpt->GetMaxWorkers() >= 0) {
+		std::cout<<"Opening proof with '"<<Form("workers=%d", gGRSIOpt->GetMaxWorkers())<<"'"<<std::endl;
+		gGRSIProof = TGRSIProof::Open(Form("workers=%d", gGRSIOpt->GetMaxWorkers()));
+	} else if(gGRSIOpt->SelectorOnly()) {
+		std::cout<<"Opening proof with one worker (selector-only)"<<std::endl;
+		gGRSIProof = TGRSIProof::Open("workers=1");
+	} else {
+		gGRSIProof = TGRSIProof::Open("");
+	}
 
-   if(gGRSIProof == nullptr) {
-      std::cout<<"Couldn't connect to proof on first attempt, trying again"<<std::endl;
+	if(gGRSIProof == nullptr) {
+		std::cout<<"Couldn't connect to proof on first attempt, trying again"<<std::endl;
 		if(gGRSIOpt->GetMaxWorkers() >= 0) {
 			std::cout<<"Opening proof with '"<<Form("workers=%d", gGRSIOpt->GetMaxWorkers())<<"'"<<std::endl;
 			gGRSIProof = TGRSIProof::Open(Form("workers=%d", gGRSIOpt->GetMaxWorkers()));
@@ -231,40 +249,40 @@ int main(int argc, char** argv)
 		} else {
 			gGRSIProof = TGRSIProof::Open("");
 		}
-   }
+	}
 
-   if(gGRSIProof == nullptr) {
-      std::cout<<"Still can't connect to proof, try running it again?"<<std::endl;
-      return 0;
-   }
+	if(gGRSIProof == nullptr) {
+		std::cout<<"Still can't connect to proof, try running it again?"<<std::endl;
+		return 0;
+	}
 
 	startedProof = true;
 
-   gGRSIProof->SetBit(TProof::kUsingSessionGui);
-   gGRSIProof->AddEnvVar("GRSISYS", pPath);
-   gInterpreter->AddIncludePath(Form("%s/include", pPath));
-   gGRSIProof->AddIncludePath(Form("%s/include", pPath));
-   gGRSIProof->AddDynamicPath(Form("%s/lib", pPath));
+	gGRSIProof->SetBit(TProof::kUsingSessionGui);
+	gGRSIProof->AddEnvVar("GRSISYS", pPath);
+	gInterpreter->AddIncludePath(Form("%s/include", pPath));
+	gGRSIProof->AddIncludePath(Form("%s/include", pPath));
+	gGRSIProof->AddDynamicPath(Form("%s/lib", pPath));
 
-   gGRSIProof->AddInput(gGRSIOpt->AnalysisOptions());
-   gGRSIProof->AddInput(new TNamed("pwd", getenv("PWD")));
-   int i = 0;
-   for(const auto& valFile : gGRSIOpt->ValInputFiles()) {
-      gGRSIProof->AddInput(new TNamed(Form("valFile%d", i++), valFile.c_str()));
-   }
-   i = 0;
-   for(const auto& calFile : gGRSIOpt->CalInputFiles()) {
-      gGRSIProof->AddInput(new TNamed(Form("calFile%d", i++), calFile.c_str()));
-   }
-   i = 0;
-   for(const auto& cutFile : gGRSIOpt->InputCutFiles()) {
-      gGRSIProof->AddInput(new TNamed(Form("cutFile%d", i++), cutFile.c_str()));
-   }
+	gGRSIProof->AddInput(gGRSIOpt->AnalysisOptions());
+	gGRSIProof->AddInput(new TNamed("pwd", getenv("PWD")));
+	int i = 0;
+	for(const auto& valFile : gGRSIOpt->ValInputFiles()) {
+		gGRSIProof->AddInput(new TNamed(Form("valFile%d", i++), valFile.c_str()));
+	}
+	i = 0;
+	for(const auto& calFile : gGRSIOpt->CalInputFiles()) {
+		gGRSIProof->AddInput(new TNamed(Form("calFile%d", i++), calFile.c_str()));
+	}
+	i = 0;
+	for(const auto& cutFile : gGRSIOpt->InputCutFiles()) {
+		gGRSIProof->AddInput(new TNamed(Form("cutFile%d", i++), cutFile.c_str()));
+	}
 	gGRSIProof->AddInput(new TNamed("ParserLibrary", library.c_str()));
 
-   Analyze("FragmentTree");
-   Analyze("AnalysisTree");
-   Analyze("Lst2RootTree");
+	Analyze("FragmentTree");
+	Analyze("AnalysisTree");
+	Analyze("Lst2RootTree");
 
 	AtExitHandler();
 

--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -25,7 +25,6 @@ public:
    TBgo(const TBgo&);
    virtual ~TBgo();
 
-public:
    TBgoHit* GetBgoHit(const Int_t& i) { return static_cast<TBgoHit*>(GetHit(i)); }
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0); //!<!
@@ -43,6 +42,7 @@ public:
    virtual void Copy(TObject&) const override;            //!<!
    virtual void Clear(Option_t* opt = "all") override;    //!<!
    virtual void Print(Option_t* opt = "") const override; //!<!
+	virtual void Print(std::ostream& out) const override;  //!<!
 
    /// \cond CLASSIMP
    ClassDefOverride(TBgo, 1) // Bgo Physics structure

--- a/include/TBgoHit.h
+++ b/include/TBgoHit.h
@@ -31,10 +31,11 @@ public:
    /////////////////////////		/////////////////////////////////////
    inline UShort_t GetArrayNumber() const override { return (20 * (GetDetector() - 1) + 5 * GetCrystal() + GetSegment()); } //!<!
 
-   virtual void Copy(TObject&) const override;            //!<!
-   virtual void Clear(Option_t* opt = "all") override;    //!<!
-   virtual void Print(Option_t* opt = "") const override; //!<!
-	virtual void Print(std::ostream& out) const override;  //!<!
+	using TObject::Copy;
+   virtual void Copy(TObject&, bool copywave) const override; //!<!
+   virtual void Clear(Option_t* opt = "all") override;        //!<!
+   virtual void Print(Option_t* opt = "") const override;     //!<!
+	virtual void Print(std::ostream& out) const override;      //!<!
 
    /// \cond CLASSIMP
    ClassDefOverride(TBgoHit, 1)

--- a/include/TBgoHit.h
+++ b/include/TBgoHit.h
@@ -31,6 +31,11 @@ public:
    /////////////////////////		/////////////////////////////////////
    inline UShort_t GetArrayNumber() const override { return (20 * (GetDetector() - 1) + 5 * GetCrystal() + GetSegment()); } //!<!
 
+   virtual void Copy(TObject&) const override;            //!<!
+   virtual void Clear(Option_t* opt = "all") override;    //!<!
+   virtual void Print(Option_t* opt = "") const override; //!<!
+	virtual void Print(std::ostream& out) const override;  //!<!
+
    /// \cond CLASSIMP
    ClassDefOverride(TBgoHit, 1)
    /// \endcond

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -106,6 +106,7 @@ public:
    Long64_t GetTimeStamp() const { return fTimeStamp; }
 
 private:
+	static short       fTimestampUnits; ///< timestamp units of the PPG (10 ns)
    ULong64_t   fTimeStamp; ///< time stamp in ns
    EPpgPattern fOldPpg;
    EPpgPattern fNewPpg;
@@ -178,7 +179,6 @@ public:
    }
 
 private:
-	static short       fTimestampUnits; ///< timestamp units of the PPG (10 ns)
    static TPPG*       fPPG; ///< static pointer to TPPG
    PPGMap_t::iterator MapBegin() const { return ++(fPPGStatusMap->begin()); }
    PPGMap_t::iterator MapEnd() const { return fPPGStatusMap->end(); }

--- a/include/TSingleton.h
+++ b/include/TSingleton.h
@@ -31,7 +31,7 @@ template <class T>
 class TSingleton : public TObject
 {
 public:
-	static T* Get()
+	static T* Get(bool verbose = false)
 	{
 		// if we don't have an instance yet or changed into another directory
 		// we want to read from the current directory
@@ -39,7 +39,7 @@ public:
 			if((gDirectory->GetFile()) != nullptr) {
 				TList* list = gDirectory->GetFile()->GetListOfKeys();
 				TIter  iter(list);
-				std::cout<<"Reading "<<T::Class()->GetName()<<R"( from file ")"<<CYAN<<gDirectory->GetFile()->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
+				if(verbose) std::cout<<"Reading "<<T::Class()->GetName()<<R"( from file ")"<<CYAN<<gDirectory->GetFile()->GetName()<<RESET_COLOR<<R"(")"<<std::endl;
 				while(TKey* key = static_cast<TKey*>(iter.Next())) {
 					if(strcmp(key->GetClassName(), T::Class()->GetName()) != 0) {
 						continue;
@@ -48,6 +48,7 @@ public:
 					// this automatically deletes the old singleton if we just switched files
 					Set(static_cast<T*>(key->ReadObj()));
 					fDir = gDirectory; // in either case (read from file or created new), gDirectory is the current directory
+					break; // we will find the newest key first, so we want to break here and not try and read other instaces of the same class
 				}
 			}
 			if(fSingleton == nullptr) {

--- a/include/TSortingDiagnostics.h
+++ b/include/TSortingDiagnostics.h
@@ -74,7 +74,7 @@ public:
    void Draw(Option_t* opt = "") override;
 
    /// \cond CLASSIMP
-   ClassDefOverride(TSortingDiagnostics, 3);
+   ClassDefOverride(TSortingDiagnostics, 4);
    /// \endcond
 };
 /*! @} */

--- a/libraries/TAnalysis/TBgo/TBgo.cxx
+++ b/libraries/TAnalysis/TBgo/TBgo.cxx
@@ -124,8 +124,15 @@ void TBgo::Clear(Option_t* opt)
 
 void TBgo::Print(Option_t*) const
 {
-   std::cout<<"Bgo Contains: "<<std::endl;
-   std::cout<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
+	Print(std::cout);
+}
+
+void TBgo::Print(std::ostream& out) const
+{
+	std::ostringstream str;
+   str<<"Bgo Contains: "<<std::endl;
+   str<<std::setw(6)<<GetMultiplicity()<<" hits"<<std::endl;
+	out<<str.str();
 }
 
 TBgo& TBgo::operator=(const TBgo& rhs)

--- a/libraries/TAnalysis/TBgo/TBgoHit.cxx
+++ b/libraries/TAnalysis/TBgo/TBgoHit.cxx
@@ -19,3 +19,25 @@ TBgoHit::TBgoHit(const TBgoHit& rhs) : TDetectorHit()
 {
    rhs.Copy(*this);
 }
+
+void TBgoHit::Copy(TObject& rhs) const
+{
+   // Copy function.
+   TDetectorHit::Copy(rhs);
+}
+
+void TBgoHit::Clear(Option_t* opt)
+{
+   /// Clears the mother, and all of the hits
+   TDetectorHit::Clear(opt);
+}
+
+void TBgoHit::Print(Option_t*) const
+{
+	Print(std::cout);
+}
+
+void TBgoHit::Print(std::ostream& out) const
+{
+	TDetectorHit::Print(out);
+}

--- a/libraries/TAnalysis/TBgo/TBgoHit.cxx
+++ b/libraries/TAnalysis/TBgo/TBgoHit.cxx
@@ -17,13 +17,13 @@ TBgoHit::~TBgoHit() = default;
 
 TBgoHit::TBgoHit(const TBgoHit& rhs) : TDetectorHit()
 {
-   rhs.Copy(*this);
+   rhs.Copy(*this, true);
 }
 
-void TBgoHit::Copy(TObject& rhs) const
+void TBgoHit::Copy(TObject& rhs, bool copywave) const
 {
    // Copy function.
-   TDetectorHit::Copy(rhs);
+   TDetectorHit::Copy(rhs, copywave);
 }
 
 void TBgoHit::Clear(Option_t* opt)

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -349,7 +349,9 @@ TChannel* TChannel::GetChannel(unsigned int temp_address, bool warn)
 		if(fMissingChannelMap->find(temp_address) == fMissingChannelMap->end()) {
 			// if there are threads running we're not in interactive mode, so we print a warning about sorting
 			if(StoppableThread::AnyThreadRunning()) {
-				std::cerr<<RED<<"Failed to find channel for address "<<hex(temp_address,4)<<", this channel won't get sorted properly!"<<RESET_COLOR<<std::endl;
+				std::ostringstream str;
+				str<<RED<<"Failed to find channel for address "<<hex(temp_address,4)<<", this channel won't get sorted properly!"<<RESET_COLOR<<std::endl;
+				std::cerr<<str.str();
 			}
 			fMissingChannelMap->insert(std::pair<unsigned int, int>(temp_address, 0));
 		}

--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -74,41 +74,43 @@ TRunInfo::~TRunInfo() = default;
 
 void TRunInfo::Print(Option_t* opt) const
 {
-   // Prints the TRunInfo. Options:
-   // a: Print out more details.
+   /// Prints the TRunInfo. Options:
+   /// a: Print out more details (array position and detector information).
 	TSingleton<TRunInfo>::PrintDirectory();
-   std::cout<<"Title: "<<RunTitle()<<std::endl;
-   std::cout<<"Comment: "<<RunComment()<<std::endl;
+	std::ostringstream str;
+   str<<"Title: "<<RunTitle()<<std::endl;
+   str<<"Comment: "<<RunComment()<<std::endl;
 	time_t tmpStart = static_cast<time_t>(RunStart());
 	time_t tmpStop  = static_cast<time_t>(RunStop());
 	struct tm runStart = *localtime(const_cast<const time_t*>(&tmpStart));
 	struct tm runStop  = *localtime(const_cast<const time_t*>(&tmpStop));
-	std::cout<<std::setfill('0');
+	str<<std::setfill('0');
 	if(RunNumber() != 0 && SubRunNumber() != -1) {
-		std::cout<<"\t\tRunNumber:          "<<std::setw(5)<<RunNumber()<<std::endl;
-		std::cout<<"\t\tSubRunNumber:       "<<std::setw(3)<<SubRunNumber()<<std::endl;
+		str<<"\t\tRunNumber:          "<<std::setw(5)<<RunNumber()<<std::endl;
+		str<<"\t\tSubRunNumber:       "<<std::setw(3)<<SubRunNumber()<<std::endl;
 	} else if(RunNumber() != 0) {
-		std::cout<<"\t\tRunNumber:          "<<std::setw(5)<<RunNumber()<<std::endl;
-		std::cout<<"\t\tSubRunNumbers:      "<<std::setw(3)<<FirstSubRunNumber()<<"-"<<std::setw(3)<<LastSubRunNumber()<<std::endl;
+		str<<"\t\tRunNumber:          "<<std::setw(5)<<RunNumber()<<std::endl;
+		str<<"\t\tSubRunNumbers:      "<<std::setw(3)<<FirstSubRunNumber()<<"-"<<std::setw(3)<<LastSubRunNumber()<<std::endl;
 	} else {
-		std::cout<<"\t\tRunNumbers:         "<<std::setw(5)<<FirstRunNumber()<<"-"<<std::setw(5)<<LastRunNumber()<<std::endl;
+		str<<"\t\tRunNumbers:         "<<std::setw(5)<<FirstRunNumber()<<"-"<<std::setw(5)<<LastRunNumber()<<std::endl;
 	}
-	std::cout<<std::setfill(' ');
+	str<<std::setfill(' ');
 	if(RunStart() != 0 && RunStop() != 0) {
-		std::cout<<"\t\tRunStart:           "<<asctime(&runStart)<<std::endl;
-		std::cout<<"\t\tRunStop:            "<<asctime(&runStop)<<std::endl;
-		std::cout<<"\t\tRunLength:          "<<RunLength()<<" s"<<std::endl;
+		str<<"\t\tRunStart:           "<<asctime(&runStart);
+		str<<"\t\tRunStop:            "<<asctime(&runStop);
+		str<<"\t\tRunLength:          "<<RunLength()<<" s"<<std::endl;
 	} else {
-		std::cout<<"\t\tCombined RunLength: "<<RunLength()<<" s"<<std::endl;
+		str<<"\t\tCombined RunLength: "<<RunLength()<<" s"<<std::endl;
 	}
    if(strchr(opt, 'a') != nullptr) {
-      std::cout<<std::endl;
-      std::cout<<"\t=============================="<<std::endl;
-      std::cout<<DBLUE "\t\tArray Position (mm) = "<<DRED<<TRunInfo::HPGeArrayPosition()<<RESET_COLOR<<std::endl;
+      str<<std::endl;
+      str<<"\t=============================="<<std::endl;
+      str<<DBLUE "\t\tArray Position (mm) = "<<DRED<<TRunInfo::HPGeArrayPosition()<<RESET_COLOR<<std::endl;
 		if(fDetectorInformation != nullptr) fDetectorInformation->Print(opt);
-		else std::cout<<"no detector information"<<std::endl;
-      std::cout<<"\t=============================="<<std::endl;
+		else str<<"no detector information"<<std::endl;
+      str<<"\t=============================="<<std::endl;
    }
+	std::cout<<str.str();
 }
 
 void TRunInfo::Clear(Option_t*)

--- a/libraries/TFormat/TSortingDiagnostics.cxx
+++ b/libraries/TFormat/TSortingDiagnostics.cxx
@@ -95,7 +95,7 @@ void TSortingDiagnostics::Print(Option_t* opt) const
 	if(!fMissingChannels.empty()) {
 		std::cout<<"Missing channels:"<<std::endl;
 		for(auto it : fMissingChannels) {
-			std::cout<<"0x"<<std::hex<<std::setfill('0')<<std::setw(4)<<it.first<<std::dec<<std::setfill(' ')<<": "<<it.second<<std::endl;
+			std::cout<<hex(it.first,4)<<": "<<it.second<<std::endl;
 		}
 	}
 	if(!fMissingDetectorClasses.empty()) {

--- a/libraries/TFormat/TSortingDiagnostics.cxx
+++ b/libraries/TFormat/TSortingDiagnostics.cxx
@@ -101,7 +101,7 @@ void TSortingDiagnostics::Print(Option_t* opt) const
 	if(!fMissingDetectorClasses.empty()) {
 		std::cout<<"Missing detector classes:"<<std::endl;
 		for(auto it : fMissingDetectorClasses) {
-			std::cout<<it.first->GetName()<<": "<<it.second<<std::endl;
+			std::cout<<(it.first == nullptr?"nullptr":it.first->GetName())<<": "<<it.second<<std::endl;
 		}
 	}
    std::string color;


### PR DESCRIPTION
- Added Print(std::ostream) to TBgo and TBgoHit and silenced warnings when compiling selectors from shadowed functions.
- Made TRunInfo::Print threadsafe and removed extra newlines after dates.
- Fixed some of the "class already in TClassTable" messages when running grsiproof.
- Fixed a bug in TPPG that caused it to fail to get the right cycle information from the TPPG events in the data.
- TSortingDiagnostics: fixed version number and added check for nullptr.
- TSingleton: fixed Get() in case of multiple keys (e.g. when updating a key), also made the function be quiet by default. Get(true) will get the old verbosity (printing the filename the current instance was read from).