### PR TITLE
Fix math error in TPulseAnalyzer linear equation solver

### DIFF
--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <cstring>
 
 #include "TMath.h"
 

--- a/libraries/TAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -105,6 +105,7 @@ long double TPulseAnalyzer::determinant(int m)
    if(m == 1) {
       return copy_matrix[0][0];
    }
+   int sign = 1;
    if(copy_matrix[m - 1][m - 1] == 0.) {
       int j = m - 1;
       while(copy_matrix[m - 1][j] == 0 && j >= 0) {
@@ -118,13 +119,14 @@ long double TPulseAnalyzer::determinant(int m)
          copy_matrix[i][m - 1] = copy_matrix[i][j];
          copy_matrix[i][j]     = s;
       }
+      sign *= -1;
    }
    for(int j = m - 2; j >= 0; j--) {
       for(int i = 0; i < m; i++) {
          copy_matrix[i][j] -= copy_matrix[i][m - 1] /copy_matrix[m - 1][m - 1] * copy_matrix[m - 1][j];
       }
    }
-   return copy_matrix[m - 1][m - 1] * determinant(m - 1);
+   return copy_matrix[m - 1][m - 1] * sign * determinant(m - 1);
 }
 
 ////////////////////////////////////////


### PR DESCRIPTION
Kris S recently found a math error (wrong sign for certain terms when computing matrix determinants) in the linear equation solver code he uses to fit TIP waveforms, which was adapted into the TPulseAnayzer class in GRSISort some time ago.  Thankfully, this didn't have a major effect on past analyses, but he found that this caused issues when he tried to adapt his code for different detector types/pulse shapes at SFU.  I've added Kris's fix here (looks good to me when testing it with some of my own TIP data).

Also, I was getting yet another CentOS 7 / gcc 4.x compilation error:

```
Compiling .build/libraries/GROOT/GCanvas.o    [ERROR]
libraries/GROOT/GCanvas.cxx: In member function ‘bool GCanvas::StorePosition(Int_t, Int_t, Int_t)’:
libraries/GROOT/GCanvas.cxx:482:5: error: ‘strcmp’ is not a member of ‘std’
  if(std::strcmp(GetName(), "LevelScheme") != 0) return false;
     ^
```
Seems to be fixed after including `<cstring>` in GCanvas.cxx.