### PR TITLE
Using new TUnpackedEvent::SetRawData function

### DIFF
--- a/include/TFragment.h
+++ b/include/TFragment.h
@@ -43,7 +43,7 @@ public:
    void SetModuleType(UShort_t value) { fModuleType = value; }
    void SetDeadTime(UShort_t value) { fDeadTime = value; }
    void SetDetectorType(UShort_t value) { fDetectorType = value; }
-   void                          SetEntryNumber() { fEntryNumber = fNumberOfFragments++; }
+   void SetEntryNumber() { fEntryNumber = fNumberOfFragments++; }
    void SetDaqId(Int_t value) { fDaqId = value; }
    void SetFragmentId(Int_t value) { fFragmentId = value; }
    void SetDaqTimeStamp(time_t value) { fDaqTimeStamp = value; }

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -25,6 +25,7 @@ public:
    std::vector<std::shared_ptr<TDetector>>& GetDetectors() { return fDetectors; }
    void AddDetector(const std::shared_ptr<TDetector>& det) { fDetectors.push_back(det); }
    void AddRawData(const std::shared_ptr<const TFragment>& frag);
+   void SetRawData(const std::vector<std::shared_ptr<const TFragment>>& fragments) { fFragments = fragments; }
 #endif
    void ClearRawData();
 

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -274,6 +274,8 @@ void TPeakFitter::InitializeParameters(TH1* fit_hist)
 
 void TPeakFitter::UpdateFitterParameters()
 {
+	/// This functions gets the parameters and their limits from the peak functions and 
+	/// sets them for the total fit function
 	Int_t param_counter = 0;
 	Int_t peak_counter = 0;
 	for(auto p_it : fPeaksToFit) {

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1399,7 +1399,8 @@ void TChannel::ReadEnergyNonlinearities(TFile* file, const char* graphName, bool
 void TChannel::SetDigitizerType(TPriorityValue<std::string> tmp)
 {
 	fDigitizerTypeString = tmp;
-	fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType, fTimeStampUnit);
+	if(fMnemonic.Value() != nullptr) fMnemonic.Value()->EnumerateDigitizer(fDigitizerTypeString, fDigitizerType, fTimeStampUnit);
+	else std::cerr<<__PRETTY_FUNCTION__<<": mnemonic not set, can't set digitizer type and timestamp unit from "<<fDigitizerTypeString<<std::endl;
 }
 
 double TChannel::GetTime(Long64_t timestamp, Float_t cfd, double energy) const

--- a/libraries/TLoops/TDetBuildingLoop.cxx
+++ b/libraries/TLoops/TDetBuildingLoop.cxx
@@ -49,10 +49,7 @@ bool TDetBuildingLoop::Iteration()
    ++fItemsPopped;
 
    std::shared_ptr<TUnpackedEvent> outputEvent = std::make_shared<TUnpackedEvent>();
-   for(const auto& frag : frags) {
-      // passes ownership of all TFragments, no need to delete here
-      outputEvent->AddRawData(frag);
-   }
+	outputEvent->SetRawData(frags);
    outputEvent->Build();
    for(const auto& outQueue : fOutputQueues) {
       outQueue->Push(outputEvent);


### PR DESCRIPTION
Instead of looping over the vector of fragments and adding the fragments one at a time, we now simply set the vector.