### PR TITLE
Only read the calibration once from the root file

### DIFF
--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -35,6 +35,14 @@ Bool_t TRunInfo::ReadInfoFromFile(TFile* tempf)
 
    tempf = gDirectory->GetFile();
 
+	// try and read the run info directly
+	if(tempf->FindObjectAny("TRunInfo") != nullptr) {
+		Get()->fDetectorInformation = static_cast<TDetectorInformation*>(tempf->Get("TRunInfo"));
+      savdir->cd();
+      return true;
+	}
+
+	// if the above failed we try all keys to find a run info
    TList* list = tempf->GetListOfKeys();
    TIter  iter(list);
 	TKey* key;

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -364,7 +364,8 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
 			}
 
 			if(file->FindObjectAny("Channel") != nullptr) {
-				file->Get("Channel"); // this calls TChannel::Streamer
+				// not necessary to do anything as FindObjectAny already seems to call the streamer?
+				//file->Get("Channel"); // this calls TChannel::Streamer
 			}
 			if(file->FindObjectAny("Values") != nullptr) {
 				file->Get("Values");


### PR DESCRIPTION
Previously the calibration would be read three time from the root file when opened normally:
- When we try to check if we have a calibration in the file we use TFile::FindObjectAny("Channel").
- When we then actually want to read the calibration (using TFile::Get("Channel")).
- And again when we try to read the TRunInfo by looping over all keys in the file, trying to cast them to TRunInfo pointers until we find the TRunInfo entry.

I now removed the explicit reading of the channel as the TFile::FindObjectAny function apparently already does this, and I changed the function to read the run info from file to first try and just read a key name "TRunInfo" before resorting to reading all keys.