### PR TITLE
Fix for #1378 and correcting default word count

### DIFF
--- a/include/TGRSIMap.h
+++ b/include/TGRSIMap.h
@@ -102,7 +102,7 @@ public:
 			}
 		}
 
-	std::string detail() {
+	std::string detail() const noexcept {
 		std::ostringstream str;
 		str<<"Key "<<fKey<<" not found in '";
 		for(auto key = fKeys.begin(); key != fKeys.end(); ++key) {
@@ -114,6 +114,8 @@ public:
 		str<<"'";
 		return str.str();
 	}
+
+	const char* what() const noexcept { return strdup(detail().c_str()); }
 
 private:
 	key_type fKey;

--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -81,7 +81,7 @@ void TGRSIOptions::Clear(Option_t*)
    fWriteFragmentTree= false;
    fWriteBadFrags    = false;
    fWriteDiagnostics = false;
-	fWordOffset       = 1;
+	fWordOffset       = -1;
 
    fBatch = false;
 
@@ -298,7 +298,7 @@ void TGRSIOptions::Load(int argc, char** argv)
 			.colour(DGREEN);
 		parser.option("word-count-offset", &fWordOffset, true)
 			.description("Offset to the word count in the GRIFFIN header word, default is -1 (disabled).")
-			.default_value(1).colour(DGREEN);
+			.default_value(-1).colour(DGREEN);
 		parser.option("log-errors", &fLogErrors, true);
 		parser.option("reading-material", &fReadingMaterial, true);
 		parser.option("write-fragment-tree write-frag-tree", &fWriteFragmentTree, true)


### PR DESCRIPTION
This fixes #1378 and also sets the word count flag to -1 as default (instead of +1) not just when the ```--recommended``` flag is used but in general.