### PR TITLE
Small improvement and bug fixes

### DIFF
--- a/Examples/sort.sh
+++ b/Examples/sort.sh
@@ -30,7 +30,7 @@ for run in `seq $firstRun $lastRun` ; do
    fi
 	# loop over all subruns that haven't been changed in the last three minutes
 	# (only important when using this during an experiment)
-   for midasFile in `find ${DATADIR} -amin +3 -name "run${run}_???.mid"` ; do
+   for midasFile in `find ${DATADIR} -maxdepth 1 -amin +3 -name "run${run}_???.mid"` ; do
       subrun=$(basename $midasFile | cut -d '_' -f2 | cut -d '.' -f1)
 		# if the analysis file exists, we don't re-run the analysis
       if [ -e analysis${run}_${subrun}.root ] ; then

--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -287,9 +287,14 @@ int main(int argc, char** argv)
 	}
 	gGRSIProof->AddInput(new TNamed("ParserLibrary", library.c_str()));
 
-	Analyze("FragmentTree");
-	Analyze("AnalysisTree");
-	Analyze("Lst2RootTree");
+	if(gGRSIOpt->TreeName().empty()) {
+		Analyze("FragmentTree");
+		Analyze("AnalysisTree");
+		Analyze("Lst2RootTree");
+	} else {
+		std::cout<<"Running selector on tree '"<<gGRSIOpt->TreeName()<<"'"<<std::endl;
+		Analyze(gGRSIOpt->TreeName().c_str());
+	}
 
 	AtExitHandler();
 

--- a/include/GValue.h
+++ b/include/GValue.h
@@ -47,7 +47,7 @@ public:
    bool AppendValue(GValue*);
    bool ReplaceValue(GValue*);
 
-   // virtual void Clear(Option_t *opt="");
+   using TNamed::Clear;
    void Print(Option_t* opt = "") const override;
    void Copy(TObject& obj) const override;
    // virtual bool Notify();

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -130,6 +130,7 @@ public:
 	// Proof only
 	int  GetMaxWorkers() const { return fMaxWorkers; }
 	bool SelectorOnly() const { return fSelectorOnly; }
+	std::string TreeName() const { return fTreeName; }
 
 	void SuppressErrors(bool suppress) { fSuppressErrors = suppress; }
 
@@ -225,8 +226,9 @@ private:
 	bool         fLongFileDescription;
 
 	// Proof only
-	int  fMaxWorkers;   ///< Max workers used in grsiproof
-	bool fSelectorOnly; ///< Flag to turn PROOF off in grsiproof
+	int         fMaxWorkers;   ///< Max workers used in grsiproof
+	bool        fSelectorOnly; ///< Flag to turn PROOF off in grsiproof
+	std::string fTreeName;     ///< Name of tree to be analyzed (default is empty, i.e. FragmentTree, AnalysisTree, and Lst2RootTree are checked)
 
 	// shared object libraries
 	std::string fParserLibrary; ///< location of shared object library for data parser and files

--- a/include/TGRSISelector.h
+++ b/include/TGRSISelector.h
@@ -62,6 +62,7 @@ public:
    virtual void InitializeBranches(TTree* tree) = 0;
    virtual void EndOfSort() {};
    void SetOutputPrefix(const char* prefix) { fOutputPrefix = prefix; }
+	std::string GetOutputPrefix() const { return fOutputPrefix; }
 
 protected:
    TGRSIMap<std::string, TH1*>        fH1; //!<! map for 1-D histograms

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -1125,6 +1125,11 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, UInt_t* keysym)
 			}
 			fCuts.push_back(static_cast<TCutG*>(gROOT->FindObject("CUTG")));
 			fCuts.back()->SetName(fCutName);
+			std::cout<<"Added cut to list of cuts: ";
+			for(auto cut : fCuts) {
+				std::cout<<cut->GetName()<<" ";
+			}
+			std::cout<<std::endl;
 		}
 		break;
 

--- a/libraries/TFormat/TPPG.cxx
+++ b/libraries/TFormat/TPPG.cxx
@@ -675,6 +675,10 @@ void TPPG::operator+=(const TPPG& rhs)
 
 void TPPG::Add(const TPPG* ppg)
 {
+	if(ppg == nullptr) {
+		std::cerr<<"Passed nullptr to TPPG::Add(const TPPG* ppg)!"<<std::endl;
+		return;
+	}
    PPGMap_t::iterator ppgit;
    for(ppgit = ppg->MapBegin(); ppgit != ppg->MapEnd(); ++ppgit) {
       if(ppgit->second != nullptr) {

--- a/libraries/TGRSIProof/TGRSISelector.cxx
+++ b/libraries/TGRSIProof/TGRSISelector.cxx
@@ -216,6 +216,7 @@ void TGRSISelector::SlaveTerminate()
 	EndOfSort();
 	CheckSizes("send to server");
 	fOutput->Add(new TChannel(TChannel::GetChannelMap()->begin()->second));
+	fOutput->Add(new TNamed("prefix", GetOutputPrefix().c_str()));
 }
 
 void TGRSISelector::Terminate()
@@ -234,6 +235,10 @@ void TGRSISelector::Terminate()
 	}
 	Int_t runNumber    = fRunInfo->RunNumber();
 	Int_t subRunNumber = fRunInfo->SubRunNumber();
+
+	if(fOutput->FindObject("prefix") != nullptr) {
+		fOutputPrefix = static_cast<TNamed*>(fOutput->FindObject("prefix"))->GetTitle();
+	}
 
 	TFile* outputFile;
 	std::string outputFileName;

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -117,6 +117,7 @@ void TGRSIOptions::Clear(Option_t*)
    // Proof only
    fMaxWorkers   = -1;
    fSelectorOnly = false;
+	fTreeName.clear();
 
    fHelp          = false;
 
@@ -176,6 +177,7 @@ void TGRSIOptions::Print(Option_t*) const
 				<<std::endl
             <<"fMaxWorkers: "<<fMaxWorkers<<std::endl
             <<"fSelectorOnly: "<<fSelectorOnly<<std::endl
+				<<"fTreeName: "<<fTreeName<<std::endl
 				<<std::endl
 				<<"fHelp: "<<fHelp<<std::endl
 				<<std::endl
@@ -335,6 +337,9 @@ void TGRSIOptions::Load(int argc, char** argv)
 		parser.option("selector-only", &fSelectorOnly, true)
 			.description("Turns off PROOF to run a selector on the main thread");
 		parser.option("log-file", &fLogFile, true).description("File logs from grsiproof are written to");
+
+		parser.option("tree-name", &fTreeName, true)
+			.description("Name of tree to be proofed, default is empty, i.e. FragmentTree, AnalysisTree, and Lst2RootTree are checked");
 	}
 
 	parser.option("max-events", &fNumberOfEvents, true)


### PR DESCRIPTION
- Improved sort.sh example script by adding "-maxdepth 1" to find command to exclude sub-directories.
- Added option to grsiproof to set the name of the input tree (e.g. to create histograms from a tree created by grsiproof).
- Added code to allow the grsiproof file prefix to be changed during the execution of the workers (e.g. to change the file name based on g-values passed to the selector).
- Added more verbosity to 2D-histogram hotkeys for cuts.
- Added null pointer check to TPPG::Add.
- Fixed a compiler warning.