### PR TITLE
Improved functionality of TCalibrationGraphSet

### DIFF
--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -78,10 +78,11 @@ public:
 	void DrawCalibration(Option_t* opt = "", TLegend* legend = nullptr);
 	void DrawResidual(Option_t* opt = "", TLegend* legend = nullptr);
 
+	void RemoveGraph(size_t i) { fGraphs.erase(fGraphs.begin()+i); ResetTotalGraph(); }
 	Int_t RemovePoint();
 	Int_t RemoveResidualPoint();
 
-	void Scale(); ///< scale all graphs to fit each other (based on the first graph)
+	void Scale(bool useAllPrevious = true);
 
 	void Print(Option_t* opt = "") const override;
 


### PR DESCRIPTION
- Added function to completely remove a graph from the set.
- Added option to use non-continuous scaling of graphs, meaning if there is a gap between the graphs, only those that have overlaps are scaled to each other (instead of not doing anything if there is a gap between graphs).