### PR TITLE
Fix compile error on CentOS 7

### DIFF
--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -126,7 +126,7 @@ Double_t TGRSIFunctions::PhotoPeakBG(Double_t* dim, Double_t* par)
 {
    // Returns a single RadWare style peak
    double result = Gaus(dim, par) + SkewedGaus(dim, par) + StepFunction(dim, par) + PolyBg(dim, &par[6], 2);
-	if(isfinite(result)) return result;
+	if(std::isfinite(result)) return result;
    return 0.;
 }
 


### PR DESCRIPTION
Fixes a minor compile error on CentOS 7.  

Compiler output following `make -j`:

```
Compiling .build/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.o[ERROR]
Compiling TBgoHit.o                                                   [OK]
libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx: In function ‘Double_t TGRSIFunctions::PhotoPeakBG(Double_t*, Double_t*)’:
libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx:129:20: error: ‘isfinite’ was not declared in this scope
  if(isfinite(result)) return result;
                    ^
libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx:129:20: note: suggested alternative:
In file included from /data1/jwilliams/GRSISort/include/TGRSIFunctions.h:11:0,
                 from libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx:1:
/usr/include/c++/4.8.2/cmath:596:5: note:   ‘std::isfinite’
     isfinite(_Tp __x)
     ^
make: *** [.build/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.o] Error 1
make: *** Waiting for unfinished jobs....
```
Compiler info:

```
g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/lto-wrapper
Target: x86_64-redhat-linux
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-linker-hash-style=gnu --enable-languages=c,c++,objc,obj-c++,java,fortran,ada,go,lto --enable-plugin --enable-initfini-array --disable-libgcj --with-isl=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/isl-install --with-cloog=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/cloog-install --enable-gnu-indirect-function --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux
Thread model: posix
gcc version 4.8.5 20150623 (Red Hat 4.8.5-44) (GCC) 
```