### PR TITLE
Writing scaler trees to fragment file

### DIFF
--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -130,7 +130,8 @@ public:
    ~TPPG() override;
 
    void Copy(TObject& obj) const override;
-	// not sure why these arguments are here, they are not being used? And why do we have a non-const version that just calls the const version?
+	// why do we have a non-const version that just calls the const version?
+	// the arguments are needed to match the TObject version and thus override it
    Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) override
    {
       return static_cast<const TPPG*>(this)->Write(name, option, bufsize);

--- a/include/TScaler.h
+++ b/include/TScaler.h
@@ -55,6 +55,10 @@ public:
                   <<fScaler.size()<<std::endl;
       }
    }
+	void SetScaler(UInt_t* data, int size)
+	{
+		fScaler = std::vector<uint32_t>(data, data+size);
+	}
 
    UInt_t              GetAddress() const { return fAddress; }
    UInt_t              GetNetworkPacketId() const { return fNetworkPacketId; }
@@ -104,7 +108,6 @@ public:
 
    void Copy(TObject& obj) const override;
 
-public:
    std::vector<UInt_t> GetScaler(UInt_t address, ULong64_t time) const;
    UInt_t GetScaler(UInt_t address, ULong64_t time, size_t index) const;
    UInt_t GetScalerDifference(UInt_t address, ULong64_t time, size_t index) const;
@@ -124,13 +127,13 @@ public:
    void ListHistograms();
 
 private:
+	void ReadTree(bool loadIntoMap);
+
    TTree*       fTree;
    TScalerData* fScalerData;
    Long64_t     fEntries;
-   std::map<UInt_t, std::map<ULong64_t, std::vector<UInt_t>>>
-      fScalerMap; //!<! an address-map of timestamp mapped scaler values
-   std::map<UInt_t, ULong64_t>
-      fTimePeriod; //!<! a map between addresses and time differences (used to calculate the time period)
+   std::map<UInt_t, std::map<ULong64_t, std::vector<UInt_t>>> fScalerMap; //!<! an address-map of timestamp mapped scaler values
+   std::map<UInt_t, ULong64_t> fTimePeriod; //!<! a map between addresses and time differences (used to calculate the time period)
    std::map<UInt_t, std::map<ULong64_t, int>> fNumberOfTimePeriods; //!<!
    ULong64_t fTotalTimePeriod;                                      //!<!
    std::map<ULong64_t, int> fTotalNumberOfTimePeriods;              //!<!

--- a/include/TScalerQueue.h
+++ b/include/TScalerQueue.h
@@ -25,8 +25,6 @@ public:
    static TDeadtimeScalerQueue* Get(); // Returns the Queue
    ~TDeadtimeScalerQueue() override;
 
-   int ScalersInQueue() { return fScalersInQueue; }
-
 private:
    TDeadtimeScalerQueue();
    static TDeadtimeScalerQueue* fDeadtimeScalerQueueClassPointer; // Pointer to the scaler Q singleton
@@ -84,8 +82,6 @@ class TRateScalerQueue : public TObject {
 public:
    static TRateScalerQueue* Get(); // Returns the Queue
    ~TRateScalerQueue() override;
-
-   int ScalersInQueue() { return fScalersInQueue; }
 
 private:
    TRateScalerQueue();

--- a/libraries/TFormat/TPPG.cxx
+++ b/libraries/TFormat/TPPG.cxx
@@ -11,7 +11,7 @@ ClassImp(TPPG)
 /// \endcond
 
 short TPPGData::fTimestampUnits = 10;
-TPPG* TPPG::fPPG = nullptr;
+TPPG* TPPG::fPPG = nullptr; // not used anywhere?
 
 TPPGData::TPPGData()
 {
@@ -446,11 +446,12 @@ void TPPG::Clear(Option_t*)
 	fCycleSet = false;
 }
 
-Int_t TPPG::Write(const char*, Int_t, Int_t) const
+Int_t TPPG::Write(const char* name, Int_t, Int_t) const
 {
+	if(name == nullptr) name = "TPPG";
    if(PPGSize() > 0 || OdbPPGSize() > 0) {
       std::cout<<"Writing PPG with "<<PPGSize()<<" events and "<<OdbPPGSize()<<" ODB settings"<<std::endl;
-      return TObject::Write("TPPG", TObject::kSingleKey);
+      return TObject::Write(name, TObject::kSingleKey);
    }
 
    return 0;

--- a/libraries/TFormat/TScaler.cxx
+++ b/libraries/TFormat/TScaler.cxx
@@ -43,7 +43,7 @@ void TScalerData::Print(Option_t*) const
 {
    std::cout<<"time: "<<std::setw(16)<<GetTimeStamp()<<", address: "<<hex(fAddress,4);
    for(size_t i = 0; i < fScaler.size(); ++i) {
-      std::cout<<"\t Scaler["<<i<<"]: "<<hex(fScaler[i],7);
+      std::cout<<"\t Scaler["<<i<<"]: "<<hex(fScaler[i],8);
    }
    std::cout<<std::endl;
 }
@@ -54,25 +54,21 @@ TScaler::TScaler(bool loadIntoMap)
    ///\param[in] loadIntoMap Flag telling TScaler to load all scaler data into fScalerMap.
    Clear();
    fTree = static_cast<TTree*>(gROOT->FindObject("ScalerTree"));
-   if(fTree != nullptr) {
-      fEntries = fTree->GetEntries();
-      fTree->SetBranchAddress("TScalerData", &fScalerData);
-      if(loadIntoMap) {
-         for(Long64_t entry = 0; entry < fEntries; ++entry) {
-            fTree->GetEntry(entry);
-            fScalerMap[fScalerData->GetAddress()][fScalerData->GetTimeStamp()] = fScalerData->GetScaler();
-         }
-      }
-   }
+	ReadTree(loadIntoMap);
 }
 
 TScaler::TScaler(TTree* tree, bool loadIntoMap)
 {
    Clear();
    fTree = tree;
+	ReadTree(loadIntoMap);
+}
+
+void TScaler::ReadTree(bool loadIntoMap)
+{
    if(fTree != nullptr) {
       fEntries = fTree->GetEntries();
-      fTree->SetBranchAddress("TScalerData", &fScalerData);
+      fTree->SetBranchAddress("ScalerData", &fScalerData);
       if(loadIntoMap) {
          for(Long64_t entry = 0; entry < fEntries; ++entry) {
             fTree->GetEntry(entry);

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -149,7 +149,7 @@ void TAnalysisWriteLoop::Write()
 		}
 		runInfo->WriteToRoot(outputFile);
 		options->AnalysisOptions()->WriteToFile(outputFile);
-		ppg->Write("PPG", TObject::kOverwrite);
+		ppg->Write("PPG");
 
 		if(options->WriteDiagnostics()) {
 			diag->Write("SortingDiagnostics", TObject::kOverwrite);


### PR DESCRIPTION
Main change is that ```TFragWriteLoop``` now writes the ```TDeadtimeScalerQueue``` and ```TRateScalerQueue``` into trees in the fragment file (so far these two queues would get filled by the data parsers but nothing was done with the data afterwards).
Also made some small changes like cleaning up code and comments.