### PR TITLE
Small changes

### DIFF
--- a/include/ArgParser.h
+++ b/include/ArgParser.h
@@ -299,10 +299,13 @@ private:
 /// Example usage:
 /// ```
 /// ArgParser parser;
+/// int myOption = 0;
 /// parser.option("some-option s", &myOption, true).description("my cool option").default_value(42);
 /// parser.parse(argc, argv, true);
 /// ```
-/// to read the flag "--some-option" or "-s" into the integer variable myOption.
+/// This example reads the number after the flag "--some-option" or "-s"
+/// into the integer variable myOption. If no flag is provided, the default
+/// value of 42 is used.
 ///
 /// The 3rd argument in ArgParser::option and ArgParser::parse that are set
 /// to true here are the "firstPass" arguments which simply means we want
@@ -329,12 +332,12 @@ public:
 
    void parse(int argc, char** argv, bool firstPass)
    {
-      /// this version takes argc and argv, parses them, and sets only those
-      /// that have the matching firstPass flag set
-      /// this allows us to parse command line arguments in two stages, one
+      /// This version takes argc and argv, parses them, and sets only those
+      /// that have the matching firstPass flag set.
+      /// This allows us to parse command line arguments in two stages, one
       /// to get the normal options and file names (from which the run info
-      /// and analysis options are read), and a second stage where only the
-      /// run info and analysis option flags are parsed
+      /// and analysis options are read), and a second stage, where only the
+      /// run info and analysis option flags are parsed.
       bool double_dash_encountered = false;
 
       int iarg = 1;

--- a/include/ArgParser.h
+++ b/include/ArgParser.h
@@ -44,14 +44,14 @@ public:
       if(!ignore_num_arguments) {
          if((num_arguments() == -1 && arguments.empty()) ||
             (num_arguments() != -1 && arguments.size() != static_cast<size_t>(num_arguments()))) {
-            std::stringstream str;
+            std::ostringstream error;
             if(num_arguments() == -1) {
-               str << R"(Flag ")" << name << R"(" expected at least one argument)";
+               error << R"(Flag ")" << name << R"(" expected at least one argument)";
             } else {
-               str << R"(Flag ")" << name << R"(" expected )" << num_arguments() << " argument(s) and received "
-                   << arguments.size();
+               error << R"(Flag ")" << name << R"(" expected )" << num_arguments() << " argument(s) and received "
+                     << arguments.size();
             }
-            throw ParseError(str.str());
+            throw ParseError(error.str());
          }
       }
 
@@ -69,7 +69,7 @@ class ArgParseConfig : public ArgParseItem {
 public:
    ArgParseConfig(const std::string& flag_list, bool firstPass) : ArgParseItem(firstPass)
    {
-      std::stringstream str(flag_list);
+      std::istringstream str(flag_list);
       while(!str.eof()) {
          std::string temp;
          str >> temp;
@@ -132,34 +132,34 @@ public:
 
    std::string printable(int description_column, int* chars_before_desc) const override
    {
-      std::stringstream str;
+      std::ostringstream output;
 
-      str << "  " << fColour;
+      output << "  " << fColour;
 
       bool has_singlechar_flag = false;
       for(const auto& flag : fFlags) {
          if(flag.length() == 2) {
-            str << flag << " ";
+            output << flag << " ";
             has_singlechar_flag = true;
          }
       }
       for(const auto& flag : fFlags) {
          if(flag.length() != 2) {
             if(has_singlechar_flag) {
-               str << "[ ";
+               output << "[ ";
             }
-            str << flag << " ";
+            output << flag << " ";
             if(has_singlechar_flag) {
-               str << "]";
+               output << "]";
             }
          }
       }
 
       if(num_arguments() != 0) {
-         str << " arg ";
+         output << " arg ";
       }
 
-      auto chars = str.tellp();
+      auto chars = output.tellp();
       chars -= fColour.length();
       if(chars_before_desc != nullptr) {
          *chars_before_desc = static_cast<int>(chars);
@@ -167,13 +167,13 @@ public:
 
       if(description_column != -1 && chars < description_column) {
          for(unsigned int i = 0; i < description_column - chars; i++) {
-            str << " ";
+            output << " ";
          }
       }
 
-      str << fDescription << RESET_COLOR;
+      output << fDescription << RESET_COLOR;
 
-      return str.str();
+      return output.str();
    }
 
 private:
@@ -209,7 +209,7 @@ public:
 
    void parse_item(const std::vector<std::string>& arguments) override
    {
-      std::stringstream str(arguments[0]);
+      std::istringstream str(arguments[0]);
       str >> *fOutput_location;
    }
 
@@ -246,7 +246,7 @@ public:
       if(arguments.empty()) {
          *fOutput_location = !fStored_default_value;
       } else {
-         std::stringstream str(arguments[0]);
+         std::istringstream str(arguments[0]);
          str >> std::boolalpha >> *fOutput_location;
       }
    }
@@ -270,8 +270,8 @@ public:
    void parse_item(const std::vector<std::string>& arguments) override
    {
       for(const auto& arg : arguments) {
-         std::stringstream str(arg);
-         T                 val;
+         std::istringstream str(arg);
+         T                  val;
          str >> val;
          fOutput_location->push_back(val);
       }
@@ -355,9 +355,9 @@ public:
 
       for(auto& val : values) {
          if(val->is_required() && !val->is_present()) {
-            std::stringstream str;
-            str << R"(Required argument ")" << val->flag_name() << R"(" is not present)";
-            throw ParseError(str.str());
+            std::ostringstream error;
+            error << R"(Required argument ")" << val->flag_name() << R"(" is not present)";
+            throw ParseError(error.str());
          }
       }
    }
@@ -375,7 +375,7 @@ public:
          std::string remainder;
          if(has_colon) {
             flag = line.substr(0, colon);
-            std::stringstream(flag) >> flag;   // Strip out whitespace
+            std::istringstream(flag) >> flag;   // Strip out whitespace
             if(flag.length() == 1) {
                flag.insert(0, 1, '-');
             } else {
@@ -388,7 +388,7 @@ public:
          }
 
          std::vector<std::string> args;
-         std::stringstream        str(remainder);
+         std::istringstream       str(remainder);
          std::string              tmparg;
          while(str >> tmparg) {
             args.push_back(tmparg);
@@ -528,13 +528,13 @@ private:
          }
       }
 
-      std::stringstream str;
+      std::ostringstream error;
       if(flag.at(0) == '-') {
-         str << R"(Unknown option: ")" << flag << R"(")";
+         error << R"(Unknown option: ")" << flag << R"(")";
       } else {
-         str << R"(Was passed ")" << flag << R"(" as a non-option argument, when no non-option arguments are allowed)";
+         error << R"(Was passed ")" << flag << R"(" as a non-option argument, when no non-option arguments are allowed)";
       }
-      throw ParseError(str.str());
+      throw ParseError(error.str());
    }
 
    std::vector<ArgParseItem*> values;

--- a/include/GCanvas.h
+++ b/include/GCanvas.h
@@ -204,7 +204,7 @@ public:
 /// - M	Toggle off marker mode.
 /// - n	Remove all markers / functions drawn on the histogram.
 /// - N	Remove all markers and the LAST function drawn on the histogram.
-/// - o	Unzoom the entire histogram.
+/// - o/u	Unzoom the entire histogram.
 /// - p	If the 1d hist was made using the global ProjectionX/ProjectionY; gating the original 2D matrix this histogram came from is possible by placing markers around the gate and pressing p. The gates spectra is immediately drawn.
 /// - P	Draws parent histogram???
 /// - q	If markers have been set, fit a GPeak between the last two markers on the first histogram (skewed gaus for gamma-rays with automatic bg).
@@ -223,7 +223,7 @@ public:
 /// - i	Initialize a new cut.
 /// - l/z	Toggle z-axis from linear to logarithmic and vice versa.
 /// - n	Remove all markers / functions drawn on the histogram.
-/// - o	Unzoom the entire histogram.
+/// - o/u	Unzoom the entire histogram.
 /// - P	Get projections from this histogram and draw the first one if it exists.
 /// - r	Expand the y-axis between the last two markers.
 /// - R	Bring up the dialogue box to set the desired y-axis range.

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -88,7 +88,7 @@ void SetGRSIEnv();
 //-------------------- three function templates that print all arguments into a string
 // this template uses existing stream and appends the last argument to it
 template <typename T>
-void Append(std::stringstream& stream, const T& tail)
+void Append(std::ostringstream& stream, const T& tail)
 {
    // append last argument
    stream << tail;
@@ -96,7 +96,7 @@ void Append(std::stringstream& stream, const T& tail)
 
 // this template uses existing stream and appends to it
 template <typename T, typename... U>
-void Append(std::stringstream& stream, const T& head, const U&... tail)
+void Append(std::ostringstream& stream, const T& head, const U&... tail)
 {
    // append first argument
    stream << head;
@@ -110,7 +110,7 @@ template <typename T, typename... U>
 std::string Stringify(const T& head, const U&... tail)
 {
    // print first arguments to string
-   std::stringstream stream;
+   std::ostringstream stream;
    stream << head;
 
    // call the second template (or the third if tail is just one argument)
@@ -164,8 +164,8 @@ static inline std::string sh(const std::string& cmd)
 // print a demangled stack backtrace of the caller function (copied from https://panthema.net/2008/0901-stacktrace-demangled/)
 static inline void PrintStacktrace(std::ostream& out = std::cout, int maxFrames = 63)
 {
-   std::stringstream str;
-   str << "stack trace:" << std::endl;
+   std::ostringstream output;
+   output << "stack trace:" << std::endl;
 
    // storage array for stack trace address data
    void** addrlist = new void*[maxFrames + 1];
@@ -174,8 +174,8 @@ static inline void PrintStacktrace(std::ostream& out = std::cout, int maxFrames 
    int addrlen = backtrace(addrlist, maxFrames + 1);
 
    if(addrlen == 0) {
-      str << "  <empty, possibly corrupt>" << std::endl;
-      out << str.str();
+      output << "  <empty, possibly corrupt>" << std::endl;
+      out << output.str();
       return;
    }
 
@@ -210,7 +210,7 @@ static inline void PrintStacktrace(std::ostream& out = std::cout, int maxFrames 
       // try and decode file and line number (only if we have an absolute path)
       // std::string line;
       // if(symbollist[i][0] == '/') {
-      //	std::stringstream command;
+      //	std::ostringstream command;
       //	std::string filename = symbollist[i];
       //	command<<"addr2line "<<addrlist[i]<<" -e "<<filename.substr(0, filename.find_first_of('('));
       //	//std::cout<<symbollist[i]<<": executing command "<<command.str()<<std::endl;
@@ -230,22 +230,22 @@ static inline void PrintStacktrace(std::ostream& out = std::cout, int maxFrames 
          char* ret    = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
          if(status == 0) {
             funcname = ret;   // use possibly realloc()-ed string
-            str << "  " << symbollist[i] << ": " << funcname << "+" << begin_offset << std::endl;
+            output << "  " << symbollist[i] << ": " << funcname << "+" << begin_offset << std::endl;
          } else {
             // demangling failed. Output function name as a C function with
             // no arguments.
-            str << "  " << symbollist[i] << ": " << begin_name << "()+" << begin_offset << std::endl;
+            output << "  " << symbollist[i] << ": " << begin_name << "()+" << begin_offset << std::endl;
          }
       } else {
          // couldn't parse the line? print the whole line.
-         str << "  " << symbollist[i] << std::endl;
+         output << "  " << symbollist[i] << std::endl;
       }
-      // str<<line;
+      // output << line;
    }
 
    delete[] funcname;
    delete symbollist;
-   out << str.str();
+   out << output.str();
 }
 
 #if !__APPLE__

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -64,7 +64,7 @@ public:
 #ifndef __CINT__
    virtual std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& AddGoodOutputQueue(size_t maxSize = 50000)
    {
-      std::stringstream name;
+      std::ostringstream name;
       name << "good_frag_queue_" << fGoodOutputQueues.size();
       fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>(name.str(), maxSize));
       return fGoodOutputQueues.back();

--- a/include/TDetBuildingLoop.h
+++ b/include/TDetBuildingLoop.h
@@ -45,7 +45,7 @@ public:
    }
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>& AddOutputQueue(size_t maxSize = 50000)
    {
-      std::stringstream name;
+      std::ostringstream name;
       name << "event_queue_" << fOutputQueues.size();
       fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>(name.str(), maxSize));
       return fOutputQueues.back();

--- a/include/TRunInfo.h
+++ b/include/TRunInfo.h
@@ -184,12 +184,20 @@ public:
    static void RemoveBadCycle(int cycle);
    static bool IsBadCycle(int cycle);
 
-   void PrintRunList();
+   void PrintRunList() const;
+	std::string ListOfMissingRuns() const;
 
    static std::string CreateLabel(bool quiet = false);
 
    static void                  SetDetectorInformation(TDetectorInformation* inf) { Get()->fDetectorInformation = inf; }
    static TDetectorInformation* GetDetectorInformation() { return Get()->fDetectorInformation; }
+
+   void Print(Option_t* opt = "") const override;
+   void Clear(Option_t* opt = "") override;
+
+   static bool        WriteToRoot(TFile* fileptr = nullptr);
+   static bool        WriteInfoFile(const std::string& filename);
+   static std::string PrintToString(Option_t* opt = "");
 
 private:
    std::string                      fRunTitle;                ///< The title of the run
@@ -230,17 +238,9 @@ private:
 
    TDetectorInformation* fDetectorInformation{nullptr};   //!<! pointer to detector specific information (set by each parser library)
 
-public:
-   void Print(Option_t* opt = "") const override;
-   void Clear(Option_t* opt = "") override;
-
-   static bool        WriteToRoot(TFile* fileptr = nullptr);
-   static bool        WriteInfoFile(const std::string& filename);
-   static std::string PrintToString(Option_t* opt = "");
-
    /// \cond CLASSIMP
    ClassDefOverride(TRunInfo, 17)   // NOLINT(readability-else-after-return)
-                                    /// \endcond
+   /// \endcond
 };
 /*! @} */
 #endif

--- a/libraries/GROOT/GCanvas.cxx
+++ b/libraries/GROOT/GCanvas.cxx
@@ -873,6 +873,7 @@ bool GCanvas::Process1DKeyboardPress(Event_t*, const UInt_t* keysym)
       edited = true;
       break;
    case kKey_o:
+   case kKey_u:
       for(auto* hist : hists) {
          hist->GetXaxis()->UnZoom();
          hist->GetYaxis()->UnZoom();
@@ -1347,6 +1348,7 @@ bool GCanvas::Process2DKeyboardPress(Event_t*, const UInt_t* keysym)
       edited = true;
       break;
    case kKey_o:
+   case kKey_u:
       for(auto* hist : hists) {
          TH2* h = static_cast<TH2*>(hist);
          h->GetXaxis()->UnZoom();

--- a/libraries/GROOT/GRootCommands.cxx
+++ b/libraries/GROOT/GRootCommands.cxx
@@ -310,7 +310,7 @@ TPeak* AltPhotoPeakFit(TH1* hist, double xlow, double xhigh, Option_t* opt)
 
 std::string MergeStrings(const std::vector<std::string>& strings, char split)
 {
-   std::stringstream ss;
+   std::ostringstream ss;
    for(auto it = strings.begin(); it != strings.end(); it++) {
       ss << *it;
 

--- a/libraries/GROOT/TLevelScheme.cxx
+++ b/libraries/GROOT/TLevelScheme.cxx
@@ -1470,9 +1470,9 @@ void TLevelScheme::ParseENSDF(const std::string& filename)
       return;
    }
 
-   std::string       line;
-   std::stringstream str;
-   TLevel*           currentLevel = nullptr;
+   std::string        line;
+   std::istringstream str;
+   TLevel*            currentLevel = nullptr;
 
    // general identifier format of line (first 8 characters)
    // 1-3 mass

--- a/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
@@ -852,9 +852,9 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
 
    // quick sanity check, should have at least one vector the size of that vector should equal the source size and file size
    if(fSources.size() != fFiles.size() || fHistograms[0].size() != fFiles.size() || fHistograms.size() != fDataType.size()) {
-      std::stringstream str;
-      str << "Wrong sizes, from " << fFiles.size() << " file(s) we got " << fSources.size() << " source(s), and " << fHistograms[0].size() << " histogram(s), " << fDataType.size() << " data types, and " << fHistograms.size() << " data type histogram(s)!" << std::endl;
-      throw std::runtime_error(str.str());
+      std::ostringstream error;
+      error << "Wrong sizes, from " << fFiles.size() << " file(s) we got " << fSources.size() << " source(s), and " << fHistograms[0].size() << " histogram(s), " << fDataType.size() << " data types, and " << fHistograms.size() << " data type histogram(s)!" << std::endl;
+      throw std::runtime_error(error.str());
    }
 
    fOutput = new TFile("TEfficiencyCalibrator.root", "recreate");

--- a/libraries/TAnalysis/TNucleus/TNucleus.cxx
+++ b/libraries/TAnalysis/TNucleus/TNucleus.cxx
@@ -40,7 +40,7 @@ TNucleus::TNucleus(const char* name)
          if(line.length() < 1) {
             continue;
          }
-         std::stringstream ss(line);
+         std::istringstream ss(line);
          ss >> n;
          ss >> z;
          ss >> sym_name;
@@ -356,10 +356,10 @@ bool TNucleus::LoadTransitionFile()
       if(line.compare(0, 1, "#") == 0) {
          continue;
       }
-      double            temp = 0.;
-      auto*             tran = new TTransition;
-      std::stringstream str(line);
-      int               counter = 0;
+      double             temp = 0.;
+      auto*              tran = new TTransition;
+      std::istringstream str(line);
+      int                counter = 0;
       while(!(str >> temp).fail()) {
          counter++;
          if(counter == 1) {

--- a/libraries/TAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
+++ b/libraries/TAnalysis/TPulseAnalyzer/TPulseAnalyzer.cxx
@@ -1711,10 +1711,10 @@ double TPulseAnalyzer::SiLiFitFunction(double* i, double* p)   // NOLINT(readabi
 TF1 TPulseAnalyzer::Getsilifit()
 {
    if(set && cWpar != nullptr) {
-      std::stringstream ss;
-      ss << "Fit" << fNameIter;
+      std::ostringstream name;
+      name << "Fit" << fNameIter;
       ++fNameIter;
-      TF1 g(ss.str().c_str(), SiLiFitFunction, 0, cN, 8);
+      TF1 g(name.str().c_str(), SiLiFitFunction, 0, cN, 8);
 
       g.SetParameter(0, cWpar->t0);
       g.SetParameter(1, cWpar->tauDecay);
@@ -1774,11 +1774,10 @@ TH1I* TPulseAnalyzer::GetWaveHist()
    if(cN == 0 || !set) {
       return nullptr;
    }
-   std::stringstream ss;
-   ss << "WaveformHist" << fNameIter;
+   std::ostringstream name;
+   name << "WaveformHist" << fNameIter;
    ++fNameIter;   // Avoid naming conflicts with TNamed
-   TH1I* h = new TH1I(ss.str().c_str(), ss.str().c_str(), cN, -0.5,
-                      cN - 0.5);   // midpoint should be the value, else time is off
+   TH1I* h = new TH1I(name.str().c_str(), name.str().c_str(), cN, -0.5, cN - 0.5);   // midpoint should be the value, else time is off
    for(Int_t i = 0; i < cN; i++) {
       h->SetBinContent(i + 1, cWavebuffer[i]);
    }

--- a/libraries/TAnalysis/TSRIM/TSRIM.cxx
+++ b/libraries/TAnalysis/TSRIM/TSRIM.cxx
@@ -55,11 +55,11 @@ void TSRIM::ReadEnergyLossFile(const char* filename, double emax, double emin, b
       if(line.length() == 0u) {
          continue;
       }
-      std::stringstream linestream(line);
+      std::istringstream linestream(line);
       number_input.clear();
       string_input.clear();
       while(!(linestream >> word).fail()) {
-         std::stringstream str(word);
+         std::istringstream str(word);
          if(!(str >> temp).fail()) {   // if it's a number
             number_input.push_back(temp);
          } else {

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -77,12 +77,12 @@ void TDataParser::Push(ThreadsafeQueue<std::shared_ptr<const TBadFragment>>& que
 
 std::string TDataParser::OutputQueueStatus()
 {
-   std::stringstream str;
-   str << "********************************************************************************" << std::endl;
+   std::ostringstream status;
+   status << "********************************************************************************" << std::endl;
    for(const auto& queue : fGoodOutputQueues) {
-      str << queue->Name() << ": " << queue->ItemsPushed() << " pushed, " << queue->ItemsPopped() << " popped, "
-          << queue->Size() << " left" << std::endl;
+      status << queue->Name() << ": " << queue->ItemsPushed() << " pushed, " << queue->ItemsPopped() << " popped, "
+             << queue->Size() << " left" << std::endl;
    }
-   str << "********************************************************************************" << std::endl;
-   return str.str();
+   status << "********************************************************************************" << std::endl;
+   return status.str();
 }

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1155,7 +1155,7 @@ void TChannel::SaveToSelf()
 {
    /// This function saves the current cal-file to fFileData.
    /// For some reason it does the latter not by using WriteCalBuffer ???
-   std::stringstream buffer;
+   std::ostringstream buffer;
    std::streambuf*   std_out = std::cout.rdbuf(buffer.rdbuf());
    WriteCalFile();
    fFileData.assign(buffer.str());

--- a/libraries/TFormat/TDataFrameLibrary.cxx
+++ b/libraries/TFormat/TDataFrameLibrary.cxx
@@ -99,13 +99,13 @@ void TDataFrameLibrary::Compile(std::string& path, const size_t& dot, const size
    // first we get the stats of the file's involved (.cxx, .hh, .so, and the libTGRSIFrame.so)
    struct stat sourceStat {};
    if(stat(sourceFile.c_str(), &sourceStat) != 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to access stat of source file " << sourceFile << std::endl;
       throw std::runtime_error(str.str());
    }
    struct stat headerStat {};
    if(stat(headerFile.c_str(), &headerStat) != 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to access stat of header file " << headerFile << std::endl;
       throw std::runtime_error(str.str());
    }
@@ -113,12 +113,12 @@ void TDataFrameLibrary::Compile(std::string& path, const size_t& dot, const size
    // get path of libTGRSIFrame via
    Dl_info info;
    if(dladdr(reinterpret_cast<void*>(DummyFunctionToLocateTGRSIFrameLibrary), &info) == 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to find location of DummyFunctionToLocateTGRSIFrameLibrary" << std::endl;
       throw std::runtime_error(str.str());
    }
    if(stat(info.dli_fname, &frameLibStat) != 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to access stat of " << info.dli_fname << std::endl;
       throw std::runtime_error(str.str());
    }
@@ -141,22 +141,22 @@ void TDataFrameLibrary::Compile(std::string& path, const size_t& dot, const size
    // so we can simply take everything between "last '/' + 3" and "last '.'" to be the name?
    std::string       parserLibraryName = parserLibraryPath.substr(parserLibraryPath.find_last_of('/') + 4, parserLibraryPath.find_last_of('.') - parserLibraryPath.find_last_of('/') - 4);
    std::string       objectFile        = path.replace(dot, std::string::npos, ".o");
-   std::stringstream command;
+   std::ostringstream command;
    command << "g++ -c -fPIC -g $(grsi-config --cflags --" << parserLibraryName << "-cflags) $(root-config --cflags) -I" << includePath;
 #ifdef OS_DARWIN
    command << " -I/opt/local/include ";
 #endif
    command << " -o " << objectFile << " " << sourceFile;
    if(std::system(command.str().c_str()) != 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to compile source file " << sourceFile << " using " << DBLUE << "'" << command.str() << "'" << RESET_COLOR << std::endl;
       throw std::runtime_error(str.str());
    }
    std::cout << DCYAN << "----------  starting linking user code  -----------------" << RESET_COLOR << std::endl;
-   std::stringstream().swap(command);   // create new (empty) stringstream and swap it with command this resets the underlying string and all error flags
+   std::ostringstream().swap(command);   // create new (empty) stringstream and swap it with command this resets the underlying string and all error flags
    command << "g++ -fPIC -g -shared $(grsi-config --libs --" << parserLibraryName << "-libs) $(root-config --glibs) -o " << sharedLibrary << " " << objectFile;
    if(std::system(command.str().c_str()) != 0) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Unable to link shared object library " << sharedLibrary << " using " << DBLUE << "'" << command.str() << "'" << RESET_COLOR << std::endl;
       throw std::runtime_error(str.str());
    }

--- a/libraries/TFormat/TGRSIFrame.cxx
+++ b/libraries/TFormat/TGRSIFrame.cxx
@@ -38,7 +38,7 @@ TGRSIFrame::TGRSIFrame()
       check.Close();
    }
    if(treeName.empty()) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "Failed to find 'AnalysisTree' or 'FragmentTree' in '" << fOptions->RootInputFiles()[0] << "', either provide a different tree name via --tree-name flag or check input file" << std::endl;
       throw std::runtime_error(str.str());
    }

--- a/libraries/TFormat/TGRSIHelper.cxx
+++ b/libraries/TFormat/TGRSIHelper.cxx
@@ -10,7 +10,7 @@ TGRSIHelper::TGRSIHelper(TList* input)
    *(TGRSIOptions::AnalysisOptions()) = *static_cast<TAnalysisOptions*>(input->FindObject("TAnalysisOptions"));
    // check that we have a parser library
    if(TGRSIOptions::Get()->ParserLibrary().empty()) {
-      std::stringstream str;
+      std::ostringstream str;
       str << DRED << "No parser library set!" << RESET_COLOR << std::endl;
       throw std::runtime_error(str.str());
    }
@@ -222,7 +222,7 @@ void TGRSIHelper::CheckSizes(unsigned int slot, const char* usage)
          TBufferFile buf(TBuffer::kWrite, 10000);
          obj->IsA()->WriteBuffer(buf, obj);
          if(buf.Length() > fSizeLimit) {
-            std::stringstream str;
+            std::ostringstream str;
             str << DRED << slot << ". slot: " << obj->ClassName() << " '" << obj->GetName() << "' too large to " << usage << ": " << buf.Length() << " bytes = " << buf.Length() / 1024. / 1024. / 1024. << " GB, removing it!" << RESET_COLOR << std::endl;
             std::cout << str.str();
             // we only remove it from the output list, not deleting the object itself

--- a/libraries/TFormat/TUserSettings.cxx
+++ b/libraries/TFormat/TUserSettings.cxx
@@ -45,7 +45,7 @@ bool TUserSettings::ReadSettings(const std::string& settingsFile)
 
       // check if this is a comma separated list of values
       if(value.find(',') != std::string::npos) {
-         std::stringstream valueStream(value);
+         std::istringstream valueStream(value);
          while(std::getline(valueStream, line, ',')) {
             trim(line);
             ParseValue(name, line, true);
@@ -97,7 +97,7 @@ void TUserSettings::ParseValue(const std::string& name, const std::string& value
    std::string copy = value;
    std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);
    bool              boolVal = false;
-   std::stringstream str(copy);
+   std::istringstream str(copy);
    str >> std::boolalpha >> boolVal;
    if(str.good()) {
       if(!vector) {

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -700,21 +700,21 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
          if(FilledBin(fMatrices[i], bin)) {   // good bin in the current matrix
             // current index is tmpBins, so we check if the bin agrees with what we have
             if(fChannelToIndex.find(bin) == fChannelToIndex.end() || tmpBins != fChannelToIndex[bin]) {   // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
-               std::stringstream str;
-               str << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (fChannelToIndex.find(bin) == fChannelToIndex.end() ? "not filled" : Form("%d", fChannelToIndex[bin])) << std::endl;
-               throw std::invalid_argument(str.str());
+               std::ostringstream error;
+               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (fChannelToIndex.find(bin) == fChannelToIndex.end() ? "not filled" : Form("%d", fChannelToIndex[bin])) << std::endl;
+               throw std::invalid_argument(error.str());
             }
             if(strcmp(fMatrices[0]->GetXaxis()->GetBinLabel(bin), fMatrices[i]->GetXaxis()->GetBinLabel(bin)) != 0) {   // bin is full and matches the bin in the first matrix so we check the labels
-               std::stringstream str;
-               str << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
-               throw std::invalid_argument(str.str());
+               std::ostringstream error;
+               error << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
+               throw std::invalid_argument(error.str());
             }
             ++tmpBins;
          } else {
             if(fChannelToIndex.find(bin) != fChannelToIndex.end()) {   //found an empty bin that was full in the first matrix
-               std::stringstream str;
-               str << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << fChannelToIndex[bin] << ". filled bin" << std::endl;
-               throw std::invalid_argument(str.str());
+               std::ostringstream error;
+               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << fChannelToIndex[bin] << ". filled bin" << std::endl;
+               throw std::invalid_argument(error.str());
             }
          }
       }
@@ -1742,13 +1742,13 @@ void TSourceCalibration::UpdateChannel(const int& channelId)
 void TSourceCalibration::WriteCalibration()
 {
    if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   std::stringstream str;
+   std::ostringstream fileName;
    for(auto* source : fSource) {
-      str << source->GetName();
+      fileName << source->GetName();
    }
-   str << ".cal";
-   TChannel::WriteCalFile(str.str());
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": wrote " << str.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   fileName << ".cal";
+   TChannel::WriteCalFile(fileName.str());
+   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fVerboseLevel > 2) { TChannel::WriteCalFile(); }
 }
 

--- a/libraries/TLoops/DynamicLibrary.cxx
+++ b/libraries/TLoops/DynamicLibrary.cxx
@@ -27,7 +27,7 @@ int incremental_id()
 DynamicLibrary::DynamicLibrary(std::string libname_param, bool unique_name) : fLibName(std::move(libname_param))
 {
    if(unique_name) {
-      std::stringstream str;
+      std::ostringstream str;
       str << "/tmp/temp_dynlib_" << getpid() << "_" << incremental_id() << ".so";
       fTempName = str.str();
 

--- a/libraries/TLoops/StoppableThread.cxx
+++ b/libraries/TLoops/StoppableThread.cxx
@@ -48,9 +48,9 @@ std::string StoppableThread::AnyThreadStatus()
 {
    for(auto& elem : fThreadMap) {
       if(elem.second->IsRunning()) {
-         std::stringstream str;
-         str << elem.first << ":\t " << elem.second->Status();
-         return str.str();
+         std::ostringstream status;
+         status << elem.first << ":\t " << elem.second->Status();
+         return status.str();
       }
    }
    return "";
@@ -58,21 +58,21 @@ std::string StoppableThread::AnyThreadStatus()
 
 std::string StoppableThread::AllThreadProgress()
 {
-   std::stringstream str;
+   std::ostringstream progress;
    for(auto& elem : fThreadMap) {
       if(elem.second->IsRunning()) {
-         str << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << elem.second->Progress().substr(0, fColumnWidth - 1) << "|";
+         progress << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << elem.second->Progress().substr(0, fColumnWidth - 1) << "|";
       } else {
          std::string prog = "not running";
-         str << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << prog.substr(0, fColumnWidth - 1) << "|";
+         progress << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << prog.substr(0, fColumnWidth - 1) << "|";
       }
    }
-   return str.str().substr(0, fStatusWidth);
+   return progress.str().substr(0, fStatusWidth);
 }
 
 std::string StoppableThread::AllThreadHeader()
 {
-   std::stringstream str;
+   std::ostringstream str;
    for(auto& elem : fThreadMap) {
       // left align, fill with spaces
       str << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << elem.first.substr(0, fColumnWidth - 1) << "|";
@@ -82,7 +82,7 @@ std::string StoppableThread::AllThreadHeader()
 
 std::string StoppableThread::AllThreadStatus()
 {
-   std::stringstream str;
+   std::ostringstream str;
    for(auto& elem : fThreadMap) {
       if(elem.second->IsRunning()) {
          str << std::left << std::setw(static_cast<int>(fColumnWidth - 1)) << elem.second->Status().substr(0, fColumnWidth - 1) << "|";
@@ -110,7 +110,7 @@ void StoppableThread::ResumeAll()
 
 std::string StoppableThread::Status()
 {
-   std::stringstream str;
+   std::ostringstream str;
    str << std::setw(static_cast<int>(fColumnWidth / 2 - 1)) << fItemsPopped << "/" << std::setw(static_cast<int>(fColumnWidth / 2 - 1))
        << fItemsPopped + fInputSize;
    return str.str();
@@ -118,7 +118,7 @@ std::string StoppableThread::Status()
 
 std::string StoppableThread::Progress()
 {
-   std::stringstream str;
+   std::ostringstream str;
    float             percentDone = 100.f * static_cast<float>(fItemsPopped);
    if(fItemsPopped + fInputSize > 0) {
       percentDone /= static_cast<float>(fItemsPopped + fInputSize);

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -76,7 +76,7 @@ void TAnalysisWriteLoop::ClearQueue()
 
 std::string TAnalysisWriteLoop::EndStatus()
 {
-   std::stringstream str;
+   std::ostringstream str;
    str << Name() << ":\t" << std::setw(8) << ItemsPopped() << "/" << InputSize() + ItemsPopped() << ", "
        << "??? good events" << std::endl;
    return str.str();

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -255,7 +255,7 @@ bool TEventBuildingLoop::CheckTriggerIdCondition(const std::shared_ptr<const TFr
 
 std::string TEventBuildingLoop::EndStatus()
 {
-   std::stringstream str;
+   std::ostringstream str;
    str << fInputQueue->Name() << ": " << ItemsPopped() << "/" << fInputQueue->ItemsPopped() << " items popped"
        << std::endl;
 

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -80,7 +80,7 @@ void TFragWriteLoop::ClearQueue()
 
 std::string TFragWriteLoop::EndStatus()
 {
-   std::stringstream str;
+   std::ostringstream str;
    str << std::endl
        << Name() << ": " << std::setw(8) << ItemsPopped() << "/" << ItemsPopped() + InputSize() << ", "
        << fEventTree->GetEntries() << " good fragments, " << fBadEventTree->GetEntries() << " bad fragments"

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -75,13 +75,13 @@ bool TUnpackingLoop::Iteration()
 
 std::string TUnpackingLoop::EndStatus()
 {
-   std::stringstream str;
+   std::ostringstream status;
    if(fFragsReadFromRaw > 0) {
-      str << "\r" << Name() << ":\t" << fGoodFragsRead << " good fragments out of " << fFragsReadFromRaw
-          << " fragments => " << 100. * static_cast<double>(fGoodFragsRead) / static_cast<double>(fFragsReadFromRaw) << "% passed" << std::endl;
+      status << "\r" << Name() << ":\t" << fGoodFragsRead << " good fragments out of " << fFragsReadFromRaw
+             << " fragments => " << 100. * static_cast<double>(fGoodFragsRead) / static_cast<double>(fFragsReadFromRaw) << "% passed" << std::endl;
    } else {
-      str << "\rno fragments read from midas => none parsed!" << std::endl;
+      status << "\rno fragments read from midas => none parsed!" << std::endl;
    }
-   str << fParser->OutputQueueStatus();
-   return str.str();
+   status << fParser->OutputQueueStatus();
+   return status.str();
 }


### PR DESCRIPTION
- Replaced `std::stringstream` with `std::ostringstream` or `std::istringstream` where appropriate.
- Made `u` an alternative key to `o` for unzooming 1D- or 2D-histograms.
- Added list of missing runs to `TRunInfo::Print`, this should address #1320, but it hasn't been tested yet.
- Some minor changes to doxygen comments.