### PR TITLE
Bug fixes

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -34,12 +34,12 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
 {
 	for(auto g1 = 0; g1 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g1) {
 		auto grif1 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g1) : fGriffin.GetSuppressedHit(g1));
-		if(ExcludeDetector(grif1->GetDetector()) || ExcludeCrystal(grif1->GetArrayNumber()) continue;
+		if(ExcludeDetector(grif1->GetDetector()) || ExcludeCrystal(grif1->GetArrayNumber())) continue;
 
 		for(auto g2 = 0; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
 			if(g1 == g2) continue;
 			auto grif2 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g2) : fGriffin.GetSuppressedHit(g2));
-			if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber()) continue;
+			if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber())) continue;
 
 			// skip hits in the same detector when using addback, or in the same crystal when not using addback
 			if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) {
@@ -71,7 +71,7 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
 			auto fLastBgo = fBgoDeque[slot][l];
 			for(auto g2 = 0; g2 < (fAddback ? fLastGriffin->GetSuppressedAddbackMultiplicity(fLastBgo) : fLastGriffin->GetSuppressedMultiplicity(fLastBgo)); ++g2) {
 				auto grif2 = (fAddback ? fLastGriffin->GetSuppressedAddbackHit(g2) : fLastGriffin->GetSuppressedHit(g2));
-				if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber()) continue;
+				if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber())) continue;
 
 				// skip hits in the same detector when using addback, or in the same crystal when not using addback
 				if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) continue; 

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -40,8 +40,17 @@ public :
 			fAddback = fUserSettings->GetBool("Addback", true);
 			fFolding = fUserSettings->GetBool("Folding", false);
 			fGrouping = fUserSettings->GetBool("Grouping", false);
-			fExcludedDetectors = fUserSettings->GetIntVector("ExcludedDetector", true); // be quiet if we don't find this
-			fExcludedCrystals = fUserSettings->GetIntVector("ExcludedCrystal", true); // be quiet if we don't find this
+
+			try {
+				fExcludedDetectors = fUserSettings->GetIntVector("ExcludedDetector", true); // be quiet if we don't find this
+			} catch(std::out_of_range&) {
+				// do nothing, we simply don't have any detectors to exclude
+			}
+			try {
+				fExcludedCrystals = fUserSettings->GetIntVector("ExcludedCrystal", true); // be quiet if we don't find this
+			} catch(std::out_of_range&) {
+				// do nothing, we simply don't have any crystals to exclude
+			}
 
 			fPrompt = fUserSettings->GetDouble("MaxPromptTime", 200.);
 			fTimeRandomLow = fUserSettings->GetDouble("TimeRandom.Low", 400.);

--- a/include/TDataFrameLibrary.h
+++ b/include/TDataFrameLibrary.h
@@ -1,5 +1,7 @@
 #ifndef TDATAFRAMELIBRARY_H
 #define TDATAFRAMELIBRARY_H
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 
 #include <string>
 
@@ -35,4 +37,5 @@ private:
 	/// \endcond
 };
 
+#endif
 #endif

--- a/include/TGRSIFrame.h
+++ b/include/TGRSIFrame.h
@@ -1,5 +1,7 @@
 #ifndef TGRSIFRAME_H
 #define TGRSIFRAME_H
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 
 #include <map>
 #include <string>
@@ -41,4 +43,5 @@ private:
 /*! @} */
 void DummyFunctionToLocateTGRSIFrameLibrary();
 
+#endif
 #endif

--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -64,8 +64,8 @@ namespace TGRSIFunctions {
 #endif
 
 	// functions used for angular correlations
-	double ClebschGordan(double j1, double m1, double j2, double m2, double j, double m);
 	double RacahW(double a, double b, double c, double d, double e, double f);
+	double ClebschGordan(double j1, double m1, double j2, double m2, double j, double m);
 	double F(double k, double jf, double L1, double L2, double ji);
 	double A(double k, double ji, double jf, double L1, double L2, double delta);
 	double B(double k, double ji, double jf, double L1, double L2, double delta);

--- a/include/TGRSIHelper.h
+++ b/include/TGRSIHelper.h
@@ -1,5 +1,7 @@
 #ifndef TGRSIHELPER_H
 #define TGRSIHELPER_H
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 #include "ROOT/RDataFrame.hxx"
 #include "TObject.h"
 #include "TList.h"
@@ -80,4 +82,5 @@ public:
 	std::string GetActionName() const { return Prefix(); } // apparently a required function (not documented but doesn't compile w/o it)
 };
 
+#endif
 #endif

--- a/include/TSingleton.h
+++ b/include/TSingleton.h
@@ -166,7 +166,7 @@ public:
 
 	static void PrintDirectory()
 	{
-		std::cout<<"Read singleton "<<fSingleton<<" from "<<(fDir!=nullptr?fDir->GetName():"N/A")<<std::endl;
+		std::cout<<"Singleton "<<fSingleton<<" was read from "<<(fDir!=nullptr?fDir->GetName():"N/A")<<std::endl;
 	}
 
 protected:

--- a/include/TUserSettings.h
+++ b/include/TUserSettings.h
@@ -65,6 +65,16 @@ public:
 	double GetDouble(std::string parameter, double def) const { try { return fDouble.at(parameter); } catch(std::out_of_range& e) { return def; } }
 	std::string GetString(std::string parameter, std::string def) const { try { return fString.at(parameter); } catch(std::out_of_range& e) { return def; } }
 	
+	// setter functions
+	void SetBool(std::string parameter, bool value) { fBool[parameter] = value; }
+	void SetInt(std::string parameter, int value) { fInt[parameter] = value; }
+	void SetDouble(std::string parameter, double value) { fDouble[parameter] = value; }
+	void SetString(std::string parameter, std::string value) { fString[parameter] = value; }
+	void SetBoolVector(std::string parameter, std::vector<bool> value) { fBoolVector[parameter] = value; }
+	void SetIntVector(std::string parameter, std::vector<int> value) { fIntVector[parameter] = value; }
+	void SetDoubleVector(std::string parameter, std::vector<double> value) { fDoubleVector[parameter] = value; }
+	void SetStringVector(std::string parameter, std::vector<std::string> value) { fStringVector[parameter] = value; }
+
 	void Print(Option_t* opt = "") const override;
 	void Clear(Option_t* = "") override { fBool.clear(); fInt.clear(); fDouble.clear(); fString.clear(); fBoolVector.clear(); fIntVector.clear(); fDoubleVector.clear(); fStringVector.clear(); SetName(""); }
 

--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -493,11 +493,11 @@ double TGRSIFunctions::ClebschGordan(double j1, double m1, double j2, double m2,
 	 // Coefficients Liang Zuo, et. al.
 	 // J. Appl. Cryst. (1993). 26, 302-304
 }
-
+	
 double TGRSIFunctions::RacahW(double a, double b, double c, double d, double e, double f)
 {
 #ifdef HAS_MATHMORE
-	return TMath::Power((-1), int(a+b+d+c))*ROOT::Math::wigner_6j(int(2*a),int(2*b),int(2*e),int(2*d),int(2*c),int(2*f));
+	return TMath::Power((-1), int(a+b+d+c))*::ROOT::Math::wigner_6j(int(2*a),int(2*b),int(2*e),int(2*d),int(2*c),int(2*f));
 #else
 	std::cout<<"Mathmore feature of ROOT is missing, "<<__PRETTY_FUNCTION__<<" will always return 1!"<<std::endl;
 	return 1.;

--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -496,7 +496,12 @@ double TGRSIFunctions::ClebschGordan(double j1, double m1, double j2, double m2,
 
 double TGRSIFunctions::RacahW(double a, double b, double c, double d, double e, double f)
 {
+#ifdef HAS_MATHMORE
 	return TMath::Power((-1), int(a+b+d+c))*ROOT::Math::wigner_6j(int(2*a),int(2*b),int(2*e),int(2*d),int(2*c),int(2*f));
+#else
+	std::cout<<"Mathmore feature of ROOT is missing, "<<__PRETTY_FUNCTION__<<" will always return 1!"<<std::endl;
+	return 1.;
+#endif
 }
 
 double TGRSIFunctions::F(double k, double jf, double L1, double L2, double ji)

--- a/libraries/TFormat/TDataFrameLibrary.cxx
+++ b/libraries/TFormat/TDataFrameLibrary.cxx
@@ -1,4 +1,6 @@
 #include "TDataFrameLibrary.h"
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 
 #define dlsym __bull__
 #include <dlfcn.h>
@@ -144,3 +146,4 @@ void TDataFrameLibrary::Compile(std::string& path, const size_t& dot, const size
 	}
 	std::cout<<DCYAN<<"----------  done compiling user code  -------------------"<<RESET_COLOR<<std::endl;
 }
+#endif

--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -346,7 +346,7 @@ bool TRunInfo::WriteToRoot(TFile* fileptr)
       bool2return = false;
    } else {
       runInfo->Write("RunInfo", TObject::kOverwrite);
-		runInfo->fDetectorInformation->Write("DetectorInformation", TObject::kOverwrite);
+		if(runInfo->fDetectorInformation != nullptr) runInfo->fDetectorInformation->Write("DetectorInformation", TObject::kOverwrite);
    }
 
    std::cout<<"Writing TRunInfo to "<<gDirectory->GetFile()->GetName()<<std::endl;

--- a/libraries/TGRSIFrame/TGRSIFrame.cxx
+++ b/libraries/TGRSIFrame/TGRSIFrame.cxx
@@ -1,4 +1,6 @@
 #include "TGRSIFrame.h"
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 
 #include <iostream>
 #include <sstream>
@@ -180,3 +182,4 @@ void TGRSIFrame::Run()
 void DummyFunctionToLocateTGRSIFrameLibrary() {
 	// does nothing
 }
+#endif

--- a/libraries/TGRSIFrame/TGRSIHelper.cxx
+++ b/libraries/TGRSIFrame/TGRSIHelper.cxx
@@ -1,4 +1,6 @@
 #include "TGRSIHelper.h"
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 
 TGRSIHelper::TGRSIHelper(TList* input) {
 	fPpg = static_cast<TPPG*>(input->FindObject("TPPG"));
@@ -235,4 +237,4 @@ void TGRSIHelper::CheckSizes(unsigned int slot, const char* usage) {
 		}
 	}
 }
-
+#endif

--- a/libraries/TGRSIint/FullPath.cxx
+++ b/libraries/TGRSIint/FullPath.cxx
@@ -1,6 +1,6 @@
 #include "FullPath.h"
 
-//#ifdef __linux__
+//#ifdef __LINUX__
 
 #include <cstdlib>
 #include <climits>

--- a/util/LeanAnalyzeComptonMatrices.cxx
+++ b/util/LeanAnalyzeComptonMatrices.cxx
@@ -176,25 +176,14 @@ TList* ComptonPol(TFile* f, TStopwatch* w)
   char* XiHistGeoTitle = Form("Possible #xi Angles in GRIFFIN Array ( %.1f <= #theta <= %.1f ) -> UseDetCoincidenceAngle = %d;Experimental Angle #xi (#circ);Counts", RestrictCoincidenceAngleMin, RestrictCoincidenceAngleMax, UseDetCoincidenceAngle );
   char* XiHistNonCoTitle = Form("Measured #xi Angles for Non-Coincident #gamma_{1} and #gamma_{2} ( %.1f <= #theta <= %.1f ) -> UseDetCoincidenceAngle = %d;Experimental Angle #xi (#circ);Counts", RestrictCoincidenceAngleMin, RestrictCoincidenceAngleMax, UseDetCoincidenceAngle ); 
 
-  TH1D* XiHist      = new TH1D("XiHist", XiHistTitle, XiBins, 0, 180.000001); list->Add(XiHist);
-  TH1D* XiHistGeo   = new TH1D("XiHist_Geo", XiHistGeoTitle, XiBins, 0.0, 180.000001); list->Add(XiHistGeo);
-  TH1D* XiHistNonCo = new TH1D("XiHist_NonCo", XiHistNonCoTitle, XiBins, 0, 180.000001); list->Add(XiHistNonCo);
+  TH1D* XiHist      = new TH1D("XiHist", XiHistTitle, XiBins, XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(1), XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(XiBins+1)); list->Add(XiHist);
+  TH1D* XiHistGeo   = new TH1D("XiHist_Geo", XiHistGeoTitle, XiBins, XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(1), XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(XiBins+1)); list->Add(XiHistGeo);
+  TH1D* XiHistNonCo = new TH1D("XiHist_NonCo", XiHistNonCoTitle, XiBins, XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(1), XiHist2D_DetDet->GetXaxis()->GetBinLowEdge(XiBins+1)); list->Add(XiHistNonCo);
   
   TGraphErrors* AsymmetryNonCo         = new TGraphErrors(); list->Add(AsymmetryNonCo);
   TGraphErrors* AsymmetryBinnedNonCo   = new TGraphErrors(); list->Add(AsymmetryBinnedNonCo);
   TGraphErrors* AsymmetryBinFoldNonCo   = new TGraphErrors(); list->Add(AsymmetryBinFoldNonCo);
   
-  TH1D* gammaSinglesAll    = (TH1D*)f->Get("gammaSingles");    list->Add(gammaSinglesAll);
-  TH2D* gammagammaAll    = (TH2D*)f->Get("gammagamma"); list->Add(gammagammaAll);
-  TH2D* gammaCrystalAll    = (TH2D*)f->Get("gammaCrystal"); list->Add(gammaCrystalAll);
-  
-  TH1D* gammaSingles_g1    = (TH1D*)f->Get("gammaSingles_g1"); list->Add(gammaSingles_g1);
-  TH1D* gammaSingles_g2    = (TH1D*)f->Get("gammaSingles_g2"); list->Add(gammaSingles_g2);
-  TH1D* gammaSingles_g3    = (TH1D*)f->Get("gammaSingles_g3"); list->Add(gammaSingles_g3);
-  TH1D* ggTimeDiff_g1g2    = (TH1D*)f->Get("ggTimeDiff_g1g2"); list->Add(ggTimeDiff_g1g2);
-  TH1D* ggTimeDiff_g1g3    = (TH1D*)f->Get("ggTimeDiff_g1g3"); list->Add(ggTimeDiff_g1g3);
-  TH1D* ggTimeDiff_g2g3    = (TH1D*)f->Get("ggTimeDiff_g2g3"); list->Add(ggTimeDiff_g2g3);
-
   /////////////////////////////////////////////////////////////////////////////////////
   //-------------------------- Gated Projection Plots -------------------------------//
   /////////////////////////////////////////////////////////////////////////////////////

--- a/util/grsiframe.cxx
+++ b/util/grsiframe.cxx
@@ -2,6 +2,8 @@
 #include <string>
 #include <vector>
 
+#include "RVersion.h"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,14,0)
 #include "TStyle.h"
 #include "TFile.h"
 #include "TChain.h"
@@ -78,3 +80,10 @@ int main(int argc, char** argv)
 
 	return 0;
 }
+#else
+int main(int, char** argv)
+{
+	std::cerr<<argv[0]<<": need at least ROOT version 6.14"<<std::endl;
+	return 1;
+}
+#endif


### PR DESCRIPTION
Two fixes to fix #1392:
- Added check to anything relate to RDataFrame that the ROOT version is at least 6.14.0 for which RDataFrame was introduced. For older versions running grsiframe just outputs an error message.
- Fixed bug in `TGRSIFunctions::RacahW`, the namespace was missing the leading colons to signify that we should start in the global namespace instead of the current one, which caused an issue for older ROOT versions, but not newer ones? Also added a check that math more is available.
Other bug fixes:
- Fixed missing parentheses bug in AngularCorrelationHelper.
- Added check that the detector information is not a null pointer before accessing it in `TRunInfo::WriteToRoot`.

Also, TUserSettings got some setter functions.