### PR TITLE
Now also reading $(HOME)/.grsirc for user specific settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GRSISort
 
-A lean, mean, sorting machine.    
+A lean, mean, sorting machine base on [ROOT](https://root.cern.ch), used to analyze data from experiments at Triumf, ILL, iThemba, or HIL. 
 
 **For Up-To-Date Information** please Join the [Analysis_User](https://github.com/orgs/GRIFFINCollaboration/teams/analysis_users) team.
 

--- a/libraries/TFormat/TDataFrameLibrary.cxx
+++ b/libraries/TFormat/TDataFrameLibrary.cxx
@@ -136,7 +136,7 @@ void TDataFrameLibrary::Compile(std::string& path, const size_t& dot, const size
 	}
 	std::cout<<DCYAN<<"----------  starting linking user code  -----------------"<<RESET_COLOR<<std::endl;
 	command.clear();
-	command<<"g++ -fPIC -g -shared -Wl,-dylib -o "<<sharedLibrary<<" "<<objectFile<<std::endl;
+	command<<"g++ -fPIC -g -shared -o "<<sharedLibrary<<" "<<objectFile<<std::endl;
 	if(std::system(command.str().c_str()) != 0) {
 		std::stringstream str;
 		str<<"Unable to link shared object library "<<sharedLibrary<<" using '"<<command.str()<<"'"<<std::endl;

--- a/src/grsisort.cxx
+++ b/src/grsisort.cxx
@@ -92,13 +92,22 @@ int main(int argc, char** argv)
 
 void SetGRSIEnv()
 {
-   std::string grsi_path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
-   if(grsi_path.length() > 0) {
-      grsi_path += "/";
+	/// function to read user defined options first from the .grsirc file in $GRSISYS, then the .grsirc file in $HOME
+   std::string path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
+   if(path.length() > 0) {
+      path += "/";
    }
    // Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
-   grsi_path += ".grsirc";
-   gEnv->ReadFile(grsi_path.c_str(), kEnvChange);
+   path += ".grsirc";
+   gEnv->ReadFile(path.c_str(), kEnvChange);
+	// read from home directory for user-specific settings (in case $GRSISYS is a multi-user installation)
+   path = getenv("HOME"); // Finds the HOME path to be used by other parts of the grsisort code
+   if(path.length() > 0) {
+      path += "/";
+   }
+   // Read in grsirc in the HOME directory to set user defined options on grsisort startup - these overwrite previous settings
+   path += ".grsirc";
+   gEnv->ReadFile(path.c_str(), kEnvChange);
 }
 
 void SetGRSIPluginHandlers()


### PR DESCRIPTION
This allows users to have their own history of commands, even when using a GRSISort installation shared with other users. Simply add a .grsirc file to your home directory with this content:
```
Rint.History: $(HOME)/.grsi_history
```
Of course any of the other settings of GRSISort (or ROOT) can also be overwritten in this file.