### PR TITLE
Added option to have vectors in TUserSettings

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -43,10 +43,12 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
 {
 	for(auto g1 = 0; g1 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g1) {
 		auto grif1 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g1) : fGriffin.GetSuppressedHit(g1));
+		if(ExcludeDetector(grif1->GetDetector()) || ExcludeCrystal(grif1->GetArrayNumber()) continue;
 
 		for(auto g2 = 0; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
 			if(g1 == g2) continue;
 			auto grif2 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g2) : fGriffin.GetSuppressedHit(g2));
+			if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber()) continue;
 
 			// skip hits in the same detector when using addback, or in the same crystal when not using addback
 			if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) {
@@ -78,6 +80,7 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
 			auto fLastBgo = fBgoDeque[slot][l];
 			for(auto g2 = 0; g2 < (fAddback ? fLastGriffin->GetSuppressedAddbackMultiplicity(fLastBgo) : fLastGriffin->GetSuppressedMultiplicity(fLastBgo)); ++g2) {
 				auto grif2 = (fAddback ? fLastGriffin->GetSuppressedAddbackHit(g2) : fLastGriffin->GetSuppressedHit(g2));
+				if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber()) continue;
 
 				// skip hits in the same detector when using addback, or in the same crystal when not using addback
 				if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) continue; 

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -12,11 +12,16 @@ private:
 	bool fFolding{false};
 	bool fGrouping{false};
 	bool fAddback{true};
+	std::vector<int> fExcludedDetectors;
+	std::vector<int> fExcludedCrystals;
 
 	TGriffinAngles* fAngles{nullptr};
 
 	std::map<unsigned int, std::deque<TGriffin*>> fGriffinDeque;
 	std::map<unsigned int, std::deque<TGriffinBgo*>> fBgoDeque;
+
+	bool ExcludeDetector(int detector) { for(auto exclude : fExcludedDetectors) { if(detector == exclude) return true; } return false; }
+	bool ExcludeCrystal(int arraynumber) { for(auto exclude : fExcludedCrystals) { if(arraynumber == exclude) return true; } return false; }
 
 public :
 	AngularCorrelationHelper(TList* list) : TGRSIHelper(list) {
@@ -27,6 +32,8 @@ public :
 			fAddback = fUserSettings->GetBool("Addback");
 			fFolding = fUserSettings->GetBool("Folding");
 			fGrouping = fUserSettings->GetBool("Grouping");
+			fExcludedDetectors = fUserSettings->GetIntVector("ExcludedDetector");
+			fExcludedCrystals = fUserSettings->GetIntVector("ExcludedCrystal");
 		} else {
 			std::cout<<"No user settings provided, using default settings: ";
 		}

--- a/examples/AngularCorrelationSettings.par
+++ b/examples/AngularCorrelationSettings.par
@@ -13,3 +13,14 @@ TimeRandomNormalization: 1.
 Peak.Position: 1173.7
 Peak.Low: 1140.
 Peak.High: 1200.
+
+# it's also possible to exclude specific detectors, e.g. to exclude detectors 1-3 comment back in:
+//ExcludeDetector: 1, 2, 3
+
+# settings for the mixing methods analysis, need to specify J's of high, middle, and low level
+# all of them are vectors, but only one of these can be a vector with more than one element
+# this will produce plots of reduced chi^2 vs mixing angle for spins from 0 to 4 for the high level
+TwoJ.Low: 0,
+TwoJ.Middle: 4,
+TwoJ.High: 0, 2, 4, 6, 8
+

--- a/include/TUserSettings.h
+++ b/include/TUserSettings.h
@@ -1,6 +1,7 @@
 #ifndef TUSERSETTINGS_H
 #define TUSERSETTINGS_H
 
+#include <iostream>
 #include <map>
 #include <string>
 #include <vector>
@@ -18,7 +19,8 @@
 ///
 /// The TUserSettings class defines user settings that can be
 /// read from text or root files. It stores them in separate
-/// maps for booleans, integers, floats, and strings.
+/// maps for booleans, integers, floats, and strings as well
+/// as vectors of those types.
 ///
 /////////////////////////////////////////////////////////////
 
@@ -31,36 +33,57 @@ public:
 
 	bool Read(std::string settingsFile);
 
-	bool empty() { return fBool.empty() && fInt.empty() && fDouble.empty() && fString.empty(); }
+	bool empty() { return fBool.empty() && fInt.empty() && fDouble.empty() && fString.empty() && fBoolVector.empty() && fIntVector.empty() && fDoubleVector.empty() && fStringVector.empty(); }
 
+	// getter functions
 	template<typename T>
 		T Get(std::string parameter) const
 		{
-			if(std::is_same<T, bool>::value) return fBool.at(parameter);
-			if(std::is_same<T, int>::value) return fInt.at(parameter);
-			if(std::is_same<T, double>::value) return fDouble.at(parameter);
-			if(std::is_same<T, std::string>::value) return fString.at(parameter);
-			throw std::runtime_error("Unknown type, only bool, int, double, or std::string allowed");
+			if(std::is_same<T, bool>::value)                     return GetBool(parameter);
+			if(std::is_same<T, int>::value)                      return GetInt(parameter);
+			if(std::is_same<T, double>::value)                   return GetDouble(parameter);
+			if(std::is_same<T, std::string>::value)              return GetString(parameter);
+			if(std::is_same<T, std::vector<bool>>::value)        return GetBoolVector(parameter);
+			if(std::is_same<T, std::vector<int>>::value)         return GetIntVector(parameter);
+			if(std::is_same<T, std::vector<double>>::value)      return GetDoubleVector(parameter);
+			if(std::is_same<T, std::vector<std::string>>::value) return GetStringVector(parameter);
+			throw std::runtime_error("Unknown type, only bool, int, double, std::string or vectors of those types allowed");
 		}
 
-	bool GetBool(std::string parameter) const { return fBool.at(parameter); }
-	int GetInt(std::string parameter) const { return fInt.at(parameter); }
-	double GetDouble(std::string parameter) const { return fDouble.at(parameter); }
-	std::string GetString(std::string parameter) const { return fString.at(parameter); }
+	bool GetBool(std::string parameter, bool quiet = false) const;
+	int GetInt(std::string parameter, bool quiet = false) const;
+	double GetDouble(std::string parameter, bool quiet = false) const;
+	std::string GetString(std::string parameter, bool quiet = false) const;
+	std::vector<bool> GetBoolVector(std::string parameter, bool quiet = false) const;
+	std::vector<int> GetIntVector(std::string parameter, bool quiet = false) const;
+	std::vector<double> GetDoubleVector(std::string parameter, bool quiet = false) const;
+	std::vector<std::string> GetStringVector(std::string parameter, bool quiet = false) const;
 
+	// getter functions with default value
+	// can't do this for GetBool as the default bool would clash with the signature with the "quiet" bool 
+	int GetInt(std::string parameter, int def) const { try { return fInt.at(parameter); } catch(std::out_of_range& e) { return def; } }
+	double GetDouble(std::string parameter, double def) const { try { return fDouble.at(parameter); } catch(std::out_of_range& e) { return def; } }
+	std::string GetString(std::string parameter, std::string def) const { try { return fString.at(parameter); } catch(std::out_of_range& e) { return def; } }
+	
 	void Print(Option_t* opt = "") const override;
-	void Clear() { fBool.clear(); fInt.clear(); fDouble.clear(); fString.clear(); SetName(""); }
+	void Clear() { fBool.clear(); fInt.clear(); fDouble.clear(); fString.clear(); fBoolVector.clear(); fIntVector.clear(); fDoubleVector.clear(); fStringVector.clear(); SetName(""); }
 
 private:
+	void ParseValue(const std::string& name, const std::string& value, bool vector);
+
 	std::map<std::string, bool> fBool;
 	std::map<std::string, int> fInt;
 	std::map<std::string, double> fDouble;
 	std::map<std::string, std::string> fString;
+	std::map<std::string, std::vector<bool>> fBoolVector;
+	std::map<std::string, std::vector<int>> fIntVector;
+	std::map<std::string, std::vector<double>> fDoubleVector;
+	std::map<std::string, std::vector<std::string>> fStringVector;
 
 	std::vector<std::string> fSettingsFiles;
 
 	/// \cond CLASSIMP
-	ClassDefOverride(TUserSettings, 2)
+	ClassDefOverride(TUserSettings, 5)
 	/// \endcond
 };
 /*! @} */

--- a/libraries/TFormat/TUserSettings.cxx
+++ b/libraries/TFormat/TUserSettings.cxx
@@ -17,7 +17,8 @@ bool TUserSettings::Read(std::string settingsFile)
 	/// The file is expected to have the format
 	/// <parameter name>: <value>
 	/// where <parameter name> is a string w/o whitespace and <value> is the value of the parameter
-	/// the type of the value (bool, int, double, or std::string) will be determined automatically
+	/// the type of the value (bool, int, double, std::string, or vectors of these types) will be determined automatically
+	/// vectors are comma separated values of one type
 	/// the default type will be std::string
 	/// any lines starting with '#' or '//' or without a colon will be ignored
 	SetName("UserSettings");
@@ -44,47 +45,181 @@ bool TUserSettings::Read(std::string settingsFile)
 		// remove leading and trailing whitespace
 		trim(value);
 
-		// try and parse as integer, if pos is equal to the length of the string we were successful:
-		// add it to the map and go to the next line
-		size_t pos;
-		try {
-			auto intVal = std::stoi(value, &pos);
-			if(pos == value.length()) {
-				fInt[name] = intVal;
-				continue;
+		// check if this is a comma separated list of values
+		if(value.find(',') != std::string::npos) {
+			std::stringstream valueStream(value);
+			while(std::getline(valueStream, line, ',')) {
+				trim(line);
+				ParseValue(name, line, true);
 			}
-		} catch(std::invalid_argument& e) {
-			// do nothing, we failed to parse the input as integer, just go on to the next type
+		} else {
+			ParseValue(name, value, false);
 		}
-
-		// try and parse as double, if pos is equal to the length of the string we were successful:
-		// add it to the map and go to the next line
-		try {
-			auto doubleVal = std::stod(value, &pos);
-			if(pos == value.length()) {
-				fDouble[name] = doubleVal;
-				continue;
-			}
-		} catch(std::invalid_argument& e) {
-			// do nothing, we failed to parse the input as double, just go on to the next type
-		}
-
-		// try and parse as bool: convert a copy to lower case and use stringstream with std::boolalpha
-		std::string copy = value;
-		std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);
-		bool boolVal;
-		std::stringstream str(copy);
-		str>>std::boolalpha>>boolVal;
-		if(str.good()) {
-			fBool[name] = boolVal;
-			continue;
-		}
-
-		// trying to parse as integer, double, or bool failed, so we assume it's a string and just add it to the map
-		fString[name] = value;
 	}
 
 	return true;
+}
+
+void TUserSettings::ParseValue(const std::string& name, const std::string& value, bool vector)
+{
+	// try and parse as integer, if pos is equal to the length of the string we were successful:
+	// add it to the map and go to the next line
+	size_t pos;
+	try {
+		auto intVal = std::stoi(value, &pos);
+		if(pos == value.length()) {
+			if(!vector) {
+				fInt[name] = intVal;
+			} else {
+				fIntVector[name].push_back(intVal);
+			}
+			return;
+		}
+	} catch(std::invalid_argument& e) {
+		// do nothing, we failed to parse the input as integer, just go on to the next type
+	}
+
+	// try and parse as double, if pos is equal to the length of the string we were successful:
+	// add it to the map and go to the next line
+	try {
+		auto doubleVal = std::stod(value, &pos);
+		if(pos == value.length()) {
+			if(!vector) {
+				fDouble[name] = doubleVal;
+			} else {
+				fDoubleVector[name].push_back(doubleVal);
+			}
+			return;
+		}
+	} catch(std::invalid_argument& e) {
+		// do nothing, we failed to parse the input as double, just go on to the next type
+	}
+
+	// try and parse as bool: convert a copy to lower case and use stringstream with std::boolalpha
+	std::string copy = value;
+	std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);
+	bool boolVal;
+	std::stringstream str(copy);
+	str>>std::boolalpha>>boolVal;
+	if(str.good()) {
+		if(!vector) {
+			fBool[name] = boolVal;
+		} else {
+			fBoolVector[name].push_back(boolVal);
+		}
+		return;
+	}
+
+	// trying to parse as integer, double, or bool failed, so we assume it's a string and just add it to the map
+	if(!vector) {
+		fString[name] = value;
+	} else {
+		fStringVector[name].push_back(value);
+	}
+}
+
+bool TUserSettings::GetBool(std::string parameter, bool quiet) const
+{
+	try { 
+		return fBool.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in boolean map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+int TUserSettings::GetInt(std::string parameter, bool quiet) const
+{
+	try {
+		return fInt.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in integer map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+double TUserSettings::GetDouble(std::string parameter, bool quiet) const
+{
+	try {
+		return fDouble.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in double map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+std::string TUserSettings::GetString(std::string parameter, bool quiet) const
+{
+	try {
+		return fString.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in string map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+std::vector<bool> TUserSettings::GetBoolVector(std::string parameter, bool quiet) const
+{
+	try {
+		return fBoolVector.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in boolean vector map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+std::vector<int> TUserSettings::GetIntVector(std::string parameter, bool quiet) const
+{
+	try {
+		return fIntVector.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in integer vector map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+std::vector<double> TUserSettings::GetDoubleVector(std::string parameter, bool quiet) const
+{
+	try {
+		return fDoubleVector.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in double vector map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
+}
+
+std::vector<std::string> TUserSettings::GetStringVector(std::string parameter, bool quiet) const
+{
+	try {
+		return fStringVector.at(parameter);
+	} catch(std::out_of_range& e) {
+		if(!quiet) {
+			std::cout<<"Failed to find \""<<parameter<<"\" in string vector map"<<std::endl;
+			Print();
+		}
+		throw e;
+	}
 }
 
 void TUserSettings::Print(Option_t*) const
@@ -92,16 +227,52 @@ void TUserSettings::Print(Option_t*) const
 	std::cout<<"Settings read from";
 	for(auto file : fSettingsFiles) std::cout<<" "<<file;
 	std::cout<<":"<<std::endl;
+	if(!fBool.empty()) std::cout<<"---------- booleans ----------"<<std::endl;
 	for(auto val : fBool) {
 		std::cout<<std::boolalpha<<val.first<<": "<<val.second<<std::endl;
 	}
+	if(!fInt.empty()) std::cout<<"---------- integers ----------"<<std::endl;
 	for(auto val : fInt) {
 		std::cout<<val.first<<": "<<val.second<<std::endl;
 	}
+	if(!fDouble.empty()) std::cout<<"---------- doubles ----------"<<std::endl;
 	for(auto val : fDouble) {
 		std::cout<<val.first<<": "<<val.second<<std::endl;
 	}
+	if(!fString.empty()) std::cout<<"---------- strings ----------"<<std::endl;
 	for(auto val : fString) {
 		std::cout<<val.first<<": "<<val.second<<std::endl;
+	}
+	if(!fBoolVector.empty()) std::cout<<"---------- boolean vectors ----------"<<std::endl;
+	for(auto val : fBoolVector) {
+		std::cout<<std::boolalpha<<val.first<<": ";
+		for(auto item : val.second) {
+			std::cout<<item<<" ";
+		}
+		std::cout<<std::endl;
+	}
+	if(!fIntVector.empty()) std::cout<<"---------- integer vectors ----------"<<std::endl;
+	for(auto val : fIntVector) {
+		std::cout<<val.first<<": ";
+		for(auto item : val.second) {
+			std::cout<<item<<" ";
+		}
+		std::cout<<std::endl;
+	}
+	if(!fDoubleVector.empty()) std::cout<<"---------- double vectors ----------"<<std::endl;
+	for(auto val : fDoubleVector) {
+		std::cout<<val.first<<": ";
+		for(auto item : val.second) {
+			std::cout<<item<<" ";
+		}
+		std::cout<<std::endl;
+	}
+	if(!fStringVector.empty()) std::cout<<"---------- string vectors ----------"<<std::endl;
+	for(auto val : fStringVector) {
+		std::cout<<val.first<<": ";
+		for(auto item : val.second) {
+			std::cout<<item<<" ";
+		}
+		std::cout<<std::endl;
 	}
 }


### PR DESCRIPTION
- Vectors in TUserSettings are recognized by being a list of comma
  separated values. This means commas can't be used in the values for
  strings, and if a setting is supposed to be a vector it has to have a
  comma, even if there is only one value in the vector.
- Added an example of this to the AngularCorrelationSettings.par file.
- Added option to exclude detectors or crystals via user settings in AngularCorrelationsHelper.