### PR TITLE
Reworked angular correlations helper

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -1,270 +1,109 @@
 #include "AngularCorrelationHelper.hh"
 
-double gbLow  = -50.;  // min. time difference gamma-beta
-double gbHigh = 500.;  // max. time difference gamma-beta
-double ggHigh = 400.;  // max. absolute time difference gamma-gamma
-double bgLow  = 1000.; // min. time difference gamma-gamma background
-double bgHigh = 2000.; // max. time difference gamma-gamma background
+double ggHigh = 200.;  // Max. absolute time difference for gamma-gamma
+double bgLow  = 400.; // Min. time difference for gamma-gamma background
+double bgHigh = 600.; // Max. time difference for gamma-gamma background
+
+// Limits and bins for gamma-gamma
+int nbin = 3000;
+float binMin = 0.;
+float binMax = 3000.;
 
 void AngularCorrelationHelper::CreateHistograms(unsigned int slot)
 {
-   // for each angle (and the sum) we want
-   // for single crystal and addback
-   // with and without coincident betas
-   // coincident and time-random gamma-gamma
-   for(int i = 0; i < static_cast<int>(fAngleCombinations.size()); ++i) {
-      fH2[slot][Form("gammaGamma%d", i)] =
-         new TH2D(Form("gammaGamma%d", i), Form("%.1f^{o}: #gamma-#gamma, |#Deltat_{#gamma-#gamma}| < %.1f",
-                                                fAngleCombinations[i].first, ggHigh),
-                  2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("gammaGammaBeta%d", i)] = new TH2D(
-         Form("gammaGammaBeta%d", i),
-         Form("%.1f^{o}: #gamma-#gamma, |#Deltat_{#gamma-#gamma}| < %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-              fAngleCombinations[i].first, ggHigh, gbLow, gbHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("gammaGammaBG%d", i)] =
-         new TH2D(Form("gammaGammaBG%d", i), Form("%.1f^{o}: #gamma-#gamma, #Deltat_{#gamma-#gamma} = %.1f - %.1f",
-                                                  fAngleCombinations[i].first, bgLow, bgHigh),
-                  2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("gammaGammaBetaBG%d", i)] = new TH2D(
-         Form("gammaGammaBetaBG%d", i),
-         Form("%.1f^{o}: #gamma-#gamma, #Deltat_{#gamma-#gamma} = %.1f - %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-              fAngleCombinations[i].first, bgLow, bgHigh, gbLow, gbHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-   }
-   for(int i = 0; i < static_cast<int>(fAngleCombinationsAddback.size()); ++i) {
-      fH2[slot][Form("addbackAddback%d", i)] = new TH2D(
-         Form("addbackAddback%d", i), Form("%.1f^{o}: #gamma-#gamma with addback, |#Deltat_{#gamma-#gamma}| < %.1f",
-                                           fAngleCombinationsAddback[i].first, ggHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("addbackAddbackBeta%d", i)] = new TH2D(
-         Form("addbackAddbackBeta%d", i), Form("%.1f^{o}: #gamma-#gamma with addback, |#Deltat_{#gamma-#gamma}| < "
-                                               "%.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-                                               fAngleCombinationsAddback[i].first, ggHigh, gbLow, gbHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("addbackAddbackBG%d", i)] =
-         new TH2D(Form("addbackAddbackBG%d", i),
-                  Form("%.1f^{o}: #gamma-#gamma with addback, #Deltat_{#gamma-#gamma} = %.1f - %.1f",
-                       fAngleCombinationsAddback[i].first, bgLow, bgHigh),
-                  2000, 0., 2000., 2000, 0., 2000.);
-      fH2[slot][Form("addbackAddbackBetaBG%d", i)] = new TH2D(
-         Form("addbackAddbackBetaBG%d", i), Form("%.1f^{o}: #gamma-#gamma with addback, #Deltat_{#gamma-#gamma} = %.1f "
-                                                 "- %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-                                                 fAngleCombinationsAddback[i].first, bgLow, bgHigh, gbLow, gbHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-   }
-   fH2[slot]["gammaGamma"] = new TH2D("gammaGamma", Form("#gamma-#gamma, |#Deltat_{#gamma-#gamma}| < %.1f", ggHigh), 2000, 0.,
-                                2000., 2000, 0., 2000.);
-   fH2[slot]["gammaGammaBeta"] = new TH2D(
-      "gammaGammaBeta", Form("#gamma-#gamma, |#Deltat_{#gamma-#gamma}| < %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-                             ggHigh, gbLow, gbHigh),
-      2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["gammaGammaBG"] =
-      new TH2D("gammaGammaBG", Form("#gamma-#gamma, #Deltat_{#gamma-#gamma} = %.1f - %.1f", bgLow, bgHigh), 2000, 0.,
-               2000., 2000, 0., 2000.);
-   fH2[slot]["gammaGammaBetaBG"] =
-      new TH2D("gammaGammaBetaBG",
-               Form("#gamma-#gamma, #Deltat_{#gamma-#gamma} = %.1f - %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f", bgLow,
-                    bgHigh, gbLow, gbHigh),
-               2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddback"] =
-      new TH2D("addbackAddback", Form("#gamma-#gamma with addback, |#Deltat_{#gamma-#gamma}| < %.1f", ggHigh), 2000, 0.,
-               2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddbackBeta"] = new TH2D(
-      "addbackAddbackBeta",
-      Form("#gamma-#gamma with addback, |#Deltat_{#gamma-#gamma}| < %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f", ggHigh,
-           gbLow, gbHigh),
-      2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddbackBG"] = new TH2D(
-      "addbackAddbackBG", Form("#gamma-#gamma with addback, #Deltat_{#gamma-#gamma} = %.1f - %.1f", bgLow, bgHigh),
-      2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddbackBetaBG"] = new TH2D(
-      "addbackAddbackBetaBG",
-      Form("#gamma-#gamma with addback, #Deltat_{#gamma-#gamma} = %.1f - %.1f, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-           bgLow, bgHigh, gbLow, gbHigh),
-      2000, 0., 2000., 2000, 0., 2000.);
-   // plus hitpatterns for gamma-gamma and beta-gamma for single crystals
-   fH2[slot]["gammaGammaHP"] = new TH2D("gammaGammaHP", "#gamma-#gamma hit pattern", 65, 0., 65., 65, 0., 65.);
-   fH2[slot]["betaGammaHP"]  = new TH2D("betaGammaHP", "#beta-#gamma hit pattern", 21, 0., 21., 65, 0., 65.);
-   fH2[slot]["addbackAddbackHP"] =
-      new TH2D("addbackAddbackHP", "#gamma-#gamma hit pattern with addback", 65, 0., 65., 65, 0., 65.);
-   fH2[slot]["betaAddbackHP"] = new TH2D("betaAddbackHP", "#beta-#gamma hit pattern with addback", 21, 0., 21., 65, 0., 65.);
+	// set up the queue for event mixing by filling it with empty events
+	// we chose 10 here as a reasonable compromise between statistics and computing power/memory needed
+	for(int i = 0; i < 10; ++i) {
+		fGriffinDeque[slot].emplace_back(new TGriffin);
+		fBgoDeque[slot].emplace_back(new TGriffinBgo);
+	}
 
-   // same for event mixing
-   for(int i = 0; i < static_cast<int>(fAngleCombinations.size()); ++i) {
-      fH2[slot][Form("gammaGammaMixed%d", i)] =
-         new TH2D(Form("gammaGammaMixed%d", i), Form("%.1f^{o}: #gamma-#gamma", fAngleCombinations[i].first), 2000, 0.,
-                  2000., 2000, 0., 2000.);
-      fH2[slot][Form("gammaGammaBetaMixed%d", i)] = new TH2D(
-         Form("gammaGammaBetaMixed%d", i), Form("%.1f^{o}: #gamma-#gamma, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-                                                fAngleCombinations[i].first, gbLow, gbHigh),
-         2000, 0., 2000., 2000, 0., 2000.);
-   }
-   for(int i = 0; i < static_cast<int>(fAngleCombinationsAddback.size()); ++i) {
-      fH2[slot][Form("addbackAddbackMixed%d", i)] =
-         new TH2D(Form("addbackAddbackMixed%d", i),
-                  Form("%.1f^{o}: #gamma-#gamma with addback", fAngleCombinationsAddback[i].first), 2000, 0., 2000.,
-                  2000, 0., 2000.);
-      fH2[slot][Form("addbackAddbackBetaMixed%d", i)] =
-         new TH2D(Form("addbackAddbackBetaMixed%d", i),
-                  Form("%.1f^{o}: #gamma-#gamma with addback, #Deltat_{#gamma-#beta} = %.1f - %.1f",
-                       fAngleCombinationsAddback[i].first, gbLow, gbHigh),
-                  2000, 0., 2000., 2000, 0., 2000.);
-   }
-   fH2[slot]["gammaGammaMixed"] = new TH2D("gammaGammaMixed", "#gamma-#gamma", 2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["gammaGammaBetaMixed"] =
-      new TH2D("gammaGammaBetaMixed", Form("#gamma-#gamma, #Deltat_{#gamma-#beta} = %.1f - %.1f", gbLow, gbHigh), 2000,
-               0., 2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddbackMixed"] =
-      new TH2D("addbackAddbackMixed", "#gamma-#gamma with addback", 2000, 0., 2000., 2000, 0., 2000.);
-   fH2[slot]["addbackAddbackBetaMixed"] =
-      new TH2D("addbackAddbackBetaMixed",
-               Form("#gamma-#gamma with addback, #Deltat_{#gamma-#beta} = %.1f - %.1f", gbLow, gbHigh), 2000, 0., 2000.,
-               2000, 0., 2000.);
-   // plus hitpatterns for gamma-gamma and beta-gamma for single crystals
-   fH2[slot]["gammaGammaHPMixed"] = new TH2D("gammaGammaHPMixed", "#gamma-#gamma hit pattern", 65, 0., 65., 65, 0., 65.);
-   fH2[slot]["betaGammaHPMixed"]  = new TH2D("betaGammaHPMixed", "#beta-#gamma hit pattern", 21, 0., 21., 65, 0., 65.);
-   fH2[slot]["addbackAddbackHPMixed"] =
-      new TH2D("addbackAddbackHPMixed", "#gamma-#gamma hit pattern with addback", 65, 0., 65., 65, 0., 65.);
-   fH2[slot]["betaAddbackHPMixed"] =
-      new TH2D("betaAddbackHPMixed", "#beta-#gamma hit pattern with addback", 21, 0., 21., 65, 0., 65.);
+	std::string conditions = fAddback ? "using addback" : "without addback";
+	conditions += fFolding ? ", folded around 90^{o}" : "";
+	conditions += fGrouping ? ", grouped" : "";
 
-   // additionally 1D spectra of gammas
-   // for single crystal and addback
-   // with and without coincident betas
-   fH1[slot]["gammaEnergy"]     = new TH1D("gammaEnergy", "#gamma Singles", 12000, 0, 3000);
-   fH1[slot]["gammaEnergyBeta"] = new TH1D("gammaEnergyBeta", "#gamma singles in rough #beta coincidence", 12000, 0, 3000);
-   fH1[slot]["addbackEnergy"]   = new TH1D("addbackEnergy", "#gamma singles with addback", 12000, 0, 3000);
-   fH1[slot]["addbackEnergyBeta"] = new TH1D("addbackEnergyBeta", "#gamma singles with addback in rough #beta coincidence", 12000, 0, 3000);
+	for(auto angle = fAngles->begin(); angle != fAngles->end(); ++angle) {
+		int i = std::distance(fAngles->begin(), angle);
+		fH2[slot][Form("AngularCorrelation%d", i)] = new TH2D(Form("AngularCorrelation%d", i), Form("%.1f^{o}: Suppressed #gamma-#gamma %s, |#Deltat_{#gamma-#gamma}| < %.1f", *angle, conditions.c_str(), ggHigh), nbin, binMin, binMax, nbin, binMin, binMax);
+		fH2[slot][Form("AngularCorrelationBG%d", i)] = new TH2D(Form("AngularCorrelationBG%d", i), Form("%.1f^{o}: Suppressed #gamma-#gamma %s, |#Deltat_{#gamma-#gamma}| = %.1f - %.1f", *angle, conditions.c_str(), bgLow, bgHigh), nbin, binMin, binMax, nbin, binMin, binMax);
+		fH2[slot][Form("AngularCorrelationMixed%d", i)] = new TH2D(Form("AngularCorrelationMixed%d", i),Form("%.1f^{o}: Event mixed suppressed #gamma-#gamma %s", *angle, conditions.c_str()), nbin, binMin, binMax,nbin, binMin, binMax);
+	}
 
-   // and timing spectra for gamma-gamma and beta-gamma
-   fH1[slot]["gammaGammaTiming"]     = new TH1D("gammaGammaTiming", "#Deltat_{#gamma-#gamma}", 3000, 0., 3000.);
-   fH1[slot]["betaGammaTiming"]      = new TH1D("betaGammaTiming", "#Deltat_{#beta-#gamma}", 2000, -1000., 1000.);
-   fH1[slot]["addbackAddbackTiming"] = new TH1D("addbackAddbackTiming", "#Deltat_{#addback-#addback}", 2000, 0., 3000.);
-   fH1[slot]["betaAddbackTiming"]    = new TH1D("betaAddbackTiming", "#Deltat_{#beta-#gamma}", 2000, -1000., 1000.);
+	fH2[slot]["AngularCorrelation"] = new TH2D("AngularCorrelation", Form("Suppressed #gamma-#gamma %s, |#Deltat_{#gamma-#gamma}| < %.1f", conditions.c_str(), ggHigh), nbin, binMin, binMax, nbin, binMin, binMax);
+	fH2[slot]["AngularCorrelationBG"] = new TH2D("AngularCorrelationBG", Form("Suppressed #gamma-#gamma %s, #Deltat_{#gamma-#gamma} = %.1f - %.1f", conditions.c_str(), bgLow, bgHigh), nbin, binMin, binMax, nbin, binMin, binMax);
+	fH2[slot]["AngularCorrelationMixed"] = new TH2D("AngularCorrelationMixed", Form("Event mixed suppressed #gamma-#gamma %s", conditions.c_str()), nbin, binMin, binMax, nbin, binMin, binMax);
+
+	// for the first slot we also write the griffin angles
+	if(slot == 0) {
+		fObject[slot]["GriffinAngles"] = fAngles;
+	}
 }
 
-void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& grif, TSceptar& scep)
+void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGriffinBgo& fGriffinBgo)
 {
-   // without addback
-   for(auto g1 = 0; g1 < grif.GetMultiplicity(); ++g1) {
-      auto grif1 = grif.GetGriffinHit(g1);
-      // check for coincident betas
-      bool coincBeta = false;
-      for(auto s = 0; s < scep.GetMultiplicity(); ++s) {
-         auto scep1 = scep.GetSceptarHit(s);
-         if(!coincBeta && gbLow <= grif1->GetTime() - scep1->GetTime() && grif1->GetTime() - scep1->GetTime() <= gbHigh)
-            coincBeta = true;
-         fH1[slot].at("betaGammaTiming")->Fill(scep1->GetTime() - grif1->GetTime());
-         fH2[slot].at("betaGammaHP")->Fill(scep1->GetDetector(), grif1->GetArrayNumber());
-      }
-      fH1[slot].at("gammaEnergy")->Fill(grif1->GetEnergy());
-      if(coincBeta) fH1[slot].at("gammaEnergyBeta")->Fill(grif1->GetEnergy());
-      for(auto g2 = 0; g2 < grif.GetMultiplicity(); ++g2) {
-         if(g1 == g2) continue;
-         auto   grif2 = grif.GetGriffinHit(g2);
-         double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
-         if(angle < 0.0001) continue;
-         auto   angleIndex = fAngleMap.lower_bound(angle - 0.0005);
-         double ggTime     = TMath::Abs(grif1->GetTime() - grif2->GetTime());
-         fH1[slot].at("gammaGammaTiming")->Fill(ggTime);
-         fH2[slot].at("gammaGammaHP")->Fill(grif1->GetArrayNumber(), grif2->GetArrayNumber());
+	for(auto g1 = 0; g1 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g1) {
+		auto grif1 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g1) : fGriffin.GetSuppressedHit(g1));
 
-         if(ggTime < ggHigh) {
-            fH2[slot].at("gammaGamma")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("gammaGamma%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            if(coincBeta) {
-               fH2[slot].at("gammaGammaBeta")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-               fH2[slot].at(Form("gammaGammaBeta%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            }
-         } else if(bgLow < ggTime && ggTime < bgHigh) {
-            fH2[slot].at("gammaGammaBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("gammaGammaBG%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            if(coincBeta) {
-               fH2[slot].at("gammaGammaBetaBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-               fH2[slot].at(Form("gammaGammaBetaBG%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            }
-         }
-      }
-      // event mixing, we use the last event as second griffin 
-		// if there was no last event the default constructed TGriffin will have a multiplicity of zero
-      for(auto g2 = 0; g2 < fLastGrif[slot].GetMultiplicity(); ++g2) {
-         if(g1 == g2) continue;
-         auto   grif2 = fLastGrif[slot].GetGriffinHit(g2);
-         double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
-         if(angle < 0.0001) continue;
-         auto   angleIndex = fAngleMap.lower_bound(angle - 0.0005);
-         double ggTime     = TMath::Abs(grif1->GetTime() - grif2->GetTime());
-         fH2[slot].at("gammaGammaHPMixed")->Fill(grif1->GetArrayNumber(), grif2->GetArrayNumber());
+		for(auto g2 = 0; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
+			if(g1 == g2) continue;
+			auto grif2 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g2) : fGriffin.GetSuppressedHit(g2));
 
-         fH2[slot].at("gammaGammaMixed")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         fH2[slot].at(Form("gammaGammaMixed%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         if(coincBeta) {
-            fH2[slot].at("gammaGammaBetaMixed")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("gammaGammaBetaMixed%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         }
-      }
-   }
-   // with addback
-   for(auto g1 = 0; g1 < grif.GetAddbackMultiplicity(); ++g1) {
-      auto grif1 = grif.GetAddbackHit(g1);
-      // check for coincident betas
-      bool coincBeta = false;
-      for(auto s = 0; s < scep.GetMultiplicity(); ++s) {
-         auto scep1 = scep.GetSceptarHit(s);
-         if(!coincBeta && gbLow <= grif1->GetTime() - scep1->GetTime() && grif1->GetTime() - scep1->GetTime() <= gbHigh)
-            coincBeta = true;
-         fH1[slot].at("betaAddbackTiming")->Fill(scep1->GetTime() - grif1->GetTime());
-         fH2[slot].at("betaAddbackHP")->Fill(scep1->GetDetector(), grif1->GetArrayNumber());
-      }
-      fH1[slot].at("addbackEnergy")->Fill(grif1->GetEnergy());
-      if(coincBeta) fH1[slot].at("addbackEnergyBeta")->Fill(grif1->GetEnergy());
-      for(auto g2 = 0; g2 < grif.GetAddbackMultiplicity(); ++g2) {
-         if(g1 == g2) continue;
-         auto   grif2 = grif.GetAddbackHit(g2);
-         double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
-         if(angle < 0.0001) continue;
-         auto   angleIndex = fAngleMapAddback.lower_bound(angle - 0.0005);
-         double ggTime     = TMath::Abs(grif1->GetTime() - grif2->GetTime());
-         fH1[slot].at("addbackAddbackTiming")->Fill(ggTime);
-         fH2[slot].at("addbackAddbackHP")->Fill(grif1->GetArrayNumber(), grif2->GetArrayNumber());
+			// skip hits in the same detector when using addback, or in the same crystal when not using addback
+			if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) {
+				continue; 
+			}
 
-         if(ggTime < ggHigh) {
-            fH2[slot].at("addbackAddback")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("addbackAddback%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            if(coincBeta) {
-               fH2[slot].at("addbackAddbackBeta")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-               fH2[slot].at(Form("addbackAddbackBeta%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            }
-         } else if(bgLow < ggTime && ggTime < bgHigh) {
-            fH2[slot].at("addbackAddbackBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("addbackAddbackBG%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            if(coincBeta) {
-               fH2[slot].at("addbackAddbackBetaBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-               fH2[slot].at(Form("addbackAddbackBetaBG%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            }
-         }
-      }
-      // event mixing, we use the last event as second griffin
-      for(auto g2 = 0; g2 < fLastGrif[slot].GetAddbackMultiplicity(); ++g2) {
-         if(g1 == g2) continue;
-         auto   grif2 = fLastGrif[slot].GetAddbackHit(g2);
-         double angle = grif1->GetPosition().Angle(grif2->GetPosition()) * 180. / TMath::Pi();
-         if(angle < 0.0001) continue;
-         auto   angleIndex = fAngleMapAddback.lower_bound(angle - 0.0005);
-         double ggTime     = TMath::Abs(grif1->GetTime() - grif2->GetTime());
-         fH2[slot].at("addbackAddbackHPMixed")->Fill(grif1->GetArrayNumber(), grif2->GetArrayNumber());
+			// calculate the angle
+			double angle = grif1->GetPosition(fGriffinDistance).Angle(grif2->GetPosition(fGriffinDistance)) * 180./TMath::Pi();
+			if(angle < 0.0001) continue;
+			if(fFolding && angle > 90.) angle = 180. - angle;
 
-         fH2[slot].at("addbackAddbackMixed")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         fH2[slot].at(Form("addbackAddbackMixed%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         if(coincBeta) {
-            fH2[slot].at("addbackAddbackBetaMixed")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-            fH2[slot].at(Form("addbackAddbackBetaMixed%d", angleIndex->second))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
-         }
-      }
-   }
+			// find the index of the angle
+			auto angleIndex = fAngles->Index(angle);
+			if(angleIndex < 0) continue;
+			// check the timing to see if these are coincident or time-random hits
+			double ggTime  = TMath::Abs(grif2->GetTime() - grif1->GetTime());
+			if(ggTime <= ggHigh) { 
+				fH2[slot].at("AngularCorrelation")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				fH2[slot].at(Form("AngularCorrelation%d", angleIndex))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+			} else if(bgLow <= ggTime && ggTime <= bgHigh) {
+				fH2[slot].at("AngularCorrelationBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				fH2[slot].at(Form("AngularCorrelationBG%d", angleIndex))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+			}
+		}
 
-   // update "last" event
-   fLastGrif[slot] = grif;
-   fLastScep[slot] = scep;
+		// Event mixing: loop over all stored events for this thread/slot and use them as the "second" gamma ray
+		for(auto l = 0; l < fGriffinDeque[slot].size(); ++l) {
+			auto fLastGriffin = fGriffinDeque[slot][l];
+			auto fLastBgo = fBgoDeque[slot][l];
+			for(auto g2 = 0; g2 < (fAddback ? fLastGriffin->GetSuppressedAddbackMultiplicity(fLastBgo) : fLastGriffin->GetSuppressedMultiplicity(fLastBgo)); ++g2) {
+				auto grif2 = (fAddback ? fLastGriffin->GetSuppressedAddbackHit(g2) : fLastGriffin->GetSuppressedHit(g2));
+
+				// skip hits in the same detector when using addback, or in the same crystal when not using addback
+				if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) continue; 
+
+				double angle = grif1->GetPosition(fGriffinDistance).Angle(grif2->GetPosition(fGriffinDistance)) * 180. / TMath::Pi();
+				if(angle < 0.0001) continue;
+				if(fFolding && angle > 90.) angle = 180. - angle;
+
+				// find the index of the angle
+				auto angleIndex = fAngles->Index(angle);
+				if(angleIndex < 0) continue;
+				// no point in checking the time here, the two hits are from different events
+				fH2[slot].at("AngularCorrelationMixed")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+				fH2[slot].at(Form("AngularCorrelationMixed%d", angleIndex))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+			}
+		}
+	}
+
+	// Add the current event to the queue, delete the oldest event in the queue, and pop the pointer from the queue.
+	fGriffinDeque[slot].emplace_back(new TGriffin(fGriffin));
+	fBgoDeque[slot].emplace_back(new TGriffinBgo(fGriffinBgo));
+
+	delete fGriffinDeque[slot].front();
+	delete fBgoDeque[slot].front();
+
+	fGriffinDeque[slot].pop_front();
+	fBgoDeque[slot].pop_front();
 }
+

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -1,141 +1,45 @@
 #ifndef AngularCorrelationHelper_h
 #define AngularCorrelationHelper_h
 
-// Header file for the classes stored in the TTree if any.
 #include "TGriffin.h"
-#include "TSceptar.h"
+#include "TGriffinBgo.h"
+#include "TGriffinAngles.h"
 #include "TGRSIHelper.h"
-
-// function to calculate angles (from LeanCorrelations), implemented at the end of this file
-std::vector<std::pair<double, int>> AngleCombinations(double distance = 110., bool folding = false,
-                                                      bool addback = false);
 
 class AngularCorrelationHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl<AngularCorrelationHelper> {
 private:
-   std::vector<std::pair<double, int>> fAngleCombinations;
-   std::vector<std::pair<double, int>> fAngleCombinationsAddback; // with addback
-   std::map<double, int>               fAngleMap;
-   std::map<double, int>               fAngleMapAddback; // with addback
+	double fGriffinDistance = 145.;
 
-	std::map<unsigned int, TGriffin> fLastGrif;
-	std::map<unsigned int, TSceptar> fLastScep;
+	bool fFolding = true;
+	bool fGrouping = true;
+	bool fAddback = true;
 
-public:
-   AngularCorrelationHelper(TList* list) : TGRSIHelper(list) {
-      Prefix("AngularCorrelation");
-      // calculate angle combinations
-      fAngleCombinations        = AngleCombinations(110., false, false);
-      fAngleCombinationsAddback = AngleCombinations(110., false, true); // with addback
-      for(int i = 0; i < static_cast<int>(fAngleCombinations.size()); ++i) {
-         fAngleMap.insert(std::make_pair(fAngleCombinations[i].first, i));
-      }
-      for(int i = 0; i < static_cast<int>(fAngleCombinationsAddback.size()); ++i) {
-         fAngleMapAddback.insert(std::make_pair(fAngleCombinationsAddback[i].first, i));
-      }
+	TGriffinAngles* fAngles = new TGriffinAngles(fGriffinDistance, fFolding, fGrouping, fAddback);
+
+	std::map<unsigned int, std::deque<TGriffin*>> fGriffinDeque;
+	std::map<unsigned int, std::deque<TGriffinBgo*>> fBgoDeque;
+
+public :
+	AngularCorrelationHelper(TList* list) : TGRSIHelper(list) {
+		Prefix("AngularCorrelation");
+
+		fAngles->Print();
+
 		// Setup calls CreateHistograms, which uses the stored angle combinations, so we need those set before
 		Setup();
-   }
+	}
+
 	ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override {
-      return d->Book<TGriffin, TSceptar>(std::move(*this), {"TGriffin", "TSceptar"});
-   }
-   void          CreateHistograms(unsigned int slot);
-   void          Exec(unsigned int slot, TGriffin& grif, TSceptar& scep);
+		return d->Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
+	}
+
+	void CreateHistograms(unsigned int slot);
+	void Exec(unsigned int slot, TGriffin& fGriffin, TGriffinBgo& fGriffinBgo);
 };
+
 #endif
 
-// These are needed functions used by TDataFrameLibrary to create and destroy the instance of this helper
 extern "C" AngularCorrelationHelper* CreateHelper(TList* list) { return new AngularCorrelationHelper(list); }
 
 extern "C" void DestroyHelper(TGRSIHelper* helper) { delete helper; }
 
-std::vector<std::pair<double, int>> AngleCombinations(double distance, bool folding, bool addback)
-{
-   std::vector<std::pair<double, int>> result;
-   std::vector<std::pair<double, int>> grouped_result;
-   std::vector<double> angle;
-   for(int firstDet = 1; firstDet <= 16; ++firstDet) {
-      for(int firstCry = 0; firstCry < 4; ++firstCry) {
-         for(int secondDet = 1; secondDet <= 16; ++secondDet) {
-            for(int secondCry = 0; secondCry < 4; ++secondCry) {
-               if(firstDet == secondDet && firstCry == secondCry) {
-                  continue;
-               }
-               if(!addback) {
-                  angle.push_back(TGriffin::GetPosition(firstDet, firstCry, distance)
-                                     .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                                  180. / TMath::Pi());
-               }
-               if(addback) {
-                  if(((TGriffin::GetPosition(firstDet, firstCry, distance)
-                             .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                          180. / TMath::Pi() >
-                       18.786) &&
-                      (TGriffin::GetPosition(firstDet, firstCry, distance)
-                             .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                          180. / TMath::Pi() <
-                       18.788)) ||
-                     ((TGriffin::GetPosition(firstDet, firstCry, distance)
-                             .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                          180. / TMath::Pi() >
-                       26.6800) &&
-                      (TGriffin::GetPosition(firstDet, firstCry, distance)
-                             .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                          180. / TMath::Pi() <
-                       26.6915))) {
-                     angle.push_back(18.7868);
-                  } else {
-                     angle.push_back(TGriffin::GetPosition(firstDet, firstCry, distance)
-                                        .Angle(TGriffin::GetPosition(secondDet, secondCry, distance)) *
-                                     180. / TMath::Pi());
-                  }
-               }
-               if(folding && angle.back() > 90.) {
-                  angle.back() = 180. - angle.back();
-               }
-            }
-         }
-      }
-   }
-
-   std::sort(angle.begin(), angle.end());
-   size_t r;
-   for(size_t a = 0; a < angle.size(); ++a) {
-      for(r = 0; r < result.size(); ++r) {
-         if(angle[a] >= result[r].first - 0.001 && angle[a] <= result[r].first + 0.001) {
-            (result[r].second)++;
-            break;
-         }
-      }
-      if(result.size() == 0 || r == result.size()) {
-         result.push_back(std::make_pair(angle[a], 1));
-      }
-   }
-
-   if(folding) { // if we fold we also want to group
-      std::vector<std::pair<double, int>> groupedResult;
-      for(size_t i = 0; i < result.size(); ++i) {
-         switch(i) {
-         case 0:
-         case 1: groupedResult.push_back(result[i]); break;
-         case 2:
-         case 4:
-         case 6:
-            if(i + 1 >= result.size()) {
-               std::cerr<<"Error!"<<std::endl;
-            }
-            groupedResult.push_back(
-               std::make_pair((result[i].first + result[i + 1].first) / 2., result[i].second + result[i + 1].second));
-            ++i;
-            break;
-         default:
-            groupedResult.push_back(std::make_pair((result[i].first + result[i + 1].first + result[i + 2].first) / 3.,
-                                                   result[i].second + result[i + 1].second + result[i + 2].second));
-            i += 2;
-            break;
-         }
-      }
-      return groupedResult;
-   }
-
-   return result;
-}

--- a/include/TGRSIHelper.h
+++ b/include/TGRSIHelper.h
@@ -32,6 +32,7 @@ protected:
    std::vector<TGRSIMap<std::string, GHSym*>> fSym; //!<! one map per data processing slot for GRSISort's symmectric 2D histograms
    std::vector<TGRSIMap<std::string, GCube*>> fCube; //!<! one map per data processing slot for GRSISort's 3D histograms
    std::vector<TGRSIMap<std::string, TTree*>> fTree; //!<! one map per data processing slot for trees
+   std::vector<TGRSIMap<std::string, TObject*>> fObject; //!<! one map per data processing slot for any TObjects
 	TPPG*     fPpg{nullptr};     //!<! pointer to the PPG
 	TRunInfo* fRunInfo{nullptr}; //!<! pointer to the run info
 	std::map<std::string, TCutG*>      fCuts; //!<! map of cuts


### PR DESCRIPTION
- Uses the new TGriffinAngles class to get the angles and store them in the output root file. For this the option to write anything inheriting from TObject to file was added to TGRSIHelper.
- Only creates the bare minimum of histograms (prompt, time random, and mixed for each angle), plus the versions for all angles of these matrices.
- Automatically handles folding, grouping, and addback based on the three boolean flags.
- Properly handles event mixing for 10 events per slot/thread. 10 is right now hard-coded into the .cxx file, but that could be changed to a user-set variable.
- Possible improvements:
  - Change the helper to read the settings (the three flags, # of mixed events, and distance of detectors from center of array) from a settings file. Need a new class that handles reading those settings (GValue only works for doubles).
  - Add an option to automatically create beta-tagged matrices if a flag is set? Or we could create a separate version of the helper that does that. Problem with this is that it might be impossible to do with the need to know which detectors are present in the data ...