### PR TITLE
Fix for Debian 11 compilation issues

### DIFF
--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -40,7 +40,7 @@ public:
    Double_t CentroidErr() const override;
    Double_t Width() const override;
    Double_t Sigma() const override;
-   Double_t FWHM() const override;
+   Double_t FWHM() const;
 
    void DrawComponents(Option_t *opt = "") override;
 

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -53,7 +53,7 @@ public:
    virtual Double_t CentroidErr() const = 0;
    virtual Double_t Width() const = 0;
    virtual Double_t Sigma() const = 0;
-   virtual Double_t FWHM() const;
+   Double_t FWHM() const;
 
    virtual void Print(Option_t * = "" ) const override;
    virtual void Draw(Option_t * opt = "") override;

--- a/libraries/TAnalysis/TCal/LinkDef.h
+++ b/libraries/TAnalysis/TCal/LinkDef.h
@@ -1,4 +1,4 @@
-//TCal.h TCalManager.h TCFDCal.h TEfficiencyCal.h TEnergyCal.h TGainMatch.h TTimeCal.h TCalPoint.h TCalList.h TSourceList.h TCalGraph.h TEfficiencyGraph.h TEfficiencyCalibration.h
+//TCal.h TCalManager.h TCFDCal.h TEfficiencyCal.h TEnergyCal.h TGainMatch.h TTimeCal.h TCalPoint.h TCalList.h TSourceList.h TCalGraph.h TEfficiencyGraph.h TEfficiencyCalibration.h TEfficiencyCalibrator.h
 
 #ifdef __CINT__
 
@@ -22,6 +22,7 @@
 #pragma link C++ class TEfficiencyGraph+;
 
 #pragma link C++ class TEfficiencyCalibration+;
+#pragma link C++ class TEfficiencyCalibrator+;
 
 #endif
 


### PR DESCRIPTION
This should fix issue #1361. I suppose it is a global problem, but somehow Mac doesn't care about the missing symbols?!