### PR TITLE
Improvements for grsiframe and TSourceCalibration

### DIFF
--- a/examples/AlphanumericHelper.hh
+++ b/examples/AlphanumericHelper.hh
@@ -19,7 +19,7 @@ class AlphanumericHelper : public TGRSIHelper, public ROOT::Detail::RDF::RAction
 		Setup();
    }
 	//These functions are expected to exist
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TGriffin>(std::move(*this), {"TGriffin"});
    }
    void CreateHistograms(unsigned int slot);

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -35,7 +35,7 @@ public:
 		// Setup calls CreateHistograms, which uses the stored angle combinations, so we need those set before
 		Setup();
    }
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TGriffin, TSceptar>(std::move(*this), {"TGriffin", "TSceptar"});
    }
    void          CreateHistograms(unsigned int slot);

--- a/examples/CrossTalkHelper.hh
+++ b/examples/CrossTalkHelper.hh
@@ -12,7 +12,7 @@ public:
 		Prefix("Crosstalk");
 		Setup();
 	}
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
 	}
 	void          CreateHistograms(unsigned int slot);

--- a/examples/DirectoryHelper.cxx
+++ b/examples/DirectoryHelper.cxx
@@ -1,0 +1,104 @@
+#include "DirectoryHelper.hh"
+
+void DirectoryHelper::CreateHistograms(unsigned int slot)
+{
+	// some variables to easily change range and binning for multiple histograms at once
+	int energyBins = 10000;
+	double lowEnergy = 0.;
+	double highEnergy = 2000.;
+
+	// unsuppressed spectra
+	fH1[slot]["unsuppressed/singles/griffinE"] = new TH1F("griffinE", Form("Unsuppressed griffin energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	// suppressed spectra
+	fH1[slot]["suppressed/singles/griffinESupp"] = new TH1F("griffinESupp", Form("Suppressed griffin energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	// unsuppressed addback spectra
+	fH1[slot]["unsuppressed/addback/griffinEAddback"] = new TH1F("griffinEAddback", Form("Unsuppressed griffin addback energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	// suppressed addback spectra
+	fH1[slot]["suppressed/addback/griffinESuppAddback"] = new TH1F("griffinESuppAddback", Form("Suppressed griffin addback energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+
+	// initialize the two arrays to keep time
+	fLastTS.resize(64, 0.);
+	fLastSuppressedTS.resize(64, 0.);
+	fLastTime.resize(64, 0.);
+	fLastSuppressedTime.resize(64, 0.);
+	fLastTSNoPileup.resize(64, 0.);
+	fLastSuppressedTSNoPileup.resize(64, 0.);
+	fLastTimeNoPileup.resize(64, 0.);
+	fLastSuppressedTimeNoPileup.resize(64, 0.);
+
+	// timing spectra
+	fH2[slot]["griffinDeadTS"] = new TH2F("griffinDeadTS", "timestamp difference between consecutive hits in a griffin channel", 200, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinSuppressedDeadTS"] = new TH2F("griffinSuppressedDeadTS", "timestamp difference between consecutive suppressed hits in a griffin channel", 200, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinDeadTime"] = new TH2F("griffinDeadTime", "time difference between consecutive hits in a griffin channel", 2000, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinSuppressedDeadTime"] = new TH2F("griffinSuppressedDeadTime", "time difference between consecutive suppressed hits in a griffin channel", 2000, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinDeadTSNoPileup"] = new TH2F("griffinDeadTSNoPileup", "timestamp difference between consecutive hits in a griffin channel w/o pileups", 200, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinSuppressedDeadTSNoPileup"] = new TH2F("griffinSuppressedDeadTSNoPileup", "timestamp difference between consecutive suppressed hits in a griffin channel w/o pileups", 200, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinDeadTimeNoPileup"] = new TH2F("griffinDeadTimeNoPileup", "time difference between consecutive hits in a griffin channel w/o pileups", 2000, 0., 2000., 64, 0.5, 64.5);
+	fH2[slot]["griffinSuppressedDeadTimeNoPileup"] = new TH2F("griffinSuppressedDeadTimeNoPileup", "time difference between consecutive suppressed hits in a griffin channel w/o pileups", 2000, 0., 2000., 64, 0.5, 64.5);
+}
+
+// Coincidences Gates
+bool PromptCoincidence(TGriffinHit *h1, TGriffinHit *h2) { // Griffin-Griffin
+	return -250. <= h2->GetTime() - h1->GetTime() && h2->GetTime() - h1->GetTime() <= 250.;
+}
+bool TimeRandom(TGriffinHit *h1, TGriffinHit *h2) {
+	return (-500. <= h1->GetTime() - h2->GetTime() && h1->GetTime() - h2->GetTime() <= -250.) || (250. <= h1->GetTime() - h2->GetTime() && h1->GetTime() - h2->GetTime() <=500.);
+}
+
+void DirectoryHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo)
+{
+	// we use .at() here instead of [] so that we get meaningful error message if a histogram we try to fill wasn't created
+	// e.g. because of a typo
+
+	// loop over unsuppressed griffin hits
+	for(int g = 0; g < grif.GetMultiplicity(); ++g) {
+		auto grif1 = grif.GetGriffinHit(g);
+		fH1[slot].at("unsuppressed/singles/griffinE")->Fill(grif1->GetEnergy());
+		if(grif1->GetArrayNumber() <= 64) {
+			if(fLastTS[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinDeadTS")->Fill(grif1->GetTimeStampNs() - fLastTS[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+			fLastTS[grif1->GetArrayNumber()] = grif1->GetTimeStampNs();
+			if(fLastTime[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinDeadTime")->Fill(grif1->GetTime() - fLastTime[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+			fLastTime[grif1->GetArrayNumber()] = grif1->GetTime();
+			if(grif1->GetKValue() != 379) {
+				if(fLastTSNoPileup[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinDeadTSNoPileup")->Fill(grif1->GetTimeStampNs() - fLastTSNoPileup[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+				fLastTSNoPileup[grif1->GetArrayNumber()] = grif1->GetTimeStampNs();
+				if(fLastTimeNoPileup[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinDeadTimeNoPileup")->Fill(grif1->GetTime() - fLastTimeNoPileup[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+				fLastTimeNoPileup[grif1->GetArrayNumber()] = grif1->GetTime();
+			}
+		}
+	}
+
+	// loop over suppressed griffin hits
+	for(int g = 0; g < grif.GetSuppressedMultiplicity(&grifBgo); ++g) {
+		auto grif1 = grif.GetSuppressedHit(g);
+		fH1[slot].at("suppressed/singles/griffinESupp")->Fill(grif1->GetEnergy());
+		if(grif1->GetArrayNumber() <= 64) {
+			if(fLastSuppressedTS[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinSuppressedDeadTS")->Fill(grif1->GetTimeStampNs() - fLastSuppressedTS[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+			fLastSuppressedTS[grif1->GetArrayNumber()] = grif1->GetTimeStampNs();
+			if(fLastSuppressedTime[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinSuppressedDeadTime")->Fill(grif1->GetTime() - fLastSuppressedTime[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+			fLastSuppressedTime[grif1->GetArrayNumber()] = grif1->GetTime();
+			if(grif1->GetKValue() != 379) {
+				if(fLastSuppressedTSNoPileup[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinSuppressedDeadTSNoPileup")->Fill(grif1->GetTimeStampNs() - fLastSuppressedTSNoPileup[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+				fLastSuppressedTSNoPileup[grif1->GetArrayNumber()] = grif1->GetTimeStampNs();
+				if(fLastSuppressedTimeNoPileup[grif1->GetArrayNumber()] != 0) fH2[slot].at("griffinSuppressedDeadTimeNoPileup")->Fill(grif1->GetTime() - fLastSuppressedTimeNoPileup[grif1->GetArrayNumber()], grif1->GetArrayNumber());
+				fLastSuppressedTimeNoPileup[grif1->GetArrayNumber()] = grif1->GetTime();
+			}
+		}
+	}
+
+	// loop over unsuppressed griffin addback hits
+	for(int g = 0; g < grif.GetAddbackMultiplicity(); ++g) {
+		auto grif1 = grif.GetAddbackHit(g);
+		fH1[slot].at("unsuppressed/addback/griffinEAddback")->Fill(grif1->GetEnergy());
+	}
+
+	// loop over suppressed griffin addback hits
+	for(int g = 0; g < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++g) {
+		auto grif1 = grif.GetSuppressedAddbackHit(g);
+		fH1[slot].at("suppressed/addback/griffinESuppAddback")->Fill(grif1->GetEnergy());
+	}
+}
+
+void DirectoryHelper::EndOfSort(std::shared_ptr<std::map<std::string, TList>> list)
+{
+}

--- a/examples/DirectoryHelper.hh
+++ b/examples/DirectoryHelper.hh
@@ -1,48 +1,50 @@
-// TODO: Replace all EXAMPLEVENT and ExampleEvent with the name you want to use for this helper action
-#ifndef EXAMPLEEVENTHELPER_HH
-#define EXAMPLEEVENTHELPER_HH
+#ifndef TESTHELPER_HH
+#define TESTHELPER_HH
 
 #include "TGRSIHelper.h"
 
-// TODO: edit these include statments to match the detectors you want to use!
 #include "TGriffin.h"
 #include "TGriffinBgo.h"
-#include "TZeroDegree.h"
 
 // This is a custom action which respects a well defined interface. It supports parallelism,
 // in the sense that it behaves correctly if implicit multi threading is enabled.
 // Note the plural: in presence of a MT execution, internally more than a single TList is created.
 // The detector types in the specifcation of Book must match those in the call to it as well as those in the Exec function (and be in the same order)!
 
-class ExampleEventHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl<ExampleEventHelper> {
+class DirectoryHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl<DirectoryHelper> {
 public:
 	// constructor sets the prefix (which is used for the output file as well)
 	// and calls Setup which in turn also calls CreateHistograms
-	ExampleEventHelper(TList* list) : TGRSIHelper(list) {
-		Prefix("ExampleEventHelper");
+	DirectoryHelper(TList* list) : TGRSIHelper(list) {
+		Prefix("DirectoryHelper");
 		Setup();
 	}
 
 	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
-		// TODO: edit the template specification and branch names to match the detectors you want to use!
-		return d->Book<TGriffin, TGriffinBgo, TZeroDegree>(std::move(*this), {"TGriffin", "TGriffinBgo", "TZeroDegree"});
+		return d->Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
 	}
 	// this function creates and books all histograms
 	void CreateHistograms(unsigned int slot) override;
 	// this function gets called for every single event and fills the histograms
-	// TODO: edit the function arguments to match the detectors you want to use!
-	void Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo, TZeroDegree& zds);
+	void Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo);
 	// this function is optional and is called after the output lists off all slots/workers have been merged
 	void EndOfSort(std::shared_ptr<std::map<std::string, TList>> list) override;
 
 private:
 	// any constants that are set in the CreateHistograms function and used in the Exec function can be stored here
 	// or any other settings
-	Long64_t fCycleLength{0};
+	std::vector<double> fLastTS;
+	std::vector<double> fLastSuppressedTS;
+	std::vector<double> fLastTime;
+	std::vector<double> fLastSuppressedTime;
+	std::vector<double> fLastTSNoPileup;
+	std::vector<double> fLastSuppressedTSNoPileup;
+	std::vector<double> fLastTimeNoPileup;
+	std::vector<double> fLastSuppressedTimeNoPileup;
 };
 
 // These are needed functions used by TDataFrameLibrary to create and destroy the instance of this helper
-extern "C" ExampleEventHelper* CreateHelper(TList* list) { return new ExampleEventHelper(list); }
+extern "C" DirectoryHelper* CreateHelper(TList* list) { return new DirectoryHelper(list); }
 
 extern "C" void DestroyHelper(TGRSIHelper* helper) { delete helper; }
 

--- a/examples/ExampleEventHelper.cxx
+++ b/examples/ExampleEventHelper.cxx
@@ -134,23 +134,23 @@ void ExampleEventHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& gr
 	}
 }
 
-void ExampleEventHelper::EndOfSort(std::shared_ptr<TList> list)
+void ExampleEventHelper::EndOfSort(std::shared_ptr<std::map<std::string, TList>> list)
 {
-	auto coincident = static_cast<TH2*>(list->FindObject(fH2[0].at("griffinESuppAddbackMatrixBeta")));
+	auto coincident = static_cast<TH2*>(list->at("").FindObject(fH2[0].at("griffinESuppAddbackMatrixBeta")));
 	if(coincident == nullptr) {
 		std::cout<<"Failed to find griffinESuppAddbackMatrixBeta histogram in list:"<<std::endl;
-		list->Print();
+		list->at("").Print();
 		return;
 	}
-	auto timeRandom = static_cast<TH2*>(list->FindObject(fH2[0].at("griffinESuppAddbackMatrixBetaBg")));
+	auto timeRandom = static_cast<TH2*>(list->at("").FindObject(fH2[0].at("griffinESuppAddbackMatrixBetaBg")));
 	if(timeRandom == nullptr) {
 		std::cout<<"Failed to find griffinESuppAddbackMatrixBetaBg histogram in list:"<<std::endl;
-		list->Print();
+		list->at("").Print();
 		return;
 	}
 
 	auto corrected = static_cast<TH2*>(coincident->Clone("griffinESuppAddbackMatrixBetaCorr"));
 	// coinc = -250 - 250 = 500 wide, bg = -500 - -250 plus 250 - 500 = 500 wide
 	corrected->Add(timeRandom, -1.);
-	list->Add(corrected);
+	list->at("").Add(corrected);
 }

--- a/examples/ExampleFragmentHelper.hh
+++ b/examples/ExampleFragmentHelper.hh
@@ -11,7 +11,7 @@ public:
 		Prefix("ExampleFragment");
 		Setup();
 	}
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TFragment>(std::move(*this), {"TFragment"});
    }
 

--- a/examples/ExampleTreeHelper.cxx
+++ b/examples/ExampleTreeHelper.cxx
@@ -5,14 +5,15 @@ void ExampleTreeHelper::CreateHistograms(unsigned int slot) {
 	fTree[slot].emplace("coinc", new TTree("coinc", "coincident events"));
 	fTree[slot]["timebg"] = new TTree("timebg", "time random events");
 
+	fSuppressedAddback2[slot] = new double[3];
 	// set branch addresses for output tree (these can be different for different trees)
 	// four coincident gammas a,b,c,d will be saved as a,b,c, a,b,d, a,c,d, and b,c,d
-	fTree[slot]["coinc"]->Branch("energy", &fSuppressedAddback);
-	fTree[slot]["coinc"]->Branch("timing", &fBetaGammaTiming);
-	fTree[slot]["coinc"]->Branch("mult", &fGriffinMultiplicity, "mult/I");
+	fTree[slot]["coinc"]->Branch("energy", &(fSuppressedAddback2[slot]), "energy[3]/D");
+	//fTree[slot]["coinc"]->Branch("timing", &(fBetaGammaTiming[slot]));
+	fTree[slot]["coinc"]->Branch("mult", &(fGriffinMultiplicity[slot]), "mult/I");
 
-	fTree[slot]["timebg"]->Branch("energy", &fSuppressedAddback);
-	fTree[slot]["timebg"]->Branch("timing", &fBetaGammaTiming);
+	fTree[slot]["timebg"]->Branch("energy", &(fSuppressedAddback[slot]));
+	fTree[slot]["timebg"]->Branch("timing", &(fBetaGammaTiming[slot]));
 
 	//We can also create histograms at the same time, maybe for some diagnostics or simple checks
 	fH1[slot]["asE"]	= new TH1D("asE", "suppressed Addback Singles", 12000,0,3000);
@@ -41,39 +42,44 @@ void ExampleTreeHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& gri
 	// histograms without these cuts.
 	
 	// clear the vectors and other variables
-	fSuppressedAddback.resize(3, 0.);
-	fBetaGammaTiming.resize(3, -1e6);
+	fSuppressedAddback[slot].resize(3, 0.);
+	fBetaGammaTiming[slot].resize(3, -1e6);
+	for(int i = 0; i < 3; ++i) fSuppressedAddback2[slot][i] = 0.;
 
 	fH2[slot].at("sceptarMult")->Fill(grif.GetSuppressedAddbackMultiplicity(&grifBgo), scep.GetMultiplicity());
 	fH2[slot].at("zdsMult")->Fill(grif.GetSuppressedAddbackMultiplicity(&grifBgo), zds.GetMultiplicity());
 
 	//Loop over all suppressed addback Griffin Hits
-	fGriffinMultiplicity = grif.GetSuppressedAddbackMultiplicity(&grifBgo);
-   for(auto i = 0; i < fGriffinMultiplicity; ++i) {
+	fGriffinMultiplicity[slot] = grif.GetSuppressedAddbackMultiplicity(&grifBgo);
+	if(fGriffinMultiplicity[slot] < 3) return;
+   for(auto i = 0; i < fGriffinMultiplicity[slot]; ++i) {
 		auto grif1 = grif.GetSuppressedAddbackHit(i);
       fH1[slot].at("asE")->Fill(grif1->GetEnergy());
-		fSuppressedAddback[0] = grif1->GetEnergy();
+		fSuppressedAddback[slot][0] = grif1->GetEnergy();
+		fSuppressedAddback2[slot][0] = grif1->GetEnergy();
 		for(auto j = i+1; j < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++j) {
 			auto grif2 = grif.GetSuppressedAddbackHit(j);
-			fSuppressedAddback[1] = grif2->GetEnergy();
+			fSuppressedAddback[slot][1] = grif2->GetEnergy();
+			fSuppressedAddback2[slot][1] = grif2->GetEnergy();
 			for(auto k = j+1; k < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++k) {
 				auto grif3 = grif.GetSuppressedAddbackHit(k);
-				fSuppressedAddback[2] = grif3->GetEnergy();
+				fSuppressedAddback[slot][2] = grif3->GetEnergy();
+				fSuppressedAddback2[slot][2] = grif3->GetEnergy();
 				// we now have three suppressed addback hits i, j, and k so now we need a coincident beta-tag
 				bool foundBeta = false;
 				for(auto b = 0; b < zds.GetMultiplicity(); ++b) {
 					auto beta = zds.GetZeroDegreeHit(b);
 					if(b == 0) {
 						// use the time of the first beta as reference in case we don't find a coincident beta
-						fBetaGammaTiming[0] = grif1->GetTime() - beta->GetTime();
-						fBetaGammaTiming[1] = grif2->GetTime() - beta->GetTime();
-						fBetaGammaTiming[2] = grif3->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][0] = grif1->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][1] = grif2->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][2] = grif3->GetTime() - beta->GetTime();
 					}
 					if(PromptCoincidence(grif1, beta) && PromptCoincidence(grif2, beta) && PromptCoincidence(grif3, beta)) {
 						foundBeta = true;
-						fBetaGammaTiming[0] = grif1->GetTime() - beta->GetTime();
-						fBetaGammaTiming[1] = grif2->GetTime() - beta->GetTime();
-						fBetaGammaTiming[2] = grif3->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][0] = grif1->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][1] = grif2->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][2] = grif3->GetTime() - beta->GetTime();
 						break;
 					}
 				}
@@ -82,32 +88,21 @@ void ExampleTreeHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& gri
 					auto beta = scep.GetSceptarHit(b);
 					if(b == 0) {
 						// use the time of the first beta as reference in case we don't find a coincident beta
-						fBetaGammaTiming[0] = grif1->GetTime() - beta->GetTime();
-						fBetaGammaTiming[1] = grif2->GetTime() - beta->GetTime();
-						fBetaGammaTiming[2] = grif3->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][0] = grif1->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][1] = grif2->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][2] = grif3->GetTime() - beta->GetTime();
 					}
 					if(PromptCoincidence(grif1, beta) && PromptCoincidence(grif2, beta) && PromptCoincidence(grif3, beta)) {
 						foundBeta = true;
-						fBetaGammaTiming[0] = grif1->GetTime() - beta->GetTime();
-						fBetaGammaTiming[1] = grif2->GetTime() - beta->GetTime();
-						fBetaGammaTiming[2] = grif3->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][0] = grif1->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][1] = grif2->GetTime() - beta->GetTime();
+						fBetaGammaTiming[slot][2] = grif3->GetTime() - beta->GetTime();
 						break;
 					}
 				}
 
 				if(foundBeta) {
-					auto entries = fTree[slot].at("coinc")->GetEntries();
-					if(entries < 10) {
-						std::cout<<slot<<" "<<fGriffinMultiplicity<<" "<<fSuppressedAddback.size();
-						for(auto e : fSuppressedAddback) {
-							std::cout<<" "<<e;
-						}
-						std::cout<<std::endl;
-					}
 					fTree[slot].at("coinc")->Fill();
-					if(entries < 10) {
-						fTree[slot].at("coinc")->Scan("*");
-					}
 				} else {
 					fTree[slot].at("timebg")->Fill();
 				}

--- a/examples/ExampleTreeHelper.hh
+++ b/examples/ExampleTreeHelper.hh
@@ -30,7 +30,7 @@ public :
 		Setup();
 	}
 	//These functions are expected to exist
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TGriffin, TGriffinBgo, TZeroDegree, TSceptar>(std::move(*this), {"TGriffin", "TGriffinBgo", "TZeroDegree", "TSceptar"});
 	}
 	void CreateHistograms(unsigned int slot);
@@ -38,9 +38,12 @@ public :
 
 private:
 	// branches of output trees
-	std::vector<double> fSuppressedAddback; ///< vector of suppressed addback energies
-	std::vector<double> fBetaGammaTiming; ///< vector of beta-gamma timing
-	int fGriffinMultiplicity; ///< multiplicity of suppressed addback energies
+	// all of these need to be maps for the different slots/workers, we're using maps as they don't need to be resized and once accessed
+	// the address of key stays the same (important to be able to create branches)
+	std::map<unsigned int, double*> fSuppressedAddback2; ///< vector of suppressed addback energies
+	std::map<unsigned int, std::vector<double>> fSuppressedAddback; ///< vector of suppressed addback energies
+	std::map<unsigned int, std::vector<double>> fBetaGammaTiming; ///< vector of beta-gamma timing
+	std::map<unsigned int, int> fGriffinMultiplicity; ///< multiplicity of suppressed addback energies
 };
 
 extern "C" ExampleTreeHelper* CreateHelper(TList* list) { return new ExampleTreeHelper(list); }

--- a/examples/GriffinKValueHelper.hh
+++ b/examples/GriffinKValueHelper.hh
@@ -13,7 +13,7 @@ public:
 		Prefix("GriffinKValue");
 		Setup();
 	}
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
 		return d->Book<TFragment>(std::move(*this), {"TFragment"});
 	}
    void          CreateHistograms(unsigned int slot);

--- a/examples/TimeWalkHelper.hh
+++ b/examples/TimeWalkHelper.hh
@@ -13,7 +13,7 @@ class TimeWalkHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl
 		Setup();
    }
 	//These functions are expected to exist
-	ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame* d) override {
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
       return d->Book<TGriffin, TSceptar>(std::move(*this), {"TGriffin", "TSceptar"});
 	}
    void CreateHistograms(unsigned int slot);

--- a/include/TGRSIFrame.h
+++ b/include/TGRSIFrame.h
@@ -1,6 +1,7 @@
 #ifndef TGRSIFRAME_H
 #define TGRSIFRAME_H
 
+#include <map>
 #include <string>
 
 #include "TList.h"
@@ -12,6 +13,10 @@
 #include "ROOT/RLogger.hxx"
 #endif
 
+/** \addtogroup Framing
+ *  * @{
+ *  */
+
 class TGRSIFrame {
 public:
    TGRSIFrame();
@@ -20,7 +25,7 @@ public:
 
 private:
 	std::string fOutputPrefix{"default"};
-	ROOT::RDF::RResultPtr<TList> fOutput;
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> fOutput;
 
 	TGRSIOptions* fOptions{nullptr};
 	TPPG* fPpg{nullptr};
@@ -33,6 +38,7 @@ private:
 #endif
 };
 
+/*! @} */
 void DummyFunctionToLocateTGRSIFrameLibrary();
 
 #endif

--- a/include/TGRSIHelper.h
+++ b/include/TGRSIHelper.h
@@ -25,7 +25,7 @@
 
 class TGRSIHelper : public TObject {
 protected:
-   std::vector<std::shared_ptr<TList>> fLists;   //!<! one list per data processing slot to hold all output objects
+   std::vector<std::shared_ptr<std::map<std::string, TList>>> fLists;   //!<! one map of lists and directories per data processing slot to hold all output objects
 	std::vector<TGRSIMap<std::string, TH1*>> fH1; //!<! one map per data processing slot for 1D histograms
    std::vector<TGRSIMap<std::string, TH2*>> fH2; //!<! one map per data processing slot for 2D histograms
    std::vector<TGRSIMap<std::string, TH3*>> fH3; //!<! one map per data processing slot for 3D histograms
@@ -42,7 +42,7 @@ private:
 
 public:
    /// This type is a requirement for every helper.
-   using Result_t = TList;
+   using Result_t = std::map<std::string, TList>;
  
    TGRSIHelper(TList* input);
 
@@ -55,14 +55,14 @@ public:
 		std::cout<<this<<" - "<<__PRETTY_FUNCTION__<<", "<<Prefix()<<": This function should not get called, the user's code should replace it. Not creating any histograms!"<<std::endl;
 	}
 	/// This method will call the Book action on the provided dataframe
-	virtual ROOT::RDF::RResultPtr<TList> Book(ROOT::RDataFrame*) {
+	virtual ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame*) {
 		std::cout<<this<<" - "<<__PRETTY_FUNCTION__<<", "<<Prefix()<<": This function should not get called, the user's code should replace it. Returning empty list!"<<std::endl; 
-		return ROOT::RDF::RResultPtr<TList>();
+		return ROOT::RDF::RResultPtr<std::map<std::string, TList>>();
 	}
 
 	TGRSIHelper(TGRSIHelper &&) = default;
 	TGRSIHelper(const TGRSIHelper &) = delete;
-	std::shared_ptr<TList> GetResultPtr() const { return fLists[0]; }
+	std::shared_ptr<std::map<std::string, TList>> GetResultPtr() const { return fLists[0]; }
 	void InitTask(TTreeReader *, unsigned int) {}
 	void Initialize() {} // required method, gets called once before starting the event loop
 	/// This required method is called at the end of the event loop. It is used to merge all the internal TLists which
@@ -70,7 +70,7 @@ public:
 	void Finalize();
 
 	/// This method gets called at the end of Finalize()
-	virtual void EndOfSort(std::shared_ptr<TList>) {}
+	virtual void EndOfSort(std::shared_ptr<std::map<std::string, TList>>) {}
 
 	std::string Prefix() const { return fPrefix; }
 	void Prefix(const std::string& val) { fPrefix = val; }

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -51,7 +51,7 @@ public:
    TF1* GetFitFunction() { return fTotalFitFunction; }
    void SetRange(const Double_t& low, const Double_t& high);
    Int_t GetNParameters() const;
-   void Fit(TH1* fit_hist,Option_t* opt="");
+   TFitResultPtr Fit(TH1* fit_hist,Option_t* opt="");
    void DrawPeaks(Option_t* = "") const;
 
 	void ResetInitFlag() { fInitFlag = false; }

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -179,6 +179,7 @@ public:
 	
 	void VerboseLevel(int val) { fVerboseLevel = val; for(auto source : fSourceTab) source->VerboseLevel(val); }
 
+	static void ZoomX();
 	static void ZoomY();
 
 private:

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -81,14 +81,14 @@ void TPeakFitter::SetRange(const Double_t &low, const Double_t &high)
 	fRangeHigh = high;
 }
 
-void TPeakFitter::Fit(TH1* fit_hist, Option_t *opt)
+TFitResultPtr TPeakFitter::Fit(TH1* fit_hist, Option_t *opt)
 {
 	/// Fit the histogram. Recognized options are "q" for a quiet fit, "retryfit" to retry a fit without parameter limits
 	/// if one of the parameters got close to its limit. All options (apart from "retryfit") are passed on to the actual 
 	/// call to TH1::Fit.
 	if(fPeaksToFit.empty()) {
 		std::cout<<"No peaks provided!"<<std::endl;
-		return;
+		return TFitResultPtr();
 	}
 
 	TString options = opt;
@@ -172,6 +172,8 @@ void TPeakFitter::Fit(TH1* fit_hist, Option_t *opt)
 	fit_hist->GetXaxis()->SetRange(firstBin, lastBin);
 	// reset the default back to minuit in case we switched to minos in between
 	ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2", "Combination");
+
+	return fit_res;
 }
 
 void TPeakFitter::UpdatePeakParameters(const TFitResultPtr& fit_res, TH1* fit_hist)

--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -144,7 +144,22 @@ void TGRSIFrame::Run()
 		// accessing the result from Book causes the actual processing of the helper
 		// so we try and catch any exception
 		try {
-			fOutput->Write();
+			for(auto& list : *fOutput) {
+				// try and switch to the directory this list should be written to
+				if(gDirectory->GetDirectory(list.first.c_str()) && gDirectory->cd(list.first.c_str())) {
+					list.second.Write();
+				} else {
+					// directory this list should be written to doesn't exist, so create it
+					gDirectory->mkdir(list.first.c_str());
+					if(gDirectory->cd(list.first.c_str())) {
+						list.second.Write();
+					} else {
+						std::cout<<"Error, failed to find or create path "<<list.first<<", writing into "<<gDirectory->GetPath()<<std::endl;
+					}
+				}
+				// switch back to topmost directory
+				while(gDirectory->GetDirectory("..")) { gDirectory->cd(".."); }
+			}
          std::cout<<"\r["<<std::left<<std::setw(barWidth)<<progressBar<<' '<<"100 %]"<<std::flush;
 		} catch(TGRSIMapException<std::string>& e) {
 			std::cout<<DRED<<"Exception in "<<__PRETTY_FUNCTION__<<": "<<e.detail()<<RESET_COLOR<<std::endl;

--- a/libraries/TGRSIFrame/TGRSIHelper.cxx
+++ b/libraries/TGRSIFrame/TGRSIHelper.cxx
@@ -61,7 +61,7 @@ TGRSIHelper::TGRSIHelper(TList* input) {
 		}
 		++i;
 	}
-	for(auto cut : fCuts) {
+	for(auto& cut : fCuts) {
 		std::cout<<cut.first<<" = "<<cut.second<<std::endl;
 	}
 
@@ -76,7 +76,7 @@ void TGRSIHelper::Setup() {
 	const auto nSlots = ROOT::IsImplicitMTEnabled() ? TGRSIOptions::Get()->GetMaxWorkers() : 1;
 	TH1::AddDirectory(false); // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
 	for(auto i : ROOT::TSeqU(nSlots)) {
-		fLists.emplace_back(std::make_shared<TList>());
+		fLists.emplace_back(std::make_shared<std::map<std::string, TList>>());
 		fH1.emplace_back(TGRSIMap<std::string, TH1*>());
 		fH2.emplace_back(TGRSIMap<std::string, TH2*>());
 		fH3.emplace_back(TGRSIMap<std::string, TH3*>());
@@ -84,23 +84,59 @@ void TGRSIHelper::Setup() {
 		fCube.emplace_back(TGRSIMap<std::string, GCube*>());
 		fTree.emplace_back(TGRSIMap<std::string, TTree*>());
 		CreateHistograms(i);
-		for(auto it : fH1[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fH1[i]) {
+			// if the key/name of the histogram does not contain a forward slash we put it in the root-directory
+			if(it.first.find_last_of('/') == std::string::npos) {
+				(*fLists[i])[""].Add(it.second);
+			} else {
+				// extract the path from the key/name
+				auto lastSlash = it.first.find_last_of('/');
+				(*fLists[i])[it.first.substr(0, lastSlash)].Add(it.second);
+			}
 		}
-		for(auto it : fH2[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fH2[i]) {
+			// if the key/name of the histogram does not contain a forward slash we put it in the root-directory
+			if(it.first.find_last_of('/') == std::string::npos) {
+				(*fLists[i])[""].Add(it.second);
+			} else {
+				// extract the path from the key/name
+				auto lastSlash = it.first.find_last_of('/');
+				(*fLists[i])[it.first.substr(0, lastSlash)].Add(it.second);
+			}
 		}
-		for(auto it : fH3[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fH3[i]) {
+			// if the key/name of the histogram does not contain a forward slash we put it in the root-directory
+			if(it.first.find_last_of('/') == std::string::npos) {
+				(*fLists[i])[""].Add(it.second);
+			} else {
+				// extract the path from the key/name
+				auto lastSlash = it.first.find_last_of('/');
+				(*fLists[i])[it.first.substr(0, lastSlash)].Add(it.second);
+			}
 		}
-		for(auto it : fSym[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fSym[i]) {
+			// if the key/name of the histogram does not contain a forward slash we put it in the root-directory
+			if(it.first.find_last_of('/') == std::string::npos) {
+				(*fLists[i])[""].Add(it.second);
+			} else {
+				// extract the path from the key/name
+				auto lastSlash = it.first.find_last_of('/');
+				(*fLists[i])[it.first.substr(0, lastSlash)].Add(it.second);
+			}
 		}
-		for(auto it : fCube[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fCube[i]) {
+			// if the key/name of the histogram does not contain a forward slash we put it in the root-directory
+			if(it.first.find_last_of('/') == std::string::npos) {
+				(*fLists[i])[""].Add(it.second);
+			} else {
+				// extract the path from the key/name
+				auto lastSlash = it.first.find_last_of('/');
+				(*fLists[i])[it.first.substr(0, lastSlash)].Add(it.second);
+			}
 		}
-		for(auto it : fTree[i]) {
-			fLists[i]->Add(it.second);
+		for(auto& it : fTree[i]) {
+			// trees can only be written into the root-directory due to the way they get merge in Finalize (for now?)
+			(*fLists[i])[""].Add(it.second);
 		}
 		CheckSizes(i, "use");
 	}
@@ -108,6 +144,7 @@ void TGRSIHelper::Setup() {
 }
 
 void TGRSIHelper::Finalize() {
+	/// This function merges all maps of lists into the map of the first slot (slot 0)
 	CheckSizes(0, "write");
 	// get all objects from the first slot
 	auto& res = fLists[0];
@@ -116,31 +153,34 @@ void TGRSIHelper::Finalize() {
 	// loop over all other slots
 	for(auto slot : ROOT::TSeqU(1, fLists.size())) {
 		CheckSizes(slot, "write");
-		// loop over each object in the list we merge into
-		for(const auto&& obj : *res) {
-			// check if object exists in the slot's list
-			if(fLists[slot]->FindObject(obj->GetName()) != nullptr) {
-				// check object type and merge correspondingly
-				if(obj->InheritsFrom(TH1::Class())) {
-					// histograms can just be added together
-					static_cast<TH1*>(obj)->Add(static_cast<TH1*>(fLists[slot]->FindObject(obj->GetName())));
-				} else if(obj->InheritsFrom(TTree::Class())) {
-					// trees are added to the list and merged later
-					TTree* tree = static_cast<TTree*>(obj);
-					//std::cout<<slot<<" copied "<<tree->CopyEntries(static_cast<TTree*>(fLists[slot]->FindObject(obj->GetName())))<<" bytes to tree "<<tree->GetName()<<std::endl;
-					treeList.emplace(tree, new TList); // emplace does not overwrite existing elements!
-					treeList.at(tree)->Add(fLists[slot]->FindObject(obj->GetName()));
-					std::cout<<slot<<": adding "<<treeList.at(tree)->GetSize()<<". "<<tree->GetName()<<" tree with "<<static_cast<TTree*>(fLists[slot]->FindObject(obj->GetName()))->GetEntries()<<" entries"<<std::endl;
+		// loop over each TList in the map we merge into
+		for(const auto& list : *res) {
+			// loop over each object in the list
+			for(const auto&& obj : list.second) {
+				// check if object exists in the slot's list
+				if((*fLists[slot]).at(list.first).FindObject(obj->GetName()) != nullptr) {
+					// check object type and merge correspondingly
+					if(obj->InheritsFrom(TH1::Class())) {
+						// histograms can just be added together
+						static_cast<TH1*>(obj)->Add(static_cast<TH1*>((*fLists[slot]).at(list.first).FindObject(obj->GetName())));
+					} else if(obj->InheritsFrom(TTree::Class())) {
+						// trees are added to the list and merged later
+						TTree* tree = static_cast<TTree*>(obj);
+						//std::cout<<slot<<" copied "<<tree->CopyEntries(static_cast<TTree*>((*fLists[slot]).at(list.first).FindObject(obj->GetName())))<<" bytes to tree "<<tree->GetName()<<std::endl;
+						treeList.emplace(tree, new TList); // emplace does not overwrite existing elements!
+						treeList.at(tree)->Add((*fLists[slot]).at(list.first).FindObject(obj->GetName()));
+						std::cout<<slot<<": adding "<<treeList.at(tree)->GetSize()<<". "<<tree->GetName()<<" tree with "<<static_cast<TTree*>((*fLists[slot]).at(list.first).FindObject(obj->GetName()))->GetEntries()<<" entries"<<std::endl;
+					} else {
+						std::cerr<<"Object '"<<obj->GetName()<<"' is not a histogram ("<<obj->ClassName()<<"), don't know what to do with it!"<<std::endl;
+					}
 				} else {
-					std::cerr<<"Object '"<<obj->GetName()<<"' is not a histogram ("<<obj->ClassName()<<"), don't know what to do with it!"<<std::endl;
+					std::cerr<<"Failed to find object '"<<obj->GetName()<<"' in "<<slot<<". list"<<std::endl;
 				}
-			} else {
-				std::cerr<<"Failed to find object '"<<obj->GetName()<<"' in "<<slot<<". list"<<std::endl;
 			}
 		}
 	}
 	// merge the trees in the list (if there are any)
-	for(auto tree : treeList) {
+	for(auto& tree : treeList) {
 		tree.second->Add(tree.first);
 		Long64_t entries = 0;
 		int i = 0;
@@ -151,8 +191,8 @@ void TGRSIHelper::Finalize() {
 		std::cout<<"total of "<<entries<<" entries"<<std::endl;
 		auto newTree = TTree::MergeTrees(tree.second);
 		std::cout<<"Got new tree with "<<newTree->GetEntries()<<" => "<<entries-newTree->GetEntries()<<" less than total"<<std::endl;
-		res->Remove(tree.first);
-		res->Add(newTree);
+		(*res).at("").Remove(tree.first);
+		(*res).at("").Add(newTree);
 	//	std::cout<<"Adding "<<tree.second->GetSize()<<" "<<tree.first->GetName()<<" trees to "<<tree.first->GetEntries()<<" entries"<<std::endl;
 	//	tree.first->Merge(tree.second);
 	//	std::cout<<"Got "<<tree.first->GetEntries()<<" entries"<<std::endl;
@@ -161,18 +201,22 @@ void TGRSIHelper::Finalize() {
 }
 
 void TGRSIHelper::CheckSizes(unsigned int slot, const char* usage) {
-	// check size of each object in the output list
-	for(const auto&& obj : *fLists[slot]) {
-		TBufferFile b(TBuffer::kWrite, 10000);
-		obj->IsA()->WriteBuffer(b, obj);
-		if(b.Length() > SIZE_LIMIT) {
-			std::stringstream str;
-			str<<DRED<<slot<<". slot: "<<obj->ClassName()<<" '"<<obj->GetName()<<"' too large to "<<usage<<": "<<b.Length()<<" bytes = "<<b.Length()/1024./1024./1024.<<" GB, removing it!"<<RESET_COLOR<<std::endl;
-			std::cout<<str.str();
-			// we only remove it from the output list, not deleting the object itself
-			// this way the filling of that histogram will still work, it just won't get written to file
-			// we remove it from all lists though, not just the first one
-			fLists[slot]->Remove(obj);
+	/// check size of each object in the output list
+	// loop over each TList in the map
+	for(auto& list : *fLists[slot]) {
+		// loop over each object in the list
+		for(const auto&& obj : list.second) {
+			TBufferFile b(TBuffer::kWrite, 10000);
+			obj->IsA()->WriteBuffer(b, obj);
+			if(b.Length() > SIZE_LIMIT) {
+				std::stringstream str;
+				str<<DRED<<slot<<". slot: "<<obj->ClassName()<<" '"<<obj->GetName()<<"' too large to "<<usage<<": "<<b.Length()<<" bytes = "<<b.Length()/1024./1024./1024.<<" GB, removing it!"<<RESET_COLOR<<std::endl;
+				std::cout<<str.str();
+				// we only remove it from the output list, not deleting the object itself
+				// this way the filling of that histogram will still work, it just won't get written to file
+				// we remove it from all lists though, not just the first one
+				list.second.Remove(obj);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- To address the issue of writing histograms to separate directories in grsiframe the return type was changed from a TList to a map of TLists which maps the TLists to the path they are written to. This path is taken from the key used in the histogram maps in the ```CreateHistograms``` and ```Exec``` functions of the helper. Everything before the last ```/``` is used as a path, if no path is found the main directory of the file is used.
- TSourceCalibration now zooms the y-axis of the residuals when the range of the y-axis of the calibration graph is changed and vice versa.
- Also changed TPeakFitter::Fit to return the FitResultPtr used internally so that users can access it.