### PR TITLE
Small changes

### DIFF
--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -52,7 +52,7 @@ TGRSIFrame::TGRSIFrame()
 		if(chain->Add(fileName.c_str(), 0) >= 1) { // setting nentries parameter to zero make TChain load the file header and return a 1 if the file was opened successfully
 			TFile* file = TFile::Open(fileName.c_str());
 			TRunInfo::AddCurrent();
-			auto ppg = static_cast<TPPG*>(file->Get("TPPG"));
+			auto ppg = static_cast<TPPG*>(file->Get("PPG"));
 			if(ppg != nullptr) {
 				fPpg->Add(ppg);
 			}

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -429,7 +429,7 @@ void TGRSIint::SetupPipeline()
 	}
 
 	// Which input files do we have
-	bool has_raw_file = !opt->InputFiles().empty() && opt->SortRaw() && !missing_raw_file;
+	bool has_raw_file = !opt->InputFiles().empty() && opt->SortRaw() && !missing_raw_file && !fRawFiles.empty();
 	bool has_input_fragment_tree = gFragment != nullptr; // && opt->SortRoot();
 	bool has_input_analysis_tree = gAnalysis != nullptr; // && opt->SortRoot();
 


### PR DESCRIPTION
- Added check to TGRSIint for open raw files. Otherwise we would try to access the first raw file, even if that one failed to open. So having a problem opening a raw file doesn't lead to a crash but the program exits normally (with an error messages on the terminal).
- TGRSIFrame: read "PPG" instead of "TPPG" from root files. This should fix issues with reading the PPG in grsiframe (same as was done before for grsiproof). Not sure if this poses an issue for older versions (which maybe wrote the PPG as "TPPG"?). If that is the case we would have to change the read to try and read "TPPG" if reading "PPG" fails.