### PR TITLE
Added more grsiproof options

### DIFF
--- a/GRSIProof/grsiproof.cxx
+++ b/GRSIProof/grsiproof.cxx
@@ -265,6 +265,46 @@ int main(int argc, char** argv)
 
 	startedProof = true;
 
+	// set some proof parameters	
+	// average rate, can also be set via Proof.RateEstimation in gEnv ("current" or "average)
+   if(gGRSIOpt->AverageRateEstimation()) gGRSIProof->SetParameter("PROOF_RateEstimation", "average");
+
+   // Parallel unzip, can also be set via ProofPlayer.UseParallelUnzip
+   if(gGRSIOpt->ParallelUnzip()) {
+      gGRSIProof->SetParameter("PROOF_UseParallelUnzip", 1);
+   } else {
+      gGRSIProof->SetParameter("PROOF_UseParallelUnzip", 0);
+   }
+
+   // Tree cache
+   if(gGRSIOpt->CacheSize() >= 0) {
+      if(gGRSIOpt->CacheSize() == 0) {
+         gGRSIProof->SetParameter("PROOF_UseTreeCache", 0);
+      } else {
+         gGRSIProof->SetParameter("PROOF_UseTreeCache", 1);
+         gGRSIProof->SetParameter("PROOF_CacheSize", gGRSIOpt->CacheSize());
+      }
+   } else {
+      // Use defaults
+      gGRSIProof->DeleteParameters("PROOF_UseTreeCache");
+      gGRSIProof->DeleteParameters("PROOF_CacheSize");
+   }
+
+   // Enable submergers, if required
+   if(gGRSIOpt->Submergers() >= 0) {
+      gGRSIProof->SetParameter("PROOF_UseMergers", gGRSIOpt->Submergers());
+   } else {
+      gGRSIProof->DeleteParameters("PROOF_UseMergers");
+   }
+
+   // enable perfomance output
+   if(gGRSIOpt->ProofStats()) {
+      gGRSIProof->SetParameter("PROOF_StatsHist", "");
+      gGRSIProof->SetParameter("PROOF_StatsTrace", "");
+      gGRSIProof->SetParameter("PROOF_RateTrace", "");
+      gGRSIProof->SetParameter("PROOF_SlaveStatsTrace", "");
+   }
+
 	gGRSIProof->SetBit(TProof::kUsingSessionGui);
 	gGRSIProof->AddEnvVar("GRSISYS", pPath);
 	gInterpreter->AddIncludePath(Form("%s/include", pPath));

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -131,6 +131,11 @@ public:
 	int  GetMaxWorkers() const { return fMaxWorkers; }
 	bool SelectorOnly() const { return fSelectorOnly; }
 	std::string TreeName() const { return fTreeName; }
+   bool AverageRateEstimation() const { return fAverageRateEstimation; }
+   bool ParallelUnzip() const { return fParallelUnzip; }
+   int CacheSize() const { return fCacheSize; }
+   int Submergers() const { return fSubmergers; }
+   bool ProofStats() const { return fProofStats; }
 
 	void SuppressErrors(bool suppress) { fSuppressErrors = suppress; }
 
@@ -229,6 +234,11 @@ private:
 	int         fMaxWorkers;   ///< Max workers used in grsiproof
 	bool        fSelectorOnly; ///< Flag to turn PROOF off in grsiproof
 	std::string fTreeName;     ///< Name of tree to be analyzed (default is empty, i.e. FragmentTree, AnalysisTree, and Lst2RootTree are checked)
+   bool        fAverageRateEstimation; ///< enable average rate estimation
+   bool        fParallelUnzip;         ///< enable use of parallel unzipping
+   int         fCacheSize;             ///< set tree cache size, default is -1 (off)
+   int         fSubmergers;            ///< set number of sub-mergers (0 = automatic), default is -1 (off) 
+   bool        fProofStats;            ///< enable proof stats
 
 	// shared object libraries
 	std::string fParserLibrary; ///< location of shared object library for data parser and files

--- a/libraries/TAnalysis/TDetector/TDetector.cxx
+++ b/libraries/TAnalysis/TDetector/TDetector.cxx
@@ -54,6 +54,7 @@ void TDetector::Print(std::ostream& out) const
 {
 	/// Print detector to stream out. Iterates over hits and prints them.
 	std::ostringstream str;
+	str<<"TDetector "<<this<<":"<<std::endl;
 	for(auto hit : fHits) {
 		hit->Print(str);
 	}

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -118,6 +118,11 @@ void TGRSIOptions::Clear(Option_t*)
    fMaxWorkers   = -1;
    fSelectorOnly = false;
 	fTreeName.clear();
+   fAverageRateEstimation = false;
+   fParallelUnzip = false;
+   fCacheSize = -1;
+   fSubmergers = -1;
+   fProofStats = false;
 
    fHelp          = false;
 
@@ -178,6 +183,11 @@ void TGRSIOptions::Print(Option_t*) const
             <<"fMaxWorkers: "<<fMaxWorkers<<std::endl
             <<"fSelectorOnly: "<<fSelectorOnly<<std::endl
 				<<"fTreeName: "<<fTreeName<<std::endl
+				<<"fAverageRateEstimation: "<<fAverageRateEstimation<<std::endl
+   			<<"fParallelUnzip: "<<fParallelUnzip<<std::endl
+   			<<"fCacheSize: "<<fCacheSize<<std::endl
+   			<<"fSubmergers: "<<fSubmergers<<std::endl
+   			<<"fProofStats: "<<fProofStats<<std::endl
 				<<std::endl
 				<<"fHelp: "<<fHelp<<std::endl
 				<<std::endl
@@ -340,6 +350,16 @@ void TGRSIOptions::Load(int argc, char** argv)
 
 		parser.option("tree-name", &fTreeName, true)
 			.description("Name of tree to be proofed, default is empty, i.e. FragmentTree, AnalysisTree, and Lst2RootTree are checked");
+		parser.option("average-rate", &fAverageRateEstimation, true)
+			.description("use average rate instead of current rate");
+		parser.option("parallel-unzip", &fParallelUnzip, true)
+			.description("use parallel unzipping of input files");
+		parser.option("cache-size", &fCacheSize, true)
+			.description("set tree cache size (default = -1 = off)");
+		parser.option("sub-mergers", &fSubmergers, true)
+			.description("use sub mergers to merge result from workers (default = -1 = off, 0 = automatic number of mergers)");
+		parser.option("proof-stats", &fProofStats, true)
+			.description("enable proof stats");
 	}
 
 	parser.option("max-events", &fNumberOfEvents, true)


### PR DESCRIPTION
New grsiproof options:
- ```--average-rate``` use average rate instead of current rate for progress bar.
- ```--parallel-unzip``` use parallel unzipping of input files.
- ```--cache-size``` set the tree cache size (default = -1 = off).
- ```--sub-mergers``` use sub mergers to merge results from workers (default = -1 = off, 0 = automatic number of mergers, everything else = this many mergers are used).
- ```--proof-stats``` enable proof stats.
