### PR TITLE
New program to set ODB cycle information from PPG data

### DIFF
--- a/util/SetOdbFromData.cxx
+++ b/util/SetOdbFromData.cxx
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <iomanip>
+
+#include "TFile.h"
+
+#include "Globals.h"
+#include "TPPG.h"
+
+int main(int argc, char** argv)
+{
+	if(argc == 1) {
+		std::cerr<<"Usage: "<<argv[0]<<" <list of files>"<<std::endl;
+		return 1;
+	}
+
+	// loop over all file names provided
+	for(int i = 1; i < argc; ++i) {
+		// open file
+		TFile f(argv[i], "update");
+		if(!f.IsOpen()) {
+			std::cerr<<DYELLOW<<"Failed to open file "<<argv[i]<<RESET_COLOR<<std::endl;
+			continue;
+		}
+
+		// get TPPG
+		TPPG* ppg = static_cast<TPPG*>(f.Get("TPPG"));
+		if(ppg == nullptr) {
+			std::cerr<<DRED<<"Failed to find TPPG in "<<argv[i]<<" maybe this is a source run?"<<RESET_COLOR<<std::endl;
+			f.Close();
+			continue;
+		}
+
+		// check if ODB matches data, if so we're done
+		if(ppg->OdbMatchesData()) {
+			std::cout<<BLUE<<argv[i]<<": ODB already matches data, skipping it."<<RESET_COLOR<<std::endl;
+			f.Close();
+			continue;
+		}
+
+		// check if ODB is empty
+		if(ppg->MapIsEmpty()) {
+			std::cout<<DBLUE<<argv[i]<<": PPG is empty, probably a source run, skipping it."<<RESET_COLOR<<std::endl;
+			f.Close();
+			continue;
+		}
+
+		// set odb from data
+		ppg->SetOdbFromData();
+
+		// check that odb matches data, otherwise we have a problem
+		if(!ppg->OdbMatchesData()) {
+			std::cerr<<RED<<"ODB doesn't match data after we set it from the data!? Please check file "<<RESET_COLOR<<argv[i]<<std::endl;
+			ppg->Print();
+			f.Close();
+			continue;
+		}
+
+		// write ppg and close file
+		std::cout<<GREEN<<argv[i]<<" writing ODB set from data:"<<RESET_COLOR<<std::endl;
+		ppg->Write();
+		f.Close();
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This program takes any root file with a TPPG saved in it (e.g. fragment,
analysis, or selector output files), and try to set the ODB cycle
information from the PPG data.

If the ODB information in TPPG already matches the PPG data the program
won't do anything, otherwise it will try to determine the durations of
the stages of the cycle from the PPG data and write the updated TPPG to
file.

There are different colors for the output:
- dark yellow: file was not found.
- dark red: failed to find a TPPG in the file, this might happen for
source runs.
- blue: ODB matches PPG data, file is skipped.
- dark blue: PPG data is empty, most likely a source run, file is
skipped.
- red: ODB doesn't match the PPG data after setting it from the data.
This is a weird state to get in (not sure if it's even possible to get
in this state).
- green: ODB information was successfully set from the PPG data.