### PR TITLE
More changes in TGRSIFrame/Helper for older ROOT versions

### DIFF
--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -52,7 +52,7 @@ TGRSIFrame::TGRSIFrame()
 		if(chain->Add(fileName.c_str(), 0) >= 1) { // setting nentries parameter to zero make TChain load the file header and return a 1 if the file was opened successfully
 			TFile* file = TFile::Open(fileName.c_str());
 			TRunInfo::AddCurrent();
-			auto ppg = file->Get<TPPG>("TPPG");
+			auto ppg = static_cast<TPPG*>(file->Get("TPPG"));
 			if(ppg != nullptr) {
 				fPpg->Add(ppg);
 			}

--- a/libraries/TGRSIFrame/TGRSIHelper.cxx
+++ b/libraries/TGRSIFrame/TGRSIHelper.cxx
@@ -73,7 +73,7 @@ TGRSIHelper::TGRSIHelper(TList* input) {
 }
 
 void TGRSIHelper::Setup() {
-	const auto nSlots = ROOT::IsImplicitMTEnabled() ? ROOT::GetThreadPoolSize() : 1;
+	const auto nSlots = ROOT::IsImplicitMTEnabled() ? TGRSIOptions::Get()->GetMaxWorkers() : 1;
 	TH1::AddDirectory(false); // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
 	for(auto i : ROOT::TSeqU(nSlots)) {
 		fLists.emplace_back(std::make_shared<TList>());


### PR DESCRIPTION
The template version of ```TFile::Get``` doesn't exist in older versions, as well as ```ROOT::GetThreadPoolSize()```. So we use the old version of ```TFile::Get``` and use the max-worker option directly (which is what the pool size is set to anyway).