### PR TITLE
Disable TLevelScheme class in older gcc versions, to avoid compile errors

### DIFF
--- a/include/TLevelScheme.h
+++ b/include/TLevelScheme.h
@@ -1,3 +1,4 @@
+#if __GNUC__ > 6
 #ifndef TLEVELSCHEME_H
 #define TLEVELSCHEME_H
 
@@ -285,4 +286,5 @@ private:
 };
 /*! @} */
 
+#endif
 #endif

--- a/include/TLevelScheme.h
+++ b/include/TLevelScheme.h
@@ -1,4 +1,4 @@
-#if __GNUC__ > 6
+#if __cplusplus >= 201703L
 #ifndef TLEVELSCHEME_H
 #define TLEVELSCHEME_H
 

--- a/libraries/TAnalysis/TLevelScheme/LinkDef.h
+++ b/libraries/TAnalysis/TLevelScheme/LinkDef.h
@@ -1,5 +1,6 @@
 //TLevelScheme.h
 
+#if __GNUC__ > 6
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -20,3 +21,4 @@
 
 #endif
 
+#endif

--- a/libraries/TAnalysis/TLevelScheme/LinkDef.h
+++ b/libraries/TAnalysis/TLevelScheme/LinkDef.h
@@ -1,6 +1,6 @@
 //TLevelScheme.h
 
-#if __GNUC__ > 6
+#if __cplusplus >= 201703L
 #ifdef __CINT__
 
 #pragma link off all globals;

--- a/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
+++ b/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
@@ -1,4 +1,4 @@
-#if __GNUC__ > 6
+#if __cplusplus >= 201703L
 #include "TLevelScheme.h"
 
 #include <iostream>

--- a/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
+++ b/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
@@ -1,3 +1,4 @@
+#if __GNUC__ > 6
 #include "TLevelScheme.h"
 
 #include <iostream>
@@ -1231,4 +1232,4 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 
 	input.close();
 }
-
+#endif


### PR DESCRIPTION
Fixes #1345 in about the worst way possible, by just disabling the entire TLevelScheme class for older gcc versions.
There's probably a better way to handle this, if you have any ideas, I can test them on my machine.