### PR TITLE
Bunch of accumulated changes

### DIFF
--- a/examples/CrossTalkHelper.cxx
+++ b/examples/CrossTalkHelper.cxx
@@ -1,6 +1,6 @@
 #include "CrossTalkHelper.hh"
 
-bool pileup_reject = true;
+bool pileup_reject = false;
 
 const double gg_time_low  = -200.;
 const double gg_time_high = 300.;
@@ -10,7 +10,7 @@ const double gb_time_low  = -250.;
 const double gb_time_high = 350.;
 
 // default k-value this might have to be adjusted for each experiment!!!
-const Short_t defaultKValue = 700;
+const Short_t defaultKValue = 379;
 
 bool Addback(TGriffinHit* one, TGriffinHit* two)
 {

--- a/examples/EfficiencyHelper.cxx
+++ b/examples/EfficiencyHelper.cxx
@@ -163,7 +163,7 @@ void EfficiencyHelper::EndOfSort(std::shared_ptr<std::map<std::string, TList>> l
 				continue;
 			}
 			double factor = (promptHigh-promptLow)/(2.*(bgHigh-bgLow)); // factor two for BG window because we use absolute time here, might be wrong for asymmetric histograms?
-			std::cout<<"Found \""<<timeRandom->GetName()<<"\" after finding \""<<name<<"\", creating corrected spectrum using factor "<<factor<<std::endl;
+			std::cout<<"Found \""<<timeRandom->GetName()<<"\" after finding \""<<obj->GetName()<<"\", creating corrected spectrum using factor "<<factor<<std::endl;
 			auto corrected = static_cast<TH2*>(obj->Clone(name.replace(coinc, 5, "Corr").c_str()));
 			corrected->Add(timeRandom, -factor);
 			list->at("").Add(corrected);

--- a/examples/EfficiencyHelper.cxx
+++ b/examples/EfficiencyHelper.cxx
@@ -1,0 +1,172 @@
+#include "EfficiencyHelper.hh"
+
+// Coincidences Gates
+double promptLow = -250.;
+double promptHigh = 250.;
+bool PromptCoincidence(TGriffinHit *h1, TGriffinHit *h2) { // Griffin-Griffin
+	return promptLow <= h2->GetTime() - h1->GetTime() && h2->GetTime() - h1->GetTime() <= promptHigh;
+}
+double bgLow = 500.;
+double bgHigh = 1500.;
+bool TimeRandom(TGriffinHit *h1, TGriffinHit *h2) {
+	return (bgLow <= std::fabs(h1->GetTime() - h2->GetTime()) && std::fabs(h1->GetTime() - h2->GetTime()) <= bgHigh);
+}
+
+void EfficiencyHelper::CreateHistograms(unsigned int slot)
+{
+	// some variables to easily change range and binning for multiple histograms at once
+	int energyBins = 10000;
+	int energyBins2D = 2000;
+	double lowEnergy = 0.;
+	double highEnergy = 2000.;
+
+	// five histograms for each type: 1D singles, coincident and time random 2D matrix (unsuppressed on y-axis for suppressed data)
+	// and coincident and time random E_1 vs E_1+E_2, all 2D histograms are at 180 degree
+	
+	// unsuppressed spectra
+	fH1[slot]["griffinE"] = new TH1F("griffinE", Form("Unsuppressed griffin energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinE180Coinc"] = new TH2F("griffinGriffinE180Coinc", "Unsuppressed griffin-griffin energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinE180Bg"] = new TH2F("griffinGriffinE180Bg", "Unsuppressed griffin-griffin energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESum180Coinc"] = new TH2F("griffinGriffinESum180Coinc", "Unsuppressed griffin energy vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESum180Bg"] = new TH2F("griffinGriffinESum180Bg", "Unsuppressed griffin energy vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	// suppressed spectra
+	fH1[slot]["griffinESupp"] = new TH1F("griffinESupp", Form("Suppressed griffin energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESuppSum180Coinc"] = new TH2F("griffinGriffinESuppSum180Coinc", "Suppressed griffin energy vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESuppSum180Bg"] = new TH2F("griffinGriffinESuppSum180Bg", "Suppressed griffin energy vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEMixed180Coinc"] = new TH2F("griffinGriffinEMixed180Coinc", "Unsuppressed/suppressed griffin-griffin energy @ 180^{o};suppressed energy [keV];unsuppressed energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEMixed180Bg"] = new TH2F("griffinGriffinEMixed180Bg", "Unsuppressed/suppressed griffin-griffin energy @ 180^{o};suppressed energy [keV];unsuppressed energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	// unsuppressed addback spectra
+	fH1[slot]["griffinEAddback"] = new TH1F("griffinEAddback", Form("Unsuppressed griffin addback energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEAddback180Coinc"] = new TH2F("griffinGriffinEAddback180Coinc", "Unsuppressed griffin-griffin addback @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEAddback180Bg"] = new TH2F("griffinGriffinEAddback180Bg", "Unsuppressed griffin-griffin addback @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEAddbackSum180Coinc"] = new TH2F("griffinGriffinEAddbackSum180Coinc", "Unsuppressed griffin addback vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEAddbackSum180Bg"] = new TH2F("griffinGriffinEAddbackSum180Bg", "Unsuppressed griffin addback vs griffin sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	// suppressed addback spectra
+	fH1[slot]["griffinESuppAddback"] = new TH1F("griffinESuppAddback", Form("Suppressed griffin addback energy;energy [keV];counts/%.1f keV", (highEnergy-lowEnergy)/energyBins), energyBins, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESuppAddbackSum180Coinc"] = new TH2F("griffinGriffinESuppAddbackSum180Coinc", "Suppressed griffin addback vs sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinESuppAddbackSum180Bg"] = new TH2F("griffinGriffinESuppAddbackSum180Bg", "Suppressed griffin addback vs sum energy @ 180^{o};energy [keV];energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEMixedAddback180Coinc"] = new TH2F("griffinGriffinEMixedAddback180Coinc", "Unsuppressed/suppressed griffin-griffin addback @ 180^{o};suppressed energy [keV];unsuppressed energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+	fH2[slot]["griffinGriffinEMixedAddback180Bg"] = new TH2F("griffinGriffinEMixedAddback180Bg", "Unsuppressed/suppressed griffin-griffin addback @ 180^{o};suppressed energy [keV];unsuppressed energy [keV]", energyBins2D, lowEnergy, highEnergy, energyBins2D, lowEnergy, highEnergy);
+}
+
+void EfficiencyHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo)
+{
+	// we use .at() here instead of [] so that we get meaningful error message if a histogram we try to fill wasn't created
+	// e.g. because of a typo
+
+	// loop over unsuppressed griffin hits
+	for(int g = 0; g < grif.GetMultiplicity(); ++g) {
+		auto grif1 = grif.GetGriffinHit(g);
+		fH1[slot].at("griffinE")->Fill(grif1->GetEnergy());
+		for(int g2 = g+1; g2 < grif.GetMultiplicity(); ++g2) {
+			auto grif2 = grif.GetGriffinHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinE180Coinc")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+					fH2[slot].at("griffinGriffinE180Coinc")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
+					fH2[slot].at("griffinGriffinESum180Coinc")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinE180Bg")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+					fH2[slot].at("griffinGriffinE180Bg")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
+					fH2[slot].at("griffinGriffinESum180Bg")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				}
+			}
+		}
+	}
+
+	// loop over suppressed griffin hits
+	for(int g = 0; g < grif.GetSuppressedMultiplicity(&grifBgo); ++g) {
+		auto grif1 = grif.GetSuppressedHit(g);
+		fH1[slot].at("griffinESupp")->Fill(grif1->GetEnergy());
+		for(int g2 = g+1; g2 < grif.GetSuppressedMultiplicity(&grifBgo); ++g2) {
+			auto grif2 = grif.GetSuppressedHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinESuppSum180Coinc")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinESuppSum180Bg")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				}
+			}
+		}
+		for(int g2 = 0; g2 < grif.GetMultiplicity(); ++g2) {
+			if(g == g2) continue;
+			auto grif2 = grif.GetGriffinHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEMixed180Coinc")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEMixed180Bg")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				}
+			}
+		}
+	}
+
+	// loop over unsuppressed griffin addback hits
+	for(int g = 0; g < grif.GetAddbackMultiplicity(); ++g) {
+		auto grif1 = grif.GetAddbackHit(g);
+		fH1[slot].at("griffinEAddback")->Fill(grif1->GetEnergy());
+		for(int g2 = g+1; g2 < grif.GetAddbackMultiplicity(); ++g2) {
+			auto grif2 = grif.GetAddbackHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEAddback180Coinc")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+					fH2[slot].at("griffinGriffinEAddback180Coinc")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
+					fH2[slot].at("griffinGriffinEAddbackSum180Coinc")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEAddback180Bg")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+					fH2[slot].at("griffinGriffinEAddback180Bg")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
+					fH2[slot].at("griffinGriffinEAddbackSum180Bg")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				}
+			}
+		}
+	}
+
+	// loop over suppressed griffin addback hits
+	for(int g = 0; g < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++g) {
+		auto grif1 = grif.GetSuppressedAddbackHit(g);
+		fH1[slot].at("griffinESuppAddback")->Fill(grif1->GetEnergy());
+		for(int g2 = g+1; g2 < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++g2) {
+			auto grif2 = grif.GetSuppressedAddbackHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinESuppAddbackSum180Coinc")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinESuppAddbackSum180Bg")->Fill(grif1->GetEnergy() + grif2->GetEnergy(), grif1->GetEnergy());
+				}
+			}
+		}
+		for(int g2 = 0; g2 < grif.GetAddbackMultiplicity(); ++g2) {
+			if(g == g2) continue;
+			auto grif2 = grif.GetAddbackHit(g2);
+			if(grif1->GetPosition().Angle(grif2->GetPosition()) * 180. > 179.) {
+				if(PromptCoincidence(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEMixedAddback180Coinc")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				} else if(TimeRandom(grif1, grif2)) {
+					fH2[slot].at("griffinGriffinEMixedAddback180Bg")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				}
+			}
+		}
+	}
+}
+
+void EfficiencyHelper::EndOfSort(std::shared_ptr<std::map<std::string, TList>> list)
+{
+	std::cout<<std::endl;
+	for(auto obj : list->at("")) {
+		std::string name = obj->GetName();
+		size_t coinc = name.rfind("Coinc");
+		if(coinc == name.length()-5) {
+			auto timeRandom = static_cast<TH2*>(list->at("").FindObject(name.replace(coinc, 5, "Bg").c_str()));
+			if(timeRandom == nullptr) {
+				std::cout<<"Failed to find \""<<name.replace(coinc, 5, "Bg")<<"\" after finding \""<<name<<"\" in list:"<<std::endl;
+				list->at("").Print();
+				continue;
+			}
+			double factor = (promptHigh-promptLow)/(2.*(bgHigh-bgLow)); // factor two for BG window because we use absolute time here, might be wrong for asymmetric histograms?
+			std::cout<<"Found \""<<timeRandom->GetName()<<"\" after finding \""<<name<<"\", creating corrected spectrum using factor "<<factor<<std::endl;
+			auto corrected = static_cast<TH2*>(obj->Clone(name.replace(coinc, 5, "Corr").c_str()));
+			corrected->Add(timeRandom, -factor);
+			list->at("").Add(corrected);
+		}
+	}
+}

--- a/examples/EfficiencyHelper.hh
+++ b/examples/EfficiencyHelper.hh
@@ -1,0 +1,44 @@
+#ifndef EXAMPLEEVENTHELPER_HH
+#define EXAMPLEEVENTHELPER_HH
+
+#include "TGRSIHelper.h"
+
+#include "TGriffin.h"
+#include "TGriffinBgo.h"
+
+// This is a custom action which respects a well defined interface. It supports parallelism,
+// in the sense that it behaves correctly if implicit multi threading is enabled.
+// Note the plural: in presence of a MT execution, internally more than a single TList is created.
+// The detector types in the specifcation of Book must match those in the call to it as well as those in the Exec function (and be in the same order)!
+
+class EfficiencyHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl<EfficiencyHelper> {
+public:
+	// constructor sets the prefix (which is used for the output file as well)
+	// and calls Setup which in turn also calls CreateHistograms
+	EfficiencyHelper(TList* list) : TGRSIHelper(list) {
+		Prefix("EfficiencyHelper");
+		Setup();
+	}
+
+	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
+		return d->Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
+	}
+	// this function creates and books all histograms
+	void CreateHistograms(unsigned int slot) override;
+	// this function gets called for every single event and fills the histograms
+	void Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo);
+	// this function is optional and is called after the output lists off all slots/workers have been merged
+	void EndOfSort(std::shared_ptr<std::map<std::string, TList>> list) override;
+
+private:
+	// any constants that are set in the CreateHistograms function and used in the Exec function can be stored here
+	// or any other settings
+	Long64_t fCycleLength{0};
+};
+
+// These are needed functions used by TDataFrameLibrary to create and destroy the instance of this helper
+extern "C" EfficiencyHelper* CreateHelper(TList* list) { return new EfficiencyHelper(list); }
+
+extern "C" void DestroyHelper(TGRSIHelper* helper) { delete helper; }
+
+#endif

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -40,7 +40,7 @@ public:
    Double_t CentroidErr() const override;
    Double_t Width() const override;
    Double_t Sigma() const override;
-   Double_t FWHM() const override;
+   //Double_t FWHM() const override;
 
    void DrawComponents(Option_t *opt = "") override;
 

--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -47,10 +47,15 @@ public:
 	~TCalibrationGraphSet();
 
 	bool SetResidual(const bool& force = false);
-	int Add(TGraphErrors*, const std::string& label);
+	int Add(TGraphErrors*, const std::string& label); ///< Add new graph to set, using the label when creating legends during plotting
 
 	void SetLineColor(int index, int color)   { fGraphs[index].SetLineColor(color);   fResidualGraphs[index].SetLineColor(color); }   ///< Set the line color of the graph and residuals at index
-	void SetMarkerColor(int index, int color) { fGraphs[index].SetMarkerColor(color); fResidualGraphs[index].SetMarkerColor(color); } ///< Set the marker color of the graph and residuals at index
+	void SetMarkerColor(int index, int color) { if(fVerboseLevel > 3) std::cout<<"setting marker color of graph "<<index<<" to "<<color<<std::endl; fGraphs[index].SetMarkerColor(color); fResidualGraphs[index].SetMarkerColor(color); } ///< Set the marker color of the graph and residuals at index
+	void SetMarkerStyle(int index, int style) { fGraphs[index].SetMarkerStyle(style); fResidualGraphs[index].SetMarkerStyle(style); } ///< Set the marker style of the graph and residuals at index
+	void SetColor(int index, int color)       { SetLineColor(index, color); SetMarkerColor(index, color); }                           ///< Set the line and marker color of the graph and residuals at index
+	void SetColorStyle(int index, int val)    { SetLineColor(index, val); SetMarkerColor(index, val); SetMarkerStyle(index, val); }   ///< Set the line and marker color and marker style of the graph and residuals at index
+
+	void SetAxisTitle(const char* title); ///< Set axis title for the graph (form "x-axis title;y-axis title")
 
 	int GetN() { return fTotalGraph->GetN(); }     ///< Returns GetN(), i.e. number of points of the total graph.
 	double* GetX() { return fTotalGraph->GetX(); } ///< Returns an array of x-values of the total graph.
@@ -78,8 +83,7 @@ public:
 
 	void Scale(); ///< scale all graphs to fit each other (based on the first graph)
 
-	using TObject::Print;
-	void Print(Option_t* opt);
+	void Print(Option_t* opt = "") const override;
 
 	void ResetTotalGraph(); ///< reset the total graph and add the individual ones again (used e.g. after scaling of individual graphs is done)
 
@@ -104,7 +108,7 @@ public:
 		return *this;
 	}
 
-	void VerboseLevel(int val) { fVerboseLevel = val; for(auto graph : fGraphs) graph.VerboseLevel(val); for(auto graph : fResidualGraphs) graph.VerboseLevel(val); }
+	void VerboseLevel(int val) { fVerboseLevel = val; for(auto& graph : fGraphs) graph.VerboseLevel(val); for(auto& graph : fResidualGraphs) graph.VerboseLevel(val); }
 
 private:
 	std::vector<TCalibrationGraph> fGraphs; ///< These are the graphs used for plotting the calibration points per source.

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -91,26 +91,26 @@ private:
    mutable int fSegmentNumber;
    mutable int fCrystalNumber;
 
-	TPriorityValue<Long64_t>    fTimeOffset;
-	TPriorityValue<double>		fTimeDrift; 	// Time drift factor
-	TPriorityValue<TMnemonic*>  fMnemonic;
-	static TClassRef			fMnemonicClass;
+   TPriorityValue<Long64_t>    fTimeOffset;
+	TPriorityValue<double>		fTimeDrift; 	///< Time drift factor
+   TPriorityValue<TMnemonic*>  fMnemonic;
+	static TClassRef  			 fMnemonicClass;
 
-	TPriorityValue<std::vector<std::vector<Float_t> > >      fENGCoefficients;     // Energy calibration coeffs (low to high order)
-	TPriorityValue<std::vector<std::pair<double, double> > > fENGRanges;           // Range of energy calibrations
-	TPriorityValue<std::vector<double> >                     fENGChi2;             // Chi2 of the energy calibration
-	TPriorityValue<std::vector<Float_t> >                    fENGDriftCoefficents; // Energy drift coefficents (applied after energy calibration has been applied)
-	TPriorityValue<std::vector<double> >                     fCFDCoefficients;     // CFD calibration coeffs (low to high order)
-	TPriorityValue<double>                                   fCFDChi2;             // Chi2 of the CFD calibration
-	TPriorityValue<std::vector<double> >                     fLEDCoefficients;     // LED calibration coeffs (low to high order)
-	TPriorityValue<double>                                   fLEDChi2;             // Chi2 of LED calibration
-	TPriorityValue<std::vector<double> >                     fTIMECoefficients;    // Time calibration coeffs (low to high order)
-	TPriorityValue<double>                                   fTIMEChi2;            // Chi2 of the Time calibration
-	TPriorityValue<std::vector<double> >                     fEFFCoefficients;     // Efficiency calibration coeffs (low to high order)
-	TPriorityValue<double>                                   fEFFChi2;             // Chi2 of Efficiency calibration
-	TPriorityValue<std::vector<double> >                     fCTCoefficients;      // Cross talk coefficients
-	TPriorityValue<TGraph>                                   fEnergyNonlinearity;  // Energy nonlinearity as TGraph, is used as E=E+GetEnergyNonlinearity(E), so y should be E(source)-calibration(peak)
-	
+	TPriorityValue<std::vector<std::vector<Float_t> > >      fENGCoefficients;     ///< Energy calibration coeffs (low to high order)
+	TPriorityValue<std::vector<std::pair<double, double> > > fENGRanges;           ///< Range of energy calibrations
+	TPriorityValue<std::vector<double> >                     fENGChi2;             ///< Chi2 of the energy calibration
+	TPriorityValue<std::vector<Float_t> >                    fENGDriftCoefficents; ///< Energy drift coefficents (applied after energy calibration has been applied)
+	TPriorityValue<std::vector<double> >                     fCFDCoefficients;     ///< CFD calibration coeffs (low to high order)
+	TPriorityValue<double>                                   fCFDChi2;             ///< Chi2 of the CFD calibration
+	TPriorityValue<std::vector<double> >                     fLEDCoefficients;     ///< LED calibration coeffs (low to high order)
+	TPriorityValue<double>                                   fLEDChi2;             ///< Chi2 of LED calibration
+	TPriorityValue<std::vector<double> >                     fTIMECoefficients;    ///< Time calibration coeffs (low to high order)
+	TPriorityValue<double>                                   fTIMEChi2;            ///< Chi2 of the Time calibration
+	TPriorityValue<std::vector<double> >                     fEFFCoefficients;     ///< Efficiency calibration coeffs (low to high order)
+	TPriorityValue<double>                                   fEFFChi2;             ///< Chi2 of Efficiency calibration
+	TPriorityValue<std::vector<double> >                     fCTCoefficients;      ///< Cross talk coefficients
+	TPriorityValue<TGraph>                                   fEnergyNonlinearity;  ///< Energy nonlinearity as TGraph, is used as E=E+GetEnergyNonlinearity(E), so y should be E(source)-calibration(peak)
+
    struct WaveFormShapePar {
       bool   InUse;
       double BaseLine;
@@ -156,23 +156,23 @@ public:
 	void SetSegmentNumber(int tempint) { fSegmentNumber = tempint; }
 	void SetCrystalNumber(int tempint) { fCrystalNumber = tempint; }
 
-	double				GetTime(Long64_t timestamp, Float_t cfd, double energy) const;
-	int					GetDetectorNumber() const;
-	int					GetSegmentNumber() const;
-	int					GetCrystalNumber() const;
-	const TMnemonic*	GetMnemonic() const;
-	TClass*				GetClassType() const;
-	void				SetClassType(TClass* cl_type);
+	double            GetTime(Long64_t timestamp, Float_t cfd, double energy) const;
+	int               GetDetectorNumber() const;
+	int               GetSegmentNumber() const;
+	int               GetCrystalNumber() const;
+   const TMnemonic*  GetMnemonic() const;
+   TClass*           GetClassType() const;
+   void              SetClassType(TClass* cl_type);
 
-	int				GetNumber() const { return fNumber.Value(); }
-	unsigned int	GetAddress() const { return fAddress; }
-	int				GetIntegration() const { return fIntegration.Value(); }
-	int				GetStream() const { return fStream.Value(); }
-	int				GetUserInfoNumber() const { return fUserInfoNumber.Value(); }
-	const char*		GetDigitizerTypeString() const { return fDigitizerTypeString.c_str(); }
-	EDigitizer		GetDigitizerType() const { return fDigitizerType.Value(); }
-	int				GetTimeStampUnit() const { return fTimeStampUnit.Value(); }
-	Long64_t		GetTimeOffset() const { return fTimeOffset.Value(); }
+	int          GetNumber() const { return fNumber.Value(); }
+	unsigned int GetAddress() const { return fAddress; }
+	int          GetIntegration() const { return fIntegration.Value(); }
+	int          GetStream() const { return fStream.Value(); }
+	int          GetUserInfoNumber() const { return fUserInfoNumber.Value(); }
+	const char*  GetDigitizerTypeString() const { return fDigitizerTypeString.c_str(); }
+	EDigitizer   GetDigitizerType() const { return fDigitizerType.Value(); }
+	int          GetTimeStampUnit() const { return fTimeStampUnit.Value(); }
+	Long64_t     GetTimeOffset() const { return fTimeOffset.Value(); }
 	double			GetTimeDrift() const { return fTimeDrift.Value(); }
 	// write the rest of the gettters/setters...
 

--- a/include/TEfficiencyCalibrator.h
+++ b/include/TEfficiencyCalibrator.h
@@ -174,60 +174,6 @@ class TEfficiencyCalibrator : public TGMainFrame {
 ///
 /////////////////////////////////////////////////////////////////
 
-class TEfficiencyTab {
-public:
-	enum EPeakType { kRWPeak, kABPeak, kAB3Peak, kGaussian };
-
-   TEfficiencyTab(TSourceCalibration* parent, TNucleus* nucleus, std::tuple<TH1*, TH2*, TH2*> hists, TGCompositeFrame* frame, const double& sigma, const double& threshold, const int& degree, TGHProgressBar* progressBar);
-   ~TEfficiencyTab();
-
-	void FindPeaks();
-   void MakeConnections();
-   void Disconnect();
-
-   void VerboseLevel(int val) { fVerboseLevel = val; for(auto channel : fChannel) channel->VerboseLevel(val); }
-
-private:
-   // graphic elements
-   TGCompositeFrame* fFrame{nullptr}; ///< main frame of this tab
-   TGHProgressBar*      fProgressBar{nullptr};
-
-   // storage elements
-   TNucleus* fNucleus; ///< the source nucleus
-   TSourceCalibration* fParent; ///< the parent of this tab
-   TH1* fSingles{nullptr}; ///< the singles histogram we're using
-   TH2* fMatrix{nullptr}; ///< the (mixed) matrix we're using
-   TH2* fSumMatrix{nullptr}; ///< the sum matrix we're using
-   double fSigma{2.}; ///< the sigma used in the peak finder
-   double fThreshold{0.05}; ///< the threshold (relative to the largest peak) used in the peak finder
-   int fDegree{1}; ///< degree of polynomial function used to calibrate
-	TPeakFitter fPeakFitter;
-	EPeakType fPeakType{EPeakType::kRWPeak};
-	std::vector<TH1*> fSummingInProj;
-	std::vector<TH1*> fSummingInProjBg;
-	std::vector<TH1*> fSummingOutProj;
-	TH1* fSummingOutTotalProj;
-	TH1* fSummingOutTotalProjBg;
-	std::tuple<double, double, double, double, double, double, double, double, double, double> fPeaks;
-   int fVerboseLevel{0}; ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
-};
-
-class TEfficiencyCalibrator : public TGMainFrame {
-public:
-   TEfficiencyCalibrator(double sigma, double threshold, int n...);
-	~TEfficiencyCalibrator();
-
-private:
-   void BuildFirstInterface();
-   void MakeFirstConnections();
-
-	double fSigma;
-	double fThreshold;
-	std::vector<TFile*> fFiles;
-	std::vector<std::vector<std::tuple<TH1*, TH2*, TH2*>>> fHistograms; ///< for each type of data (suppressed, addback) in the file a vector with three histograms for each source
-	std::vector<TNucleus*> fSources;
-
-	// graphic elements
 public:
 	enum ESources { k22Na, k56Co, k60Co, k133Ba, k152Eu, k241Am	};
 	enum EEntry { kStartButton, kSourceBox = 100, kSigmaEntry = 200, kThresholdEntry = 300, kDegreeEntry = 400 };

--- a/include/TEfficiencyCalibrator.h
+++ b/include/TEfficiencyCalibrator.h
@@ -1,0 +1,101 @@
+#ifndef TEFFICIENCYCALIBRATOR_H__
+#define TEFFICIENCYCALIBRATOR_H__
+
+/** \addtogroup Calibration
+ *  @{
+ */
+
+/////////////////////////////////////////////////////////////////
+///
+/// \class TEfficiencyCalibrator
+///
+/// This is a class that determines the efficiency from source
+/// data.
+/// It expects a list of files with a 1D singles histogram and time random
+/// corrected 2D histograms of energy vs. (suppressed) energy and
+/// energy vs. sum of energies. In case of suppressed data only the
+/// x-axis of the former 2D histogram should use suppressed data,
+/// the y-axis needs to be unsuppressed data!
+/// If the file name contains a source isotope at the beginning of 
+/// the name, the source selection will be automatic, otherwise
+/// a window will pop up with the option to select the isotope for
+/// each file.
+///
+/// The efficiency curves can be:
+/// e(E) = ln E + (ln E)/E + (ln E)^2/E + (ln E)^3/E + (ln E)^4/E,
+/// or the radware form
+/// ln(e(E)) = ((a1 + a2 x + a3 x^2)^-a7 + (a4 + a5 y + a6 y^2)^-a7)^-1/a7
+/// with x = ln(E/100), y = ln(E/1000)
+/// or a polynomial ln(e(E)) = sum i 0->8 a_i (ln(E))^i (Ryan's & Andrew's PhD theses)
+///
+/////////////////////////////////////////////////////////////////
+
+class TEfficiencyTab {
+public:
+	enum EPeakType { kRWPeak, kABPeak, kAB3Peak, kGaussian };
+
+   TEfficiencyTab(TSourceCalibration* parent, TNucleus* nucleus, std::tuple<TH1*, TH2*, TH2*> hists, TGCompositeFrame* frame, const double& sigma, const double& threshold, const int& degree, TGHProgressBar* progressBar);
+   ~TEfficiencyTab();
+
+	void FindPeaks();
+   void MakeConnections();
+   void Disconnect();
+
+   void VerboseLevel(int val) { fVerboseLevel = val; for(auto channel : fChannel) channel->VerboseLevel(val); }
+
+private:
+   // graphic elements
+   TGCompositeFrame* fFrame{nullptr}; ///< main frame of this tab
+   TGHProgressBar*      fProgressBar{nullptr};
+
+   // storage elements
+   TNucleus* fNucleus; ///< the source nucleus
+   TSourceCalibration* fParent; ///< the parent of this tab
+   TH1* fSingles{nullptr}; ///< the singles histogram we're using
+   TH2* fMatrix{nullptr}; ///< the (mixed) matrix we're using
+   TH2* fSumMatrix{nullptr}; ///< the sum matrix we're using
+   double fSigma{2.}; ///< the sigma used in the peak finder
+   double fThreshold{0.05}; ///< the threshold (relative to the largest peak) used in the peak finder
+   int fDegree{1}; ///< degree of polynomial function used to calibrate
+	TPeakFitter fPeakFitter;
+	EPeakType fPeakType{EPeakType::kRWPeak};
+	std::vector<TH1*> fSummingInProj;
+	std::vector<TH1*> fSummingInProjBg;
+	std::vector<TH1*> fSummingOutProj;
+	TH1* fSummingOutTotalProj;
+	TH1* fSummingOutTotalProjBg;
+	std::tuple<double, double, double, double, double, double, double, double, double, double> fPeaks;
+   int fVerboseLevel{0}; ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
+};
+
+class TEfficiencyCalibrator : public TGMainFrame {
+public:
+   TEfficiencyCalibrator(double sigma, double threshold, int n...);
+	~TEfficiencyCalibrator();
+
+private:
+   void BuildFirstInterface();
+   void MakeFirstConnections();
+
+	double fSigma;
+	double fThreshold;
+	std::vector<TFile*> fFiles;
+	std::vector<std::vector<std::tuple<TH1*, TH2*, TH2*>>> fHistograms; ///< for each type of data (suppressed, addback) in the file a vector with three histograms for each source
+	std::vector<TNucleus*> fSources;
+
+	// graphic elements
+	TGVerticalFrame*     fLeftFrame{nullptr}; ///< Left frame for the source tabs
+   TGVerticalFrame*     fRightFrame{nullptr}; ///< Right frame for the efficiency data and fit
+	TRootEmbeddedCanvas* fEfficiencyCanvas{nullptr};
+	TGStatusBar*         fStatusBar{nullptr};
+	TGTab*               fSourceTab{nullptr};
+	TGHProgressBar*      fProgressBar{nullptr};
+	TGNumberEntry*       fDegreeEntry{nullptr};
+	TGLabel*             fDegreeLabel{nullptr};
+	
+   /// \cond CLASSIMP
+   ClassDefOverride(TEfficiencyCalibrator, 1); // Class to determine efficiency calibrations
+   /// \endcond
+};
+/*! @} */
+#endif

--- a/include/TGRSIOptions.h
+++ b/include/TGRSIOptions.h
@@ -48,7 +48,7 @@ public:
 	const std::vector<std::string>& InputCutFiles() { return fInputCutFiles; }
 	const std::vector<std::string>& WinInputFiles() { return fInputWinFiles; }
 	const std::vector<std::string>& MacroInputFiles() { return fMacroFiles; }
-	const std::string& DataFrameLibrary() { return fDataFrameLibrary; }
+	const std::string&              DataFrameLibrary() { return fDataFrameLibrary; }
 
 	const std::string& OutputFragmentFile() { return fOutputFragmentFile; }
 	const std::string& OutputAnalysisFile() { return fOutputAnalysisFile; }

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -28,58 +28,44 @@ class TNucleus : public TNamed {
 
 private:
 	static const char*  grsipath;
-	static std::string& massfile(); // The massfile to be used, which includes Z, N, atomic symbol, and mass excess
-	// static const char *massfile; //The massfile to be used, which includes Z, N, atomic symbol, and mass excess
-	// static std::string masspath;
+	static std::string& massfile(); ///< The massfile to be used, which includes Z, N, atomic symbol, and mass excess
 
 public:
-	TNucleus() {};               // Should not be use, here so we can write things to a root file.
-	TNucleus(const char* name); // Creates a nucleus based on symbol and sets all parameters from mass.dat
-	TNucleus(int charge, int neutrons, double mass, const char* symbol); // Creates a nucleus with Z, N, mass, and symbol
-	TNucleus(
-			int charge, int neutrons,
-			const char* MassFile = nullptr); // Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
+	TNucleus() {};               ///< Should not be use, here so we can write things to a root file.
+	TNucleus(const char* name); ///< Creates a nucleus based on symbol and sets all parameters from mass.dat
+	TNucleus(int charge, int neutrons, double mass, const char* symbol); ///< Creates a nucleus with Z, N, mass, and symbol
+	TNucleus(int charge, int neutrons,	const char* MassFile = nullptr); ///< Creates a nucleus with Z, N using mass table (default MassFile = "mass.dat")
 
 	~TNucleus() override;
 
-	// static void SetMassFile(const char *tmp = nullptr);// {massfile = tmp;} //Sets the mass file to be used
-
 	static std::string SortName(const char* name);
-	// void SetName(const char *name) { fName = name; }
-	void SetZ(int);              // Sets the Z (# of protons) of the nucleus
-	void SetN(int);              // Sets the N (# of neutrons) of the nucleus
-	void SetMassExcess(double);  // Sets the mass excess of the nucleus (in MeV)
-	void SetMass(double);        // Sets the mass manually (in MeV)
-	void SetMass();              // Sets the mass based on the A and mass excess of nucleus (in MeV)
-	void SetSymbol(const char*); // Sets the atomic symbol for the nucleus
+	void SetZ(int);              ///< Sets the Z (# of protons) of the nucleus
+	void SetN(int);              ///< Sets the N (# of neutrons) of the nucleus
+	void SetMassExcess(double);  ///< Sets the mass excess of the nucleus (in MeV)
+	void SetMass(double);        ///< Sets the mass manually (in MeV)
+	void SetMass();              ///< Sets the mass based on the A and mass excess of nucleus (in MeV)
+	void SetSymbol(const char*); ///< Sets the atomic symbol for the nucleus
 
-	void AddTransition(Double_t energy, Double_t intensity, Double_t energy_uncertainty = 0.0,
-			Double_t intensity_uncertainty = 0.0);
+	void AddTransition(Double_t energy, Double_t intensity, Double_t energy_uncertainty = 0.0, Double_t intensity_uncertainty = 0.0);
 	void AddTransition(TTransition* tran);
-	// Bool_t RemoveTransition(Int_t idx);
-	// TGRSITransition *GetTransition(Int_t idx);
 
-	// const char* GetName()        { return fName.c_str(); }
-	int         GetZ() const { return fZ; }                   // Gets the Z (# of protons) of the nucleus
-	int         GetN() const { return fN; }                   // Gets the N (# of neutrons) of the nucleus
-	int         GetA() const { return fN + fZ; }              // Gets the A (Z + N) of the nucleus
-	double      GetMassExcess() const { return fMassExcess; } // Gets the mass excess of the nucleus (in MeV)
-	double      GetMass() const { return fMass; }             // Gets the mass of the nucleus (in MeV)
-	const char* GetSymbol() const { return fSymbol.c_str(); } // Gets the atomic symbol of the nucleus
+	int         GetZ() const { return fZ; }                   ///< Gets the Z (# of protons) of the nucleus
+	int         GetN() const { return fN; }                   ///< Gets the N (# of neutrons) of the nucleus
+	int         GetA() const { return fN + fZ; }              ///< Gets the A (Z + N) of the nucleus
+	double      GetMassExcess() const { return fMassExcess; } ///< Gets the mass excess of the nucleus (in MeV)
+	double      GetMass() const { return fMass; }             ///< Gets the mass of the nucleus (in MeV)
+	const char* GetSymbol() const { return fSymbol.c_str(); } ///< Gets the atomic symbol of the nucleus
 
 	// Returns total kinetic energy in MeV
 	double GetEnergyFromBeta(double beta);
 	double GetBetaFromEnergy(double energy_MeV);
 
-	// Bool_t RemoveTransition(Int_t idx);
 	TTransition* GetTransition(Int_t idx);
 
 	Int_t  NTransitions() const { return fTransitionList.GetSize(); };
 	Int_t  GetNTransitions() const { return fTransitionList.GetSize(); };
 	double GetRadius() const;
 	int    GetZfromSymbol(char*);
-
-	// bool SetSourceData();
 
 	void Print(Option_t* opt = "") const override;
 	void WriteSourceFile(const std::string& outfilename = "");
@@ -92,12 +78,12 @@ public:
 private:
 	void SetName(const char* c = "") override;
 
-	int         fA{0};          // Number of nucleons (Z + N)
-	int         fN{0};          // Number of neutrons (N)
-	int         fZ{0};          // Number of protons (Z)
-	double      fMass{0.};      // Mass (in MeV)
-	double      fMassExcess{0.};// Mass excess (in MeV)
-	std::string fSymbol;        // Atomic symbol (ex. Ba, C, O, N)
+	int         fA{0};          ///< Number of nucleons (Z + N)
+	int         fN{0};          ///< Number of neutrons (N)
+	int         fZ{0};          ///< Number of protons (Z)
+	double      fMass{0.};      ///< Mass (in MeV)
+	double      fMassExcess{0.};///< Mass excess (in MeV)
+	std::string fSymbol;        ///< Atomic symbol (ex. Ba, C, O, N)
 
 	TList fTransitionList;
 	bool  LoadTransitionFile();

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -53,7 +53,7 @@ public:
    virtual Double_t CentroidErr() const = 0;
    virtual Double_t Width() const = 0;
    virtual Double_t Sigma() const = 0;
-   Double_t FWHM() const;
+   virtual Double_t FWHM(); // not constant because we have to update the parmeters of the peak function
 
    virtual void Print(Option_t * = "" ) const override;
    virtual void Draw(Option_t * opt = "") override;
@@ -67,6 +67,7 @@ public:
    void SetGlobalBackground(TF1* bg) { fGlobalBackground = bg;
       fGlobalBackground->SetLineStyle(kDashed);}
 
+   void UpdatePeakParameters();
    void UpdateBackgroundParameters();
 
    Double_t GetChi2() const { return fChi2; }

--- a/include/TTransition.h
+++ b/include/TTransition.h
@@ -46,6 +46,9 @@ public:
 
    std::string PrintToString();
 
+	bool operator>(const TTransition& rhs) const { return GetEnergy() > rhs.GetEnergy(); }
+	bool operator<(const TTransition& rhs) const { return GetEnergy() < rhs.GetEnergy(); }
+
 private:
    double fEnergy{0.};         // Energy of the transition
    double fEngUncertainty{0.}; // Uncertainty in the energy of the transition

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -679,12 +679,14 @@ bool GCanvas::ProcessNonHistKeyboardPress(Event_t*, UInt_t* keysym)
 		SetCrosshair(static_cast<Int_t>(!HasCrosshair()));
 		edited = true;
 		break;
+#if __cplusplus >= 201703L
    case kKey_u: 
 		if(GetListOfPrimitives()->FindObject("TLevelScheme") != nullptr) {
 			static_cast<TLevelScheme*>(GetListOfPrimitives()->FindObject("TLevelScheme"))->UnZoom();
 			edited = true;
 		}
 		break;
+#endif
    }
 
    return edited;

--- a/libraries/TAnalysis/TCal/LinkDef.h
+++ b/libraries/TAnalysis/TCal/LinkDef.h
@@ -1,4 +1,4 @@
-//TCal.h TCalManager.h TCFDCal.h TEfficiencyCal.h TEnergyCal.h TGainMatch.h TTimeCal.h TCalPoint.h TCalList.h TSourceList.h TCalGraph.h TEfficiencyGraph.h TEfficiencyCalibration.h
+//TCal.h TCalManager.h TCFDCal.h TEfficiencyCal.h TEnergyCal.h TGainMatch.h TTimeCal.h TCalPoint.h TCalList.h TSourceList.h TCalGraph.h TEfficiencyGraph.h TEfficiencyCalibration.h TEfficiencyCalibrator.h
 
 #ifdef __CINT__
 
@@ -22,6 +22,8 @@
 #pragma link C++ class TEfficiencyGraph+;
 
 #pragma link C++ class TEfficiencyCalibration+;
+
+#pragma link C++ class TEfficiencyCalibrator+;
 
 #endif
 

--- a/libraries/TAnalysis/TCal/LinkDef.h
+++ b/libraries/TAnalysis/TCal/LinkDef.h
@@ -22,7 +22,6 @@
 #pragma link C++ class TEfficiencyGraph+;
 
 #pragma link C++ class TEfficiencyCalibration+;
-#pragma link C++ class TEfficiencyCalibrator+;
 
 #pragma link C++ class TEfficiencyCalibrator+;
 

--- a/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
@@ -1,0 +1,491 @@
+#include "TEfficiencyCalibrator.h"
+
+#include <cstdarg>
+
+
+//////////////////////////////////////// TEfficiencyTab ////////////////////////////////////////
+TEfficiencyTab::TEfficiencyTab(TSourceCalibration* parent, TNucleus* nucleus, std::tuple<TH1*, TH2*, TH2*> hists, TGCompositeFrame* frame, const double& sigma, const double& threshold, const int& degree, TGHProgressBar* progressBar)
+   : fFrame(frame), fProgressBar(progressBar), fNucleus(nucleus), fParent(parent), fSigma(sigma), fThreshold(threshold), fDegree(degree)
+{
+	fSingles    = std::get<0>(hists);
+	fSummingOut = std::get<1>(hists);
+	fSummingIn  = std::get<2>(hists);
+	BuildInterface();
+	FindPeaks();
+}
+
+TEfficiencyTab::~TEfficiencyTab()
+{
+}
+
+void TEfficiencyTab::BuildInterface()
+{
+   // top frame with two canvases amd status bar
+   fTopFrame = new TGHorizontalFrame(fFrame, 1200, 450);
+   fProjectionCanvas = new TRootEmbeddedCanvas("ProjectionCanvas", fTopFrame, 600, 400);
+   fEfficiencyCanvas = new TRootEmbeddedCanvas("EfficiencyCanvas", fTopFrame, 600, 400);
+
+   fTopFrame->AddFrame(fProjectionCanvas, new TGLayoutHints(kLHintsLeft   | kLHintsTop | kLHintsExpandY | kLHintsExpandX, 2, 2, 2, 2));
+   fTopFrame->AddFrame(fEfficiencyCanvas, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandY | kLHintsExpandX, 2, 2, 2, 2));
+
+   fFrame->AddFrame(fTopFrame, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+
+   fStatusBar = new TGStatusBar(fFrame, 1200, 50);
+   int parts[] = {35, 15, 20, 15, 15 };
+   fStatusBar->SetParts(parts, 5);
+
+   fFrame->AddFrame(fStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+}
+
+void TEfficiencyTab::FindPeaks()
+{
+	/// Find and fit the peaks in the singles histogram, then checks for each peak how much summing in and summing out happens.
+	
+	fSummingOutTotalProj = fSummingOut->ProjectionY();
+	fSummingOutTotalProjBg = fSummingOutTotalProj->ShowBackground(fBgParamEntry->GetNumberEntry()->GetIntNumber());
+	// loop through all gamma-rays of the source
+	for(TTransition* transition : *(fNucleus->GetTransitionList())) {
+		auto energy = transition->GetEnergy();
+		double range = 4. * fSigma;
+		fPeakFitter.RemoveAllPeaks();
+		fPeakFitter.ResetInitFlag();
+		fPeakFitter.SetRange(energy - range, energy + range);
+		TSinglePeak* peak;
+		switch(fPeakType) {
+			case kRWPeak:
+				peak = new TRWPeak(energy);
+				break;
+			case kABPeak:
+				peak = new TABPeak(energy);
+				break;
+			case kAB3Peak:
+				peak = new TAB3Peak(energy);
+				break;
+			case kGaussian:
+				peak = new TGaussian(energy);
+				break;
+			default:
+				std::cerr<<"Unknow peak type "<<fPeakType<<", defaulting to TRWPeak!"<<std::endl;
+				peak = new TRWPeak(energy);
+		}
+		fPeakFitter.AddPeak(peak);
+		fPeakFitter.Fit(fSingles, "qretryfit");
+		if(peak->Area() < fThreshold) {
+			if(fVerboseLevel > 2) {
+				std::cout<<"Skipping peak at "<<energy<<" keV with centroid "<<peak->Centroid()<<", FWHM "<<peak->FWHM()<<", and area "<<peak->Area()<<std::endl;
+			}
+			continue;
+		}
+		// increase number of points of fit function
+		fPeakFitter.GetFitFunction()->SetNpx(1000);
+		double fwhm = peak->FWHM();
+		double centroid = peak->Centroid();
+		// for summing in we need to estimate the background and subtract that from the integral
+		fSummingInProj.push_back(fSummingIn->ProjectionY(fSummingIn->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingIn->GetXaxis()->FindBin(centroid-fwhm/2.)));
+		fSummingInProjBg.push_back(fSummingInProj.back()->ShowBackground(fBgParamEntry->GetNumberEntry()->GetIntNumber()));
+		double summingIn = fSummingInProj.back()->Integral() - fSummingInProjBg.back()->Integral();
+		// for summing out we need to do a background subtraction - to make this easier we just use a total projection and scale it according to the bg integral?
+		fSummingOutProj.push_back(fSummingOut->ProjectionY(fSummingOut->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingOut->GetXaxis()->FindBin(centroid-fwhm/2.)));
+		double ratio = fSummingOutTotalProjBg->Integral(fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid+fwhm/2.))/fSummingOutTotalProjBg->Integral();
+		double summingOut = fSummingOutProj.back()->Integral() - fSummingOutTotalProj->Integral()*ratio;
+
+		double correctedArea = peak->Area() - summingIn + summingOut;
+		// uncertainties for summing in and summing out is sqrt(N) (?)
+		double correctedAreaErr = TMath::Sqrt(TMath::Power(peak->AreaErr(), 2) + summingIn + summingOut);
+		fPeaks.push_back(std::make_tuple(energy, centroid, correctedArea, correctedAreaErr, transition->GetIntensity(), transition->GetIntensityUncertainty(), peak->Area(), peak->AreaErr(), summingIn, summingOut));
+	}
+	fProgressBar->Increment(1); // or maybe do this for every transition?
+}
+
+void TEfficiencyTab::MakeConnections()
+{
+}
+
+void TEfficiencyTab::Disconnect()
+{
+}
+
+//////////////////////////////////////// TEfficiencyCalibrator ////////////////////////////////////////
+TEfficiencyCalibrator::TEfficiencyCalibrator(double sigma, double threshold, int n...)
+	: TGMainFrame(nullptr, 1200, 600)
+{
+	fSigma = sigma;
+	fThreshold = threshold;
+
+	va_list args;
+	va_start(args, n);
+	for(int i = 0; i < n; ++i) {
+		const char* name = va_arg(args, const char*);
+		fFiles.push_back(new TFile(name));
+		if(!fFiles.back()->IsOpen()) {
+			std::cerr<<"Failed to open "<<i+1<<". file \""<<name<<"\""<<std::endl;
+			fFiles.pop_back();
+			continue;
+		}
+		bool goodFile = false;
+		if(fFiles.back()->FindKey("griffinE") != nullptr) {
+			// unsuppressed singles data
+			fHistograms.push_back(std::vector<std::tuple<TH1*, TH2*, TH2*>>());
+			fHistograms.back().push_back(std::make_tuple(
+						static_cast<TH1*>(fFiles.back()->Get("griffinE")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinE180Corr")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESum180Corr"))));
+			goodFile = true;
+		}
+		if(fFiles.back()->FindKey("griffinESupp") != nullptr) {
+			// suppressed singles data
+			fHistograms.push_back(std::vector<std::tuple<TH1*, TH2*, TH2*>>());
+			fHistograms.back().push_back(std::make_tuple(
+						static_cast<TH1*>(fFiles.back()->Get("griffinESupp")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEMixed180Corr")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESuppSum180Corr"))));
+			goodFile = true;
+		}
+		if(fFiles.back()->FindKey("griffinEAddback") != nullptr) {
+			// unsuppressed addback data
+			fHistograms.push_back(std::vector<std::tuple<TH1*, TH2*, TH2*>>());
+			fHistograms.back().push_back(std::make_tuple(
+						static_cast<TH1*>(fFiles.back()->Get("griffinEAddback")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEAddback180Corr")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEAddbackSum180Corr"))));
+			goodFile = true;
+		}
+		if(fFiles.back()->FindKey("griffinESuppAddback") != nullptr) {
+			// suppressed addback data
+			fHistograms.push_back(std::vector<std::tuple<TH1*, TH2*, TH2*>>());
+			fHistograms.back().push_back(std::make_tuple(
+						static_cast<TH1*>(fFiles.back()->Get("griffinESuppAddback")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEMixedAddback180Corr")), 
+						static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESuppAddbackSum180Corr"))));
+			goodFile = true;
+		}
+		if(!goodFile) {
+			std::cerr<<"Failed to find any histogram in "<<i+1<<". file \""<<name<<"\""<<std::endl;
+			fFiles.pop_back();
+			continue;
+		}
+		fSources.push_back(nullptr);
+		// check if the file name matches any source
+		if(std::strstr(name, "22Na") != nullptr) {
+			fSources.back() = new TNucleus("22Na");
+		} else if(std::strstr(name, "56Co")) {
+			fSources.back() = new TNucleus("56Co");
+		} else if(std::strstr(name, "60Co")) {
+			fSources.back() = new TNucleus("60Co");
+		} else if(std::strstr(name, "133Ba")) {
+			fSources.back() = new TNucleus("133Ba");
+		} else if(std::strstr(name, "152Eu")) {
+			fSources.back() = new TNucleus("152Eu");
+		} else if(std::strstr(name, "241Am")) {
+			fSources.back() = new TNucleus("241Am");
+		}
+	}
+	va_end(args);
+
+	if(fHistograms.empty()) {
+      throw std::runtime_error("Unable to find any suitable histograms in the provided file(s)!");
+	}
+
+	// quick sanity check, should have at least one vector the size of that vector should equal the source size and file size
+	if(fSources.size() != fFiles.size() || fHistograms[0].size() != fFiles.size()) {
+		std::stringstream str;
+		str<<"Wrong sizes, from "<<fFiles.size()<<" file(s) we got "<<fSources.size()<<" source(s), and "<<fHistograms[0].size()<<" histogram(s)!"<<std::endl;
+		throw std::runtime_error(str.str());
+	}
+
+	fOutput = new TFile("TEfficiencyCalibrator.root", "recreate");
+   if(!fOutput->IsOpen()) {
+      throw std::runtime_error("Unable to open output file \"TEfficiencyCalibrator.root\"!");
+   }
+
+	// build the first screen
+   BuildFirstInterface();
+   MakeFirstConnections();
+
+   // Set a name to the main frame
+   SetWindowName("EffiencyCalibrator");
+
+   // Map all subwindows of main frame
+   MapSubwindows();
+
+   // Initialize the layout algorithm
+   Resize(GetDefaultSize());
+
+   // Map main frame
+   MapWindow();
+}
+
+TEfficiencyCalibrator::~TEfficiencyCalibrator()
+{
+	for(auto& file : fFiles) {
+		file->Close();
+	}
+}
+
+void TEfficiencyCalibrator::BuildFirstInterface()
+{
+	/// Build initial interface with histogram <-> source assignment
+
+   auto layoutManager = new TGTableLayout(this, fFiles.size()+1, 2, true, 5);
+   if(fVerboseLevel > 1) std::cout<<"created table layout manager with 2 columns, "<<fFiles.size()+1<<" rows"<<std::endl;
+   SetLayoutManager(layoutManager);
+
+   // The matrices and source selection boxes
+   size_t i = 0;
+   for(i = 0; i < fFiles.size(); ++i) {
+      fSourceLabel.push_back(new TGLabel(this, fFiles[i]->GetName()));
+      if(fVerboseLevel > 2) std::cout<<"Text height "<<fSourceLabel.back()->GetFont()->TextHeight()<<std::endl;
+      fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
+		if(fSources[i] != nullptr) {
+			fSourceBox.back()->AddEntry(fSources[i]->GetName(), i);
+			fSourceBox.back()->Select(0);
+		} else {
+			fSourceBox.back()->AddEntry("22Na", k22Na);
+			fSourceBox.back()->AddEntry("56Co", k56Co);
+			fSourceBox.back()->AddEntry("60Co", k60Co);
+			fSourceBox.back()->AddEntry("133Ba", k133Ba);
+			fSourceBox.back()->AddEntry("152Eu", k152Eu);
+			fSourceBox.back()->AddEntry("241Am", k241Am);
+		}
+		fSourceBox.back()->SetMinHeight(200);
+		//fSourceLabel.back()->Resize(600, fLineHeight);
+		fSourceBox.back()->Resize(100, fLineHeight);
+		if(fVerboseLevel > 2) std::cout<<"Attaching "<<i<<". label to 0, 1, "<<i<<", "<<i+1<<", and box to 1, 2, "<<i<<", "<<i+1<<std::endl;
+		AddFrame(fSourceLabel.back(), new TGTableLayoutHints(0, 1, i, i+1, kLHintsRight | kLHintsCenterY));
+		AddFrame(fSourceBox.back(),   new TGTableLayoutHints(1, 2, i, i+1, kLHintsLeft  | kLHintsCenterY));
+	}
+
+   // The buttons
+   if(fVerboseLevel > 1) std::cout<<"Attaching start button to 0, 2, "<<i<<", "<<i+1<<std::endl;
+   fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
+   if(fVerboseLevel > 1) std::cout<<"start button "<<fStartButton<<std::endl;
+   AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i+1, kLHintsCenterX | kLHintsCenterY));
+   Layout();
+}
+
+void TEfficiencyCalibrator::MakeFirstConnections()
+{
+	/// Create connections for the file <-> source assignment interface
+	
+	// Connect the selection of the source
+   for(auto box : fSourceBox) {
+      box->Connect("Selected(Int_t, Int_t)", "TEfficiencyCalibrator", this, "SetSource(Int_t, Int_t)");
+   }
+
+   //Connect the clicking of buttons
+   fStartButton->Connect("Clicked()", "TEfficiencyCalibrator", this, "Start()");
+}
+
+void TEfficiencyCalibrator::DisconnectFirst()
+{
+	/// Disconnect all signals from the file <-> source assignment interface
+   for(auto box : fSourceBox) {
+      box->Disconnect("Selected(Int_t, Int_t)", this, "SetSource(Int_t, Int_t)");
+   }
+   fStartButton->Disconnect("Clicked()", this, "Start()");
+}
+
+void TEfficiencyCalibrator::DeleteFirst()
+{
+
+   fSourceBox.clear();
+   DeleteElement(fStartButton);
+   if(fVerboseLevel > 2) std::cout<<"Deleted start button "<<fStartButton<<std::endl;
+}
+
+void TEfficiencyCalibrator::SetSource(Int_t windowId, Int_t entryId)
+{
+	int index = windowId-kSourceBox;
+   if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<": windowId "<<windowId<<", entryId "<<entryId<<" => "<<index<<std::endl;
+   TNucleus* nucleus = fSources[index];
+   if(nucleus != nullptr) delete nucleus;
+   nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
+   fSources[index] = nucleus;
+}
+
+void TEfficiencyCalibrator::Start()
+{
+	if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<": fEmitter "<<fEmitter<<", fStartButton "<<fStartButton<<std::endl;
+   if(fEmitter == nullptr) { // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
+      fEmitter = fStartButton;
+      TTimer::SingleShot(100, "TEfficiencyCalibrator", this, "HandleTimer()");
+   }
+}
+
+void TEfficiencyCalibrator::HandleTimer()
+{
+	if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<": fEmitter "<<fEmitter<<", fStartButton "<<fStartButton<<std::endl;
+   if(fEmitter == fStartButton) {
+      SecondWindow();
+   }
+}
+
+void TEfficiencyCalibrator::SecondWindow()
+{
+	if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<std::endl;
+   // check that all sources have been set
+   for(size_t i = 0; i < fSources.size(); ++i) {
+      if(fSources[i] == nullptr) {
+         std::cerr<<"Source "<<i<<" not set!"<<std::endl;
+         return;
+      }
+   }
+   // now check that we don't have the same source twice (which wouldn't make sense)
+   for(size_t i = 0; i < fSources.size(); ++i) {
+      for(size_t j = i + 1; j < fSources.size(); ++j) {
+         if(*(fSources[i]) == *(fSources[j])) {
+            std::cerr<<"Duplicate sources: "<<i<<" - "<<fSources[i]->GetName()<<" and "<<j<<" - "<<fSources[j]->GetName()<<std::endl;
+            return;
+         }
+      }
+   }
+
+   // disconnect signals of first screen and remove all elements
+   DisconnectFirst();
+   RemoveAll();
+   DeleteFirst();
+
+   SetLayoutManager(new TGHorizontalLayout(this));
+
+	// create intermediate progress bar
+   fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, 600);
+   fProgressBar->SetRange(0., fMatrices.size()*fNofBins);
+   fProgressBar->Percent(true);
+   if(fVerboseLevel > 2) std::cout<<"Set range of progress bar to 0. - "<<fProgressBar->GetMax()<<" = "<<fMatrices.size()*fNofBins<<" = "<<fMatrices.size()<<"*"<<fNofBins<<std::endl;
+   AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+
+   // Map all subwindows of main frame
+   MapSubwindows();
+
+   // Initialize the layout algorithm
+   Resize(TGDimension(600, fLineHeight));
+
+   // Map main frame
+   MapWindow();
+
+   // create second screen and its connections
+   BuildSecondInterface();
+   MakeSecondConnections();
+
+   // remove progress bar
+   DeleteElement(fProgressBar);
+
+   // Map all subwindows of main frame
+   MapSubwindows();
+
+   // Initialize the layout algorithm
+   Resize(TGDimension(1200, 600));
+
+   // Map main frame
+   MapWindow();
+   if(fVerboseLevel > 2) std::cout<<__PRETTY_FUNCTION__<<" done"<<std::endl;
+}
+
+void TEfficiencyCalibrator::BuildSecondInterface()
+{
+   SetLayoutManager(new TGHorizontalLayout(this));
+
+	// left frame with tabs for each source
+	fLeftFrame = new TGVerticalFrame(this, 600, 600);
+	fSourceTab = new TGTab(fLeftFrame, 600, 600);
+   fEfficiencyTab.resize(fSources.size()+1);
+   for(size_t i = 0; i < fSource.size(); ++i) {
+      fEfficiencyTab[i] = new TEfficiencyTab(this, fSources[i], fHistograms[i], fSourceTab->AddTab(fSources[i]->GetName()), fDefaultSigma, fDefaultThreshold, fProgressBar);
+   }
+	fLeftFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 0, 0, 0, 0));
+	AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft | kLHintsExpandY, 2, 2, 2, 2));
+
+	// right frame with canvas, status bar, and the degree entry
+	fRightFrame = new TGVerticalFrame(this, 600, 600);
+	fEfficiencyCanvas = new TRootEmbeddedCanvas("EfficiencyCanvas", fRightFrame, 600, 450);
+	fStatusBar = new TGStatusBar(fRightFrame, 600, 50);
+	fDegreeEntry = new TGNumberEntry(fRightFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger);
+	fDegreeLabel = new TGLabel(fRightFrame, "Type of efficiency curve");
+	fRightFrame->AddFrame(fDegreeEntry);
+	fRightFrame->AddFrame(fDegreeLabel);
+   AddFrame(fRightFrame, new TGLayoutHints(kLHintsRight | kLHintsExpandY, 2, 2, 2, 2));
+
+   if(fVerboseLevel > 2) std::cout<<"Second interface done"<<std::endl;
+}
+
+void TEfficiencyCalibrator::MakeSecondConnections()
+{
+	if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<std::endl;
+   fNavigationGroup->Connect("Clicked(Int_t)", "TEfficiencyCalibrator", this, "Navigate(Int_t)");
+   // we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
+   for(auto sourceTab : fEfficiencyTab) {
+      sourceTab->MakeConnections();
+   }
+}
+
+void TEfficiencyCalibrator::DisconnectSecond()
+{
+   if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<std::endl;
+   fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
+   for(auto sourceTab : fEfficiencyTab) {
+      sourceTab->Disconnect();
+   }
+}
+
+void TEfficiencyCalibrator::Navigate(Int_t id)
+{
+   // we get the current source tab id and use it to get the channel tab from the right source tab
+   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+   int currentSourceId = fTab->GetCurrent();
+   int actualSourceId = fActualSourceId[currentSourceId];
+   auto currentTab = fEfficiencyTab[actualSourceId]->ChannelTab();
+   int currentChannelId = currentTab->GetCurrent();
+   int nofTabs = currentTab->GetNumberOfTabs();
+   if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<": id "<<id<<", source tab id "<<currentSourceId<<", actual source tab id "<<actualSourceId<<", channel tab id "<<currentTab->GetCurrent()<<", # of tabs "<<nofTabs<<std::endl;
+   switch(id) {
+      case 1: // previous
+         currentTab->SetTab(currentChannelId-1);
+         SelectedTab(currentChannelId-1);
+         break;
+      case 2: // find peaks
+         FindPeaks();
+         break;
+      case 3: // find peaks fast
+         FindPeaksFast();
+         break;
+      case 4: // calibrate
+         Calibrate();
+         break;
+      case 5: // discard
+         // select the next (or if we are on the last tab, the previous) tab
+         if(currentChannelId < nofTabs - 1) {
+            currentTab->SetTab(currentChannelId+1);
+         } else {
+            currentTab->SetTab(currentChannelId-1);
+         }
+         // remove the original active tab
+         currentTab->RemoveTab(currentChannelId);
+         break;
+      case 6: // accept
+         AcceptChannel(currentChannelId);
+         break;
+      case 7: // accept all (no argument = -1 = all)
+         AcceptChannel();
+         break;
+      case 8: // next
+         currentTab->SetTab(currentChannelId+1);
+         SelectedTab(currentChannelId+1);
+         break;
+      default:
+         break;
+   }
+}
+
+void TEfficiencyCalibrator::SelectedTab(Int_t id)
+{
+   /// Simple function that enables and disables the previous and next buttons depending on which tab was selected
+   if(fVerboseLevel > 1) std::cout<<__PRETTY_FUNCTION__<<": id "<<id<<std::endl;
+   if(id == 0) fPreviousButton->SetEnabled(false);
+   else        fPreviousButton->SetEnabled(true);
+
+   if(id == fEfficiencyTab[fTab->GetCurrent()]->ChannelTab()->GetNumberOfTabs() - 1) fNextButton->SetEnabled(false);
+   else                                                                          fNextButton->SetEnabled(true);
+}
+
+

--- a/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
@@ -2,12 +2,6 @@
 
 #include <cstdarg>
 
-<<<<<<< HEAD
-
-//////////////////////////////////////// TEfficiencyTab ////////////////////////////////////////
-TEfficiencyTab::TEfficiencyTab(TSourceCalibration* parent, TNucleus* nucleus, std::tuple<TH1*, TH2*, TH2*> hists, TGCompositeFrame* frame, const double& sigma, const double& threshold, const int& degree, TGHProgressBar* progressBar)
-   : fFrame(frame), fProgressBar(progressBar), fNucleus(nucleus), fParent(parent), fSigma(sigma), fThreshold(threshold), fDegree(degree)
-=======
 #include "TGTableLayout.h"
 #include "TTimer.h"
 
@@ -19,7 +13,6 @@ TEfficiencyTab::TEfficiencyTab(TSourceCalibration* parent, TNucleus* nucleus, st
 //////////////////////////////////////// TEfficiencyTab ////////////////////////////////////////
 TEfficiencyTab::TEfficiencyTab(TEfficiencySourceTab* parent, TNucleus* nucleus, std::tuple<TH1*, TH2*, TH2*> hists, TGCompositeFrame* frame, const double& range, const double& threshold, const int& bgParam)
    : fFrame(frame), fNucleus(nucleus), fParent(parent), fRange(range), fThreshold(threshold), fBgParam(bgParam)
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 {
 	fSingles    = std::get<0>(hists);
 	fSummingOut = std::get<1>(hists);
@@ -34,21 +27,11 @@ TEfficiencyTab::~TEfficiencyTab()
 
 void TEfficiencyTab::BuildInterface()
 {
-<<<<<<< HEAD
-   // top frame with two canvases amd status bar
-   fTopFrame = new TGHorizontalFrame(fFrame, 1200, 450);
-   fProjectionCanvas = new TRootEmbeddedCanvas("ProjectionCanvas", fTopFrame, 600, 400);
-   fEfficiencyCanvas = new TRootEmbeddedCanvas("EfficiencyCanvas", fTopFrame, 600, 400);
-
-   fTopFrame->AddFrame(fProjectionCanvas, new TGLayoutHints(kLHintsLeft   | kLHintsTop | kLHintsExpandY | kLHintsExpandX, 2, 2, 2, 2));
-   fTopFrame->AddFrame(fEfficiencyCanvas, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandY | kLHintsExpandX, 2, 2, 2, 2));
-=======
    // top frame with one canvas, status bar, and controls
    fTopFrame = new TGHorizontalFrame(fFrame, 1200, 450);
    fProjectionCanvas = new TRootEmbeddedCanvas("ProjectionCanvas", fTopFrame, 600, 400);
 
    fTopFrame->AddFrame(fProjectionCanvas, new TGLayoutHints(kLHintsLeft   | kLHintsTop | kLHintsExpandY | kLHintsExpandX, 2, 2, 2, 2));
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 
    fFrame->AddFrame(fTopFrame, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
 
@@ -56,11 +39,7 @@ void TEfficiencyTab::BuildInterface()
    int parts[] = {35, 15, 20, 15, 15 };
    fStatusBar->SetParts(parts, 5);
 
-<<<<<<< HEAD
-   fFrame->AddFrame(fStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
-=======
 	fFrame->AddFrame(fStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 }
 
 void TEfficiencyTab::FindPeaks()
@@ -68,16 +47,6 @@ void TEfficiencyTab::FindPeaks()
 	/// Find and fit the peaks in the singles histogram, then checks for each peak how much summing in and summing out happens.
 	
 	fSummingOutTotalProj = fSummingOut->ProjectionY();
-<<<<<<< HEAD
-	fSummingOutTotalProjBg = fSummingOutTotalProj->ShowBackground(fBgParamEntry->GetNumberEntry()->GetIntNumber());
-	// loop through all gamma-rays of the source
-	for(TTransition* transition : *(fNucleus->GetTransitionList())) {
-		auto energy = transition->GetEnergy();
-		double range = 4. * fSigma;
-		fPeakFitter.RemoveAllPeaks();
-		fPeakFitter.ResetInitFlag();
-		fPeakFitter.SetRange(energy - range, energy + range);
-=======
 	fSummingOutTotalProjBg = fSummingOutTotalProj->ShowBackground(fBgParam);
 	// loop through all gamma-rays of the source
 	for(TObject* obj : *(fNucleus->GetTransitionList())) {
@@ -86,7 +55,6 @@ void TEfficiencyTab::FindPeaks()
 		fPeakFitter.RemoveAllPeaks();
 		fPeakFitter.ResetInitFlag();
 		fPeakFitter.SetRange(energy - fRange, energy + fRange);
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 		TSinglePeak* peak;
 		switch(fPeakType) {
 			case kRWPeak:
@@ -98,13 +66,8 @@ void TEfficiencyTab::FindPeaks()
 			case kAB3Peak:
 				peak = new TAB3Peak(energy);
 				break;
-<<<<<<< HEAD
-			case kGaussian:
-				peak = new TGaussian(energy);
-=======
 			case kGauss:
 				peak = new TGauss(energy);
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 				break;
 			default:
 				std::cerr<<"Unknow peak type "<<fPeakType<<", defaulting to TRWPeak!"<<std::endl;
@@ -123,19 +86,11 @@ void TEfficiencyTab::FindPeaks()
 		double fwhm = peak->FWHM();
 		double centroid = peak->Centroid();
 		// for summing in we need to estimate the background and subtract that from the integral
-<<<<<<< HEAD
-		fSummingInProj.push_back(fSummingIn->ProjectionY(fSummingIn->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingIn->GetXaxis()->FindBin(centroid-fwhm/2.)));
-		fSummingInProjBg.push_back(fSummingInProj.back()->ShowBackground(fBgParamEntry->GetNumberEntry()->GetIntNumber()));
-		double summingIn = fSummingInProj.back()->Integral() - fSummingInProjBg.back()->Integral();
-		// for summing out we need to do a background subtraction - to make this easier we just use a total projection and scale it according to the bg integral?
-		fSummingOutProj.push_back(fSummingOut->ProjectionY(fSummingOut->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingOut->GetXaxis()->FindBin(centroid-fwhm/2.)));
-=======
 		fSummingInProj.push_back(fSummingIn->ProjectionY(Form("%s_%.0f-%.0f", fSummingIn->GetName(), centroid-fwhm/2., centroid+fwhm/2.), fSummingIn->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingIn->GetXaxis()->FindBin(centroid+fwhm/2.)));
 		fSummingInProjBg.push_back(fSummingInProj.back()->ShowBackground(fBgParam));
 		double summingIn = fSummingInProj.back()->Integral() - fSummingInProjBg.back()->Integral();
 		// for summing out we need to do a background subtraction - to make this easier we just use a total projection and scale it according to the bg integral?
 		fSummingOutProj.push_back(fSummingOut->ProjectionY(Form("%s_%.0f-%.0f", fSummingOut->GetName(), centroid-fwhm/2., centroid+fwhm/2.), fSummingOut->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingOut->GetXaxis()->FindBin(centroid+fwhm/2.)));
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 		double ratio = fSummingOutTotalProjBg->Integral(fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid-fwhm/2.), fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid+fwhm/2.))/fSummingOutTotalProjBg->Integral();
 		double summingOut = fSummingOutProj.back()->Integral() - fSummingOutTotalProj->Integral()*ratio;
 
@@ -144,10 +99,6 @@ void TEfficiencyTab::FindPeaks()
 		double correctedAreaErr = TMath::Sqrt(TMath::Power(peak->AreaErr(), 2) + summingIn + summingOut);
 		fPeaks.push_back(std::make_tuple(energy, centroid, correctedArea, correctedAreaErr, transition->GetIntensity(), transition->GetIntensityUncertainty(), peak->Area(), peak->AreaErr(), summingIn, summingOut));
 	}
-<<<<<<< HEAD
-	fProgressBar->Increment(1); // or maybe do this for every transition?
-=======
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 }
 
 void TEfficiencyTab::MakeConnections()
@@ -158,13 +109,6 @@ void TEfficiencyTab::Disconnect()
 {
 }
 
-<<<<<<< HEAD
-//////////////////////////////////////// TEfficiencyCalibrator ////////////////////////////////////////
-TEfficiencyCalibrator::TEfficiencyCalibrator(double sigma, double threshold, int n...)
-	: TGMainFrame(nullptr, 1200, 600)
-{
-	fSigma = sigma;
-=======
 
 //////////////////////////////////////// TEfficiencySourceTab ////////////////////////////////////////
 TEfficiencySourceTab::TEfficiencySourceTab(TEfficiencyCalibrator* parent, TNucleus* nucleus, std::vector<std::tuple<TH1*, TH2*, TH2*>> hists, TGCompositeFrame* frame, const double& range, const double& threshold, const int& bgParam, TGHProgressBar* progressBar)
@@ -222,7 +166,6 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(double range, double threshold, int
 	: TGMainFrame(nullptr, 1200, 600)
 {
 	fRange = range;
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 	fThreshold = threshold;
 
 	va_list args;
@@ -333,8 +276,6 @@ TEfficiencyCalibrator::~TEfficiencyCalibrator()
 	for(auto& file : fFiles) {
 		file->Close();
 	}
-<<<<<<< HEAD
-=======
 	if(fOutput != nullptr) fOutput->Close();
 }
 
@@ -344,7 +285,6 @@ void TEfficiencyCalibrator::DeleteElement(TGFrame* element)
 	RemoveFrame(element);
 	//delete element;
 	//element = nullptr;
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 }
 
 void TEfficiencyCalibrator::BuildFirstInterface()
@@ -373,10 +313,6 @@ void TEfficiencyCalibrator::BuildFirstInterface()
 			fSourceBox.back()->AddEntry("241Am", k241Am);
 		}
 		fSourceBox.back()->SetMinHeight(200);
-<<<<<<< HEAD
-		//fSourceLabel.back()->Resize(600, fLineHeight);
-=======
->>>>>>> f4cf2280f599c1276e27d5a49ca91203b4995be7
 		fSourceBox.back()->Resize(100, fLineHeight);
 		if(fVerboseLevel > 2) std::cout<<"Attaching "<<i<<". label to 0, 1, "<<i<<", "<<i+1<<", and box to 1, 2, "<<i<<", "<<i+1<<std::endl;
 		AddFrame(fSourceLabel.back(), new TGTableLayoutHints(0, 1, i, i+1, kLHintsRight | kLHintsCenterY));

--- a/libraries/TAnalysis/TDetector/TDetectorHit.cxx
+++ b/libraries/TAnalysis/TDetector/TDetectorHit.cxx
@@ -283,7 +283,7 @@ Long64_t TDetectorHit::GetCycleTimeStamp() const
 double TDetectorHit::GetTimeSinceTapeMove() const
 {
 	/// returns time in ns, minus the time of the last tape move
-	return GetTimeStampNs() - TPPG::Get()->GetLastStatusTime(GetTimeStampNs(), EPpgPattern::kTapeMove);
+	return GetTime() - TPPG::Get()->GetLastStatusTime(GetTimeStampNs(), EPpgPattern::kTapeMove);
 }
 
 // const here is rather dirty

--- a/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -60,6 +60,10 @@ Double_t TSinglePeak::TotalFunction(Double_t *dim, Double_t *par){
    return PeakFunction(dim,par) + BackgroundFunction(dim,par);
 }
 
+void TSinglePeak::UpdatePeakParameters(){
+   fPeakFunction->SetParameters(fTotalFunction->GetParameters());
+}
+
 void TSinglePeak::UpdateBackgroundParameters(){
    fBackgroundFunction->SetParameters(fTotalFunction->GetParameters());
 }
@@ -69,12 +73,19 @@ void TSinglePeak::DrawComponents(Option_t *){
    /// This means that we should delegate this task to the daughter class.
 }
 
-Double_t TSinglePeak::FWHM() const
+Double_t TSinglePeak::FWHM()
 {
    /// Return the full width at half-maximum.
-   auto max = fPeakFunction->GetMaximum();
-   auto maxX = fPeakFunction->GetMaximumX();
-   return (fTotalFunction->GetX(max/2., maxX, maxX+10.*Sigma()) - fTotalFunction->GetX(max/2., maxX-10.*Sigma(), maxX));
+	if(fPeakFunction == nullptr) {
+		std::cerr<<__PRETTY_FUNCTION__<<": peak function ("<<fPeakFunction<<") is null"<<std::endl;
+		return 0.;
+	}
+	UpdatePeakParameters();
+	double low  = Centroid() - 10.*Sigma();
+	double high = Centroid() + 10.*Sigma();
+   auto maxX = fPeakFunction->GetMaximumX(low, high);
+   auto max = fPeakFunction->Eval(maxX);
+   return (fPeakFunction->GetX(max/2., maxX, maxX+10.*Sigma()) - fPeakFunction->GetX(max/2., maxX-10.*Sigma(), maxX));
 }  
 
 

--- a/libraries/TFormat/TMnemonic.cxx
+++ b/libraries/TFormat/TMnemonic.cxx
@@ -151,6 +151,6 @@ TClass* TMnemonic::GetClassType() const
 }
 
 double TMnemonic::GetTime(Long64_t timestamp, Float_t, double, const TChannel* channel) const
-{
-	return static_cast<double>( ( timestamp + gRandom->Uniform() ) * channel->GetTimeStampUnit());
+{ 
+	return static_cast<double>((timestamp + gRandom->Uniform()) * channel->GetTimeStampUnit());
 }

--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -117,7 +117,8 @@ void TGRSIFrame::Run()
 		auto entries = fDataFrame->Count();
 		std::mutex barMutex; // Only one thread at a time can lock a mutex. Let's use this to avoid concurrent printing.
 		const auto everyN = fTotalEntries/barWidth;
-		entries.OnPartialResultSlot(everyN, [&everyN, &fTotalEntries = fTotalEntries, &barWidth, &progressBar, &barMutex](unsigned int /*slot*/, ULong64_t& /*partialList*/) {
+		//entries.OnPartialResultSlot(everyN, [&everyN, &fTotalEntries = fTotalEntries, &barWidth, &progressBar, &barMutex](unsigned int /*slot*/, ULong64_t& /*partialList*/) {
+		entries.OnPartialResultSlot(everyN, [&everyN, &fTotalEntries = fTotalEntries, &progressBar, &barMutex](unsigned int /*slot*/, ULong64_t& /*partialList*/) {
 				std::lock_guard<std::mutex> l(barMutex); // lock_guard locks the mutex at construction, releases it at destruction
 				static int counter = 1;
 				progressBar.push_back('#');

--- a/libraries/TGRSIint/grsixx.cxx
+++ b/libraries/TGRSIint/grsixx.cxx
@@ -215,7 +215,7 @@ static void DrawVersion()
    // Draw version string.
 
    char version[80];
-   sprintf(version, "Version %s", GRSI_RELEASE);
+   snprintf(version, 80, "Version %s", GRSI_RELEASE);
 
    XDrawString(gDisplay, gLogoWindow, gGC, 15, gHeight - 20, version, strlen(version));
 }
@@ -224,8 +224,7 @@ static void DrawROOTCredit()
 {
    // Draw version string.
 
-   char version[80];
-   sprintf(version, "A ROOT based package");
+   const char* version = "A ROOT based package";
 
    XDrawString(gDisplay, gLogoWindow, gGC, 15, gHeight - 35, version, strlen(version));
 }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -608,7 +608,7 @@ void TSourceTab::CreateChannelTab(int bin)
 void TSourceTab::MakeConnections()
 {
 	fChannelTab->Connect("Selected(Int_t)", "TSourceCalibration", fParent, "SelectedTab(Int_t)");
-	for(auto channel : fChannel) {
+	for(auto& channel : fChannel) {
 		channel->MakeConnections();
 	}
 }
@@ -616,7 +616,7 @@ void TSourceTab::MakeConnections()
 void TSourceTab::Disconnect()
 {
 	fChannelTab->Disconnect("Selected(Int_t)", fParent, "SelectedTab(Int_t)");
-	for(auto channel : fChannel) {
+	for(auto& channel : fChannel) {
 		channel->Disconnect();
 	}
 }

--- a/util/PlotVsRun.cxx
+++ b/util/PlotVsRun.cxx
@@ -14,7 +14,7 @@ int ReadArgs(int index, int argc, char** argv, std::vector<std::string>& output)
 int main(int argc, char** argv)
 {
 	if(argc < 5) {
-		std::cerr<<"Usage: "<<argv[0]<<" -if <list of input files> -hn <list of histogram names> (optional: -x or -y for projection on x- or y-axis)"<<std::endl;
+		std::cerr<<"Usage: "<<argv[0]<<" -if <list of input files> -hn <list of histogram names> (optional: -x or -y for projection on x- or y-axis, otherwise 2D-histograms will get split along x-axis)"<<std::endl;
 		return 1;
 	}
 
@@ -61,6 +61,10 @@ int main(int argc, char** argv)
 
 	TObject* obj = nullptr;
 	std::vector<TH2F*> outputHistograms;
+	// since we might split one 2D histogram into multiple histograms, we need to keep track of the index
+	// so that we can use outputIndex[histogram name index] to find the right output histogram
+	std::vector<int> outputIndex;
+	int index = 0;
 
 	for(auto histogramName : histogramNames) {
 		obj = input->Get(histogramName.c_str());
@@ -70,29 +74,37 @@ int main(int argc, char** argv)
 		}
 		// first check if this is a 2D-histogram because every 2D-histogram inherits from TH1 as well!
 		if(obj->InheritsFrom(TH2::Class())) {
-			if(!projectX && !projectY) {
-				std::cerr<<"Found 2D-histogram \""<<histogramName<<"\" in file \""<<input->GetName()<<"\", but neither was told to neither project on the x-axis nor the y-axis please use one of the flags -x or -y"<<std::endl;
-				return 1;
-			}
 			auto hist = static_cast<TH2*>(obj);
 			if(projectX) {
 				auto axis = hist->GetXaxis();
 				outputHistograms.emplace_back(new TH2F(Form("%sPxVsFile", histogramName.c_str()), Form("Projection of %s on the x-axis vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
-			} else {
+				outputIndex.push_back(index++);
+			} else if(projectY) {
 				auto axis = hist->GetYaxis();
 				outputHistograms.emplace_back(new TH2F(Form("%sPyVsFile", histogramName.c_str()), Form("Projection of %s on the y-axis vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
+				outputIndex.push_back(index++);
+			} else {
+				auto xAxis = hist->GetXaxis();
+				auto yAxis = hist->GetYaxis();
+				outputIndex.push_back(index);
+				for(int bin = 1; bin <= xAxis->GetNbins(); ++bin) {
+					outputHistograms.emplace_back(new TH2F(Form("%s_%.0fVsFile", histogramName.c_str(), xAxis->GetBinCenter(bin)), Form("Bin %d, center %.0f of %s vs. file #", bin, xAxis->GetBinCenter(bin), histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, yAxis->GetNbins(), yAxis->GetBinLowEdge(1), yAxis->GetBinLowEdge(yAxis->GetNbins()+1)));
+					index++;
+				}
 			}
 		} else if(obj->InheritsFrom(TH1::Class())) {
 			auto hist = static_cast<TH1*>(obj);
 			auto axis = hist->GetXaxis(); // not strictly needed, we could just use hist in its place
 			outputHistograms.emplace_back(new TH2F(Form("%sVsFile", histogramName.c_str()), Form("%s vs. file #", histogramName.c_str()), inputFiles.size()+1, 0.5, inputFiles.size()+0.5, axis->GetNbins(), axis->GetBinLowEdge(1), axis->GetBinLowEdge(axis->GetNbins()+1)));
+			outputIndex.push_back(index++);
 		} else {
 			std::cerr<<"Found object \""<<histogramName<<"\" in file \""<<input->GetName()<<"\", but it's neither a TH1 nor a TH2, it's a "<<obj->ClassName()<<std::endl;
 			return 1;
 		}
 	}
 
-	if(outputHistograms.size() != histogramNames.size()) {
+	// since we might have created multiple histograms from a single 2D histogram we can have more output histograms than input ones
+	if(outputHistograms.size() < histogramNames.size()) {
 		std::cerr<<"Something went wrong, only found "<<outputHistograms.size()<<" histograms from "<<histogramNames.size()<<" histograms?"<<std::endl;
 		return 1;
 	}
@@ -120,8 +132,18 @@ int main(int argc, char** argv)
 			if(obj->InheritsFrom(TH2::Class())) {
 				if(projectX) {
 					hist = static_cast<TH1*>(static_cast<TH2*>(obj)->ProjectionX());
-				} else {
+				} else if(projectY) {
 					hist = static_cast<TH1*>(static_cast<TH2*>(obj)->ProjectionY());
+				} else {
+					auto xAxis = static_cast<TH2*>(obj)->GetXaxis();
+					for(int xBin = 1; xBin <= xAxis->GetNbins(); ++xBin) {
+						hist = static_cast<TH1*>(static_cast<TH2*>(obj)->ProjectionY(Form("%s_py%d", histogramNames[j].c_str(), xBin), xBin, xBin));
+						for(int yBin = 0; yBin <= hist->GetNbinsX()+1; ++yBin) {
+							outputHistograms[outputIndex[j]]->SetBinContent(i+1, yBin, hist->GetBinContent(yBin));
+						}
+						outputHistograms[outputIndex[j]+xBin-1]->GetXaxis()->SetBinLabel(i+1, label.c_str());
+					}
+					continue;
 				}
 			} else if(obj->InheritsFrom(TH1::Class())) {
 				hist = static_cast<TH1*>(obj);
@@ -131,9 +153,9 @@ int main(int argc, char** argv)
 			}
 			// at this point hist is either set or we continued to the next file
 			for(int bin = 0; bin <= hist->GetNbinsX()+1; ++bin) {
-				outputHistograms[j]->SetBinContent(i+1, bin, hist->GetBinContent(bin));
+				outputHistograms[outputIndex[j]]->SetBinContent(i+1, bin, hist->GetBinContent(bin));
 			}
-			outputHistograms[j]->GetXaxis()->SetBinLabel(i+1, label.c_str());
+			outputHistograms[outputIndex[j]]->GetXaxis()->SetBinLabel(i+1, label.c_str());
 		}
 		input->Close();
 		input = nullptr;

--- a/util/grsiframe.cxx
+++ b/util/grsiframe.cxx
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
 		return 1;
 	}
 	if(opt->DataFrameLibrary().empty()) {
-		std::cout<<"No dataframe library provided!"<<std::endl;
+		std::cout<<"No dataframe library (*.cxx file or *.so library) provided!"<<std::endl;
 		return 1;
 	}
 


### PR DESCRIPTION
- CrossTalkHelper: Set pile-up rejection to false and changed default k-value to 379.
- EfficiencyHelper: Corrected output message in EndOfSort.
- TABPeak: Removed FWHM function, we're using the default one defined in TSinglePeak.
- TCalibrationGraph: Added functions to set marker style, line color and style, and axis title.
  Also added function to marker and line color together, fixed definition of Print function, and
  fixed setting the verbose level of all graphs contained in graph set to the same value. Added
  option to use "same" as plotting option. Changed a lot of instances of "auto" to "auto&".
- TChannel: Changed comments of members to be included in class documentation.
- TEfficiencyCalibrator: Put contents of header and source file inside preprocessor condition to
  only be active when using at least c++17. This version is semi-working, but the summing-in and
  summing-out corrections aren't working correctly yet.
- TNucleus: Changed comments to be included in class documentation.
- TTransition: Added comparison operators.
- Added new class TRedirect which redirects all output to a file.
- TSinglePeak: Fixed FWHM member function and added UpdatePeakParameters member function.
- TDetectorHit: Changed GetTimeSinceTapeMove (back?) to using GetTime instead of GetTimeStampNs.
- TGRSIFrame: Removed passing of reference of barWidth to lambda as it is a const and passed automatically.
- grsixx: Changed from sprintf to snprintf to remove warnings.
- TSourceCalibration: Changed "auto" to "auto&" when looping over channels to connect and disconnect.
- PlotVsRun: Added option to plot each x-axis bin of a 2D histogram vs the run number instead of a
  projection of the histogram.
- grsiframe: Corrected error message if dataframe library is missing to indicate the file type that's
  needed.