### PR TITLE
Fixed bug from last PR

### DIFF
--- a/libraries/TDataParser/TFragmentMap.cxx
+++ b/libraries/TDataParser/TFragmentMap.cxx
@@ -348,7 +348,7 @@ void TFragmentMap::Solve(std::vector<std::shared_ptr<TFragment>> frag, std::vect
 
    // all k's are needed squared so we square all elements of k
    std::vector<Long_t> kSquared = kValues;
-   for(int64_t& item : kSquared) {
+   for(auto& item : kSquared) {
       item = item * item;
    }
 

--- a/libraries/TGRSIint/FullPath.cxx
+++ b/libraries/TGRSIint/FullPath.cxx
@@ -11,7 +11,7 @@ std::string full_path(const std::string& path)
 	std::array<char, PATH_MAX + 1> buff;
    char* success = realpath(path.c_str(), buff.data());
    if(success != nullptr) {
-      return std::string(std::begin(buff), std::end(buff));
+      return std::string(buff.data()); // this ensures that we stop at the string limiting \0 (whereas buff.begin() to buff.end() would use all PATH_MAX+1 characters of the array)
    }
    // TODO: Give some sort of error message.
    return "";


### PR DESCRIPTION
The change from `int64_t` to `auto` was necessary for macOS. Apparently `Long_t` is `int64_t` on ubuntu but not on macOS?