### PR TITLE
Fixing bug in grsiframe

### DIFF
--- a/libraries/TFormat/TGRSIFrame.cxx
+++ b/libraries/TFormat/TGRSIFrame.cxx
@@ -123,8 +123,8 @@ void TGRSIFrame::Run(TRedirect*& redirect)
    TFile outputFile(outputFileName.c_str(), "recreate");
 
    // stop redirect before we start the progress bar (storing the files we redirect stdout and stderr to first)
-   auto* outFile = redirect->OutFile();
-   auto* errFile = redirect->ErrFile();
+   const auto* outFile = redirect->OutFile();
+   const auto* errFile = redirect->ErrFile();
 
    delete redirect;
    // this is needed so the function that created the redirect know it has ended

--- a/util/grsiframe.cxx
+++ b/util/grsiframe.cxx
@@ -64,6 +64,18 @@ int main(int argc, char** argv)
       return 1;
    }
 
+	// read the run info from all input files
+	bool first = true;
+	for(const auto& fileName : opt->RootInputFiles()) {
+		TFile* file = TFile::Open(fileName.c_str());
+		if(first) {
+			first = false;
+			TRunInfo::ReadInfoFromFile(file);
+		} else {
+			TRunInfo::AddCurrent();
+		}
+   }
+
    // determine the name of the helper (from the provided helper library) to create a redirect of stdout
    std::string logFileName = opt->DataFrameLibrary();
    logFileName             = logFileName.substr(logFileName.find_last_of('/') + 1);   // strip everything before the last slash

--- a/util/grsiframe.cxx
+++ b/util/grsiframe.cxx
@@ -64,16 +64,16 @@ int main(int argc, char** argv)
       return 1;
    }
 
-	// read the run info from all input files
-	bool first = true;
-	for(const auto& fileName : opt->RootInputFiles()) {
-		TFile* file = TFile::Open(fileName.c_str());
-		if(first) {
-			first = false;
-			TRunInfo::ReadInfoFromFile(file);
-		} else {
-			TRunInfo::AddCurrent();
-		}
+   // read the run info from all input files
+   bool first = true;
+   for(const auto& fileName : opt->RootInputFiles()) {
+      TFile* file = TFile::Open(fileName.c_str());
+      if(first) {
+         first = false;
+         TRunInfo::ReadInfoFromFile(file);
+      } else {
+         TRunInfo::AddCurrent();
+      }
    }
 
    // determine the name of the helper (from the provided helper library) to create a redirect of stdout


### PR DESCRIPTION
With the new creation of a log-file, we need to read the run info from all input files before we try and open the log-file.