### PR TITLE
Fix waveforms not being written to analysis tree

### DIFF
--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -126,7 +126,7 @@ Double_t TGRSIFunctions::PhotoPeakBG(Double_t* dim, Double_t* par)
 {
    // Returns a single RadWare style peak
    double result = Gaus(dim, par) + SkewedGaus(dim, par) + StepFunction(dim, par) + PolyBg(dim, &par[6], 2);
-	if(isfinite(result)) return result;
+	if(std::isfinite(result)) return result;
    return 0.;
 }
 


### PR DESCRIPTION
Since last year, we've been using older versions of GRSISort/GRSIData (from July 2019) for TIP data, because in more recent versions the event waveforms are not written to the analysis tree (preventing us from performing particle ID by fitting the waveforms offline with TPulseAnalyzer).  This problem exists for both older data taken with the TIG-10 DAQ, and newer data taken using the GRIFFIN style (GRIF-C/GRIF-16) DAQ.  The problem seems to be present regardless of whether the `--extract-waves` option is used when building the analysis tree.

After some investigation, I think this problem originates with the deep copy functionality in the TDetector class (the solution is similar to an earlier [pull request](https://github.com/GRIFFINCollaboration/GRSIData/pull/58) in GRSIData).  If I remove the deep copy (partially reverting commit 9fb1683261d04940019dec5bbd641968c4bd2e60), the waveform data gets properly written to the analysis tree.  As with the GRSIData pull request, I don't know why this fixes the issue (I guess the copy operation somehow isn't including the waveform(s)?).  In my testing with a few runs of data, this change doesn't seem to affect the sorted energies/times/event multiplicities of TIGRESS or TIP events, but I haven't tested with other detector types.  There's probably a more elegant solution.

I also made a one-line change in TGRSIFunctions to fix a compilation error on CentOS 7.