### PR TITLE
TRunInfo improvements

### DIFF
--- a/include/TRunInfo.h
+++ b/include/TRunInfo.h
@@ -9,34 +9,96 @@
 ///
 /// \class TRunInfo
 ///
-/// This Class is designed to store and run dependent
-/// information. It is used to store run numbers, existence of
-/// detector systems, reconstruction windows, etc. The
-/// TRunInfo is written alongside both the fragment and
-/// analysis trees.
+/// This Class is designed to store run dependent information.
+/// It is used to store run numbers, GRSISort version, existence of
+/// detector systems, etc.
+/// The TRunInfo is written to both the fragment and analysis trees,
+/// as well as to files create by grsiframe.
 ///
 /// TRunInfo designed to be made as the FragmentTree
 /// is created.  Right now, it simple remembers the run and
 /// subrunnumber and sets which systems are present in the odb.
 ///
-/// Due to some root quarkiness, I have done something a bit strange.
-/// The info is written ok at the end of the fragment tree process.
 /// \code
-/// root [1] TRunInfo *info = (TRunInfo*)_file0->Get("TRunInfo")
-/// root [2] TRunInfo::ReadInfoFromFile(info);
-/// root [3] info->Print()
-///   TRunInfo Status:
-///   RunNumber:    29038
-///   SubRunNumber: 000
-///   TIGRESS:      true
-///   SHARC:        true
-///   GRIFFIN:      false
-///   SCEPTAR:      false
-///   =====================
-/// root [4]
+/// GRSI [0] TRunInfo::Get()->Print()
+/// Singleton 0x5651a3d5dc10 was read from analysis22151_000.root
+/// Title: All-singles-ZDF-off 133Ba_R0794
+/// Comment: All-singles-ZDF-off 133Ba_R0794
+/// 		RunNumber:          22151
+/// 		SubRunNumber:       000
+/// 		RunStart:           Fri Dec 22 18:11:29 2023
+/// 		RunStop:            Fri Dec 22 18:42:40 2023
+/// 		RunLength:          1871 s
+/// GRSI [1]
 /// \endcode
 ///
-/// \author  P.C. Bender, <pcbend@gmail.com>
+/// When subruns/runs are added together using gadd or when multiple
+/// subruns/runs are used in grsiframe, their TRunInfos get merged.
+///
+/// If all files are from one run, and the subruns are added in order 
+/// without any missing, the information changes to reflect this:
+/// \code
+/// GRSI [0] TRunInfo::Get()->Print()
+/// Singleton 0x55ab20f209a0 was read from Final21950_000-028.root
+/// Title: 100Zr_beam_with_PACES_lasers_on
+/// Comment: 100Zr_beam_with_PACES_lasers_on
+/// 		RunNumber:          21950
+/// 		SubRunNumbers:      000-028
+/// 		RunStart:           Thu Dec 14 13:37:14 2023
+/// 		RunStop:            Thu Dec 14 14:37:14 2023
+/// 		RunLength:          3599 s
+/// GRSI [1]
+/// \endcode
+/// Internally this is signaled by the subrun number having been
+/// set to -1, while the run number is still nonzero, and the run
+/// start and run stop are set as well as the numbers of the first
+/// and last subrun.
+///
+/// If the subruns are not in order or a subrun is missing from the
+/// range added, the number of the first and last subrun are both set
+/// to -1, changing the line
+/// \code
+/// 		SubRunNumbers:      000-028
+/// \endcode
+/// to
+/// \code
+/// 		SubRunNumbers:      -1--1
+/// \endcode
+///
+/// If the files are from multiple runs that are all in consecutive
+/// order without any missing ones, the run info will say:
+/// \code
+/// Singleton 0x563c6c1c3a30 was read from Final21950-21980.root
+/// Title: 100Zr_beam_with_PACES_lasers_on
+/// Comment: 100Zr_beam_with_PACES_lasers_on
+/// 		RunNumbers:         21950-21980
+/// 		No missing runs
+/// 		RunStart:           Thu Dec 14 13:37:14 2023
+/// 		RunStop:            Fri Dec 15 19:06:11 2023
+/// 		RunLength:          101306 s
+/// \endcode
+/// 
+/// If however some runs in between are missing, it will say
+/// \code
+/// Singleton 0x55919586a8c0 was read from test50_51_54.root
+/// Title: 100Zr_beam_with_PACES_lasers_on
+/// Comment: 100Zr_beam_with_PACES_lasers_on
+/// 		RunNumbers:         21950-21954
+/// 		Missing runs:       21952, 21953
+/// 		Combined RunLength: 10794 s
+/// \endcode
+///
+/// From version 18 on TRunInfo also stores information about 
+/// the GRSISort version used to sort the data.
+/// This can be accessed via 
+/// \code
+/// TRunInfo::Get()->PrintVersion();
+/// \endcode
+/// 
+/// Using a newer version of grsiframe on data created with an
+/// older version of GRSISort should not overwrite the version
+/// reported.
+///
 /////////////////////////////////////////////////////////////////
 
 #include <cstdio>
@@ -70,47 +132,63 @@ public:
 
    static Bool_t ReadInfoFromFile(TFile* tempf = nullptr);
 
-   static const char* GetVersion() { return fVersion.c_str(); }
-   static void        ClearVersion() { fVersion.clear(); }
-   static void        SetVersion(const char* ver)
+   static std::string GetVersion() { return Get()->fVersion; }
+   static void        ClearVersion() { Get()->fVersion.clear(); }
+   static void        SetVersion(const char* ver) { SetVersion(std::string(ver)); }
+   static void        SetVersion(std::string ver)
    {
-      if(fVersion.length() != 0) {
-         std::cout << ALERTTEXT << "WARNING; VERSION ALREADY SET TO " << fVersion << "!!" << RESET_COLOR << std::endl;
+      if(!Get()->fVersion.empty() && Get()->fVersion != ver) {
+         std::cout << ALERTTEXT << "WARNING; VERSION ALREADY SET TO " << Get()->fVersion << " NOT " << ver << "!!" << RESET_COLOR << std::endl;
       } else {
-         fVersion.assign(ver);
+         Get()->fVersion = std::move(ver);
       }
    }
 
-   static const char* GetFullVersion() { return fFullVersion.c_str(); }
-   static void        ClearFullVersion() { fFullVersion.clear(); }
-   static void        SetFullVersion(const char* ver)
+   static std::string GetFullVersion() { return Get()->fFullVersion; }
+   static void        ClearFullVersion() { Get()->fFullVersion.clear(); }
+   static void        SetFullVersion(const char* ver) { SetFullVersion(std::string(ver)); }
+   static void        SetFullVersion(std::string ver)
    {
-      if(fFullVersion.length() != 0) {
-         std::cout << ALERTTEXT << "WARNING; FULL VERSION ALREADY SET TO " << fFullVersion << "!!" << RESET_COLOR << std::endl;
+      if(!Get()->fFullVersion.empty() && Get()->fFullVersion != ver) {
+         std::cout << ALERTTEXT << "WARNING; FULL VERSION ALREADY SET TO " << Get()->fFullVersion << " NOT " << ver << "!!" << RESET_COLOR << std::endl;
       } else {
-         fFullVersion.assign(ver);
+         Get()->fFullVersion = std::move(ver);
       }
    }
 
-   static const char* GetDate() { return fDate.c_str(); }
-   static void        ClearDate() { fDate.clear(); }
-   static void        SetDate(const char* ver)
+   static std::string GetDate() { return Get()->fDate; }
+   static void        ClearDate() { Get()->fDate.clear(); }
+   static void        SetDate(const char* ver) { SetDate(std::string(ver)); }
+   static void        SetDate(std::string ver)
    {
-      if(fDate.length() != 0) {
-         std::cout << ALERTTEXT << "WARNING; DATE ALREADY SET TO " << fDate << "!!" << RESET_COLOR << std::endl;
+      if(!Get()->fDate.empty() && Get()->fDate != ver) {
+         std::cout << ALERTTEXT << "WARNING; DATE ALREADY SET TO " << Get()->fDate << " NOT " << ver << "!!" << RESET_COLOR << std::endl;
       } else {
-         fDate.assign(ver);
+         Get()->fDate = std::move(ver);
       }
    }
 
-   static const char* GetLibraryVersion() { return fLibraryVersion.c_str(); }
-   static void        ClearLibraryVersion() { fLibraryVersion.clear(); }
-   static void        SetLibraryVersion(const char* ver)
+   static std::string GetLibraryVersion() { return Get()->fLibraryVersion; }
+   static void        ClearLibraryVersion() { Get()->fLibraryVersion.clear(); }
+   static void        SetLibraryVersion(const char* ver) { SetLibraryVersion(std::string(ver)); }
+   static void        SetLibraryVersion(std::string ver)
    {
-      if(fLibraryVersion.length() != 0) {
-         std::cout << ALERTTEXT << "WARNING; VERSION ALREADY SET TO " << fLibraryVersion << "!!" << RESET_COLOR << std::endl;
+      if(!Get()->fLibraryVersion.empty() && Get()->fLibraryVersion != ver) {
+         std::cout << ALERTTEXT << "WARNING; LIBRARY VERSION ALREADY SET TO " << Get()->fLibraryVersion << " NOT " << ver << "!!" << RESET_COLOR << std::endl;
       } else {
-         fLibraryVersion.assign(ver);
+         Get()->fLibraryVersion = std::move(ver);
+      }
+   }
+
+   static std::string GetLibraryPath() { return Get()->fLibraryPath; }
+   static void        ClearLibraryPath() { Get()->fLibraryPath.clear(); }
+   static void        SetLibraryPath(const char* ver) { SetLibraryPath(std::string(ver)); }
+   static void        SetLibraryPath(std::string ver)
+   {
+      if(!Get()->fLibraryPath.empty() && Get()->fLibraryPath != ver) {
+         std::cout << ALERTTEXT << "WARNING; LIBRARY PATH ALREADY SET TO " << Get()->fLibraryPath << " NOT " << ver << "!!" << RESET_COLOR << std::endl;
+      } else {
+         Get()->fLibraryPath = std::move(ver);
       }
    }
 
@@ -186,6 +264,7 @@ public:
 
    void        PrintRunList() const;
    std::string ListOfMissingRuns() const;
+	void PrintVersion() const;
 
    static std::string CreateLabel(bool quiet = false);
 
@@ -210,36 +289,37 @@ private:
    int                           fLastSubRunNumber{-1};    ///< The last sub run number (for combined subruns)
    std::set<std::pair<int, int>> fRunList;                 ///< List of all runs added to this run info
 
-   double fRunStart{0.};    // The start  of the current run in seconds - no idea why we store this as double?
-   double fRunStop{0.};     // The stop   of the current run in seconds - no idea why we store this as double?
-   double fRunLength{0.};   // The length of the current run in seconds - no idea why we store this as double?
+   double fRunStart{0.};    ///< The start  of the current run in seconds - no idea why we store this as double?
+   double fRunStop{0.};     ///< The stop   of the current run in seconds - no idea why we store this as double?
+   double fRunLength{0.};   ///< The length of the current run in seconds - no idea why we store this as double?
 
-   static std::string fVersion;          // The version of GRSISort that generated the file - GRSI_RELEASE from GVersion.h
-   static std::string fFullVersion;      // The full version of GRSISort that generated the file (includes last commit) - GRSI_GIT_COMMIT from GVersion.h
-   static std::string fDate;             // The date of the last commit used in this version - GRSI_GIT_COMMIT_TIME from GVersion.h
-   static std::string fLibraryVersion;   // The version of the parser/file library that generated the file
+   std::string fVersion;          ///< The version of GRSISort that generated the file - GRSI_RELEASE from GVersion.h
+   std::string fFullVersion;      ///< The full version of GRSISort that generated the file (includes last commit) - GRSI_GIT_COMMIT from GVersion.h
+   std::string fDate;             ///< The date of the last commit used in this version - GRSI_GIT_COMMIT_TIME from GVersion.h
+   std::string fLibraryVersion;   ///< The version of the parser/file library that generated the file
+   std::string fLibraryPath;      ///< The path of the parser/file library that generated the file
 
-   std::string fCalFileName;   // Name of calfile that generated cal
-   std::string fCalFile;       // Cal File to load into Cal of tree
+   std::string fCalFileName;   ///< Name of calfile that generated cal
+   std::string fCalFile;       ///< Cal File to load into Cal of tree
 
-   std::string fXMLODBFileName;   // Name of XML Odb file
-   std::string fXMLODBFile;       // The odb
+   std::string fXMLODBFileName;   ///< Name of XML Odb file
+   std::string fXMLODBFile;       ///< The odb
 
    /////////////////////////////////////////////////
    //////////////// Building Options ///////////////
    /////////////////////////////////////////////////
 
-   std::string fRunInfoFileName;   // The name of the Run info file
-   std::string fRunInfoFile;       // The contents of the run info file
+   std::string fRunInfoFileName;   ///< The name of the Run info file
+   std::string fRunInfoFile;       ///< The contents of the run info file
 
-   double fHPGeArrayPosition{110.};   // Position of the HPGe Array (default = 110.0 mm );
+   double fHPGeArrayPosition{110.};   ///< Position of the HPGe Array (default = 110.0 mm );
 
    std::vector<int> fBadCycleList;   //!<!List of bad cycles to be used for cycle rejection
 
    TDetectorInformation* fDetectorInformation{nullptr};   //!<! pointer to detector specific information (set by each parser library)
 
    /// \cond CLASSIMP
-   ClassDefOverride(TRunInfo, 17)   // NOLINT(readability-else-after-return)
+   ClassDefOverride(TRunInfo, 18)   // NOLINT(readability-else-after-return)
    /// \endcond
 };
 /*! @} */

--- a/libraries/TAnalysis/TGRSIFit/LinkDef.h
+++ b/libraries/TAnalysis/TGRSIFit/LinkDef.h
@@ -20,9 +20,9 @@
 #pragma link C++ class std::vector < TSingleDecay*> + ;
 #pragma link C++ class std::vector < TDecayChain*> + ;
 #pragma link C++ class TDecayChain + ;
-#pragma link C++ class TDecayFit - ;
+#pragma link C++ class TDecayFit + ;
 #pragma link C++ class TDecay + ;
-#pragma link C++ class TVirtualDecay - ;
+#pragma link C++ class TVirtualDecay + ;
 #pragma link C++ class std::map < Int_t, std::vector < TSingleDecay*>> + ;
 
 #pragma link C++ class TLMFitter + ;

--- a/libraries/TAnalysis/TGRSIFit/TDecay.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TDecay.cxx
@@ -51,16 +51,6 @@ TFitResultPtr TDecayFit::Fit(TH1* hist, Option_t* opt)
    return tmpres;
 }
 
-void TDecayFit::Streamer(TBuffer& R__b)
-{
-   /// Stream an object of class TDecayFit.
-   if(R__b.IsReading()) {
-      R__b.ReadClassBuffer(TDecayFit::Class(), this);
-   } else {
-      R__b.WriteClassBuffer(TDecayFit::Class(), this);
-   }
-}
-
 void TDecayFit::DefaultGraphs()
 {
    fResiduals.SetMarkerStyle(20);   // Filled circle
@@ -114,16 +104,6 @@ void TVirtualDecay::DrawComponents(Option_t* opt, Bool_t)
 {
    std::cout << "Draw components has not been set in " << ClassName() << std::endl;
    Draw(Form("same%s", opt));
-}
-
-void TVirtualDecay::Streamer(TBuffer& R__b)
-{
-   /// Stream an object of class TVirtualDecay.
-   if(R__b.IsReading()) {
-      R__b.ReadClassBuffer(TVirtualDecay::Class(), this);
-   } else {
-      R__b.WriteClassBuffer(TVirtualDecay::Class(), this);
-   }
 }
 
 TSingleDecay::TSingleDecay(TSingleDecay* parent, Double_t tlow, Double_t thigh)

--- a/libraries/TFormat/TParserLibrary.cxx
+++ b/libraries/TFormat/TParserLibrary.cxx
@@ -6,6 +6,7 @@
 
 #include "TGRSIOptions.h"
 #include "TGRSIUtilities.h"
+#include "TRunInfo.h"
 
 // redeclare dlsym to be a function returning a function pointer instead of void *
 extern "C" void* (*dlsym(void* handle, const char* symbol))();
@@ -63,4 +64,6 @@ void TParserLibrary::Load()
    }
    fInitLibrary();
    std::cout << "\tUsing library " << TGRSIOptions::Get()->ParserLibrary() << " version " << fLibraryVersion() << std::endl;
+	TRunInfo::SetLibraryVersion(fLibraryVersion());
+	TRunInfo::SetLibraryPath(TGRSIOptions::Get()->ParserLibrary());
 }

--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -12,11 +12,6 @@
 #include "GVersion.h"
 #include "TGRSIUtilities.h"
 
-std::string TRunInfo::fVersion;
-std::string TRunInfo::fFullVersion;
-std::string TRunInfo::fDate;
-std::string TRunInfo::fLibraryVersion;
-
 Bool_t TRunInfo::ReadInfoFromFile(TFile* tempf)
 {
    TDirectory* savdir = gDirectory;
@@ -95,10 +90,12 @@ void TRunInfo::Print(Option_t* opt) const
       str << "\t\tSubRunNumbers:      " << std::setw(3) << FirstSubRunNumber() << "-" << std::setw(3) << LastSubRunNumber() << std::endl;
    } else if(FirstRunNumber() != LastRunNumber()) {
       str << "\t\tRunNumbers:         " << std::setw(5) << FirstRunNumber() << "-" << std::setw(5) << LastRunNumber() << std::endl;
-		str << "\t\tMissing runs:       " << ListOfMissingRuns() << std::endl;
-   } else {
+		str << "\t\tNo missing runs" << std::endl;
+   } else if(!fRunList.empty()) {
       str << "\t\tRunNumbers:         " << std::setw(5) << fRunList.begin()->first << "-" << std::setw(5) << fRunList.rbegin()->first << std::endl;
 		str << "\t\tMissing runs:       " << ListOfMissingRuns() << std::endl;
+	} else {
+		str << "\t\tNo runs in list?" << std::endl;
 	}
    str << std::setfill(' ');
    if(RunStart() != 0 && RunStop() != 0) {
@@ -176,8 +173,7 @@ void TRunInfo::SetAnalysisTreeBranches(TTree*)
 
 Bool_t TRunInfo::ReadInfoFile(const char* filename)
 {
-   // Read in a run info file. These files have the extension .info.
-   // An example can be found in the "examples" directory.
+   /// Read in a run info file. These files have the extension .info.
    std::string infilename;
    infilename.append(filename);
    std::cout << "Reading info from file: " << CYAN << filename << RESET_COLOR << std::endl;
@@ -493,6 +489,8 @@ void TRunInfo::Add(TRunInfo* runinfo, bool verbose)
          // with multiple non-sequential subruns added, the sub run number and start/stop have no meaning anymore
          fRunStart = 0.;
          fRunStop  = 0.;
+         fFirstSubRunNumber = -1;
+         fLastSubRunNumber  = -1;
       }
       // sub run number is only meaningful if it's the only sub run
       fSubRunNumber = -1;
@@ -556,6 +554,17 @@ std::string TRunInfo::ListOfMissingRuns() const
    return result.str();
 }
 
+void TRunInfo::PrintVersion() const
+{
+   if(fVersion.empty()) {
+      std::cout << YELLOW << "Unknown version, this file was probably generated with TRunInfo version 17 or older" << RESET_COLOR << std::endl;
+   } else {
+      std::cout << "This file was generated with GRSISort version " << fVersion << " (" << fFullVersion << ")" << std::endl
+                << "From " << fDate << std::endl
+                << "Using the parser library version " << fLibraryVersion << " from " << fLibraryPath << std::endl;
+   }
+}
+
 std::string TRunInfo::CreateLabel(bool quiet)
 {
    /// This function creates a label/string based on the run number and the subrun number.
@@ -579,3 +588,37 @@ std::string TRunInfo::CreateLabel(bool quiet)
 
    return result;
 }
+
+//void TRunInfo::Streamer(TBuffer &R__b)
+//{
+//   /// Stream an object of class TRunInfo.
+//	/// Explicitly writes and reads the static members as well!
+//
+//   if(R__b.IsReading()) {
+//      R__b.ReadClassBuffer(TRunInfo::Class(),this);
+//		Version_t R__v = R__b.ReadVersion();
+//		std::cout << "Got R__v = " << R__v << std::endl;
+//		if(R__v > 17) {
+//			R__b.ReadStdString(fVersion);
+//			R__b.ReadStdString(fFullVersion);
+//			R__b.ReadStdString(fDate);
+//			R__b.ReadStdString(fLibraryVersion);
+//			R__b.ReadStdString(fLibraryPath);
+//		} else {
+//			fVersion = "unknown";
+//			fFullVersion = "unknown";
+//			fDate = "unknown";
+//			fLibraryVersion = "unknown";
+//			fLibraryPath = "unknown";
+//		}
+//	} else {
+//		R__b.WriteClassBuffer(TRunInfo::Class(),this);
+//		R__b.WriteVersion(TRunInfo::Class(), true);
+//		R__b.WriteStdString(fVersion);
+//		R__b.WriteStdString(fFullVersion);
+//		R__b.WriteStdString(fDate);
+//		R__b.WriteStdString(fLibraryVersion);
+//		R__b.WriteStdString(fLibraryPath);
+//	}
+//}
+

--- a/libraries/TGUI/LinkDef.h
+++ b/libraries/TGUI/LinkDef.h
@@ -10,8 +10,8 @@
 #pragma link C++ class TBGSubtraction + ;
 #pragma link C++ class TCalibrateDescant + ;
 #pragma link C++ class TSourceCalibration + ;
-#pragma link C++ class TCalibrationGraph - ;
+#pragma link C++ class TCalibrationGraph + ;
 #pragma link C++ class std::vector < TCalibrationGraph*> + ;
-#pragma link C++ class TCalibrationGraphSet - ;
+#pragma link C++ class TCalibrationGraphSet + ;
 
 #endif

--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -29,16 +29,6 @@ void TCalibrationGraph::Scale(const double& scale)
 }
 #endif
 
-void TCalibrationGraph::Streamer(TBuffer& R__b)
-{
-   // Stream an object of class TCalibrationGraphSet.
-   if(R__b.IsReading()) {
-      R__b.ReadClassBuffer(TCalibrationGraph::Class(), this);
-   } else {
-      R__b.WriteClassBuffer(TCalibrationGraph::Class(), this);
-   }
-}
-
 TCalibrationGraphSet::TCalibrationGraphSet(TGraphErrors* graph, const std::string& label)
    : fTotalGraph(new TGraphErrors), fTotalResidualGraph(new TGraphErrors)
 {
@@ -508,12 +498,3 @@ void TCalibrationGraphSet::Print(Option_t* opt) const
    std::cout << "---------------------" << std::endl;
 }
 
-void TCalibrationGraphSet::Streamer(TBuffer& R__b)
-{
-   // Stream an object of class TCalibrationGraphSet.
-   if(R__b.IsReading()) {
-      R__b.ReadClassBuffer(TCalibrationGraphSet::Class(), this);
-   } else {
-      R__b.WriteClassBuffer(TCalibrationGraphSet::Class(), this);
-   }
-}


### PR DESCRIPTION
The doxygen documentation for TRunInfo was improved, adding examples of how the information looks for different scenarios. TRunInfo now also stores and reports (via `TRunInfo::PrintVersion()`) the version and date of GRSISort used to sort the data, as well as the version and path of the parser library used.

Also removed some custom streamers that did the same thing as the default streamers.