### PR TITLE
Fixing #1467

### DIFF
--- a/include/TGRSIFunctions.h
+++ b/include/TGRSIFunctions.h
@@ -58,10 +58,8 @@ Double_t DeadTimeAffect(Double_t function, Double_t deadtime, Double_t binWidth 
 Double_t ConvolutedDecay(Double_t* x, Double_t* par);
 Double_t ConvolutedDecay2(Double_t* x, Double_t* par);
 
-#ifdef HAS_MATHMORE
 // Angular correlation fitting
 Double_t LegendrePolynomial(Double_t* x, Double_t* p);
-#endif
 
 // functions used for angular correlations
 double RacahW(double a, double b, double c, double d, double e, double f);

--- a/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TGRSIFunctions.cxx
@@ -374,13 +374,16 @@ Double_t TGRSIFunctions::DeadTimeAffect(Double_t function, Double_t deadtime, Do
    return function / (1. + function * deadtime / (binWidth * 1000000.));
 }
 
-#ifdef HAS_MATHMORE
 Double_t TGRSIFunctions::LegendrePolynomial(Double_t* x, Double_t* p)   // NOLINT(readability-non-const-parameter)
 {
+#ifdef HAS_MATHMORE
    Double_t val = p[0] * (1 + p[1] * ::ROOT::Math::legendre(2, x[0]) + p[2] * ::ROOT::Math::legendre(4, x[0]));
    return val;
-}
+#else
+   std::cout << "Mathmore feature of ROOT is missing, " << __PRETTY_FUNCTION__ << " will always return 1!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   return 1.;
 #endif
+}
 
 Double_t TGRSIFunctions::PhotoEfficiency(Double_t* dim, Double_t* par)   // NOLINT(readability-non-const-parameter)
 {


### PR DESCRIPTION
Changed the pre-processor fence to be inside the function (returning a default value and giving an error message when mathmore is missing) instead of suppressing the function completely.