### PR TITLE
Pulse analyzer updates to match latest SFU code

### DIFF
--- a/include/TPulseAnalyzer.h
+++ b/include/TPulseAnalyzer.h
@@ -161,6 +161,7 @@ public:
    void   DrawCsIExclusion();
    void   DrawCsIFit();
    int    GetCsIChiSq();
+   int    GetCsIFitType();
 
 private:
    bool         set;
@@ -170,6 +171,8 @@ private:
    std::vector<Short_t> cWavebuffer;
    SinPar*              spar;
    ShapePar*            shpar;
+   WaveFormPar*         csiTestWpar[4]; //used for testing different CsI fit types
+   ShapePar*            csiTestShpar[4]; //used for testing different CsI fit types
 
    std::string fName;
 
@@ -187,9 +190,10 @@ private:
 
    // CsI functions
    void   GetCsIExclusionZone();
-   double GetCsITau(int);
-   double GetCsIt0();
+   double GetCsITau(int, ShapePar*);
+   double GetCsIt0(ShapePar*, WaveFormPar*);
    int    GetCsIShape();
+   int    FitCsIShape(int, ShapePar*, WaveFormPar*);
 
    bool   CsISet;
 	double EPS;
@@ -223,19 +227,23 @@ private:
    void GetQuickPara();
 
    // bad chi squares for debugging
-   const static int BADCHISQ_SMOOTH_T0 = -1024 - 2; // smooth_t0 gives bad result
-   const static int BADCHISQ_PAR_T0    = -1024 - 3; // parabolic_t0 gives bad result
-   const static int BADCHISQ_LIN_T0    = -1024 - 4; // linear_t0 gives bad result
-   const static int BADCHISQ_MAT       = -1024 - 5; // matrix for fit is not invertable
-   const static int BADCHISQ_EXC       = -1024 - 8; // -1032	bad exclusion zone
+   const static int BADCHISQ_SMOOTH_T0   = -1024 - 2; // smooth_t0 gives bad result
+   const static int BADCHISQ_PAR_T0      = -1024 - 3; // parabolic_t0 gives bad result
+   const static int BADCHISQ_LIN_T0      = -1024 - 4; // linear_t0 gives bad result
+   const static int BADCHISQ_MAT         = -1024 - 5; // matrix for fit is not invertable
+   const static int BADCHISQ_FAIL_DIRECT = -1024 - 9; //generic fit failure
+   const static int BAD_EXCLUSION_ZONE   = -1024 - 10; //fails finding exclusion zone
+   const static int BAD_MAX              = -1024 - 11;
+   const static int BAD_BASELINE_RANGE   = -1024 - 12;
+   const static int BAD_PID              = -1024; //PID value returned when the fit fails
+
    // new definitions for Kris' changes to the waveform analyzer
    const static int PIN_BASELINE_RANGE = 16; // minimum ticks before max for a valid signal
-   const static int BAD_BASELINE_RANGE = -1024 - 11;
    const static int MAX_SAMPLES        = 4096;
 
-   const static int CSI_BASELINE_RANGE = 50;
-   const static int NOISE_LEVEL_CSI    = 100;
-   const static int NSHAPE             = 5;
+   const static int CSI_BASELINE_RANGE = 50; //baseline range in channels
+   const static int NOISE_LEVEL_CSI    = 100; //noise level for CsI
+   const static int NSHAPE             = 5; //number of trial functions for waveform fit
 
    const static int BADCHISQ_T0   = -1024 - 7;
    const static int BADCHISQ_NEG  = -1024 - 1;


### PR DESCRIPTION
This adds some additional CsI fit types to TPulseAnalyzer, matching the SFU code [here](https://github.com/e-j-w/TIPsort/blob/master/current/utils/waveform_analyzer.c).  It's mostly a copy/paste from the SFU code, with slight modifications to match the GRSISort coding conventions.

Under this scheme, CsI waveforms are fit using 4 fit types (two component, slow component only, fast component only, and a shape representing gamma interactions with the PIN diode), and the fit type with the best chisq value is retained.  Previously only the two component type was used.  Of course this makes it take longer to fit each waveform, but when combined with the earlier [changes](https://github.com/GRIFFINCollaboration/GRSIData/pull/77) to allow waveform fits when building the analysis tree, this isn't a huge concern since the waveforms only need to be fit once.

There is a part with manual memory management: lines 997-998 and 1085-1086 of TPulseAnalyzer.cxx allocate and free temporary structures containing fit parameters for the 4 fit types.  This is changed from the C-style `malloc()` and `free()` calls in the original code to `new` and `delete` calls (which I think is more conventional for C++ ?).  I haven't seen any obvious memory utilization differences between the previous and new code (measured 9.4% memory use with both versions when sorting a recent midas file containing TIP data).