### PR TITLE
Add compatibility checks for older ROOT and gcc.

### DIFF
--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -24,6 +24,7 @@
 #include "TRootEmbeddedCanvas.h"
 #include "TH2.h"
 #include "TPaveText.h"
+#include "RVersion.h"
 
 #include "GPeak.h"
 #include "TSinglePeak.h"

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -5,7 +5,9 @@
 #include <type_traits>
 #include <memory>
 #endif
+#if __GNUC__ > 5
 #include <sstream>
+#endif
 
 #include "TClass.h"
 
@@ -34,7 +36,9 @@ public:
 
    int Size() { return fDetectors.size(); }
 
+   #if __GNUC__ > 5
 	std::ostringstream Print();
+   #endif
 
 private:
    void BuildHits();

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -1247,10 +1247,14 @@ void TSourceCalibration::BuildThirdInterface()
 	fTab = new TGTab(this, 600, 600);
 	auto calTab = fTab->AddTab("Calibration");
 	fFinalTabs.push_back(new TGTab(calTab, 600, 600));
+	#if ROOT_VERSION_CODE >= ROOT_VERSION(6,26,11)
 	fFinalTabs.back()->SetScrollingEnabled();
+	#endif
 	auto effTab = fTab->AddTab("Efficiency");
 	fFinalTabs.push_back(new TGTab(effTab, 600, 600));
+	#if ROOT_VERSION_CODE >= ROOT_VERSION(6,26,11)
 	fFinalTabs.back()->SetScrollingEnabled();
+	#endif
 	if(fVerboseLevel > 2) std::cout<<"# of tabs before adding: "<<fTab->GetNumberOfTabs()<<std::endl;
 	// we're re-using the actual source id for the channels here
 	fActualSourceId.resize(fNofBins);

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -67,6 +67,7 @@ std::shared_ptr<TDetector> TUnpackedEvent::GetDetector(TClass* cls, bool make_if
    return nullptr;
 }
 
+#if __GNUC__ > 5
 std::ostringstream TUnpackedEvent::Print()
 {
 	std::ostringstream str;
@@ -80,3 +81,4 @@ std::ostringstream TUnpackedEvent::Print()
 	}
 	return str;
 }
+#endif


### PR DESCRIPTION
Fixes #1337 on my machine.  I'm not sure if this affects the functionality of TSourceCalibration in some way.