### PR TITLE
Small updates and a bug fix

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -186,10 +186,11 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& grif, TSceptar&
             }
          }
       }
-      // event mixing, we use the last event as second griffin
-      for(auto g2 = 0; g2 < fLastGrif.GetMultiplicity(); ++g2) {
+      // event mixing, we use the last event as second griffin 
+		// if there was no last event the default constructed TGriffin will have a multiplicity of zero
+      for(auto g2 = 0; g2 < fLastGrif[slot].GetMultiplicity(); ++g2) {
          if(g1 == g2) continue;
-         auto   grif2 = fLastGrif.GetGriffinHit(g2);
+         auto   grif2 = fLastGrif[slot].GetGriffinHit(g2);
          double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
          if(angle < 0.0001) continue;
          auto   angleIndex = fAngleMap.lower_bound(angle - 0.0005);
@@ -245,9 +246,9 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& grif, TSceptar&
          }
       }
       // event mixing, we use the last event as second griffin
-      for(auto g2 = 0; g2 < fLastGrif.GetAddbackMultiplicity(); ++g2) {
+      for(auto g2 = 0; g2 < fLastGrif[slot].GetAddbackMultiplicity(); ++g2) {
          if(g1 == g2) continue;
-         auto   grif2 = fLastGrif.GetAddbackHit(g2);
+         auto   grif2 = fLastGrif[slot].GetAddbackHit(g2);
          double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
          if(angle < 0.0001) continue;
          auto   angleIndex = fAngleMapAddback.lower_bound(angle - 0.0005);
@@ -264,6 +265,6 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& grif, TSceptar&
    }
 
    // update "last" event
-   fLastGrif = grif;
-   fLastScep = scep;
+   fLastGrif[slot] = grif;
+   fLastScep[slot] = scep;
 }

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -17,8 +17,8 @@ private:
    std::map<double, int>               fAngleMap;
    std::map<double, int>               fAngleMapAddback; // with addback
 
-   TGriffin fLastGrif;
-   TSceptar fLastScep;
+	std::map<unsigned int, TGriffin> fLastGrif;
+	std::map<unsigned int, TSceptar> fLastScep;
 
 public:
    AngularCorrelationHelper(TList* list) : TGRSIHelper(list) {

--- a/examples/ExampleEventHelper.cxx
+++ b/examples/ExampleEventHelper.cxx
@@ -3,19 +3,19 @@
 void ExampleEventHelper::CreateHistograms(unsigned int i)
 {
 	// try and get the cycle length if we have a PPG provided
-   if(fPpg != nullptr) {
-		// the ODB cycle length is in microseconds!
-      fCycleLength = fPpg->OdbCycleLength();
-		// only print this for one worker, should be the same result for all them after all
-		if(i == 0) {
+	// only necessary for the first worker, this is shared with all other workers
+   if(i == 0) {
+		if(fPpg != nullptr) {
+			// the ODB cycle length is in microseconds!
+			fCycleLength = fPpg->OdbCycleLength();
 			std::stringstream str;
-			str<<"Got ODB cycle length "<<fCycleLength<<" ns = "<<fCycleLength/1e6<<" s"<<std::endl;
+			str<<"Got ODB cycle length "<<fCycleLength<<" us = "<<fCycleLength/1e6<<" s"<<std::endl;
+			std::cerr<<str.str();
+		} else {
+			std::stringstream str;
+			str<<DRED<<"No ppg provided, can't fill cycle spectra!"<<RESET_COLOR<<std::endl;
 			std::cerr<<str.str();
 		}
-   } else if(i == 0) {
-		std::stringstream str;
-		str<<DRED<<"No ppg provided, can't fill cycle spectra!"<<RESET_COLOR<<std::endl;
-		std::cerr<<str.str();
 	}
 
 	// some variables to easily change range and binning for multiple histograms at once

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -53,6 +53,7 @@ public:
    } //!<!
 #endif
 
+	virtual void AddHit(TDetectorHit* hit) { fHits.push_back(hit); }
    virtual void Copy(TObject&) const override;                        //!<!
    void Clear(Option_t* = "") override { fHits.clear(); } //!<!
    virtual void ClearTransients();                            //!<!

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -257,7 +257,7 @@ private:
 
 	int fOldErrorLevel; ///< Used to store old value of gErrorIgnoreLevel (set to kError for the scope of the class)
 
-	int fVerboseLevel{3}; ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
+	int fVerboseLevel{0}; ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
 
 	double fDefaultSigma{2.}; ///< The default sigma used for the peak finding algorithm, can be changed later.
 	double fDefaultThreshold{0.05}; ///< The default threshold used for the peak finding algorithm, can be changed later. Co-56 source needs a much lower threshold, 0.01 or 0.02, but that makes it much slower too.


### PR DESCRIPTION
- TSourceCalibration: Fixed bug when using only one source and set default verbosity to zero, see #1295.
- AngularCorrelationHelper: Fixed bug so that it works with more than one helper.
- ExampleEventHelper: Only print messages for the first worker.
- TDetector: Added option to Add a hit directly. This means we can also add hits directly to all detector classes that inherit from TDetector and use it's fHits vector.