### PR TITLE
Changed push_back to emplace_back due to segfault

### DIFF
--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -116,8 +116,8 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
 
 	if(fVerboseLevel > 2) std::cout<<"Adding new calibration graph and label to vectors"<<std::endl;
 	// add graph and label to our vectors
-	fGraphs.push_back(TCalibrationGraph(this, graph));
-	fResidualGraphs.push_back(TCalibrationGraph(this, 0, true));
+	fGraphs.emplace_back(this, graph);
+	fResidualGraphs.emplace_back(this, 0, true);
 	fLabel.push_back(label);
 	// set initial color
 	fGraphs.back().SetLineColor(fGraphs.size());


### PR DESCRIPTION
This is a segfault when running TSourceCalibration, zooming in on spectra and using Find Peaks (fast) before accepting all. 
It seems to have something to do with pushing back the new objects. This could be because we're out of memory, but for now I changed this to emplace_back (which should be better anyway) to see if that might fix it as well.

The lines below might hint at the cause of the crash. If you see question
marks as part of the stack trace, try to recompile with debugging information
enabled and export CLING_DEBUG=1 environment variable before running.
You may get help by asking at the ROOT forum https://root.cern/forum
preferably using the command (.forum bug) in the ROOT prompt.
Only if you are really convinced it is a bug in ROOT then please submit a
report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
the ROOT prompt. Please post the ENTIRE stack trace
from above as an attachment in addition to anything else
that might help us fixing this issue.
===========================================================
#10 0x000078f5d98475ff in THashList::RecursiveRemove(TObject*) () from /snap/root-framework/931/usr/local/lib/libCore.so
#11 0x000078f5d97db9ee in TROOT::RecursiveRemove(TObject*) () from /snap/root-framework/931/usr/local/lib/libCore.so
#12 0x000078f5d9f4abd7 in ROOT::CallRecursiveRemoveIfNeeded(TObject&) () from /snap/root-framework/931/usr/local/lib/libGui.so
#13 0x000078f5d97b2e88 in TNamed::~TNamed() () from /snap/root-framework/931/usr/local/lib/libCore.so
#14 0x000078f5d85ee813 in TGraph::~TGraph() () from /snap/root-framework/931/usr/local/lib/libHist.so
#15 0x000078f5d8602ac6 in TGraphErrors::~TGraphErrors() () from /snap/root-framework/931/usr/local/lib/libHist.so
#16 0x000078f5da22db35 in TCalibrationGraph::~TCalibrationGraph (this=0x7ffcbb462170, __in_chrg=<optimized out>) at /home/samantha/GRSISort/include/TCalibrationGraph.h:21
#17 TCalibrationGraphSet::Add (this=this
entry=0x5b011558ebb0, graph=0x5b00e9b0cc60, label="Y100") at libraries/TGUI/TCalibrationGraph.cxx:119
#18 0x000078f5da257457 in TSourceCalibration::BuildThirdInterface (this=<optimized out>) at libraries/TGUI/TSourceCalibration.cxx:1294
#19 0x000078f5da25aaaf in TSourceCalibration::FinalWindow (this=0x5b00dcd51e40) at libraries/TGUI/TSourceCalibration.cxx:1181
#20 0x000078f5b8177014 in ?? ()
#21 0x00007ffcbb462500 in ?? ()
#22 0x000078f5cd15eded in TClingCallFunc::exec(void*, void*) () from /snap/root-framework/931/usr/local/lib/libCling.so
