### PR TITLE
Fixing bug in TRunInfo and TGRSIFrame

### DIFF
--- a/include/TRunInfo.h
+++ b/include/TRunInfo.h
@@ -263,7 +263,7 @@ public:
    static bool IsBadCycle(int cycle);
 
    void        PrintRunList() const;
-   std::string ListOfMissingRuns() const;
+   std::string ListOfMissingRuns(bool all = false) const;
    void        PrintVersion() const;
 
    static std::string CreateLabel(bool quiet = false);

--- a/libraries/TFormat/TGRSIFrame.cxx
+++ b/libraries/TFormat/TGRSIFrame.cxx
@@ -53,10 +53,16 @@ TGRSIFrame::TGRSIFrame()
    fPpg = new TPPG;
 
    // loop over input files, add them to the chain, and read the runinfo and calibration from them
+	bool first = true;
    for(const auto& fileName : fOptions->RootInputFiles()) {
       if(chain->Add(fileName.c_str(), 0) >= 1) {   // setting nentries parameter to zero make TChain load the file header and return a 1 if the file was opened successfully
          TFile* file = TFile::Open(fileName.c_str());
-         TRunInfo::AddCurrent();
+			if(first) {
+					  first = false;
+					  TRunInfo::Get();
+			} else {
+					  TRunInfo::AddCurrent();
+			}
          auto* ppg = static_cast<TPPG*>(file->Get("PPG"));
          if(ppg != nullptr) {
             fPpg->Add(ppg);

--- a/libraries/TFormat/TRunInfo.cxx
+++ b/libraries/TFormat/TRunInfo.cxx
@@ -387,9 +387,9 @@ TEventBuildingLoop::EBuildMode TRunInfo::BuildMode() const
 void TRunInfo::Add(TRunInfo* runinfo, bool verbose)
 {
    // add new run to list of runs (and check if the current run needs to be added)
-   if(fRunList.empty()) {
-      fRunList.emplace(fRunNumber, fSubRunNumber);
-   }
+   //if(fRunList.empty()) {
+   //   fRunList.emplace(fRunNumber, fSubRunNumber);
+   //}
    std::pair<int, int> newPair = std::make_pair(runinfo->fRunNumber, runinfo->fSubRunNumber);
    // check for dual entries
    if(fRunList.find(newPair) != fRunList.end()) {
@@ -529,10 +529,15 @@ void TRunInfo::PrintRunList() const
    }
 }
 
-std::string TRunInfo::ListOfMissingRuns() const
+std::string TRunInfo::ListOfMissingRuns(bool all) const
 {
    /// Outputs a comma separated list of all runs missing between fFirstRunNumber and fLastRunNumber.
    /// If no runs are missing prints "none".
+
+   if(fRunList.empty()) {
+      return {"no run list -> none missing?"};
+   }
+
    std::ostringstream result;
 
    // loop over all runs between the first and the last one (we know that these two are included)
@@ -551,6 +556,14 @@ std::string TRunInfo::ListOfMissingRuns() const
       return {"none"};
    }
 
+ 	// unless the "all" flag is set, we limit ourself to printing 140 characters (should be 20 runs?) 
+	std::cout << " current string length is " << result.str().length() << " and all is set to " << (all?"true":"false") << std::endl;
+	if(!all && result.str().length() > 140) {
+			  result.str(result.str().substr(0, 140));
+			  result.seekp(0, std::ios_base::end);
+			  result << " ... and more";
+			  std::cout << " limited string length is " << result.str().length() << std::endl;
+	}
    return result.str();
 }
 


### PR DESCRIPTION
Using grsiframe with a single run resulted in a long list of "missing runs" because it thought the first run was run 0 (and thus listed all runs between 0 and the current run number). 
These changes were made:
- TGRSIFrame only reads the run info from file if it's the first file of the list of files, and adds all other run infos to this one. Before we added all run infos to the existing empty one.
- TRunInfo does not add the current run number and subrun number to the run list if a new run is added. This might not be needed anymore/mess things up in other situations!
- ListOfMissingRuns by default prints at most 20 missing runs (with "... and more" added if more than 20 are missing). This doesn't fix the issue, it's just for cosmetics.
- ListOfMissingRuns also check if the run list exists, so it can now be called from a single file w/o crashing.
- 