### PR TITLE
Bug fixes and improvements for TLevelScheme and TPeakFitter peaks

### DIFF
--- a/include/TAB3Peak.h
+++ b/include/TAB3Peak.h
@@ -39,6 +39,7 @@ public:
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override;
+   Double_t Sigma() const override;
 
    void DrawComponents(Option_t *opt = "") override;
 

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -39,6 +39,8 @@ public:
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override;
+   Double_t Sigma() const override;
+   Double_t FWHM() const override;
 
    void DrawComponents(Option_t *opt = "") override;
 

--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -41,7 +41,8 @@ public:
 
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
-   Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }
+   Double_t Width() const override { return Sigma(); }
+   Double_t Sigma() const override { return fTotalFunction->GetParameter("sigma"); }
 
 protected:
    Double_t PeakFunction(Double_t *dim, Double_t *par) override;

--- a/include/TLevelScheme.h
+++ b/include/TLevelScheme.h
@@ -1,3 +1,4 @@
+#if __cplusplus >= 201703L
 #ifndef TLEVELSCHEME_H
 #define TLEVELSCHEME_H
 
@@ -71,6 +72,9 @@ public:
 
 	std::map<double, double> CoincidentGammas();
 	void PrintCoincidentGammas(); // *MENU*
+
+	std::vector<std::tuple<double, std::vector<double>>> ParallelGammas();
+	void PrintParallelGammas(); // *MENU*
 
 	using TArrow::Print;
 	void Print() const;
@@ -245,14 +249,21 @@ public:
 	TLevelScheme(const TLevelScheme& rhs);
 	~TLevelScheme();
 
+	static void ListLevelSchemes();
+	static TLevelScheme* GetLevelScheme(const char* name);
+
 	TLevel* AddLevel(const double energy, const std::string bandName, const std::string label);
 	TLevel* AddLevel(const double energy, const char* bandName, const char* label) { return AddLevel(energy, std::string(bandName), std::string(label)); } // *MENU*
 	TLevel* GetLevel(double energy);
 	TLevel* FindLevel(double energy, double energyUncertainty);
 
-	std::map<double, double> FeedingGammas(double levelEnergy, double factor = 100.);
-	std::map<double, double> DrainingGammas(double levelEnergy, double factor = 100.);
+	TGamma* FindGamma(double energy, double energyUncertainty = 0.);
+	std::vector<TGamma*> FindGammas(double lowEnergy, double highEnergy);
+
+	std::map<double, double> FeedingGammas(double levelEnergy, double factor = 1.);
+	std::map<double, double> DrainingGammas(double levelEnergy, double factor = 1.);
 	void ResetGammaMap() { fGammaMap.clear(); }
+	std::vector<std::tuple<double, std::vector<double>>> ParallelGammas(double initialEnergy, double finalEnergy, double factor = 1.);
 
 	void MoveToBand(const char* bandName, TLevel* level);
 
@@ -279,13 +290,13 @@ private:
 	void BuildGammaMap(double levelEnergy);
 
 	bool fDebug{false};
+	static std::vector<TLevelScheme*> gLevelSchemes;
 
 	std::vector<TBand> fBands;
 	std::multimap<double, TLine> fAuxillaryLevels;
 	std::multimap<double, TGamma*> fGammaMap;
 
 	// nuclide information
-	std::string fNuclide{""};
 	double fQValue{0.};
 	double fQValueUncertainty{0.};
 	double fNeutronSeparation{0.};
@@ -315,4 +326,5 @@ private:
 };
 /*! @} */
 
+#endif
 #endif

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -42,6 +42,7 @@ public:
    Double_t Centroid() const override;
    Double_t CentroidErr() const override;
    Double_t Width() const override { return fTotalFunction->GetParameter("sigma"); }
+   Double_t Sigma() const override { return fTotalFunction->GetParameter("sigma"); }
 
 protected:
    Double_t PeakFunction(Double_t *dim, Double_t *par) override;

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -52,6 +52,8 @@ public:
    virtual Double_t Centroid() const = 0;
    virtual Double_t CentroidErr() const = 0;
    virtual Double_t Width() const = 0;
+   virtual Double_t Sigma() const = 0;
+   virtual Double_t FWHM() const;
 
    virtual void Print(Option_t * = "" ) const override;
    virtual void Draw(Option_t * opt = "") override;
@@ -60,6 +62,7 @@ public:
 	virtual void PrintParameters() const;
 
    TF1* GetFitFunction() { return fTotalFunction; }
+   TF1* GetPeakFunction() { return fPeakFunction; }
    TF1* GetBackgroundFunction();
    void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg;
       fGlobalBackground->SetLineStyle(kDashed);}
@@ -86,6 +89,7 @@ protected:
    TF1* fBackgroundFunction{nullptr};
    TF1* fGlobalBackground{nullptr};
    TF1* fPeakOnGlobal{nullptr};
+   TF1* fPeakFunction{nullptr};
 
    std::vector<bool> fListOfBGPars;
    Double_t fArea{-0.1};

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -679,12 +679,14 @@ bool GCanvas::ProcessNonHistKeyboardPress(Event_t*, UInt_t* keysym)
 		SetCrosshair(static_cast<Int_t>(!HasCrosshair()));
 		edited = true;
 		break;
+#if __cplusplus >= 201703L
    case kKey_u: 
 		if(GetListOfPrimitives()->FindObject("TLevelScheme") != nullptr) {
 			static_cast<TLevelScheme*>(GetListOfPrimitives()->FindObject("TLevelScheme"))->UnZoom();
 			edited = true;
 		}
 		break;
+#endif
    }
 
    return edited;

--- a/libraries/TAnalysis/TLevelScheme/LinkDef.h
+++ b/libraries/TAnalysis/TLevelScheme/LinkDef.h
@@ -1,5 +1,6 @@
 //TLevelScheme.h
 
+#if __cplusplus >= 201402L
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -18,5 +19,6 @@
 #pragma link C++ class std::map<double, TLevel>+;
 #pragma link C++ class std::map<std::string, TBand>+;
 
+#endif
 #endif
 

--- a/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
+++ b/libraries/TAnalysis/TLevelScheme/TLevelScheme.cxx
@@ -1,3 +1,4 @@
+#if __cplusplus >= 201402L
 #include "TLevelScheme.h"
 
 #include <iostream>
@@ -9,6 +10,7 @@
 #include "TROOT.h"
 #include "TString.h"
 
+#include "Globals.h"
 #include "GCanvas.h"
 #include "TGRSIUtilities.h"
 
@@ -19,6 +21,8 @@ ClassImp(TLevelScheme)
 
 double TGamma::gTextSize = 0.020;
 double TLevel::gTextSize = 0.025;
+
+std::vector<TLevelScheme*> TLevelScheme::gLevelSchemes;
 
 TGamma::TGamma(TLevelScheme* levelScheme, const std::string& label, const double& br, const double& ts)
 	: TArrow()
@@ -137,7 +141,7 @@ void TGamma::Print() const
 
 std::map<double, double> TGamma::CoincidentGammas()
 {
-	/// Returns a vector with the energies and relative strength of all feeding and draining gamma rays.
+	/// Returns a map with the energies and relative strength of all feeding and draining gamma rays in coincidence with this gamma ray.
 	if(fLevelScheme == nullptr) {
 		std::cerr<<"Parent level scheme not set, can't find coincident gamma rays"<<std::endl;
 		return std::map<double, double>();
@@ -160,7 +164,7 @@ std::map<double, double> TGamma::CoincidentGammas()
 		}
 	}
 	if(fDebug) {
-		std::cout<<"Got "<<result.size()<<" coincident gammas including duplicates:";
+		std::cout<<"Got "<<result.size()<<" coincident gammas:";
 		for(auto& element : result) {
 			std::cout<<" "<<element.first<<" ("<<element.second<<"%)";
 		}
@@ -172,12 +176,60 @@ std::map<double, double> TGamma::CoincidentGammas()
 
 void TGamma::PrintCoincidentGammas()
 {
-	auto vec = CoincidentGammas();
-	std::cout<<vec.size()<<" coincident gammas for gamma "<<fEnergy<<" +- "<<fEnergyUncertainty<<" ("<<fInitialEnergy<<" to "<<fFinalEnergy<<"):";
-	for(auto gamma : vec) {
+	auto map = CoincidentGammas();
+	std::cout<<map.size()<<" coincident gammas for gamma "<<fEnergy<<" +- "<<fEnergyUncertainty<<" ("<<fInitialEnergy<<" to "<<fFinalEnergy<<"):";
+	for(auto gamma : map) {
 		std::cout<<" "<<gamma.first<<" ("<<gamma.second<<"%)";
 	}
 	std::cout<<std::endl;
+}
+
+std::vector<std::tuple<double, std::vector<double>>> TGamma::ParallelGammas()
+{
+	/// Returns a map with the relative strength and energies of all gamma rays that connect the same initial and final level.
+	/// Meaning these are all gamma rays that are parallel with this one and together add up to the same energy.
+	if(fLevelScheme == nullptr) {
+		std::cerr<<"Parent level scheme not set, can't find parallel gamma rays"<<std::endl;
+		return std::vector<std::tuple<double, std::vector<double>>>();
+	}
+	if(fDebug) {
+		std::cout<<"Looking for parallel gammas for gamma of "<<fEnergy<<" kev from level at "<<fInitialEnergy<<" keV to level at "<<fFinalEnergy<<" keV"<<std::endl;
+	}
+	auto result = fLevelScheme->ParallelGammas(fInitialEnergy, fFinalEnergy);
+	auto last = std::remove_if(result.begin(), result.end(), [](std::tuple<double, std::vector<double>> x) { return std::get<1>(x).size() < 2; });
+	if(fDebug) {
+		std::cout<<"Removing "<<std::distance(last, result.end())<<" paths, keeping "<<std::distance(result.begin(), last)<<std::endl;
+	}
+	result.erase(last, result.end());
+	//if(fDebug) {
+	//	std::cout<<"Got "<<result.size()<<" paths from level at "<<fInitialEnergy<<" keV to level at "<<fFinalEnergy<<" keV:"<<std::endl;
+	//	for(auto& element : result) {
+	//		std::cout<<std::get<0>(element)<<":";
+	//		double totalEnergy = 0.;
+	//		for(auto& energy : std::get<1>(element)) {
+	//			std::cout<<" "<<energy;
+	//			totalEnergy += energy;
+	//		}
+	//		std::cout<<" ("<<totalEnergy<<")"<<std::endl;
+	//	}
+	//}
+
+	return result;
+}
+
+void TGamma::PrintParallelGammas()
+{
+	auto vec = ParallelGammas();
+	std::cout<<vec.size()<<" parallel paths for gamma "<<fEnergy<<" +- "<<fEnergyUncertainty<<" ("<<fInitialEnergy<<" to "<<fFinalEnergy<<"):"<<std::endl;
+	for(auto& element : vec) {
+		std::cout<<std::get<0>(element)<<":";
+		double totalEnergy = 0.;
+		for(auto& energy : std::get<1>(element)) {
+			std::cout<<" "<<energy;
+			totalEnergy += energy;
+		}
+		std::cout<<" ("<<totalEnergy<<")"<<std::endl;
+	}
 }
 
 TLevel::TLevel(TLevelScheme* levelScheme, const double& energy, const std::string& label)
@@ -260,7 +312,7 @@ TGamma* TLevel::AddGamma(const double levelEnergy, const double energyUncertaint
 	/// Returns gamma if it doesn't exist yet and was successfully added, null pointer otherwise.
 	auto level = fLevelScheme->FindLevel(levelEnergy, energyUncertainty);
 	if(level == nullptr) {
-		std::cerr<<"Failed to find level at "<<levelEnergy<<" keV, can't add gamma!"<<std::endl;
+		std::cerr<<DRED<<"Failed to find level at "<<levelEnergy<<" keV, can't add gamma!"<<RESET_COLOR<<std::endl;
 		return nullptr;
 	}
 
@@ -517,7 +569,7 @@ TLevel* TBand::AddLevel(const double energy, const std::string& label)
 	}
 	auto [newLevel, success] = fLevels.emplace(std::piecewise_construct, std::forward_as_tuple(energy), std::forward_as_tuple(fLevelScheme, energy, label));
 	if(!success) {
-		std::cerr<<"Failed to add new level \""<<label<<"\" at "<<energy<<" keV to ";
+		std::cerr<<DRED<<"Failed to add new level \""<<label<<"\" at "<<energy<<" keV to "<<RESET_COLOR;
 		Print();
 	}
 
@@ -600,6 +652,7 @@ TLevelScheme::TLevelScheme(const std::string& filename, bool debug)
 {
 	fDebug = debug;
 	SetName("TLevelScheme");
+	SetLabel("Level Scheme");
 
 	// open the file and read the level scheme
 	// still need to decide what format that should be
@@ -620,6 +673,8 @@ TLevelScheme::TLevelScheme(const std::string& filename, bool debug)
 			}
 		}
 	}
+
+	gLevelSchemes.push_back(this);
 }
 
 TLevelScheme::TLevelScheme(const TLevelScheme& rhs)
@@ -628,7 +683,6 @@ TLevelScheme::TLevelScheme(const TLevelScheme& rhs)
 	fDebug = rhs.fDebug;
 	fBands = rhs.fBands;
 	fAuxillaryLevels = rhs.fAuxillaryLevels;
-	fNuclide = rhs.fNuclide;
 	fQValue = rhs.fQValue;
 	fQValueUncertainty = rhs.fQValueUncertainty;
 	fNeutronSeparation = rhs.fNeutronSeparation;
@@ -642,10 +696,34 @@ TLevelScheme::TLevelScheme(const TLevelScheme& rhs)
 	fTopMargin = rhs.fTopMargin;
 	fMinWidth = rhs.fMinWidth;
 	fMaxWidth = rhs.fMaxWidth;
+
+	gLevelSchemes.push_back(this);
 }
 
 TLevelScheme::~TLevelScheme()
 {
+}
+
+void TLevelScheme::ListLevelSchemes()
+{
+	for(auto& scheme : gLevelSchemes) {
+		std::cout<<" \""<<scheme->GetLabel()<<"\"";
+	}
+	std::cout<<std::endl;
+}
+
+TLevelScheme* TLevelScheme::GetLevelScheme(const char* name)
+{
+	for(auto& scheme : gLevelSchemes) {
+		if(strcmp(name, scheme->GetLabel()) == 0) {
+			return scheme;
+		}
+	}
+
+	std::cout<<"Failed to find level scheme \""<<name<<"\", "<<gLevelSchemes.size()<<" level schemes exist";
+	ListLevelSchemes();
+
+	return nullptr;
 }
 
 TLevel* TLevelScheme::AddLevel(const double energy, const std::string bandName, const std::string label)
@@ -709,6 +787,45 @@ TLevel* TLevelScheme::FindLevel(double energy, double energyUncertainty)
 	}
 
 	return nullptr;
+}
+
+TGamma* TLevelScheme::FindGamma(double energy, double energyUncertainty)
+{
+	/// Finds gamma ray in range [energy - energyUncertainty, energy + energyUncertainty].
+	/// If multiple gamma rays are in this range it returns the one closest to the given energy.
+	auto list = FindGammas(energy - energyUncertainty, energy + energyUncertainty);
+
+	if(list.empty()) {
+		std::cerr<<"Failed to find any gamma ray in range ["<<energy - energyUncertainty<<", "<<energy + energyUncertainty<<"]"<<std::endl;
+		return nullptr;
+	}
+
+	auto result = list[0];
+	for(size_t i = 1; i < list.size(); ++i) {
+		if(std::fabs(list[i]->Energy() - energy) < std::fabs(result->Energy() - energy)) result = list[i];
+	}
+
+	return result;
+}
+
+std::vector<TGamma*> TLevelScheme::FindGammas(double lowEnergy, double highEnergy)
+{
+	/// Returns a list of all gamma-rays in the range [lowEnergy, highEnergy]
+	std::vector<TGamma*> result;
+	// loop over all bands
+	for(auto& band : fBands) {
+		// loop over all levels in this band
+		for(auto& [levelEnergy, level] : band) {
+			// loop over all gamma-rays in the level
+			for(auto& [finalEnergy, gamma] : level) {
+				if(lowEnergy <= gamma.Energy() && gamma.Energy() <= highEnergy) {
+					result.push_back(&gamma);
+				}
+			}
+		}
+	}
+
+	return result;
 }
 
 void TLevelScheme::BuildGammaMap(double levelEnergy)
@@ -809,6 +926,120 @@ std::map<double, double> TLevelScheme::DrainingGammas(double levelEnergy, double
 	if(fDebug) {
 		std::cout<<"returning list of "<<result.size()<<" gammas draining level at "<<levelEnergy<<" keV"<<std::endl;
 	}
+	return result;
+}
+
+std::vector<std::tuple<double,std::vector<double>>> TLevelScheme::ParallelGammas(double initialEnergy, double finalEnergy, double factor)
+{
+	/// This (recursive) function returns the combined probability and energies of gamma rays that are connecting the levels at initial and final energy.
+	
+	auto level = GetLevel(initialEnergy);
+	std::vector<std::tuple<double,std::vector<double>>> result;
+	if(level == nullptr) {
+		std::cerr<<"Failed to find level at "<<initialEnergy<<" keV, returning empty list of gammas"<<std::endl;
+		Print();
+		return result;
+	}
+
+	if(fDebug) {
+		std::cout<<level<<": looping over "<<level->NofDrainingGammas()<<" gammas for level at "<<initialEnergy<<" keV (factor "<<factor<<")"<<std::endl;
+	}
+
+	result.push_back(std::make_tuple(1., std::vector<double>()));
+	// loop over all gamma rays 
+	for(auto& [levelEnergy, gamma] : *level) {
+		// if the level we populate with this gamma is below the final energy, we skip it
+		if(levelEnergy < finalEnergy) {
+			if(fDebug) {
+				std::cout<<"skipping gamma ";
+				gamma.Print();
+			}
+			continue;
+		}
+		// add this gamma ray to the path for now
+		std::get<0>(result.back()) *= gamma.BranchingRatioPercent();
+		std::get<1>(result.back()).insert(std::get<1>(result.back()).end(), gamma.Energy());
+		if(fDebug) {
+			std::cout<<"Added gamma ";
+			gamma.Print();
+			std::cout<<"New result:";
+			for(auto& entry : result) {
+				std::cout<<" "<<std::get<0>(entry)<<"-";
+				for(auto& e : std::get<1>(entry)) {
+					std::cout<<e<<",";
+				}
+			}
+			std::cout<<std::endl;
+		}
+		// if the level we populate is above the final energy, we see if we can find a gamma from that energy to the final energy
+		if(levelEnergy > finalEnergy) {
+			auto tmp = ParallelGammas(levelEnergy, finalEnergy, factor*gamma.BranchingRatioPercent());
+			// if we have multiple combinations, we don't just want to add all of them to one single entry, but create separate entries for each
+			// so we want to add n-1 copies of the last entry, this does not work if n is zero, so we check for that first
+			if(!tmp.empty()) {
+				auto it = result.insert(result.end(), tmp.size()-1, result.back());
+				// insert returns position of first inserted element or pos (=.end() in this case) if count is zero, so we need to decrement by one
+				--it;
+				if(fDebug) {
+					std::cout<<"Got "<<tmp.size()<<" paths, so added "<<tmp.size()-1<<" copies of last element:";
+					for(auto& entry : result) {
+						std::cout<<" "<<std::get<0>(entry)<<"-";
+						for(auto& e : std::get<1>(entry)) {
+							std::cout<<e<<",";
+						}
+					}
+					std::cout<<std::endl;
+				}
+				for(auto& combo : tmp) {
+					// maybe we can reject any that don't reach the final energy already here???
+					std::get<0>(*it) *= std::get<0>(combo);
+					std::get<1>(*it).insert(std::get<1>(*it).end(), std::get<1>(combo).begin(), std::get<1>(combo).end());
+					++it;
+				}
+				if(fDebug) {
+					std::cout<<"Got "<<tmp.size()<<" more gammas, new result:";
+					for(auto& entry : result) {
+						std::cout<<" "<<std::get<0>(entry)<<"-";
+						double sum = 0.;
+						for(auto& e : std::get<1>(entry)) {
+							std::cout<<e<<",";
+							sum += e;
+						}
+						std::cout<<"total "<<sum;
+					}
+					std::cout<<std::endl;
+				}
+			} else {
+				// we failed to find a path from the level this gamma populates to the final level, so we need to remove it from the path
+				// that is equivalent to re-setting the factor to one and clearing the vector of gammas
+				//std::get<0>(result.back())  = 1.;
+				//std::get<1>(result.back()).clear();
+				result.pop_back();
+				if(fDebug) {
+					std::cout<<"Failed to find path from "<<levelEnergy<<" to "<<finalEnergy<<", removed last gamma ray";
+					for(auto& entry : result) {
+						std::cout<<" "<<std::get<0>(entry)<<"-";
+						for(auto& e : std::get<1>(entry)) {
+							std::cout<<e<<",";
+						}
+					}
+					std::cout<<std::endl;
+				}
+			}
+		}
+		// if we found a path to the final energy (either via more gamma rays or by this one), we add this one and 
+		// since we are done with this path, we can add a new one (otherwise we will add to this path)
+		result.push_back(std::make_tuple(1., std::vector<double>()));
+		if(fDebug) {
+			std::cout<<"Reached final level, added new (empty) entry to result"<<std::endl;
+		}
+	} // loop over all gammas
+
+	// delete last entry if it's empty
+	if(std::get<1>(result.back()).empty()) {
+		result.pop_back();
+	}
+
 	return result;
 }
 
@@ -939,7 +1170,6 @@ void TLevelScheme::Draw(Option_t*)
 	if(fTopMargin < 0) SetY1(fX2-height/12.);
 	else SetY1(fX2-fTopMargin*0.75);
 	SetY2(fX2);
-	SetLabel("Level Scheme");
 	SetTextSize(0); // default size (?)
 	SetTextAlign(22); // centered in x and y
 	TPaveLabel::Draw();
@@ -1238,7 +1468,7 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 	//TODO: check if file exists
 	std::ifstream input(filename);
 	if(!input.is_open()) {
-		std::cerr<<"Failed to open \""<<filename<<"\""<<std::endl;
+		std::cerr<<DRED<<"Failed to open \""<<filename<<"\""<<RESET_COLOR<<std::endl;
 		return;
 	}
 
@@ -1255,9 +1485,9 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 	
 	// first line should be identification record (1-5 nuclide, 10-39 data set ident., 40-65 refs., 66-74 publ. inf., 75-80 date
 	std::getline(input, line);
-	fNuclide = line.substr(0,5);
-	trimWS(fNuclide); // trim whitespace
-	std::cout<<"Reading level scheme for "<<fNuclide<<std::endl;
+	SetLabel(line.substr(0,5).c_str());
+	//trimWS(fNuclide); // trim whitespace
+	std::cout<<"Reading level scheme for "<<GetLabel()<<std::endl;
 	// check that data set ident is "ADOPTED LEVELS, GAMMAS" or at least "ADOPTED LEVELS"
 	if(line.substr(9,14).compare("ADOPTED LEVELS") != 0) {
 		std::cout<<"Data set is not \"ADOPTED LEVELS\" or \"ADOPTED LEVELS, GAMMAS\", but \""<<line.substr(9,14)<<"\", don't know how to read that ("<<line<<")"<<std::endl;
@@ -1350,7 +1580,7 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 								 std::cout<<"\""<<line.substr(9,10)<<"\", \""<<line.substr(19,2)<<"\", \""<<line.substr(21,18)<<"\", \""<<line.substr(39,10)<<"\", \""<<line.substr(49,6)<<"\""<<std::endl;
 							 }
 							 // create new level and set it's energy uncertainty
-							 currentLevel = AddLevel(energy, fNuclide, label);
+							 currentLevel = AddLevel(energy, GetLabel(), label);
 							 currentLevel->EnergyUncertainty(energyUncertainty);
 						 } else if(fDebug) std::cout<<"Ignoring level \""<<line<<"\""<<std::endl;
 						 break;
@@ -1416,9 +1646,11 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 								 std::cout<<"\""<<line.substr(9,10)<<"\", \""<<line.substr(19,2)<<"\", \""<<line.substr(21,8)<<"\", \""<<line.substr(29,2)<<"\", \""<<line.substr(31,10)<<"\", \""<<line.substr(41,8)<<"\", \""<<line.substr(49,6)<<"\", \""<<line.substr(55,7)<<"\", \""<<line.substr(62,2)<<"\", \""<<line.substr(64,10)<<"\", \""<<line.substr(74,2)<<"\""<<std::endl;
 							 }
 							 auto gamma = currentLevel->AddGamma(currentLevel->Energy()-energy, energyUncertainty, multipolarity.c_str(), photonIntensity, totalIntensity);
-							 gamma->BranchingRatioUncertainty(photonIntensityUncertainty);
-							 gamma->TransitionStrengthUncertainty(totalIntensityUncertainty);
-							 // currently ignoring mixing ratio and conversion coefficents
+							 if(gamma != nullptr) {
+								 gamma->BranchingRatioUncertainty(photonIntensityUncertainty);
+								 gamma->TransitionStrengthUncertainty(totalIntensityUncertainty);
+								 // currently ignoring mixing ratio and conversion coefficents
+							 }
 						 } else if(fDebug) std::cout<<"Ignoring gamma \""<<line<<"\""<<std::endl;
 						 break;
 			case 'B': // beta record (1-5 nuclide, 6 blank or not '1' for cont., 7-9 " B ", ...), seems to be for decay data sets only?
@@ -1450,4 +1682,4 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
 
 	input.close();
 }
-
+#endif

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -88,6 +88,11 @@ Double_t TAB3Peak::Width() const
    return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma2");
 }
 
+Double_t TAB3Peak::Sigma() const
+{
+   return fTotalFunction->GetParameter("sigma");
+}
+
 Double_t TAB3Peak::PeakFunction(Double_t *dim, Double_t *par)
 {
    return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par) + ThreeHitPeakFunction(dim,par);

--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -78,6 +78,11 @@ Double_t TABPeak::Width() const
 	return fTotalFunction->GetParameter("sigma")*fTotalFunction->GetParameter("rel_sigma");
 }
 
+Double_t TABPeak::Sigma() const
+{
+	return fTotalFunction->GetParameter("sigma");
+}
+
 Double_t TABPeak::PeakFunction(Double_t *dim, Double_t *par)
 {
 	return OneHitPeakFunction(dim,par) + TwoHitPeakFunction(dim,par);

--- a/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
@@ -14,6 +14,7 @@ TRWPeak::TRWPeak(Double_t centroid) : TSinglePeak()
 void TRWPeak::Centroid(const Double_t& centroid)
 {
    fTotalFunction = new TF1("rw_total",this,&TRWPeak::TotalFunction,0,1,6,"TRWPeak","TotalFunction");
+   fPeakFunction =  new TF1("rw_peak",this,&TRWPeak::PeakFunction,0,1,5,"TRWPeak","PeakFunction");
    InitParNames();
    fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,1});

--- a/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -24,7 +24,7 @@ bool TSinglePeak::IsPeakParameter(const Int_t& par) const{
 }
 
 Int_t TSinglePeak::GetNParameters() const{
-   if(fTotalFunction)
+   if(fTotalFunction != nullptr)
       return fTotalFunction->GetNpar();
    else
       return 0;
@@ -65,13 +65,21 @@ void TSinglePeak::UpdateBackgroundParameters(){
 }
 
 void TSinglePeak::DrawComponents(Option_t *){
-   //This behaves like the draw function except each daughter class decides how to break the draw into multiple components.
-   //This means that we should delegate this task to the daughted class.
+   /// This behaves like the draw function except each daughter class decides how to break the draw into multiple components.
+   /// This means that we should delegate this task to the daughter class.
 }
 
+Double_t TSinglePeak::FWHM() const
+{
+   /// Return the full width at half-maximum.
+   auto max = fPeakFunction->GetMaximum();
+   auto maxX = fPeakFunction->GetMaximumX();
+   return (fTotalFunction->GetX(max/2., maxX, maxX+10.*Sigma()) - fTotalFunction->GetX(max/2., maxX-10.*Sigma(), maxX));
+}  
+
+
 Double_t TSinglePeak::PeakOnGlobalFunction(Double_t *dim, Double_t *par){
-   if(!fGlobalBackground)
-      return 0.0;
+   if(fGlobalBackground == nullptr) return 0.0;
 
    return PeakFunction(dim,par) + fGlobalBackground->EvalPar(dim,&par[fTotalFunction->GetNpar()]);
 
@@ -79,8 +87,7 @@ Double_t TSinglePeak::PeakOnGlobalFunction(Double_t *dim, Double_t *par){
 
 void TSinglePeak::Draw(Option_t *opt){
    //We need to draw this on top of the global background. Probably easiest to make another temporary TF1?
-   if(!fGlobalBackground)
-      return;
+   if(fGlobalBackground == nullptr) return;
 
    Double_t low, high;
    fGlobalBackground->GetRange(low,high);


### PR DESCRIPTION
- Added function to find all gammas parallel to given gamma to TLevelScheme.
- Added consistent access functions to Sigma and FWHM to peaks.
- Added check to not use TLevelScheme if the standard is less than c++17 to GCanvas.