### PR TITLE
Compiling on MacOs 12.4 Monterey and some changes for doxygen

### DIFF
--- a/GRSIProof/ExampleTreeSelector.h
+++ b/GRSIProof/ExampleTreeSelector.h
@@ -76,4 +76,5 @@ void ExampleTreeSelector::InitializeBranches(TTree* tree)
 	}
 }
 
+/*! @} */
 #endif // #ifdef ExampleTreeSelector_cxx

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <signal.h>
+#include <libgen.h>
 
 TGRSIProof* gGRSIProof;
 TGRSIOptions* gGRSIOpt;
@@ -115,7 +116,7 @@ void AtExitHandler()
 
 			std::string firstMacro;
 			if(!gGRSIOpt->MacroInputFiles().empty()) firstMacro = gGRSIOpt->MacroInputFiles().at(0);
-			firstMacro = basename(firstMacro.c_str()); // remove path
+			firstMacro = basename(const_cast<char*>(firstMacro.c_str())); // remove path
 			firstMacro = firstMacro.substr(0, firstMacro.find_last_of('.')); // remove extension
 
 			if(runNumber != 0 && subRunNumber != -1) {

--- a/doxygen/Makefile
+++ b/doxygen/Makefile
@@ -1,14 +1,11 @@
 
-.PHONY: filter doxygen clean
+.PHONY: doxygen clean
 
 export DOXYGEN_GRSISORT_VERSION=$(shell grsi-config --version)
 export DOXYGEN_OUTPUT_DIRECTORY=$(GRSISYS)/documentation
 export DOXYGEN_EXAMPLE_PATH=$(DOXYGEN_OUTPUT_DIRECTORY)/macros
 
 all: doxygen
-
-filter:
-	`root-config --cxx` -o filter filter.cxx `root-config --libs --glibs --cflags`
 
 doxygen:
 	if [ ! -d $(DOXYGEN_OUTPUT_DIRECTORY) ]; then mkdir $(DOXYGEN_OUTPUT_DIRECTORY); fi
@@ -22,4 +19,3 @@ doxygen:
 
 clean:
 	rm -rf $(DOXYGEN_OUTPUT_DIRECTORY)
-	rm -f filter

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -72,10 +72,6 @@ typedef char int8_t;
 #include <array>
 #include <memory>
 #include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <sys/wait.h>
-#include <sys/prctl.h>
 
 const std::string& ProgramName();
 
@@ -251,6 +247,11 @@ static inline void PrintStacktrace(std::ostream& out = std::cout, unsigned int m
 	out<<str.str();
 }
 
+#if !__APPLE__
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/prctl.h>
 static inline void PrintGdbStacktrace() {
 	char pid_buf[30];
 	sprintf(pid_buf, "%d", getpid());
@@ -266,5 +267,6 @@ static inline void PrintGdbStacktrace() {
 		waitpid(child_pid,NULL,0);
 	}
 }
+#endif
 
 #endif

--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -49,8 +49,8 @@ public:
 	bool SetResidual(const bool& force = false);
 	void Add(TGraphErrors*, const std::string& label);
 
-	void SetLineColor(int index, int color)   { fGraphs[index].SetLineColor(color);   fResidualGraphs[index].SetLineColor(color); }   ///< Set the line color of the graph and residuals at <index>
-	void SetMarkerColor(int index, int color) { fGraphs[index].SetMarkerColor(color); fResidualGraphs[index].SetMarkerColor(color); } ///< Set the marker color of the graph and residuals at <index>
+	void SetLineColor(int index, int color)   { fGraphs[index].SetLineColor(color);   fResidualGraphs[index].SetLineColor(color); }   ///< Set the line color of the graph and residuals at index
+	void SetMarkerColor(int index, int color) { fGraphs[index].SetMarkerColor(color); fResidualGraphs[index].SetMarkerColor(color); } ///< Set the marker color of the graph and residuals at index
 
 	int GetN() { return fTotalGraph->GetN(); }     ///< Returns GetN(), i.e. number of points of the total graph.
 	double* GetX() { return fTotalGraph->GetX(); } ///< Returns an array of x-values of the total graph.
@@ -63,7 +63,7 @@ public:
 	double GetMinimumY() { return fMinimumY; } ///< Return minimum y-value.
 	double GetMaximumY() { return fMaximumY; } ///< Return maximum y-value.
 
-	void Fit(TF1* function, Option_t* opt = "") { fTotalGraph->Fit(function, opt); } ///< Fits the <function> to the total graph.
+	void Fit(TF1* function, Option_t* opt = "") { fTotalGraph->Fit(function, opt); } ///< Fits the provided function to the total graph.
 	TF1* FitFunction() { return reinterpret_cast<TF1*>(fTotalGraph->GetListOfFunctions()->FindObject("fitfunction")); } ///< Gets the calibration from the total graph (might be nullptr!).
 	TGraphErrors* TotalGraph() { return fTotalGraph; }
 	size_t NumberOfGraphs() { return fGraphs.size(); }


### PR DESCRIPTION
Put the functionality for printing the gdb stacktrace into a condition that it's not a Mac, and added a const cast for basename function in grsiproof.cxx.
All other changes are just to make doxygen happy (and cleaning up the doxygen makefile).
This should solve #1275?