### PR TITLE
Improved functionality of makefile and grsi-config if TProof class is missing and/or if cmake is used

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -5,9 +5,9 @@ name: CMake on multiple platforms
 on: 
   workflow_dispatch:
   push:
-    branches: [ "cmake" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "cmake" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/ubuntu-binary-ROOT.yml
+++ b/.github/workflows/ubuntu-binary-ROOT.yml
@@ -3,9 +3,9 @@ name: CMake using downloaded binary of ROOT
 on: 
   workflow_dispatch:
   push:
-    branches: [ "cmake" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "cmake" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/util/grsi-config
+++ b/util/grsi-config
@@ -47,10 +47,11 @@ fi
 libdir=$GRSISYS/lib
 incdir=$GRSISYS/include
 
-# the repetition of '-lTGRSIint -lTFormat' is needed for debian-style OSes like ubuntu (see issue #979) - hopefully not needed anymore with the resolving of circular dependencies for cmake?
-grsilibs="-lTFormat -lTLoops -lTKinematics -lTSRIM -lTBetaDecay -lTCal -lTReaction -lTPeakFitting"
-detlibs="-lTSuppressed -lTBgo -lTPulseAnalyzer -lGROOT -lTGRSIFit -lTNucleus"
-grsimore="-lTRawFile -lTDataParser -lTGUI"
+# lists of libraries, these are used to form the "-l<library name>" flags for the linker
+grsilibs="TGRSIInt TFormat TLoops TKinematics TSRIM TBetaDecay TCal TReaction TPeakFitting"
+detlibs="TSuppressed TBgo TPulseAnalyzer GROOT TGRSIFit TNucleus"
+grsimore="TRawFile TDataParser TGUI"
+
 if [ "$(root-config --has-xml)" == "yes" ]
 then XMLlib="-lXMLParser -lXMLIO"
 else XMLlib=""
@@ -117,10 +118,11 @@ while test $# -gt 0; do
 				continue
 			fi
 			out=$"$out -L${libdir}"
-			if [ -e ${libdir}/libTGRSIint.so ] || [ -e ${libdir}/libTGRSIint.dylib ] ; then
-				out=$"$out -lTGRSIint"
-			fi
-			out=$"$out $grsilibs $detlibs "
+			for library in $grsilibs $detlibs ; do
+				if [ -e ${libdir}/lib${library}.so ] || [ -e ${libdir}/lib${library}.dylib ] ; then
+					out=$"$out -l${library}"
+				fi
+			done
 			;;
 		--all-libs)
 			if test "$alllibsout" = "yes" ; then
@@ -129,13 +131,20 @@ while test $# -gt 0; do
 			fi
 			alllibsout="yes"
 			if test "$libsout" = "yes" ; then
-				out="$out $grsimore $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
+				for library in $grsimore ; do
+					if [ -e ${libdir}/lib${library}.so ] || [ -e ${libdir}/lib${library}.dylib ] ; then
+						out=$"$out -l${library}"
+					fi
+				done
+				out="$out $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
 			else
 				out=$"$out -L${libdir}"
-				if [ -e ${libdir}/libTGRSIint.so ] || [ -e ${libdir}/libTGRSIint.dylib ] ; then
-					out=$"$out -lTGRSIint"
-				fi
-				out=$"$out $grsilibs $detlibs $grsimore $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
+				for library in $grsilibs $detlibs $grsimore ; do
+					if [ -e ${libdir}/lib${library}.so ] || [ -e ${libdir}/lib${library}.dylib ] ; then
+						out=$"$out -l${library}"
+					fi
+				done
+				out=$"$out $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
 			fi
 			if [ "$(root-config --has-mathmore)" == "yes" ]; then
 				out="$out -lMathMore"

--- a/util/grsi-config
+++ b/util/grsi-config
@@ -47,8 +47,8 @@ fi
 libdir=$GRSISYS/lib
 incdir=$GRSISYS/include
 
-# the repitition of '-lTGRSIint -lTFormat' is needed for debian-style OSes like ubuntu (see issue #979)
-grsilibs="-lTGRSIint -lTFormat -lTGRSIint -lTFormat -lTLoops -lTKinematics -lTSRIM -lTBetaDecay -lTCal -lTReaction -lTPeakFitting"
+# the repetition of '-lTGRSIint -lTFormat' is needed for debian-style OSes like ubuntu (see issue #979) - hopefully not needed anymore with the resolving of circular dependencies for cmake?
+grsilibs="-lTFormat -lTLoops -lTKinematics -lTSRIM -lTBetaDecay -lTCal -lTReaction -lTPeakFitting"
 detlibs="-lTSuppressed -lTBgo -lTPulseAnalyzer -lGROOT -lTGRSIFit -lTNucleus"
 grsimore="-lTRawFile -lTDataParser -lTGUI"
 if [ "$(root-config --has-xml)" == "yes" ]
@@ -116,7 +116,11 @@ while test $# -gt 0; do
 				shift
 				continue
 			fi
-			out=$"$out -L${libdir} $grsilibs $detlibs "
+			out=$"$out -L${libdir}"
+			if [ -e ${libdir}/libTGRSIint.so ] || [ -e ${libdir}/libTGRSIint.dylib ] ; then
+				out=$"$out -lTGRSIint"
+			fi
+			out=$"$out $grsilibs $detlibs "
 			;;
 		--all-libs)
 			if test "$alllibsout" = "yes" ; then
@@ -127,7 +131,11 @@ while test $# -gt 0; do
 			if test "$libsout" = "yes" ; then
 				out="$out $grsimore $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
 			else
-				out="$out -L${libdir} $grsilibs $detlibs $grsimore $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
+				out=$"$out -L${libdir}"
+				if [ -e ${libdir}/libTGRSIint.so ] || [ -e ${libdir}/libTGRSIint.dylib ] ; then
+					out=$"$out -lTGRSIint"
+				fi
+				out=$"$out $grsilibs $detlibs $grsimore $XMLlib -lX11 -lXpm -lProof -lGuiHtml -lMinuit -lSpectrum"
 			fi
 			if [ "$(root-config --has-mathmore)" == "yes" ]; then
 				out="$out -lMathMore"
@@ -139,6 +147,8 @@ while test $# -gt 0; do
 			# check that the config script exists
 			if [ -e "$GRSISYS/$lib/util/config" ] ; then
 				out="$out $($GRSISYS/$lib/util/config --cflags)"
+			elif [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
+				out="$out $($GRSISYS/_deps/$lib-src/util/config --cflags)"
 			fi
 			;;
 		--*-incdir)
@@ -147,6 +157,8 @@ while test $# -gt 0; do
 			# check that the config script exists
 			if [ -e "$GRSISYS/$lib/util/config" ] ; then
 				out="$out $($GRSISYS/$lib/util/config --incdir)"
+			elif [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
+				out="$out $($GRSISYS/_deps/$lib-src/util/config --incdir)"
 			fi
 			;;
 		--*-libs)
@@ -155,6 +167,8 @@ while test $# -gt 0; do
 			# check that the config script exists
 			if [ -e "$GRSISYS/$lib/util/config" ] ; then
 				out="$out $($GRSISYS/$lib/util/config --libs)"
+			elif [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
+				out="$out $($GRSISYS/_deps/$lib-src/util/config --libs)"
 			fi
 			;;
 		--root)


### PR DESCRIPTION
- The makefile now checks if proof is available (via `root-config --has-proof`) and only compiles grsiproof if that is the case.
- grsi-config uses lists of library names, and checks if the corresponding shared object files exist before adding the corresponding flags. This is necessary because some libraries (like TGRSIint) do not exist anymore as separate libraries when using cmake.
- TDataFrameLibrary doesn't use linker flags in the compilation step, only does the compilation once (instead of repeating it during the linking step), and also includes the libraries of the parser library in the linking.