### PR TITLE
Improvement for TPeakFitter, TNucleus, and TEfficiencyCalibrator

### DIFF
--- a/examples/sort.sh
+++ b/examples/sort.sh
@@ -3,6 +3,9 @@
 DATADIR=<your data directory here>
 SORTOPTIONS="your grsisort options here, e.g. --recommended"
 CALFILES="any and all cal-files you want to use"
+ANALYSISTREES="." # directory for analysis trees
+FRAGMENTTREES="." # directory for fragment trees
+LOGFILES="." # directory for log files
 
 firstRun=1
 lastRun=1
@@ -33,13 +36,13 @@ for run in `seq $firstRun $lastRun` ; do
    for midasFile in `find ${DATADIR} -maxdepth 1 -amin +3 -name "run${run}_???.mid"` ; do
       subrun=$(basename $midasFile | cut -d '_' -f2 | cut -d '.' -f1)
 		# if the analysis file exists, we don't re-run the analysis
-      if [ -e analysis${run}_${subrun}.root ] ; then
+      if [ -e ${ANALYSISTREES}/analysis${run}_${subrun}.root ] ; then
          continue
       fi
 		# touching the file means it exists now and if we run this script in multiple terminal
 		# the other scripts won't try and start sorting this file
-      touch analysis${run}_${subrun}.root
-      logFile="log${run}_${subrun}.txt"
+      touch ${ANALYSISTREES}/analysis${run}_${subrun}.root
+      logFile="${LOGFILES}/log${run}_${subrun}.txt"
 		# print the sort command to the log-file
       echo "grsisort $SORTOPTIONS $CALFILES $midasFile" | tee $logFile
 		# start sorting and append all output to the log-file
@@ -47,6 +50,9 @@ for run in `seq $firstRun $lastRun` ; do
       grsisort $SORTOPTIONS $CALFILES $midasFile 2>&1 | tee -a $logFile
 		# if necessary you can make certain file-permissions are set correctly
 		# e.g. when sorting the same data for multiple people
-      chmod 664 analysis${run}_${subrun}.root fragment${run}_${subrun}.root log${run}_${subrun}.txt
+      chmod 664 ${ANALYSISTREES}/analysis${run}_${subrun}.root fragment${run}_${subrun}.root log${run}_${subrun}.txt
+		# moved the output files into the right directories, or if that fails, remove the file we touched at the beginning
+		mv analysis${run}_${subrun}.root ${ANALYSISTREES}/analysis${run}_${subrun}.root || rm ${ANALYSISTREES}/analysis${run}_${subrun}.root
+      mv fragment${run}_${subrun}.root ${FRAGMENTTREES}/fragment${run}_${subrun}.root || rm ${ANALYSISTREES}/analysis${run}_${subrun}.root
    done
 done

--- a/include/TAB3Peak.h
+++ b/include/TAB3Peak.h
@@ -32,7 +32,7 @@ public:
    TAB3Peak(Double_t centroid);
 
    void InitParNames() override;
-   void InitializeParameters(TH1* hist) override;
+   void InitializeParameters(TH1* hist, const double& rangeLow, const double& rangeHigh) override;
 
 	void Centroid(const Double_t& centroid) override;
 

--- a/include/TABPeak.h
+++ b/include/TABPeak.h
@@ -32,7 +32,7 @@ public:
    TABPeak(Double_t centroid);
 
    void InitParNames() override;
-   void InitializeParameters(TH1* hist) override;
+   void InitializeParameters(TH1* hist, const double& rangeLow, const double& rangeHigh) override;
 
 	void Centroid(const Double_t& centroid) override;
 

--- a/include/TGauss.h
+++ b/include/TGauss.h
@@ -35,7 +35,7 @@ public:
    TGauss(Double_t centroid, Double_t relativeLimit = -1.);
 
    void InitParNames() override;
-   void InitializeParameters(TH1* hist) override;
+   void InitializeParameters(TH1* hist, const double& rangeLow, const double& rangeHigh) override;
 
 	void Centroid(const Double_t& centroid) override;
 

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -13,7 +13,7 @@
 
 #include "TObject.h"
 #include "TNamed.h"
-#include "TList.h"
+#include "TSortedList.h"
 
 /////////////////////////////////////////////////////////////////
 ///
@@ -60,17 +60,21 @@ public:
 	double GetEnergyFromBeta(double beta);
 	double GetBetaFromEnergy(double energy_MeV);
 
-	TTransition* GetTransition(Int_t idx);
+	TTransition* GetTransition(Int_t idx) { return GetTransitionByIntensity(idx); }
+	TTransition* GetTransitionByIntensity(Int_t idx);
+	TTransition* GetTransitionByEnergy(Int_t idx);
 
-	Int_t  NTransitions() const { return fTransitionList.GetSize(); };
-	Int_t  GetNTransitions() const { return fTransitionList.GetSize(); };
+	Int_t  NTransitions() const { return fTransitionListByIntensity.GetSize(); };
+	Int_t  GetNTransitions() const { return fTransitionListByIntensity.GetSize(); };
 	double GetRadius() const;
 	int    GetZfromSymbol(char*);
 
 	void Print(Option_t* opt = "") const override;
 	void WriteSourceFile(const std::string& outfilename = "");
 
-	const TList* GetTransitionList() const { return &fTransitionList; }
+	const TSortedList* GetTransitionList() const { return GetTransitionListByIntensity(); }
+	const TSortedList* GetTransitionListByIntensity() const { return &fTransitionListByIntensity; }
+	const TSortedList* GetTransitionListByEnergy() const { return &fTransitionListByEnergy; }
 
 	bool operator==(const TNucleus& rhs) const { return ((fA == rhs.fA) && (fN == rhs.fN) && (fZ == rhs.fZ)); }
 	bool operator!=(const TNucleus& rhs) const { return !(*this == rhs); }
@@ -85,7 +89,8 @@ private:
 	double      fMassExcess{0.};///< Mass excess (in MeV)
 	std::string fSymbol;        ///< Atomic symbol (ex. Ba, C, O, N)
 
-	TList fTransitionList;
+	TSortedList fTransitionListByIntensity;
+	TSortedList fTransitionListByEnergy;
 	bool  LoadTransitionFile();
 
    /// \cond CLASSIMP

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -36,9 +36,9 @@ public:
    TPeakFitter(const Double_t& range_low, const Double_t& range_high);
 
 public:
-   void AddPeak(TSinglePeak* p)     { fPeaksToFit.push_back(p); }
-   void RemovePeak(TSinglePeak* p)  { fPeaksToFit.remove(p); }
-   void RemoveAllPeaks()  { fPeaksToFit.clear(); }
+   void AddPeak(TSinglePeak* p)     { fPeaksToFit.push_back(p); ResetTotalFitFunction(); }
+   void RemovePeak(TSinglePeak* p)  { fPeaksToFit.remove(p); ResetTotalFitFunction(); }
+   void RemoveAllPeaks()  { fPeaksToFit.clear(); ResetTotalFitFunction(); }
 //   void SetPeakToFit(TMultiplePeak*  peaks_to_fit) { fPeaksToFit = peaks_to_fit; }
    void SetBackground(TF1* bg_to_fit)                 { fBGToFit = bg_to_fit; }
    void InitializeParameters(TH1* fit_hist);
@@ -62,6 +62,12 @@ private:
    void UpdateFitterParameters();
    void UpdatePeakParameters(const TFitResultPtr& fit_res,TH1* fit_hist);
    Double_t DefaultBackgroundFunction(Double_t* dim, Double_t* par);
+	void ResetTotalFitFunction() {
+		if(fTotalFitFunction != nullptr) {
+			delete fTotalFitFunction;
+			fTotalFitFunction = nullptr;
+		}
+	}
 
 private:
 //   TMultiplePeak* fPeaksToFit{nullptr};

--- a/include/TRWPeak.h
+++ b/include/TRWPeak.h
@@ -35,7 +35,7 @@ public:
    TRWPeak(Double_t centroid);
 
    void InitParNames() override;
-   void InitializeParameters(TH1* hist) override;
+   void InitializeParameters(TH1* hist, const double& rangeLow, const double& rangeHigh) override;
 
 	void Centroid(const Double_t& centroid) override;
 

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -23,7 +23,12 @@
 ///
 /// \class TSinglePeak
 ///
-///  This class is used to fit things that resemble "peaks" in data
+/// This is the base class for anything that is used to fit 
+/// things that resemble "peaks" in data.
+/// Any derived classes must implement functions to 
+/// - initialize parameters and parameter names,
+/// - set the total function and peak function,
+/// The centroid of the peak should always be parameter 1.
 ///
 /////////////////////////////////////////////////////////////////
 class TPeakFitter;
@@ -36,7 +41,7 @@ public:
    TSinglePeak();
 
    virtual void InitParNames() {}
-   virtual void InitializeParameters(TH1* = nullptr) {}
+   virtual void InitializeParameters(TH1*, const double&, const double&) {}
    bool IsBackgroundParameter(const Int_t& par) const;
    bool IsPeakParameter(const Int_t& par) const;
    void SetListOfBGPar(std::vector<bool> list_of_bg_par) { fListOfBGPars = list_of_bg_par; }

--- a/include/TTransition.h
+++ b/include/TTransition.h
@@ -30,11 +30,13 @@ public:
    bool IsSortable() const override { return true; }
    int Compare(const TObject* obj) const override;
    int CompareIntensity(const TObject* obj) const;
+   int CompareEnergy(const TObject* obj) const;
 
-   void SetEnergy(double& tmpenergy) { fEnergy = tmpenergy; }
-   void SetEnergyUncertainty(double& tmperror) { fEngUncertainty = tmperror; }
-   void SetIntensity(double& tmpintens) { fIntensity = tmpintens; }
-   void SetIntensityUncertainty(double& tmpinterror) { fIntUncertainty = tmpinterror; }
+   void SetEnergy(const double& tmpenergy) { fEnergy = tmpenergy; }
+   void SetEnergyUncertainty(const double& tmperror) { fEngUncertainty = tmperror; }
+   void SetIntensity(const double& tmpintens) { fIntensity = tmpintens; }
+   void SetIntensityUncertainty(const double& tmpinterror) { fIntUncertainty = tmpinterror; }
+	void SetCompareIntensity(const bool& val) { fCompareIntensity = val; }
 
    double GetEnergy() const { return fEnergy; }
    double GetEnergyUncertainty() const { return fEngUncertainty; }
@@ -50,10 +52,11 @@ public:
 	bool operator<(const TTransition& rhs) const { return GetEnergy() < rhs.GetEnergy(); }
 
 private:
-   double fEnergy{0.};         // Energy of the transition
-   double fEngUncertainty{0.}; // Uncertainty in the energy of the transition
-   double fIntensity{0.};      // Intensity of the transition
-   double fIntUncertainty{0.}; // Uncertainty in the intensity
+   double fEnergy{0.};           ///< Energy of the transition
+   double fEngUncertainty{0.};   ///< Uncertainty in the energy of the transition
+   double fIntensity{0.};        ///< Intensity of the transition
+   double fIntUncertainty{0.};   ///< Uncertainty in the intensity
+	bool fCompareIntensity{true}; ///< Whether to sort by intensity or energy
 
    /// \cond CLASSIMP
    ClassDefOverride(TTransition, 0) // Information about a TNucleus transition

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -289,6 +289,8 @@ void GCanvas::HandleInput(int event, Int_t x, Int_t y)
    case kButton1Down:   // single click
 		used = StorePosition(event, x, y);
 		if(used) break;
+		// next comment prevents warning about falling through for gcc, with c++17 we can also use "[[fallthrough]];"
+		// fall through
    case kButton1Double: // double click
       used = HandleMousePress(event, x, y);
       break;

--- a/libraries/TAnalysis/TNucleus/TTransition.cxx
+++ b/libraries/TAnalysis/TNucleus/TTransition.cxx
@@ -54,8 +54,18 @@ std::string TTransition::PrintToString()
 	return toString;
 }
 
+int TTransition::Compare(const TObject* obj) const
+{
+	if(fCompareIntensity) {
+		return CompareIntensity(obj);
+	} else {
+		return CompareEnergy(obj);
+	}
+}
+
 int TTransition::CompareIntensity(const TObject* obj) const
 {
+	/// Compares the intensities of the TTransitions
 	if(fIntensity > static_cast<const TTransition*>(obj)->fIntensity) {
 		return -1;
 	}
@@ -63,23 +73,16 @@ int TTransition::CompareIntensity(const TObject* obj) const
 		return 0;
 	}
 	return 1;
-
-	return -9;
 }
 
-int TTransition::Compare(const TObject* obj) const
+int TTransition::CompareEnergy(const TObject* obj) const
 {
-
-	return CompareIntensity(obj);
-
-	// Compares the intensities of the TTransitions and returns
-	if(fEnergy > static_cast<const TTransition*>(obj)->fEnergy) {
+	/// Compares the energies of the TTransitions
+	if(fEnergy < static_cast<const TTransition*>(obj)->fEnergy) {
 		return -1;
 	}
 	if(fEnergy == static_cast<const TTransition*>(obj)->fEnergy) {
 		return 0;
 	}
 	return 1;
-
-	return -9;
 }

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -15,6 +15,7 @@ TAB3Peak::TAB3Peak(Double_t centroid) : TSinglePeak()
 void TAB3Peak::Centroid(const Double_t& centroid)
 {
    fTotalFunction = new TF1("ab_fit",this,&TAB3Peak::TotalFunction,0,1,8,"TAB3Peak","TotalFunction");
+   fPeakFunction =  new TF1("ab_peak",this,&TAB3Peak::PeakFunction,0,1,7,"TAB3Peak","PeakFunction");
    InitParNames();
    fTotalFunction->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool> {0,0,0,0,0,0,0,1});
@@ -33,7 +34,7 @@ void TAB3Peak::InitParNames()
    fTotalFunction->SetParName(7, "step");
 }
 
-void TAB3Peak::InitializeParameters(TH1* fit_hist)
+void TAB3Peak::InitializeParameters(TH1* fit_hist, const double& rangeLow, const double& rangeHigh)
 {
    /// Makes initial guesses at parameters for the fit base on the histogram.
    // Make initial guesses
@@ -43,33 +44,35 @@ void TAB3Peak::InitializeParameters(TH1* fit_hist)
    // The centroid should already be set by this point in the ctor
    Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
 	if(!ParameterSetByUser(0)) {
-		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
 		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*1.5);
 	}
+	// no sense checking whether the centroid has been set, this always gets set in the constructor
+	fTotalFunction->SetParLimits(1, rangeLow, rangeHigh);
 	if(!ParameterSetByUser(2)) {
-		fTotalFunction->SetParLimits(2, 0.1, 8);
 		fTotalFunction->SetParameter("sigma", TMath::Sqrt(2.25 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+		fTotalFunction->SetParLimits(2, 0.1, 8);
 	}
 	if(!ParameterSetByUser(3)) {
-		fTotalFunction->SetParLimits(3, 0.000001, 1.0);
 		fTotalFunction->SetParameter("rel_height1", 0.25);
+		fTotalFunction->SetParLimits(3, 0.000001, 1.0);
 	}
 	if(!ParameterSetByUser(4)) {
-		fTotalFunction->SetParLimits(4, 1.0, 100); 
 		fTotalFunction->SetParameter("rel_sigma1", 2.);
+		fTotalFunction->SetParLimits(4, 1.0, 100); 
 	}
 	if(!ParameterSetByUser(5)) {
-		fTotalFunction->SetParLimits(5, 0.000001, 1.0);
 		fTotalFunction->SetParameter("rel_height2", 0.25);
+		fTotalFunction->SetParLimits(5, 0.000001, 1.0);
 	}
 	if(!ParameterSetByUser(6)) {
-		fTotalFunction->SetParLimits(6, 1.0, 100); 
 		fTotalFunction->SetParameter("rel_sigma2", 6.);
+		fTotalFunction->SetParLimits(6, 1.0, 100); 
 	}
 	if(!ParameterSetByUser(7)) {
 		// Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
-		fTotalFunction->SetParLimits(7, 0.0, 1.0E2);
 		fTotalFunction->SetParameter("step", 1.0);
+		fTotalFunction->SetParLimits(7, 0.0, 1.0E2);
 	}
 }
 

--- a/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
@@ -31,7 +31,7 @@ void TRWPeak::InitParNames()
    fTotalFunction->SetParName(5, "step");
 }
 
-void TRWPeak::InitializeParameters(TH1* fit_hist)
+void TRWPeak::InitializeParameters(TH1* fit_hist, const double& rangeLow, const double& rangeHigh)
 {
    /// Makes initial guesses at parameters for the fit base on the histogram.
    // Make initial guesses
@@ -41,27 +41,29 @@ void TRWPeak::InitializeParameters(TH1* fit_hist)
    // The centroid should already be set by this point in the ctor
    Int_t bin     = fit_hist->FindBin(fTotalFunction->GetParameter(1));
    if(!ParameterSetByUser(0)) {
-		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*2.);
 		fTotalFunction->SetParameter("Height", fit_hist->GetBinContent(bin));
+		fTotalFunction->SetParLimits(0, 0, fit_hist->GetMaximum()*2.);
 	}
+	// no sense checking whether the centroid has been set, this always gets set in the constructor
+	fTotalFunction->SetParLimits(1, rangeLow, rangeHigh);
 	if(!ParameterSetByUser(2)) {
-		fTotalFunction->SetParLimits(2, 0.01, 10.);
 		fTotalFunction->SetParameter("sigma", TMath::Sqrt(5 + 1.33 * fTotalFunction->GetParameter("centroid") / 1000. +  0.9*TMath::Power(fTotalFunction->GetParameter("centroid")/1000.,2)) / 2.35);
+		fTotalFunction->SetParLimits(2, 0.01, 10.);
 	}
 	if(!ParameterSetByUser(3)) {
-		fTotalFunction->SetParLimits(3, 0.000001, 10);
 		fTotalFunction->SetParameter("beta", fTotalFunction->GetParameter("sigma") / 2.0);
+		//fTotalFunction->SetParLimits(3, 0.000001, 10);
 		fTotalFunction->FixParameter(3, fTotalFunction->GetParameter("beta"));
 	}
 	if(!ParameterSetByUser(4)) {
-		fTotalFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
 		fTotalFunction->SetParameter("R", 0.001);
+		fTotalFunction->SetParLimits(4, 0.000001, 100); // this is a percentage. no reason for it to go to 500% - JKS
 		fTotalFunction->FixParameter(4, 0.00);
 	}
 	// Step size is allow to vary to anything. If it goes below 0, the code will fix it to 0
 	if(!ParameterSetByUser(5)) {
-		fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
 		fTotalFunction->SetParameter("step", 0.1);
+		fTotalFunction->SetParLimits(5, 0.0, 1.0E2);
 	}
 }
 


### PR DESCRIPTION
TPeakFitter: Using range of fit as limits for centroid
- Added option to include the range when initializing parameters, which uses the provided range as limits for the centroid.
- TPeakFitter uses the range selected to initialize the parameters.
- Fixed bug in TPeakFitter when re-using one TPeakFitter instance by adding and removing peaks from it.

TEfficiencyCalibrator: Added static members (with setters and getters) for range, threshold, background parameters, peak type, degree of fit function, calibration uncertainty, and flag whether to show removed fits. This allows setting them before initializing the class.

Nucleus can now list transitions sorted by energy or intensity. To this effect TNucleus now keeps two lists of transitions, one sorted by intensity, the other sorted by energy. TTransition has a new member flag that tells it whether to compare itself to another transition using their energies or intensities.