### PR TITLE
Fix for time correlation between events on different digitizer types.

### DIFF
--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -60,10 +60,10 @@ Double_t TDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
    }
 	TChannel* tmpChan = GetChannel();
 	if(tmpChan == nullptr) {
-		return SetTime(static_cast<Double_t>(GetTimeStampNs() + gRandom->Uniform()));
+		return SetTime(static_cast<Double_t>(GetTimeStamp() + gRandom->Uniform()));
 	}
 
-	return SetTime(tmpChan->GetTime(GetTimeStampNs(), GetCfd(), GetEnergy()));
+	return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd(), GetEnergy()));
 }
 
 Float_t TDetectorHit::GetCharge() const


### PR DESCRIPTION
Should close #1365, though I'm not sure whether this affects the time drift correction that was implemented in 551738af2a862d48510d5304ea84ede2e58f0c78.