### PR TITLE
PlotVsRun and ReadCalFromRoot added

### DIFF
--- a/include/Globals.h
+++ b/include/Globals.h
@@ -73,6 +73,8 @@ typedef char int8_t;
 #include <memory>
 #include <unistd.h>
 
+#include "TEnv.h"
+
 const std::string& ProgramName();
 
 namespace grsi {
@@ -88,6 +90,8 @@ public:
    const int   code;
    const char* message;
 };
+
+void SetGRSIEnv();
 
 //-------------------- three function templates that print all arguments into a string
 //this template uses existing stream and appends the last argument to it

--- a/include/TRunInfo.h
+++ b/include/TRunInfo.h
@@ -176,6 +176,8 @@ public:
 
 	void PrintRunList();
 
+	static std::string CreateLabel(bool quiet = false);
+
 	static void SetDetectorInformation(TDetectorInformation* inf) { Get()->fDetectorInformation = inf; }
 	static TDetectorInformation* GetDetectorInformation() { return Get()->fDetectorInformation; }
 

--- a/libraries/TFormat/Globals.cxx
+++ b/libraries/TFormat/Globals.cxx
@@ -1,0 +1,22 @@
+#include "Globals.h"
+
+void grsi::SetGRSIEnv()
+{
+	/// function to read user defined options first from the .grsirc file in $GRSISYS, then the .grsirc file in $HOME
+   std::string path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
+   if(path.length() > 0) {
+      path += "/";
+   }
+   // Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
+   path += ".grsirc";
+   gEnv->ReadFile(path.c_str(), kEnvChange);
+	// read from home directory for user-specific settings (in case $GRSISYS is a multi-user installation)
+   path = getenv("HOME"); // Finds the HOME path to be used by other parts of the grsisort code
+   if(path.length() > 0) {
+      path += "/";
+   }
+   // Read in grsirc in the HOME directory to set user defined options on grsisort startup - these overwrite previous settings
+   path += ".grsirc";
+   gEnv->ReadFile(path.c_str(), kEnvChange);
+}
+

--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -562,3 +562,28 @@ void TRunInfo::PrintRunList()
 		std::cout<<std::setw(5)<<std::setfill('0')<<pair.first<<"_"<<std::setw(3)<<pair.second<<std::setfill(' ')<<std::endl;
 	}
 }
+
+std::string TRunInfo::CreateLabel(bool quiet)
+{
+	/// This function creates a label/string based on the run number and the subrun number.
+	auto runInfo = Get();
+	Int_t runNumber    = runInfo->RunNumber();
+   Int_t subRunNumber = runInfo->SubRunNumber();
+
+	std::string result;
+	if(!quiet) std::cout<<"Using run number "<<runNumber<<", sub run number "<<subRunNumber<<", first/last run number "<<runInfo->FirstRunNumber()<<"/"<<runInfo->LastRunNumber()<<", and first/last sub run number"<<runInfo->FirstSubRunNumber()<<"/"<<runInfo->LastSubRunNumber()<<std::endl;
+   if(runNumber != 0 && subRunNumber != -1) {
+      // both run and subrun number set => single file processed
+      result = Form("%05d_%03d", runNumber, subRunNumber);
+   } else if(runNumber != 0) {
+      // multiple subruns of a single run
+		// we could check if first and last sub run number are both -1 (which is non-consecutive runs or not initialized, the latter would mean single file w/o a subrun number, like ILL data)
+      result = Form("%05d_%03d-%03d", runNumber, runInfo->FirstSubRunNumber(), runInfo->LastSubRunNumber());
+   } else {
+      // multiple runs
+      result = Form("%05d-%05d", runInfo->FirstRunNumber(), runInfo->LastRunNumber());
+   }
+	if(!quiet) std::cout<<"Writing to "<<result<<std::endl;
+
+	return result;
+}

--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -103,22 +103,9 @@ void TGRSIFrame::Run()
 {
 	// get runinfo and get run and sub-run number
 	auto runInfo = TRunInfo::Get();
-	Int_t runNumber    = runInfo->RunNumber();
-   Int_t subRunNumber = runInfo->SubRunNumber();
 
 	// get output file name
-	std::string outputFileName;
-	std::cout<<"Using run number "<<runNumber<<", sub run number "<<subRunNumber<<", first/last run number "<<runInfo->FirstRunNumber()<<"/"<<runInfo->LastRunNumber()<<", first/last sub run number"<<runInfo->FirstSubRunNumber()<<"/"<<runInfo->LastSubRunNumber()<<", and prefix "<<fOutputPrefix<<std::endl;
-   if(runNumber != 0 && subRunNumber != -1) {
-      // both run and subrun number set => single file processed
-      outputFileName = Form("%s%05d_%03d.root", fOutputPrefix.c_str(), runNumber, subRunNumber);
-   } else if(runNumber != 0) {
-      // multiple subruns of a single run
-      outputFileName = Form("%s%05d_%03d-%03d.root", fOutputPrefix.c_str(), runNumber, runInfo->FirstSubRunNumber(), runInfo->LastSubRunNumber());
-   } else {
-      // multiple runs
-      outputFileName = Form("%s%05d-%05d.root", fOutputPrefix.c_str(), runInfo->FirstRunNumber(), runInfo->LastRunNumber());
-   }
+	std::string outputFileName = Form("%s%s.root", fOutputPrefix.c_str(), runInfo->CreateLabel().c_str());
 	std::cout<<"Writing to "<<outputFileName<<std::endl;
 
 	TFile outputFile(outputFileName.c_str(), "recreate");

--- a/src/grsisort.cxx
+++ b/src/grsisort.cxx
@@ -6,11 +6,11 @@
 #include <stdexcept>
 #include <pwd.h>
 
-#include "TEnv.h"
 #include "TPluginManager.h"
 #include "TGRSIint.h"
 
 #include "GVersion.h"
+#include "Globals.h"
 #include "TThread.h"
 
 #ifdef __APPLE__
@@ -68,9 +68,8 @@ int main(int argc, char** argv)
       TThread::Initialize();
       TObject::SetObjectStat(false);
 
-      // Find the grsisort environment variable so that we can read in .grsirc
       SetDisplay();
-      SetGRSIEnv();
+		grsi::SetGRSIEnv();
       SetGRSIPluginHandlers();
       TGRSIint* input = nullptr;
 
@@ -88,26 +87,6 @@ int main(int argc, char** argv)
 	}
 
    return 0;
-}
-
-void SetGRSIEnv()
-{
-	/// function to read user defined options first from the .grsirc file in $GRSISYS, then the .grsirc file in $HOME
-   std::string path = getenv("GRSISYS"); // Finds the GRSISYS path to be used by other parts of the grsisort code
-   if(path.length() > 0) {
-      path += "/";
-   }
-   // Read in grsirc in the GRSISYS directory to set user defined options on grsisort startup
-   path += ".grsirc";
-   gEnv->ReadFile(path.c_str(), kEnvChange);
-	// read from home directory for user-specific settings (in case $GRSISYS is a multi-user installation)
-   path = getenv("HOME"); // Finds the HOME path to be used by other parts of the grsisort code
-   if(path.length() > 0) {
-      path += "/";
-   }
-   // Read in grsirc in the HOME directory to set user defined options on grsisort startup - these overwrite previous settings
-   path += ".grsirc";
-   gEnv->ReadFile(path.c_str(), kEnvChange);
 }
 
 void SetGRSIPluginHandlers()

--- a/util/PlotVsRun.cxx
+++ b/util/PlotVsRun.cxx
@@ -1,0 +1,160 @@
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <string>
+
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
+
+#include "TRunInfo.h"
+
+int ReadArgs(int index, int argc, char** argv, std::vector<std::string>& output);
+
+int main(int argc, char** argv)
+{
+	if(argc < 5) {
+		std::cerr<<"Usage: "<<argv[0]<<" -if <list of input files> -hn <list of histogram names> (optional: -x or -y for projection on x- or y-axis)"<<std::endl;
+		return 1;
+	}
+
+	std::vector<std::string> inputFiles;
+	std::vector<std::string> histogramNames;
+	bool projectX = false;
+	bool projectY = false;
+
+	// read all command line arguments
+	for(int i = 0; i < argc; ++i) {
+		if(argv[i][0] == '-') {
+			if(strcmp(argv[i], "-if") == 0) {
+				i = ReadArgs(i+1, argc, argv, inputFiles);
+			} else if(strcmp(argv[i], "-hn") == 0) {
+				i = ReadArgs(i+1, argc, argv, histogramNames);
+			} else if(strcmp(argv[i], "-x") == 0) {
+				projectX = true;
+			} else if(strcmp(argv[i], "-y") == 0) {
+				projectY = true;
+			}
+		}
+	}
+	
+	// verify input variables are set
+	if(inputFiles.empty()) {
+		std::cerr<<"Missing input files, please provide a list of them using the \"-if\" flag!"<<std::endl;
+		return 1;
+	}
+
+	if(histogramNames.empty()) {
+		std::cerr<<"Missing names of histograms, please provide a list of them using the \"-hn\" flag!"<<std::endl;
+		return 1;
+	}
+
+	if(projectX && projectY) {
+		std::cerr<<"Both projection on x-axis and projection on y-axis are enabled, please select only one!"<<std::endl;
+		return 1;
+	}
+
+	// open first root file and check which histograms are in it and whether they are 1D or 2D
+	auto input = new TFile(inputFiles[0].c_str());
+
+	auto output = new TFile("test.root", "recreate");
+
+	TObject* obj = nullptr;
+	std::vector<TH2F*> outputHistograms;
+
+	for(auto histogramName : histogramNames) {
+		obj = input->Get(histogramName.c_str());
+		if(obj == nullptr) {
+			std::cerr<<"Failed to find \""<<histogramName<<"\" in file \""<<input->GetName()<<"\""<<std::endl;
+			return 1;
+		}
+		// first check if this is a 2D-histogram because every 2D-histogram inherits from TH1 as well!
+		if(obj->InheritsFrom(TH2::Class())) {
+			if(!projectX && !projectY) {
+				std::cerr<<"Found 2D-histogram \""<<histogramName<<"\" in file \""<<input->GetName()<<"\", but neither was told to neither project on the x-axis nor the y-axis please use one of the flags -x or -y"<<std::endl;
+				return 1;
+			}
+			auto hist = static_cast<TH2*>(obj);
+			if(projectX) {
+				auto axis = hist->GetXaxis();
+				outputHistograms.emplace_back(new TH2F(Form("%sPxVsFile", histogramName.c_str()), Form("Projection of %s on the x-axis vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
+			} else {
+				auto axis = hist->GetYaxis();
+				outputHistograms.emplace_back(new TH2F(Form("%sPyVsFile", histogramName.c_str()), Form("Projection of %s on the y-axis vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
+			}
+		} else if(obj->InheritsFrom(TH1::Class())) {
+			auto hist = static_cast<TH1*>(obj);
+			auto axis = hist->GetXaxis(); // not strictly needed, we could just use hist in its place
+			outputHistograms.emplace_back(new TH2F(Form("%sVsFile", histogramName.c_str()), Form("%s vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
+		} else {
+			std::cerr<<"Found object \""<<histogramName<<"\" in file \""<<input->GetName()<<"\", but it's neither a TH1 nor a TH2, it's a "<<obj->ClassName()<<std::endl;
+			return 1;
+		}
+	}
+
+	if(outputHistograms.size() != histogramNames.size()) {
+		std::cerr<<"Something went wrong, only found "<<outputHistograms.size()<<" histograms from "<<histogramNames.size()<<" histograms?"<<std::endl;
+		return 1;
+	}
+
+	TH1* hist = nullptr; // could move this higher up and change the "hist" variable for the 2D case?
+
+	// loop over all files and all histograms and copy the data to the output histograms
+	// we need to know the file index, so no range for loop
+	for(size_t i = 0; i < inputFiles.size(); ++i) {
+		if(input == nullptr) { // no need to re-open the first file, it's already open!
+			input = new TFile(inputFiles[i].c_str());
+		} else { // if this is the first file change into it (we opened the output file last so we are currently in that file) so that we can read the right run info
+			input->cd();
+		}
+		// get run info from this file and create a label for the bins from it
+		auto label = TRunInfo::Get()->CreateLabel(false);
+		// we need to loop through the histogramNames and the outputHistograms at the same time
+		for(size_t j = 0; j < histogramNames.size(); ++j) {
+			obj = input->Get(histogramNames[j].c_str());
+			if(obj == nullptr) {
+				std::cerr<<"Failed to find \""<<histogramNames[j]<<"\" in file \""<<input->GetName()<<"\""<<std::endl;
+				continue;
+			}
+			if(obj->InheritsFrom(TH2::Class())) {
+				if(projectX) {
+					hist = static_cast<TH1*>(static_cast<TH2*>(obj)->ProjectionX());
+				} else {
+					hist = static_cast<TH1*>(static_cast<TH2*>(obj)->ProjectionY());
+				}
+			} else if(obj->InheritsFrom(TH1::Class())) {
+				hist = static_cast<TH1*>(obj);
+			} else {
+				std::cerr<<"Found object \""<<histogramNames[i]<<"\" in file \""<<input->GetName()<<"\", but it's neither a TH1 nor a TH2, it's a "<<obj->ClassName()<<std::endl;
+				continue;
+			}
+			// at this point hist is either set or we continued to the next file
+			for(int bin = 0; bin <= hist->GetNbinsX()+1; ++bin) {
+				outputHistograms[j]->SetBinContent(i+1, bin, hist->GetBinContent(bin));
+			}
+			outputHistograms[j]->GetXaxis()->SetBinLabel(i+1, label.c_str());
+		}
+		input->Close();
+		input = nullptr;
+	}
+
+	output->cd();
+	for(auto outputHistogram : outputHistograms) {
+		outputHistogram->Write("", TObject::kOverwrite);
+	}
+
+	output->Close();
+
+	return 0;
+}
+
+int ReadArgs(int index, int argc, char** argv, std::vector<std::string>& output)
+{
+	/// This function reads arguments starting from <index> up to argc until it encounters one with leading '-'.
+	/// Returns index of last argument pushed back onto the vector (which is argc-1 if no '-' is encountered).
+	for(int i = index; i < argc; ++i) {
+		if(argv[i][0] == '-') return i-1;
+		output.push_back(argv[i]);
+	}
+	return argc-1;
+}


### PR DESCRIPTION
- PlotVsRun plots histograms (1D or projection of 2D) vs the file index. The x-axis is also labeled by the run and sub run number (created by the new function ```TRunInfo::CreateLabel(bool quiet = false)```). First tests seem to work.
- ReadCalFromRoot does essentially the reverse of WriteCalToRoot. It takes a list of input root-files (which are expected to have a ```TChannel``` called "Channel" and a ```TRunInfo``` called "RunInfo" in them), and writes a cal-file for each one of them  (using the run number and sub run number as a name with a ```.cal``` suffix). This is mainly meant to create a backup of an existing calibration (on a file-by-file level) before new calibrations are applied, especially when a group of people is collaborating on analyzing the same files.
- In order to prevent some code duplication the function ```SetGRSIEnv``` has been moved from grsisort.cxx to the new file Globals.cxx (this function essentially reads the .grsirc file). In addition the function ```TRunInfo::CreateLabel(bool quiet = false)``` has been added which creates a label based on the run number and sub run number, taking into account if multiple runs or sub runs have been added together. This function is now also being used in ```TGRSIFrame```, but not (yet?) in grsiproof (which is doing the same thing as the function internally).