### PR TITLE
Defining global enum for verbosity level

### DIFF
--- a/include/GH1D.h
+++ b/include/GH1D.h
@@ -8,6 +8,7 @@
 #include "TList.h"
 #include "TBox.h"
 
+#include "Globals.h"
 #include "GH2I.h"
 
 class TF1;
@@ -80,8 +81,8 @@ public:
    void PrintRegions();
    void DrawRegions(Option_t* opt = "");
 
-   static void VerboseLevel(int level) { fVerboseLevel = level; }
-   static int  VerboseLevel() { return fVerboseLevel; }
+   static void       VerboseLevel(EVerbosity level) { fVerboseLevel = level; }
+   static EVerbosity VerboseLevel() { return fVerboseLevel; }
 
 private:
    void RemoveCurrentRegion();
@@ -100,7 +101,7 @@ private:
    size_t             fNofRegions{0};                                     //!<! counts number of regions in this histogram, only used to set the color of the region
    TList              fRegions;
 
-   static int fVerboseLevel;   //!<! level of verbosity
+   static EVerbosity fVerboseLevel;   //!<! level of verbosity
 
    /// /cond CLASSIMP
    ClassDefOverride(GH1D, 1)   // NOLINT(readability-else-after-return)

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -141,11 +141,11 @@ inline std::string hex(T val, int width = -1)
 }
 
 enum EVerbosity : int {
-	kQuiet,
-	kBasic,
-	kSubroutines,
-	kLoops,
-	kAll
+   kQuiet       = 0,
+   kBasic       = 1,
+   kSubroutines = 2,
+   kLoops       = 3,
+   kAll         = 4
 };
 
 static inline std::string getexepath()

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -140,6 +140,14 @@ inline std::string hex(T val, int width = -1)
    return str.str();
 }
 
+enum EVerbosity : int {
+	kQuiet,
+	kBasic,
+	kSubroutines,
+	kLoops,
+	kAll
+};
+
 static inline std::string getexepath()
 {
    std::array<char, 1024> result{};

--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -12,6 +12,8 @@
 #include "TLegend.h"
 #include "TQObject.h"
 
+#include "Globals.h"
+
 class TCalibrationGraphSet;
 
 class TCalibrationGraph : public TGraphErrors {
@@ -85,7 +87,7 @@ public:
    void SetMarkerColor(int index, Color_t color)
    {
       /// Set the marker color of the graph and residuals at index
-      if(fVerboseLevel > 3) { std::cout << "setting marker color of graph " << index << " to " << color << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "setting marker color of graph " << index << " to " << color << std::endl; }
       fGraphs[index].SetMarkerColor(color);
       fResidualGraphs[index].SetMarkerColor(color);
    }
@@ -152,8 +154,8 @@ public:
 
    void ResetTotalGraph();   ///< reset the total graph and add the individual ones again (used e.g. after scaling of individual graphs is done)
 
-   static void VerboseLevel(int val) { fVerboseLevel = val; }
-   static int  VerboseLevel() { return fVerboseLevel; }
+   static void       VerboseLevel(EVerbosity val) { fVerboseLevel = val; }
+   static EVerbosity VerboseLevel() { return fVerboseLevel; }
 
    void Clear(Option_t* option = "") override;
 
@@ -173,7 +175,7 @@ private:
    std::string                    fXAxisLabel;                    ///< The label of the x-axis.
    std::string                    fYAxisLabel;                    ///< The label of the y-axis.
 
-   static int fVerboseLevel;   ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
+   static EVerbosity fVerboseLevel;   ///< Changes verbosity
 
    /// \cond CLASSIMP
    ClassDefOverride(TCalibrationGraphSet, 3)   // NOLINT(readability-else-after-return)

--- a/include/TEfficiencyCalibrator.h
+++ b/include/TEfficiencyCalibrator.h
@@ -29,6 +29,7 @@
 #include "TPaveText.h"
 #include "RVersion.h"
 
+#include "Globals.h"
 #include "TNucleus.h"
 #include "TPeakFitter.h"
 #include "TSinglePeak.h"
@@ -281,8 +282,8 @@ public:
    static int LineHeight() { return fLineHeight; }
    static int WindowWidth() { return fWindowWidth; }
 
-   static int  VerboseLevel() { return fVerboseLevel; }
-   static void VerboseLevel(int val) { fVerboseLevel = val; }
+   static EVerbosity VerboseLevel() { return fVerboseLevel; }
+   static void       VerboseLevel(EVerbosity val) { fVerboseLevel = val; }
 
    std::vector<TCalibrationGraphSet*> EfficiencyGraphs() { return fEfficiencyGraph; }
    size_t                             NumberOfEfficiencyGraphs() { return fEfficiencyGraph.size(); }
@@ -298,7 +299,7 @@ private:
    void MakeSecondConnections();
    void DisconnectSecond();
 
-   static int                                             fVerboseLevel;   ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
+   static EVerbosity                                      fVerboseLevel;   ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
    static double                                          fRange;
    static double                                          fThreshold;
    static int                                             fBgParam;                  ///< the bg parameter used to determine the background in the gamma spectra

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -31,6 +31,7 @@
 #include "TNucleus.h"
 #include "TCalibrationGraph.h"
 #include "GH1D.h"
+#include "Globals.h"
 
 class TSourceTab;
 
@@ -170,17 +171,7 @@ private:
 
 class TSourceCalibration : public TGMainFrame {
 public:
-   enum EEntry : int {
-      kStartButton,
-      kSourceBox           = 100,
-      kSigmaEntry          = 200,
-      kThresholdEntry      = 300,
-      kDegreeEntry         = 400,
-      kPeakRatioEntry      = 500,
-      kWriteNonlinearities = 600
-   };
-
-   TSourceCalibration(double sigma, double threshold, int degree, double peakRatio, int count...);
+	TSourceCalibration(double sigma, double threshold, int degree, double peakRatio, int count...);
    TSourceCalibration(const TSourceCalibration&)                = delete;
    TSourceCalibration(TSourceCalibration&&) noexcept            = delete;
    TSourceCalibration& operator=(const TSourceCalibration&)     = delete;
@@ -230,17 +221,50 @@ public:
    void SecondWindow();
    void FinalWindow();
 
-   static void VerboseLevel(int val)
+	static void PanelWidth(int val) { fPanelWidth = val; }
+	static void PanelHeight(int val) { fPanelHeight = val; }
+	static void StatusbarHeight(int val) { fStatusbarHeight = val; }
+
+	static int PanelWidth() { return fPanelWidth; }
+	static int PanelHeight() { return fPanelHeight; }
+	static int StatusbarHeight() { return fStatusbarHeight; }
+
+	// no getters for these as they are only used in this class
+	static void ParameterHeight(int val) { fParameterHeight = val; }
+	static void SourceboxWidth(int val) { fSourceboxWidth = val; }
+	static void DigitWidth(int val) { fDigitWidth = val; }
+
+   static void VerboseLevel(EVerbosity val)
    {
       fVerboseLevel = val;
    }
-   static int VerboseLevel() { return fVerboseLevel; }
+   static EVerbosity VerboseLevel() { return fVerboseLevel; }
 
    static void ZoomX();
 
    void PrintLayout() const;
 
 private:
+	enum EEntry : int {
+      kStartButton,
+      kSourceBox           = 100,
+      kSigmaEntry          = 200,
+      kThresholdEntry      = 300,
+      kDegreeEntry         = 400,
+      kPeakRatioEntry      = 500,
+      kWriteNonlinearities = 600
+   };
+   enum ENavigate : int {
+      kPrevious      = 1,
+      kFindPeaks     = 2,
+      kFindPeaksFast = 3,
+      kCalibrate     = 4,
+      kDiscard       = 5,
+      kAccept        = 6,
+      kAcceptAll     = 7,
+      kNext          = 8
+   };
+
    void BuildFirstInterface();
    void MakeFirstConnections();
    void DisconnectFirst();
@@ -297,7 +321,16 @@ private:
    std::vector<TH2*> fMatrices;
    int               fNofBins{0};   ///< Number of filled bins in first matrix
 
+	// graphic settings
    unsigned int fLineHeight{20};   ///< Height of text boxes and progress bar
+	static int fPanelWidth;         ///< Width of one panel
+	static int fPanelHeight;        ///< Height of one panel
+	static int fStatusbarHeight;    ///< Height of status bar (also extra height needed for tabs)
+	static int fParameterHeight;    ///< Height of the frame for the parameters
+	static int fSourceboxWidth;     ///< Width of the box to select which source each histogram is from
+	static int fDigitWidth;         ///< Number of digits used for parameter entries (if they are floating point)
+
+	int fWaitMs{100};               ///< How many milliseconds we wait before we process the navigation input (to avoid double triggers?)
 
    int fOldErrorLevel;   ///< Used to store old value of gErrorIgnoreLevel (set to kError for the scope of the class)
 
@@ -308,7 +341,7 @@ private:
 
    TFile* fOutput{nullptr};
 
-   static int fVerboseLevel;   ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
+   static EVerbosity fVerboseLevel;   ///< Changes verbosity from 0 (quiet) to 4 (very verbose)
 
    /// \cond CLASSIMP
    ClassDefOverride(TSourceCalibration, 1)   // NOLINT(readability-else-after-return)

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -234,10 +234,7 @@ public:
 	static void SourceboxWidth(int val) { fSourceboxWidth = val; }
 	static void DigitWidth(int val) { fDigitWidth = val; }
 
-   static void VerboseLevel(EVerbosity val)
-   {
-      fVerboseLevel = val;
-   }
+   static void VerboseLevel(EVerbosity val) { fVerboseLevel = val; }
    static EVerbosity VerboseLevel() { return fVerboseLevel; }
 
    static void ZoomX();

--- a/libraries/GROOT/GH1D.cxx
+++ b/libraries/GROOT/GH1D.cxx
@@ -19,7 +19,7 @@
 #include "GH2I.h"
 #include "GH2D.h"
 
-int GH1D::fVerboseLevel = 0;
+EVerbosity GH1D::fVerboseLevel = EVerbosity::kQuiet;
 
 GH1D::GH1D(const TH1& source) : fParent(nullptr), fProjectionAxis(-1)
 {
@@ -257,20 +257,20 @@ void GH1D::HandleMovement(Int_t eventType, Int_t eventX, Int_t eventY, TObject* 
       } else if(eventType == kButton1Down) {
          fStartX = currentX;
          fStartY = currentY;
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             std::cout << "button 1 down at " << currentX << ", " << currentY << std::endl;
          }
       } else if(eventType == kButton1Motion) {
-         if(VerboseLevel() > 2) {
+         if(VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "button 1 motion at " << currentX << ", " << currentY << std::endl;
          }
       } else if(eventType == kButton1Up) {
          region->Update(fStartX, currentX);
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             std::cout << "button 1 up at " << currentX << ", " << currentY << std::endl;
          }
       }
-   } else if(VerboseLevel() > 3) {
+   } else if(VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "nullptr selected at " << currentX << ", " << currentY << std::endl;
    }
 }
@@ -279,7 +279,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
 {
    //auto* tgWindow = gClient->GetWindowById(window);
 
-   if(gPad != fPad && VerboseLevel() < 5) {
+   if(gPad != fPad && VerboseLevel() < EVerbosity::kAll) {
       return;
    }
 
@@ -287,9 +287,9 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
    std::array<char, 2> str;
    gVirtualX->LookupString(event, str.data(), str.size(), keySymbol);
 
-   if((VerboseLevel() > 1 && event->fType != kMotionNotify && event->fType != kLeaveNotify) ||
-      (VerboseLevel() > 2 && event->fState != 0) ||
-      (VerboseLevel() > 3)) {
+   if((VerboseLevel() > EVerbosity::kBasic && event->fType != kMotionNotify && event->fType != kLeaveNotify) ||
+      (VerboseLevel() > EVerbosity::kSubroutines && event->fState != 0) ||
+      (VerboseLevel() > EVerbosity::kLoops)) {
       std::cout << __PRETTY_FUNCTION__ << ", event " << event << ", window " << window << ", type " << event->fType << ", code " << event->fCode << ", state " << event->fState << ", x " << event->fX << ", root-x " << event->fXRoot << ", y " << event->fY << ", root-y " << event->fYRoot << ", x/y coordinates: x " << fPad->PixeltoX(event->fX) << ", y " << fPad->PixeltoY(event->fY - fPad->GetWh()) << ", root-x " << fPad->PixeltoX(event->fXRoot) << ", root-y " << fPad->PixeltoY(event->fYRoot - fPad->GetWh()) << ", key symbol " << keySymbol << " = " << hex(keySymbol) << "; fPad " << fPad << " = \"" << fPad->GetName() << "\", gPad " << gPad << " = \"" << gPad->GetName() << "\"" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
 
@@ -335,7 +335,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
          UpdatePad();
          DrawRegions();
          UpdatePad();
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             PrintRegions();
          }
          break;
@@ -345,7 +345,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
          UpdatePad();
          DrawRegions();
          UpdatePad();
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             PrintRegions();
          }
          break;
@@ -353,7 +353,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
          if(fGate || fBackground || fRegion) {
             RemoveCurrentRegion();
          }
-         if(VerboseLevel() > 0) {
+         if(VerboseLevel() > EVerbosity::kQuiet) {
             std::cout << "Escape!" << std::endl;
          }
          break;
@@ -362,7 +362,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
       case kKey_Right:
       case kKey_Down:
          // handle arrow keys
-         if(VerboseLevel() > 0) {
+         if(VerboseLevel() > EVerbosity::kQuiet) {
             std::cout << "Moving histogram" << std::endl;
          }
          Move1DHistogram(keySymbol, this);
@@ -370,7 +370,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
          UpdatePad();
          DrawRegions();
          UpdatePad();
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             PrintRegions();
          }
          break;
@@ -393,7 +393,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
                fCurrentRegion->SetFillColorAlpha(fRegionColor[fNofRegions % fRegionColor.size()], 0.2);
             }
             fCurrentRegion->Draw();
-            if(VerboseLevel() > 1) {
+            if(VerboseLevel() > EVerbosity::kBasic) {
                PrintRegions();
             }
          }
@@ -409,11 +409,11 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
             if(event->fCode == 4) {
                factor = 1.10;
             }
-            if(VerboseLevel() > 0) {
+            if(VerboseLevel() > EVerbosity::kQuiet) {
                std::cout << "factor " << factor << ": maximum " << GetMinimum() + (GetMaximum() - GetMinimum()) * factor << ", old range " << (GetMaximum() - GetMinimum()) << " = " << GetMaximum() << " - " << GetMinimum() << std::endl;
             }
             SetMaximum(GetMinimum() + (GetMaximum() - GetMinimum()) * factor);
-            if(VerboseLevel() > 0) {
+            if(VerboseLevel() > EVerbosity::kQuiet) {
                std::cout << "new range: " << (GetMaximum() - GetMinimum()) << " = " << GetMaximum() << " - " << GetMinimum() << std::endl;
             }
          } else if(event->fState == 1) {
@@ -427,7 +427,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
          UpdatePad();
          DrawRegions();
          UpdatePad();
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             PrintRegions();
          }
          break;
@@ -439,14 +439,14 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
       if(event->fState == 256 && (fGate || fBackground || fRegion)) {
          double currentX = fPad->PixeltoX(event->fX);
          double currentY = fPad->PixeltoY(event->fY - fPad->GetWh());
-         if(VerboseLevel() > 0) {
+         if(VerboseLevel() > EVerbosity::kQuiet) {
             std::cout << "current box: " << fStartX << " - " << fStartY << ", " << currentX << " - " << currentY << ", canvas: " << fPad->PixeltoX(fPad->GetCanvas()->GetEventX()) << " - " << fPad->PixeltoY(fPad->GetCanvas()->GetEventY()) << std::endl;
          }
          fCurrentRegion->SetX2(currentX);
          fCurrentRegion->SetY2(currentY);
          fCurrentRegion->Draw();
          UpdatePad();
-         if(VerboseLevel() > 1) {
+         if(VerboseLevel() > EVerbosity::kBasic) {
             PrintRegions();
          }
       }
@@ -458,16 +458,16 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
                // check whether we are in the frame or not
                double currentX = fPad->PixeltoX(event->fX);
                double currentY = fPad->PixeltoY(event->fY - fPad->GetWh());
-               if(VerboseLevel() > 1) { std::cout << "current x " << currentX << ", current y " << currentY << std::endl; }
+               if(VerboseLevel() > EVerbosity::kBasic) { std::cout << "current x " << currentX << ", current y " << currentY << std::endl; }
                if(Pad()->GetFrame()->GetX1() < currentX && currentX < Pad()->GetFrame()->GetX2() &&
                   Pad()->GetFrame()->GetY1() < currentY && currentY < Pad()->GetFrame()->GetY2()) {
-                  if(VerboseLevel() > 0) {
+                  if(VerboseLevel() > EVerbosity::kQuiet) {
                      std::cout << "inside frame" << std::endl;
                   }
                } else {
                   // not a new gate, background, or region, and we're outside the frame => we just zoomed in on the x-axis
                   GetYaxis()->UnZoom();
-                  if(VerboseLevel() > 0) {
+                  if(VerboseLevel() > EVerbosity::kQuiet) {
                      std::cout << "outside frame" << std::endl;
                   }
                }
@@ -475,7 +475,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
                UpdatePad();
                DrawRegions();
                UpdatePad();
-               if(VerboseLevel() > 1) {
+               if(VerboseLevel() > EVerbosity::kBasic) {
                   PrintRegions();
                }
             } else {
@@ -484,19 +484,19 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
                fCurrentRegion->SetX2(stopX);
                fCurrentRegion->SetY2(stopY);
                if(fGate) {
-                  if(VerboseLevel() > 0) {
+                  if(VerboseLevel() > EVerbosity::kQuiet) {
                      std::cout << "new gate: " << fStartX << " - " << stopX << std::endl;
                   }
                   fRegions.Add(new TRegion(fCurrentRegion, ERegionType::kGate, this));
                   fGate = false;
                } else if(fBackground) {
-                  if(VerboseLevel() > 0) {
+                  if(VerboseLevel() > EVerbosity::kQuiet) {
                      std::cout << "new background: " << fStartX << " - " << stopX << std::endl;
                   }
                   fRegions.Add(new TRegion(fCurrentRegion, ERegionType::kBackground, this));
                   fBackground = false;
                } else if(fRegion) {
-                  if(VerboseLevel() > 0) {
+                  if(VerboseLevel() > EVerbosity::kQuiet) {
                      std::cout << "new region: " << fStartX << " - " << stopX << std::endl;
                   }
                   fRegions.Add(new TRegion(fCurrentRegion, ERegionType::kRegion, this));
@@ -505,7 +505,7 @@ void GH1D::HandleEvent(Event_t* event, Window_t window)
                }
                RemoveCurrentRegion();
                static_cast<TRegion*>(fRegions.Last())->Draw();
-               if(VerboseLevel() > 1) {
+               if(VerboseLevel() > EVerbosity::kBasic) {
                   PrintRegions();
                }
             }
@@ -586,7 +586,7 @@ bool TRegion::Update()
    bool result = true;
 
    auto* frame = fParent->Pad()->GetFrame();
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "Frame: " << frame->GetX1() << " - " << frame->GetX2() << ", " << frame->GetY1() << " - " << frame->GetY2() << " -> updating y-range from " << GetY1() << " - " << GetY2();
    }
    if(fParent->Pad()->GetLogy() == 0) {
@@ -598,16 +598,16 @@ bool TRegion::Update()
       SetY1(TMath::Power(10., frame->GetY1()));
       SetY2(TMath::Power(10., frame->GetY2()));
    }
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << " to " << GetY1() << " - " << GetY2() << std::endl;
    }
 
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "Updating x-range from " << GetX1() << " - " << GetX2() << " (" << fLowX << " - " << fHighX << ")";
    }
    if(frame->GetX1() < fLowX && fHighX < frame->GetX2()) {
       // whole region is visible -> use original range
-      if(GH1D::VerboseLevel() > 1) {
+      if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " (whole region)";
       }
       SetX1(fLowX);
@@ -617,33 +617,33 @@ bool TRegion::Update()
       // Using GetUxmin() and GetUxmax() to set range to values outside the pad range and not just the frame range does not work.
       // So we simply hide this region whenever it is outside the frame.
       // This also means we have to actively draw it whenever it is (partly) in frame (in case it was hidden before).
-      if(GH1D::VerboseLevel() > 1) {
+      if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " (out of " << frame->GetX1() << " - " << frame->GetX2() << ")";
       }
       result = false;
    } else if(fHighX < frame->GetX2()) {
       // low part of region is out of frame -> adjust low x
-      if(GH1D::VerboseLevel() > 1) {
+      if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " (high part)";
       }
       SetX1(frame->GetX1());
       SetX2(fHighX);
    } else if(frame->GetX1() < fLowX) {
       // high part of region is out of frame -> adjust high x
-      if(GH1D::VerboseLevel() > 1) {
+      if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " (low part)";
       }
       SetX1(fLowX);
       SetX2(frame->GetX2());
    } else {
       // region is larger than visible range on both side -> adjust both
-      if(GH1D::VerboseLevel() > 1) {
+      if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " (region too big)";
       }
       SetX1(frame->GetX1());
       SetX2(frame->GetX2());
    }
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << " to " << GetX1() << " - " << GetX2() << std::endl;
    }
 
@@ -662,7 +662,7 @@ void TRegion::Draw(Option_t* opt)
    if(Update()) {
       if(fParent->Pad()->GetListOfPrimitives()->FindObject(this) == nullptr) {
          TBox::Draw(opt);
-      } else if(GH1D::VerboseLevel() > 0) {
+      } else if(GH1D::VerboseLevel() > EVerbosity::kQuiet) {
          std::cout << this << " region " << fLowX << " - " << fHighX << " already has been drawn" << std::endl;
       }
    } else {
@@ -679,7 +679,7 @@ void TRegion::Hide()
    }
 
    fParent->Pad()->GetListOfPrimitives()->Remove(this);
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "hid region " << fLowX << " - " << fHighX << std::endl;
       fParent->PrintRegions();
    }
@@ -688,7 +688,7 @@ void TRegion::Hide()
 void TRegion::Update(double startX, double stopX)
 {
    /// Depending on the starting position this function updates the left or right edge of the region to the stopping position.
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "region " << fLowX << " - " << fHighX << ", start x " << startX << ", stop x " << stopX;
    }
    if(std::abs(startX - fLowX) < std::abs(startX - fHighX)) {
@@ -696,7 +696,7 @@ void TRegion::Update(double startX, double stopX)
    } else {
       fHighX = stopX;
    }
-   if(GH1D::VerboseLevel() > 1) {
+   if(GH1D::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << " => " << fLowX << " - " << fHighX << std::endl;
    }
    Update();

--- a/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyCalibrator.cxx
@@ -21,7 +21,7 @@ TEfficiencyTab::TEfficiencyTab(TEfficiencyDatatypeTab* parent, TNucleus* nucleus
      fSingles(std::get<0>(hists)), fSummingOut(std::get<1>(hists)), fSummingIn(std::get<2>(hists))
 // name *180Corr                 // name *Sum180Corr
 {
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Assigned singles, summing out, and summing in histograms (" << fSingles->GetName() << ", " << fSummingOut->GetName() << ", " << fSummingIn->GetName() << ")" << std::endl;
    }
    BuildInterface();
@@ -47,33 +47,33 @@ void TEfficiencyTab::BuildInterface()
    fStatusBar->SetParts(parts.data(), parts.size());
 
    fFrame->AddFrame(fStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) { std::cout << "Done with " << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Done with " << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TEfficiencyTab::FindPeaks()
 {
    /// Find and fit the peaks in the singles histogram, then checks for each peak how much summing in and summing out happens.
 
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       std::cout << "Using parent " << fParent << " and transition list " << fNucleus->GetTransitionListByEnergy() << std::endl;
       fNucleus->GetTransitionListByEnergy()->Print();
       std::cout << "Using parent " << fParent << std::flush << ", trying to get peak type " << TEfficiencyCalibrator::PeakType() << std::endl;
    }
    fProjectionCanvas->GetCanvas()->cd();
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "Got peak type " << TEfficiencyCalibrator::PeakType() << ", getting projection from " << fSummingOut->GetName() << std::endl;
    }
    fSummingOutTotalProj = fSummingOut->ProjectionY();
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Writing '" << fSummingOutTotalProj->GetName() << "' to '" << gDirectory->GetName() << "'" << std::endl;
    }
    fSummingOutTotalProj->Write(nullptr, TObject::kOverwrite);
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "Got projection " << fSummingOutTotalProj << ", getting background from " << fSummingOutTotalProj->GetName() << std::endl;
    }
    fSummingOutTotalProjBg = fSummingOutTotalProj->ShowBackground(TEfficiencyCalibrator::BgParam());
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Writing '" << fSummingOutTotalProjBg->GetName() << "' to '" << gDirectory->GetName() << "'" << std::endl;
    }
    fSummingOutTotalProjBg->Write(nullptr, TObject::kOverwrite);
@@ -89,7 +89,7 @@ void TEfficiencyTab::FindPeaks()
          std::cout << "Skipping peak at " << energy << " keV of " << fNucleus->GetA() << fNucleus->GetSymbol() << ", maximum range of histogram is " << fSingles->GetXaxis()->GetXmax() << std::endl;
          continue;
       }
-      if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
          std::cout << "Fitting peak at " << energy << " keV, using range " << energy - TEfficiencyCalibrator::Range() << ", " << energy + TEfficiencyCalibrator::Range() << " peak type " << TEfficiencyCalibrator::PeakType() << " singles histogram " << fSingles->GetName() << std::endl;
       }
       fPeakFitter.RemoveAllPeaks();
@@ -102,7 +102,7 @@ void TEfficiencyTab::FindPeaks()
          auto* transition2 = static_cast<TTransition*>(fNucleus->GetTransitionListByEnergy()->At(t2));
          auto  energy2     = transition2->GetEnergy();
          if(lastEnergy + TEfficiencyCalibrator::Range() > energy2 - TEfficiencyCalibrator::Range()) {
-            if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+            if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << t << ". peak: Found " << peaks.size() << ". overlapping peak for " << lastEnergy << ", and " << energy2 << " with range " << TEfficiencyCalibrator::Range() << std::endl;
             }
             // peak ranges overlap, so we add this peak to the fit, skip it in the main loop, and update lastEnergy to refer to it instead
@@ -111,7 +111,7 @@ void TEfficiencyTab::FindPeaks()
             lastEnergy = energy2;
          } else {
             // list of transitions is sorted by energy, so all others will be outside the range as well
-            if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+            if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << t << ". peak: Found " << peaks.size() << ". overlapping peaks, stopping here with " << lastEnergy << ", and " << energy2 << " with range " << TEfficiencyCalibrator::Range() << std::endl;
             }
             break;
@@ -127,19 +127,19 @@ void TEfficiencyTab::FindPeaks()
       fPeakFitter.PrintParameters();
       fPeakFitter.Fit(fSingles, "retryfit");
       for(auto& peak : peaks) {
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "================================================================================" << std::endl;
             std::cout << "Got centroid " << peak->Centroid() << " +- " << peak->CentroidErr() << " (" << 100 * peak->CentroidErr() / peak->Centroid() << " %), area " << peak->Area() << " +- " << peak->AreaErr() << " (" << 100 * peak->AreaErr() / peak->Area() << " %), FWHM " << peak->FWHM() << ", red. chi sq. " << peak->GetReducedChi2() << std::endl;
          }
          if(peak->Area() < TEfficiencyCalibrator::Threshold() || peak->CentroidErr() > peak->Centroid() || peak->AreaErr() > peak->Area() || std::isnan(peak->Centroid()) || std::isnan(peak->Area()) || std::isnan(peak->CentroidErr()) || std::isnan(peak->AreaErr())) {
-            if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+            if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << "Skipping peak at " << energy << " keV with centroid " << peak->Centroid() << " +- " << peak->CentroidErr() << " (" << 100 * peak->CentroidErr() / peak->Centroid() << " %), FWHM " << peak->FWHM() << ", and area " << peak->Area() << " +- " << peak->AreaErr() << " (" << 100 * peak->AreaErr() / peak->Area() << " %)" << std::endl;
                std::cout << "================================================================================" << std::endl;
             }
             fRemovedFitFunctions.push_back(fPeakFitter.GetFitFunction()->Clone(Form("removed_fit_%.1f", peak->Centroid())));
             continue;
          }
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "================================================================================" << std::endl;
          }
          // increase number of points of fit function
@@ -148,17 +148,17 @@ void TEfficiencyTab::FindPeaks()
          double fwhm        = peak->FWHM();
          double centroid    = peak->Centroid();
          double centroidErr = peak->CentroidErr();
-         if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
             std::cout << "Got centroid " << centroid << " keV, FWHM " << fwhm << ":" << std::endl;
          }
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Writing '" << Form("%s_%.0fkeV", fSingles->GetName(), centroid) << "' to '" << gDirectory->GetName() << "'" << std::endl;
          }
          fSingles->Write(Form("%s_%.0fkeV", fSingles->GetName(), centroid), TObject::kOverwrite);
          // for summing in we need to estimate the background and subtract that from the integral
          fSummingInProj.push_back(fSummingIn->ProjectionY(Form("%s_%.0f_to_%.0f", fSummingIn->GetName(), centroid - fwhm / 2., centroid + fwhm / 2.), fSummingIn->GetXaxis()->FindBin(centroid - fwhm / 2.), fSummingIn->GetXaxis()->FindBin(centroid + fwhm / 2.)));
          fSummingInProjBg.push_back(fSummingInProj.back()->ShowBackground(TEfficiencyCalibrator::BgParam()));
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Writing '" << Form("%s_%.0fkeV", fSummingInProj.back()->GetName(), centroid) << "' and '" << Form("%s_%.0fkeV", fSummingInProjBg.back()->GetName(), centroid) << "' to '" << gDirectory->GetName() << "'" << std::endl;
          }
          double summingIn = fSummingInProj.back()->Integral() - fSummingInProjBg.back()->Integral();
@@ -168,13 +168,13 @@ void TEfficiencyTab::FindPeaks()
          fSummingOutProj.push_back(fSummingOut->ProjectionY(Form("%s_%.0f_to_%.0f", fSummingOut->GetName(), centroid - fwhm / 2., centroid + fwhm / 2.), fSummingOut->GetXaxis()->FindBin(centroid - fwhm / 2.), fSummingOut->GetXaxis()->FindBin(centroid + fwhm / 2.)));
          double ratio      = fSummingOutTotalProjBg->Integral(fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid - fwhm / 2.), fSummingOutTotalProjBg->GetXaxis()->FindBin(centroid + fwhm / 2.)) / fSummingOutTotalProjBg->Integral();
          double summingOut = fSummingOutProj.back()->Integral() - fSummingOutTotalProj->Integral() * ratio;
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Writing '" << Form("%s_%.0fkeV", fSummingOutProj.back()->GetName(), centroid) << "' to '" << gDirectory->GetName() << "'" << std::endl;
          }
          fSummingOutProj.back()->Write(Form("%s_%.0fkeV", fSummingOutProj.back()->GetName(), centroid), TObject::kOverwrite);
          auto* hist = static_cast<TH1*>(fSummingOutProj.back()->Clone(Form("%s_subtracted_%.0f", fSummingOutProj.back()->GetName(), 1000000 * ratio)));
          hist->Add(fSummingOutTotalProj, -ratio);
-         if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Writing '" << hist->GetName() << "' to '" << gDirectory->GetName() << "'" << std::endl;
          }
          hist->Write(nullptr, TObject::kOverwrite);
@@ -182,7 +182,7 @@ void TEfficiencyTab::FindPeaks()
          double correctedArea = peak->Area() - summingIn + summingOut;
          // uncertainties for summing in and summing out is sqrt(N) (?)
          double correctedAreaErr = TMath::Sqrt(TMath::Power(peak->AreaErr(), 2) + summingIn + summingOut);
-         if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+         if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
             std::cout << "Got summingIn " << summingIn << ", ratio " << ratio << ", summingOut " << summingOut << ", correctedArea " << correctedArea << " +- " << correctedAreaErr << std::endl;
          }
          fPeaks.emplace_back(transition, centroid, centroidErr, correctedArea, correctedAreaErr, peak->Area(), peak->AreaErr(), summingIn, summingOut);
@@ -191,13 +191,13 @@ void TEfficiencyTab::FindPeaks()
    }
 
    Redraw();
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "Unsorted peak vector:";
       for(const auto& peak : fPeaks) { std::cout << " " << std::get<0>(peak)->GetEnergy(); }
       std::cout << std::endl;
    }
    std::sort(fPeaks.begin(), fPeaks.end(), [](const std::tuple<TTransition*, double, double, double, double, double, double, double, double>& lhs, const std::tuple<TTransition*, double, double, double, double, double, double, double, double>& rhs) -> bool { return std::get<0>(lhs)->GetEnergy() < std::get<0>(rhs)->GetEnergy(); });
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "Sorted peak vector:";
       for(auto& peak : fPeaks) { std::cout << " " << std::get<0>(peak)->GetEnergy(); }
       std::cout << std::endl;
@@ -263,17 +263,17 @@ void TEfficiencyTab::Status(Int_t, Int_t px, Int_t py, TObject* selected)
 TEfficiencyDatatypeTab::TEfficiencyDatatypeTab(TEfficiencyCalibrator* parent, std::vector<TNucleus*> nucleus, std::vector<std::tuple<TH1*, TH2*, TH2*>> hists, TGCompositeFrame* frame, const std::string& dataType, TGHProgressBar* progressBar)
    : fFrame(frame), fNucleus(std::move(nucleus)), fParent(parent), fDataType(dataType)
 {
-   if(TEfficiencyCalibrator::VerboseLevel() > 1) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "======================================== creating tab for data type " << dataType << std::endl;
    }
    // create new subdirectory for this tab (and its channel tabs), but store the old directory
    fMainDirectory = gDirectory;
    fSubDirectory  = gDirectory->mkdir(dataType.c_str());
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "switching from gDirectory " << gDirectory->GetName() << " to sub directory " << fSubDirectory;
    }
    fSubDirectory->cd();
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << " = " << fSubDirectory->GetName() << ", main directory is " << fMainDirectory << " = " << (fMainDirectory == nullptr ? "" : fMainDirectory->GetName()) << std::endl;
    }
 
@@ -283,7 +283,7 @@ TEfficiencyDatatypeTab::TEfficiencyDatatypeTab(TEfficiencyCalibrator* parent, st
    fDataTab = new TGTab(fLeftFrame, TEfficiencyCalibrator::WindowWidth() / 2, 500);
    fEfficiencyTab.resize(hists.size(), nullptr);
    for(size_t i = 0; i < hists.size(); ++i) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) { std::cout << i << ": Creating efficiency tab using " << fNucleus[i] << " = " << fNucleus[i]->GetName() << ", " << std::get<0>(hists[i])->GetName() << ", " << std::get<1>(hists[i])->GetName() << ", " << std::get<2>(hists[i])->GetName() << ", " << TEfficiencyCalibrator::Range() << ", " << TEfficiencyCalibrator::Threshold() << ", " << TEfficiencyCalibrator::BgParam() << std::endl; }
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": Creating efficiency tab using " << fNucleus[i] << " = " << fNucleus[i]->GetName() << ", " << std::get<0>(hists[i])->GetName() << ", " << std::get<1>(hists[i])->GetName() << ", " << std::get<2>(hists[i])->GetName() << ", " << TEfficiencyCalibrator::Range() << ", " << TEfficiencyCalibrator::Threshold() << ", " << TEfficiencyCalibrator::BgParam() << std::endl; }
       fEfficiencyTab[i] = new TEfficiencyTab(this, fNucleus[i], hists[i], fDataTab->AddTab(fNucleus[i]->GetName()));
       progressBar->Increment(1);
    }
@@ -365,14 +365,14 @@ TEfficiencyDatatypeTab::TEfficiencyDatatypeTab(TEfficiencyCalibrator* parent, st
    fFrame->AddFrame(fRightFrame, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandY, 2, 2, 2, 2));
 
    DrawGraph();
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "switching from sub directory " << gDirectory->GetName() << " to main directory " << fMainDirectory;
    }
    fMainDirectory->cd();
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << " = " << fMainDirectory->GetName() << ", sub directory is " << fSubDirectory << " = " << (fSubDirectory == nullptr ? "" : fSubDirectory->GetName()) << std::endl;
    }
-   if(TEfficiencyCalibrator::VerboseLevel() > 1) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "======================================== done creating tab for data type " << dataType << std::endl;
    }
 }
@@ -434,7 +434,7 @@ void TEfficiencyDatatypeTab::DrawGraph()
    bool firstPlot = true;
    int  color     = 1;
    if(fPlotEfficiencyCheck->IsDown()) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << "Drawing efficiency graph " << fEfficiencyGraph << ":" << std::endl;
          fEfficiencyGraph->Print("e");
       }
@@ -445,7 +445,7 @@ void TEfficiencyDatatypeTab::DrawGraph()
       firstPlot = false;
    }
    if(fPlotUncorrEfficiencyCheck->IsDown()) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << "Drawing uncorrected efficiency graph " << fUncorrEfficiencyGraph << ":" << std::endl;
          fUncorrEfficiencyGraph->Print("e");
       }
@@ -460,7 +460,7 @@ void TEfficiencyDatatypeTab::DrawGraph()
       firstPlot = false;
    }
    if(fPlotPeakAreaCheck->IsDown()) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          fPeakAreaGraph->Print("");
       }
       for(size_t g = 0; g < fPeakAreaGraph->NumberOfGraphs(); ++g) {
@@ -474,7 +474,7 @@ void TEfficiencyDatatypeTab::DrawGraph()
       firstPlot = false;
    }
    if(fPlotSummingInCheck->IsDown()) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          fSummingInGraph->Print("");
       }
       for(size_t g = 0; g < fSummingInGraph->NumberOfGraphs(); ++g) {
@@ -488,7 +488,7 @@ void TEfficiencyDatatypeTab::DrawGraph()
       firstPlot = false;
    }
    if(fPlotSummingInCheck->IsDown()) {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          fSummingOutGraph->Print("");
       }
       for(size_t g = 0; g < fSummingOutGraph->NumberOfGraphs(); ++g) {
@@ -511,18 +511,18 @@ void TEfficiencyDatatypeTab::UpdateEfficiencyGraph()
       std::cout << "No main directory open (" << fMainDirectory << "), sub directory is " << fSubDirectory << ", gDirectory is " << gDirectory->GetName() << std::endl;
       exit(1);
    }
-   if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << __PRETTY_FUNCTION__ << ": switching from gDirectory " << gDirectory->GetName() << " to main directory " << fMainDirectory << " = " << fMainDirectory->GetName() << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    fMainDirectory->cd();
    if(fSubDirectory == nullptr) {
       std::cout << "No subdirectory open (" << fSubDirectory << "), main directory is " << fMainDirectory << ", gDirectory is " << gDirectory->GetName() << std::endl;
    } else {
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << __PRETTY_FUNCTION__ << ": switching from gDirectory " << gDirectory->GetName() << " to sub directory " << fSubDirectory;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       }
       fSubDirectory->cd();
-      if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+      if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << " = " << fSubDirectory->GetName() << ", main directory is " << fMainDirectory << " = " << (fMainDirectory == nullptr ? "" : fMainDirectory->GetName()) << std::endl;
       }
    }
@@ -536,7 +536,6 @@ void TEfficiencyDatatypeTab::UpdateEfficiencyGraph()
    fSummingInGraph = new TCalibrationGraphSet();
    delete fSummingOutGraph;
    fSummingOutGraph = new TCalibrationGraphSet();
-   TCalibrationGraphSet::VerboseLevel(TEfficiencyCalibrator::VerboseLevel());
 
    for(auto& tab : fEfficiencyTab) {
       // vector of tuple with transition and 8 doubles:
@@ -576,7 +575,7 @@ void TEfficiencyDatatypeTab::UpdateEfficiencyGraph()
             summingInVec.push_back(summingIn);
             summingOutVec.push_back(summingOut);
             ++goodPeaks;
-         } else if(TEfficiencyCalibrator::VerboseLevel() > 2) {
+         } else if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Rejecting centroid " << centroid << " +- " << centroidErr << " with area " << correctedArea << " +- " << correctedAreaErr << " for transition at " << transition->GetEnergy() << " +- " << transition->GetEnergyUncertainty() << " using calibration uncertainty " << TEfficiencyCalibrator::CalibrationUncertainty() << " (" << std::abs(transition->GetEnergy() - centroid) << " >= " << transition->GetEnergyUncertainty() + centroidErr + TEfficiencyCalibrator::CalibrationUncertainty() << ")" << std::endl;
          }
       }
@@ -611,7 +610,7 @@ void TEfficiencyDatatypeTab::UpdatePeakType()
    if(fPeakTypeBox == nullptr) {
       throw std::runtime_error("Failed to find peak type box, but got a signal it was selected?");
    }
-   if(TEfficiencyCalibrator::VerboseLevel() > 3) {
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << "peak type box " << fPeakTypeBox << std::flush << ", getting selected " << fPeakTypeBox->GetSelected() << std::endl;
    }
 
@@ -680,7 +679,7 @@ void TEfficiencyDatatypeTab::FitEfficiency()
 void TEfficiencyDatatypeTab::FittingControl(Int_t id)
 {
    int currentTabId = fDataTab->GetCurrent();
-   if(TEfficiencyCalibrator::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << ": id " << id << ", current tab id " << currentTabId << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TEfficiencyCalibrator::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": id " << id << ", current tab id " << currentTabId << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    ReadValues();
    switch(id) {
    case 1:   // re-fit
@@ -708,7 +707,7 @@ void TEfficiencyDatatypeTab::ReadValues()
 }
 
 //////////////////////////////////////// TEfficiencyCalibrator ////////////////////////////////////////
-int TEfficiencyCalibrator::fVerboseLevel = 0;
+EVerbosity TEfficiencyCalibrator::fVerboseLevel = EVerbosity::kQuiet;
 
 double                    TEfficiencyCalibrator::fRange                  = 20.;
 double                    TEfficiencyCalibrator::fThreshold              = 100.;
@@ -745,7 +744,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
          continue;
       }
       bool goodFile = false;
-      if(fVerboseLevel > 0) {
+      if(fVerboseLevel > EVerbosity::kQuiet) {
          std::cout << "Checking file \"" << name << "\":";
       }
       if(fFiles.back()->FindKey("griffinE") != nullptr) {
@@ -755,7 +754,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinE180Corr")),
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESum180Corr"))));
          goodFile = true;
-         if(fVerboseLevel > 0) {
+         if(fVerboseLevel > EVerbosity::kQuiet) {
             std::cout << " found unsuppressed singles";
          }
       }
@@ -766,7 +765,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEMixed180Corr")),
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESuppSum180Corr"))));
          goodFile = true;
-         if(fVerboseLevel > 0) {
+         if(fVerboseLevel > EVerbosity::kQuiet) {
             std::cout << " found suppressed singles";
          }
       }
@@ -777,7 +776,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEAddback180Corr")),
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEAddbackSum180Corr"))));
          goodFile = true;
-         if(fVerboseLevel > 0) {
+         if(fVerboseLevel > EVerbosity::kQuiet) {
             std::cout << " found unsuppressed addback";
          }
       }
@@ -788,11 +787,11 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinEMixedAddback180Corr")),
             static_cast<TH2*>(fFiles.back()->Get("griffinGriffinESuppAddbackSum180Corr"))));
          goodFile = true;
-         if(fVerboseLevel > 0) {
+         if(fVerboseLevel > EVerbosity::kQuiet) {
             std::cout << " found suppressed addback";
          }
       }
-      if(fVerboseLevel > 0) {
+      if(fVerboseLevel > EVerbosity::kQuiet) {
          std::cout << ": got " << fFiles.size() << " files, " << fHistograms[0].size() << " unsuppressed singles, " << fHistograms[1].size() << " suppressed singles, " << fHistograms[2].size() << " unsuppressed addback, " << fHistograms[3].size() << " suppressed addback" << std::endl;
       }
       if(!goodFile) {
@@ -824,7 +823,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
    auto type = fDataType.begin();
    for(auto it = fHistograms.begin(); it != fHistograms.end();) {
       if(it->size() != fFiles.size()) {
-         if(fVerboseLevel > 1) {
+         if(fVerboseLevel > EVerbosity::kBasic) {
             std::cout << std::distance(fHistograms.begin(), it) << ": found " << it->size() << " histograms for " << fFiles.size() << " files, removing this type" << std::endl;
          }
          it   = fHistograms.erase(it);
@@ -835,7 +834,7 @@ TEfficiencyCalibrator::TEfficiencyCalibrator(int n...)
       }
    }
 
-   if(fVerboseLevel > 0) {
+   if(fVerboseLevel > EVerbosity::kQuiet) {
       std::cout << "Read " << fFiles.size() << " files, got";
       for(auto& vec : fHistograms) {
          std::cout << " " << vec.size();
@@ -903,19 +902,19 @@ void TEfficiencyCalibrator::BuildFirstInterface()
    /// Build initial interface with histogram <-> source assignment
 
    auto* layoutManager = new TGTableLayout(this, fFiles.size() + 1, 2, true, 5);
-   if(fVerboseLevel > 1) { std::cout << "created table layout manager with 2 columns, " << fFiles.size() + 1 << " rows" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "created table layout manager with 2 columns, " << fFiles.size() + 1 << " rows" << std::endl; }
    SetLayoutManager(layoutManager);
 
    // The matrices and source selection boxes
    size_t i = 0;
    for(i = 0; i < fFiles.size(); ++i) {
       fSourceLabel.push_back(new TGLabel(this, fFiles[i]->GetName()));
-      if(fVerboseLevel > 2) { std::cout << "Text height " << fSourceLabel.back()->GetFont()->TextHeight() << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fSourceLabel.back()->GetFont()->TextHeight() << std::endl; }
       fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
       if(fSources[i] != nullptr) {
          fSourceBox.back()->AddEntry(fSources[i]->GetName(), i);
          fSourceBox.back()->Select(0);
-         if(fVerboseLevel > 2) { std::cout << "Found source, setting entry to " << fSources[i]->GetName() << " and selecting " << fSourceBox.back()->GetSelected() << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Found source, setting entry to " << fSources[i]->GetName() << " and selecting " << fSourceBox.back()->GetSelected() << std::endl; }
       } else {
          fSourceBox.back()->AddEntry("22Na", k22Na);
          fSourceBox.back()->AddEntry("56Co", k56Co);
@@ -923,19 +922,19 @@ void TEfficiencyCalibrator::BuildFirstInterface()
          fSourceBox.back()->AddEntry("133Ba", k133Ba);
          fSourceBox.back()->AddEntry("152Eu", k152Eu);
          fSourceBox.back()->AddEntry("241Am", k241Am);
-         if(fVerboseLevel > 2) { std::cout << "Didn't find source, created source box with " << fSourceBox.back()->GetNumberOfEntries() << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Didn't find source, created source box with " << fSourceBox.back()->GetNumberOfEntries() << std::endl; }
       }
       fSourceBox.back()->SetMinHeight(200);
       fSourceBox.back()->Resize(100, LineHeight());
-      if(fVerboseLevel > 2) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
       AddFrame(fSourceLabel.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
       AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
    }
 
    // The buttons
-   if(fVerboseLevel > 1) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
    fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
-   if(fVerboseLevel > 1) { std::cout << "start button " << fStartButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "start button " << fStartButton << std::endl; }
    AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
    Layout();
 }
@@ -967,13 +966,13 @@ void TEfficiencyCalibrator::DeleteFirst()
 
    fSourceBox.clear();
    DeleteElement(fStartButton);
-   if(fVerboseLevel > 2) { std::cout << "Deleted start button " << fStartButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
 }
 
 void TEfficiencyCalibrator::SetSource(Int_t windowId, Int_t entryId)
 {
    int index = windowId - kSourceBox;
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    TNucleus* nucleus = fSources[index];
    delete nucleus;
    nucleus         = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
@@ -982,7 +981,7 @@ void TEfficiencyCalibrator::SetSource(Int_t windowId, Int_t entryId)
 
 void TEfficiencyCalibrator::Start()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fEmitter == nullptr) {                                                                                                                    // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
       fEmitter = fStartButton;
       TTimer::SingleShot(100, "TEfficiencyCalibrator", this, "HandleTimer()");
@@ -991,7 +990,7 @@ void TEfficiencyCalibrator::Start()
 
 void TEfficiencyCalibrator::HandleTimer()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fEmitter == fStartButton) {
       // disconnect signals of first screen and remove all elements
       DisconnectFirst();
@@ -1004,14 +1003,14 @@ void TEfficiencyCalibrator::HandleTimer()
 
 void TEfficiencyCalibrator::SecondWindow()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    // check that all sources have been set
    for(size_t i = 0; i < fSources.size(); ++i) {
       if(fSources[i] == nullptr) {
          std::cerr << "Source " << i << " not set!" << std::endl;
          return;
       }
-      if(fVerboseLevel > 0) {
+      if(fVerboseLevel > EVerbosity::kQuiet) {
          std::cout << i << " - source " << fSources[i] << " = " << fSources[i]->GetName() << std::endl;
       }
    }
@@ -1036,7 +1035,7 @@ void TEfficiencyCalibrator::SecondWindow()
    nofHistograms *= 3;   // there are three histograms for each data type/source combo
    fProgressBar->SetRange(0., static_cast<Float_t>(nofHistograms));
    fProgressBar->Percent(true);
-   if(fVerboseLevel > 2) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fFiles.size() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fFiles.size() << std::endl; }
    AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
    // Map all subwindows of main frame
@@ -1049,7 +1048,7 @@ void TEfficiencyCalibrator::SecondWindow()
    MapWindow();
 
    // create second screen and its connections
-   if(fVerboseLevel > 2) { std::cout << "Starting to build second interface:" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Starting to build second interface:" << std::endl; }
    BuildSecondInterface();
    MakeSecondConnections();
 
@@ -1064,7 +1063,7 @@ void TEfficiencyCalibrator::SecondWindow()
 
    // Map main frame
    MapWindow();
-   if(fVerboseLevel > 2) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TEfficiencyCalibrator::BuildSecondInterface()
@@ -1075,9 +1074,9 @@ void TEfficiencyCalibrator::BuildSecondInterface()
    fDatatypeTab = new TGTab(this, WindowWidth(), WindowWidth() / 2);
    fEfficiencyDatatypeTab.resize(fHistograms.size());
    fEfficiencyGraph.resize(fHistograms.size());
-   if(fVerboseLevel > 2) { std::cout << __PRETTY_FUNCTION__ << " creating " << fHistograms.size() << " tabs" << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << " creating " << fHistograms.size() << " tabs" << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    for(size_t i = 0; i < fHistograms.size(); ++i) {
-      if(fVerboseLevel > 2) { std::cout << i << ": Creating efficiency source tab using " << fHistograms[i].size() << " histograms, and " << fSources.size() << " sources, " << fRange << ", " << fThreshold << ", " << fProgressBar << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": Creating efficiency source tab using " << fHistograms[i].size() << " histograms, and " << fSources.size() << " sources, " << fRange << ", " << fThreshold << ", " << fProgressBar << std::endl; }
       auto* frame = fDatatypeTab->AddTab(fDataType[i].c_str());
       std::replace(fDataType[i].begin(), fDataType[i].end(), ' ', '_');
       fEfficiencyDatatypeTab[i] = new TEfficiencyDatatypeTab(this, fSources, fHistograms[i], frame, fDataType[i], fProgressBar);
@@ -1086,12 +1085,12 @@ void TEfficiencyCalibrator::BuildSecondInterface()
    }
    AddFrame(fDatatypeTab, new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 0, 0, 0, 0));
 
-   if(fVerboseLevel > 2) { std::cout << "Second interface done" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Second interface done" << std::endl; }
 }
 
 void TEfficiencyCalibrator::MakeSecondConnections()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    // we don't need to connect the range, threshold, and degree number entries, those are automatically read when we start the calibration
    for(auto* sourceTab : fEfficiencyDatatypeTab) {
       sourceTab->MakeConnections();
@@ -1100,7 +1099,7 @@ void TEfficiencyCalibrator::MakeSecondConnections()
 
 void TEfficiencyCalibrator::DisconnectSecond()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    for(auto* sourceTab : fEfficiencyDatatypeTab) {
       sourceTab->Disconnect();
    }

--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -11,10 +11,10 @@
 
 Int_t TCalibrationGraph::RemovePoint()
 {
-   if(TCalibrationGraphSet::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TCalibrationGraphSet::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
-   if(TCalibrationGraphSet::VerboseLevel() > 1) { std::cout << "px, py " << px << ",  " << py << " on gPad " << gPad->GetName() << std::endl; }
+   if(TCalibrationGraphSet::VerboseLevel() > EVerbosity::kBasic) { std::cout << "px, py " << px << ",  " << py << " on gPad " << gPad->GetName() << std::endl; }
    if(fIsResidual) { return fParent->RemoveResidualPoint(px, py); }
    return fParent->RemovePoint(px, py);
 }
@@ -32,22 +32,22 @@ void TCalibrationGraph::Scale(const double& scale)
 }
 #endif
 
-int TCalibrationGraphSet::fVerboseLevel = 0;
+EVerbosity TCalibrationGraphSet::fVerboseLevel = EVerbosity::kQuiet;
 
 TCalibrationGraphSet::TCalibrationGraphSet(TGraphErrors* graph, const std::string& label)
    : fTotalGraph(new TGraphErrors), fTotalResidualGraph(new TGraphErrors)
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << " fTotalGraph " << fTotalGraph << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " fTotalGraph " << fTotalGraph << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(graph != nullptr) {
       Add(graph, label);
-      if(fVerboseLevel > 1) { Print(); }
+      if(fVerboseLevel > EVerbosity::kBasic) { Print(); }
    }
 }
 
 TCalibrationGraphSet::TCalibrationGraphSet(std::string xAxisLabel, std::string yAxisLabel)
    : fTotalGraph(new TGraphErrors), fTotalResidualGraph(new TGraphErrors), fXAxisLabel(std::move(xAxisLabel)), fYAxisLabel(std::move(yAxisLabel))
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << " fTotalGraph " << fTotalGraph << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " fTotalGraph " << fTotalGraph << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 TCalibrationGraphSet::~TCalibrationGraphSet()
@@ -58,7 +58,7 @@ TCalibrationGraphSet::~TCalibrationGraphSet()
 
 int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
 {
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       std::cout << __PRETTY_FUNCTION__ << ", fTotalGraph " << fTotalGraph << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       Print();
    }
@@ -84,7 +84,7 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
    // create one vector with x, y, ex, ey, index of graph, and index of point that we can use to sort the data
    // TODO: create a (private?) enum to reference to x, y, ex, ey, graph index, and point index
    std::vector<std::tuple<double, double, double, double, size_t, size_t>> data(fTotalGraph->GetN() + graph->GetN());
-   if(fVerboseLevel > 2) { std::cout << "Filling vector of size " << data.size() << " with " << fTotalGraph->GetN() << " and " << graph->GetN() << " entries" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Filling vector of size " << data.size() << " with " << fTotalGraph->GetN() << " and " << graph->GetN() << " entries" << std::endl; }
    for(int i = 0; i < fTotalGraph->GetN(); ++i) {
       data[i] = std::make_tuple(x[i], y[i], ex[i], ey[i], fGraphIndex[i], fPointIndex[i]);
    }
@@ -94,14 +94,14 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
 
    std::sort(data.begin(), data.end());
 
-   if(fVerboseLevel > 2) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
 
    fTotalGraph->Set(static_cast<Int_t>(data.size()));
    fTotalResidualGraph->Set(static_cast<Int_t>(data.size()));
    fGraphIndex.resize(data.size());
    fPointIndex.resize(data.size());
 
-   if(fVerboseLevel > 2) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
    for(size_t i = 0; i < data.size(); ++i) {
       fTotalGraph->SetPoint(static_cast<Int_t>(i), std::get<0>(data[i]), std::get<1>(data[i]));
       fTotalGraph->SetPointError(static_cast<Int_t>(i), std::get<2>(data[i]), std::get<3>(data[i]));
@@ -115,7 +115,7 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
    // doesn't really make sense to calculate the residual here, as we don't have a fit of all the data yet
    fResidualSet = false;
 
-   if(fVerboseLevel > 2) { std::cout << "Adding new calibration graph and label to vectors" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Adding new calibration graph and label to vectors" << std::endl; }
    // add graph and label to our vectors
    fGraphs.emplace_back(this, graph);
    fResidualGraphs.emplace_back(this, 0, true);
@@ -128,7 +128,7 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
    fResidualGraphs.back().SetMarkerColor(static_cast<Color_t>(fResidualGraphs.size()));
    fResidualGraphs.back().SetMarkerStyle(static_cast<Style_t>(fResidualGraphs.size()));
 
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       std::cout << "done" << std::endl;
       Print();
    }
@@ -137,7 +137,7 @@ int TCalibrationGraphSet::Add(TGraphErrors* graph, const std::string& label)
 
 bool TCalibrationGraphSet::SetResidual(const bool& force)
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << " gpad " << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " gpad " << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    TF1* calibration = FitFunction();
    if(calibration != nullptr && (!fResidualSet || force)) {
       double* x  = fTotalGraph->GetX();
@@ -167,14 +167,14 @@ bool TCalibrationGraphSet::SetResidual(const bool& force)
          mother->GetPad(pad)->Modified();
          mother->GetPad(pad)->Update();
          mother->cd(pad);
-         if(fVerboseLevel > 2) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
          pad++;
       }
    } else {
-      if(fVerboseLevel > 2) { std::cout << __PRETTY_FUNCTION__ << ": didn't find calibration (" << calibration << "), or the residual was already set (" << (fResidualSet ? "true" : "false") << ") and we don't force it (" << (force ? "true" : "false") << ")" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": didn't find calibration (" << calibration << "), or the residual was already set (" << (fResidualSet ? "true" : "false") << ") and we don't force it (" << (force ? "true" : "false") << ")" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       if(calibration == nullptr) { fResidualSet = false; }
    }
-   if(fVerboseLevel > 2) { Print(); }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { Print(); }
    return fResidualSet;
 }
 
@@ -207,7 +207,7 @@ void TCalibrationGraphSet::DrawCalibration(Option_t* opt, TLegend* legend)
    }
 
    for(size_t i = 0; i < fGraphs.size(); ++i) {
-      if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << " drawing " << i << ". graph with option \"" << opt << "\", marker color " << fGraphs[i].GetMarkerColor() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " drawing " << i << ". graph with option \"" << opt << "\", marker color " << fGraphs[i].GetMarkerColor() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fGraphs[i].Draw(opt);
       if(legend != nullptr) {
          legend->AddEntry(&(fGraphs[i]), fLabel[i].c_str());
@@ -230,7 +230,7 @@ void TCalibrationGraphSet::DrawResidual(Option_t* opt, TLegend* legend)
    }
 
    for(size_t i = 0; i < fResidualGraphs.size(); ++i) {
-      if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << " drawing " << i << ". residual graph with option \"" << opt << "\", marker color " << fResidualGraphs[i].GetMarkerColor() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " drawing " << i << ". residual graph with option \"" << opt << "\", marker color " << fResidualGraphs[i].GetMarkerColor() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fResidualGraphs[i].Draw(opt);
       if(legend != nullptr) {
          legend->AddEntry(&(fResidualGraphs[i]), fLabel[i].c_str());
@@ -242,7 +242,7 @@ Int_t TCalibrationGraphSet::RemovePoint(const Int_t& px, const Int_t& py)
 {
    /// This function is primarily a copy of TGraph::RemovePoint with some added bits to remove a point that has been selected in the calibration graph from it and the corresponding point from the residual graph and the total graphs
 
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       std::cout << __PRETTY_FUNCTION__ << ": point " << px << ", " << py << "; gPad " << gPad->GetName() << ": " << gPad->AbsPixeltoX(px) << ", " << gPad->AbsPixeltoY(py) << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       Print();
    }
@@ -258,38 +258,38 @@ Int_t TCalibrationGraphSet::RemovePoint(const Int_t& px, const Int_t& py)
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(y[i]));
       // TODO replace 100 with member variable?
       if(dpx * dpx + dpy * dpy < 100) {
-         if(fVerboseLevel > 2) {
+         if(fVerboseLevel > EVerbosity::kSubroutines) {
             std::cout << i << ": dpx = " << dpx << " = " << px << " - " << gPad->XtoAbsPixel(gPad->XtoPad(x[i])) << ", dpy = " << dpy << " = " << py << " - " << gPad->YtoAbsPixel(gPad->YtoPad(y[i])) << " this is the point we're looking for" << std::endl;
          }
          ipoint = i;
          break;
       }
-      if(fVerboseLevel > 2) {
+      if(fVerboseLevel > EVerbosity::kSubroutines) {
          std::cout << i << ": dpx = " << dpx << " = " << px << " - " << gPad->XtoAbsPixel(gPad->XtoPad(x[i])) << ", dpy = " << dpy << " = " << py << " - " << gPad->YtoAbsPixel(gPad->YtoPad(y[i])) << " not the point we're looking for" << std::endl;
       }
    }
    if(ipoint < 0) {
       std::cout << "Failed to find point close to " << px << ", " << py << std::endl;
-      if(fVerboseLevel > 2) {
+      if(fVerboseLevel > EVerbosity::kSubroutines) {
          std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
          Print();
       }
       return ipoint;
    }
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       Print();
    }
    fTotalGraph->RemovePoint(ipoint);
    if(fTotalResidualGraph->RemovePoint(ipoint) < 0) {
       // we failed to remove the point in the residual, so we assume it's out of whack
       fResidualSet = false;
-      if(fVerboseLevel > 2) { std::cout << ipoint << " didn't removed residual point" << std::endl; }
-   } else if(fVerboseLevel > 2) {
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " didn't removed residual point" << std::endl; }
+   } else if(fVerboseLevel > EVerbosity::kSubroutines) {
       std::cout << ipoint << " removed residual point" << std::endl;
    }
    // need to find which of the graphs we have to remove this point from -> use fGraphIndex[ipoint]
    // and also which point this is of the graph -> use fPointIndex[ipoint]
-   if(fVerboseLevel > 2) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
    if(fGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1 || fResidualGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1) {
       std::cout << "point " << ipoint << " out of range?" << std::endl;
    }
@@ -309,12 +309,12 @@ Int_t TCalibrationGraphSet::RemovePoint(const Int_t& px, const Int_t& py)
       mother->GetPad(pad)->Modified();
       mother->GetPad(pad)->Update();
       mother->cd(pad);
-      if(fVerboseLevel > 2) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
       pad++;
    }
-   if(fVerboseLevel > 1) { Print(); }
+   if(fVerboseLevel > EVerbosity::kBasic) { Print(); }
    std::array<Longptr_t, 2> args = {px, py};
-   if(fVerboseLevel > 2) { std::cout << "Emitting RemovePoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemovePoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
    Emit("RemovePoint(Int_t, Int_t)", args.data());
    return ipoint;
 }
@@ -339,14 +339,14 @@ Int_t TCalibrationGraphSet::RemoveResidualPoint(const Int_t& px, const Int_t& py
       }
    }
    if(ipoint < 0) {
-      if(fVerboseLevel > 1) { std::cout << "Failed to find point close to " << px << ", " << py << std::endl; }
-      if(fVerboseLevel > 2) {
+      if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "Failed to find point close to " << px << ", " << py << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) {
          std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
          Print();
       }
       return ipoint;
    }
-   if(fVerboseLevel > 2) {
+   if(fVerboseLevel > EVerbosity::kSubroutines) {
       std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       Print();
    }
@@ -355,7 +355,7 @@ Int_t TCalibrationGraphSet::RemoveResidualPoint(const Int_t& px, const Int_t& py
    // and also which point this is of the graph -> use fPointIndex[ipoint]
    fTotalGraph->RemovePoint(ipoint);
    fTotalResidualGraph->RemovePoint(ipoint);
-   if(fVerboseLevel > 2) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
    if(fGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1 || fResidualGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1) {
       std::cout << "point " << ipoint << " out of range?" << std::endl;
    }
@@ -370,16 +370,16 @@ Int_t TCalibrationGraphSet::RemoveResidualPoint(const Int_t& px, const Int_t& py
       }
    }
    auto* mother = gPad->GetMother();
-   if(fVerboseLevel > 2) { std::cout << "Got mother pad " << mother->GetName() << " from pad " << gPad->GetName() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Got mother pad " << mother->GetName() << " from pad " << gPad->GetName() << std::endl; }
    int pad = 0;
    while(mother->GetPad(pad) != nullptr) {
       mother->GetPad(pad)->Modified();
-      if(fVerboseLevel > 2) { std::cout << "Modified pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
       pad++;
    }
-   if(fVerboseLevel > 1) { Print(); }
+   if(fVerboseLevel > EVerbosity::kBasic) { Print(); }
    std::array<Longptr_t, 2> args = {px, py};
-   if(fVerboseLevel > 2) { std::cout << "Emitting RemoveResidualPoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemoveResidualPoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
    Emit("RemoveResidualPoint(Int_t, Int_t)", args.data());
    return ipoint;
 }
@@ -389,7 +389,7 @@ void TCalibrationGraphSet::Scale(bool useAllPrevious)
    /// Scale all graphs to fit each other (based on the first "previous" graph found or just the first graph).
    /// If no overlap is being found between the graph that is being scaled and the first graph (or all graphs before this one),
    /// the current graph isn't being scaled and we continue with the next graph.
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       Print();
    }
@@ -406,7 +406,7 @@ void TCalibrationGraphSet::Scale(bool useAllPrevious)
       for(g2 = 0; (useAllPrevious ? g2 < g : g2 < 1); ++g2) {
          double minRef = fGraphs[g2].GetX()[0];
          double maxRef = fGraphs[g2].GetX()[fGraphs[g2].GetN() - 1];
-         if(fVerboseLevel > 1) {
+         if(fVerboseLevel > EVerbosity::kBasic) {
             std::cout << "Checking overlap between " << g2 << ". graph (" << fGraphs[g2].GetN() << ": " << minRef << " - " << maxRef << ") and " << g << ". graph (" << graph.GetN() << std::flush << ": " << x[0] << " - " << x[graph.GetN() - 1] << ")" << std::endl;
          }
          if(maxRef < x[0] || x[graph.GetN() - 1] < minRef) {
@@ -421,25 +421,25 @@ void TCalibrationGraphSet::Scale(bool useAllPrevious)
             if(minRef < x[p] && x[p] < maxRef) {
                sum += fGraphs[g2].Eval(x[p]) / y[p];
                ++count;
-               if(fVerboseLevel > 3) { std::cout << g << ", " << p << ": " << count << " - " << sum << ", " << fGraphs[g2].Eval(x[p]) / y[p] << std::endl; }
+               if(fVerboseLevel > EVerbosity::kLoops) { std::cout << g << ", " << p << ": " << count << " - " << sum << ", " << fGraphs[g2].Eval(x[p]) / y[p] << std::endl; }
             }
          }
          sum /= count;
-         if(fVerboseLevel > 2) { std::cout << g << ": scaling with " << sum << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << g << ": scaling with " << sum << std::endl; }
          graph.Scale(sum);
          break;
       }
-      if(g2 == g && fVerboseLevel > 0) {
+      if(g2 == g && fVerboseLevel > EVerbosity::kQuiet) {
          std::cout << "No overlap(s) between 0. to " << g2 - 1 << ". graph and " << g << ". graph (" << graph.GetN() << ": " << x[0] << " - " << x[graph.GetN() - 1] << "), not scaling this one!" << std::endl;
       }
    }
-   if(fVerboseLevel > 1) { Print(); }
+   if(fVerboseLevel > EVerbosity::kBasic) { Print(); }
    ResetTotalGraph();
 }
 
 void TCalibrationGraphSet::ResetTotalGraph()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fGraphs.empty()) {
       std::cerr << "No graphs added yet, makes no sense to reset total graph?" << std::endl;
       return;
@@ -449,7 +449,7 @@ void TCalibrationGraphSet::ResetTotalGraph()
    for(auto& graph : fGraphs) {
       newSize += graph.GetN();
    }
-   if(fVerboseLevel > 2) { std::cout << "creating graph with " << newSize << " points" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "creating graph with " << newSize << " points" << std::endl; }
    // create one vector with x, y, ex, ey, index of graph, and index of point that we can use to sort the data
    std::vector<std::tuple<double, double, double, double, size_t, size_t>> data(newSize);
    size_t                                                                  counter = 0;
@@ -460,21 +460,21 @@ void TCalibrationGraphSet::ResetTotalGraph()
       double* eX = fGraphs[i].GetEX();
       double* eY = fGraphs[i].GetEY();
       for(int p = 0; p < fGraphs[i].GetN(); ++p, ++counter) {
-         if(fVerboseLevel > 3) { std::cout << "filling point " << counter << " of vector of size " << newSize << std::endl; }
+         if(fVerboseLevel > EVerbosity::kLoops) { std::cout << "filling point " << counter << " of vector of size " << newSize << std::endl; }
          data[counter] = std::make_tuple(x[p], y[p], eX[p], eY[p], i, p);
       }
    }
 
    std::sort(data.begin(), data.end());
 
-   if(fVerboseLevel > 2) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
 
    fTotalGraph->Set(data.size());
    fTotalResidualGraph->Set(data.size());
    fGraphIndex.resize(data.size());
    fPointIndex.resize(data.size());
 
-   if(fVerboseLevel > 2) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
    for(size_t i = 0; i < data.size(); ++i) {
       fTotalGraph->SetPoint(i, std::get<0>(data[i]), std::get<1>(data[i]));
       fTotalGraph->SetPointError(i, std::get<2>(data[i]), std::get<3>(data[i]));
@@ -492,7 +492,7 @@ void TCalibrationGraphSet::ResetTotalGraph()
 
 void TCalibrationGraphSet::Print(Option_t* opt) const
 {
-   if(fVerboseLevel > 1) {
+   if(fVerboseLevel > EVerbosity::kBasic) {
       std::cout << __PRETTY_FUNCTION__ << ", fTotalGraph " << fTotalGraph << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
 

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -31,7 +31,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
    /// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
    /// It does so in a brute force fashion where we try all combinations of channels and energies, do a linear fit through them, and keep the one with the best chi square.
 
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << RESET_COLOR << "Matching " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << RESET_COLOR << "Matching " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl; }
 
    std::map<GPeak*, std::tuple<double, double, double, double>> result;
    std::sort(peaks.begin(), peaks.end());
@@ -53,7 +53,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
    std::map<double, double> tmpMap;
 
    for(size_t num_data_points = peakValues.size(); num_data_points > 0; num_data_points--) {
-      if(TSourceCalibration::VerboseLevel() > 2) { std::cout << num_data_points << " data points:" << std::endl; }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << num_data_points << " data points:" << std::endl; }
       double best_chi2 = DBL_MAX;
       int    iteration = 0;
       for(auto peak_values : combinations(peakValues, num_data_points)) {
@@ -65,12 +65,12 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
             if(peakValues.size() > 3) {
                double pratio = peak_values.front() / peak_values.at(peak_values.size() - 2);
                double sratio = source_values.front() / source_values.at(source_values.size() - 2);
-               if(TSourceCalibration::VerboseLevel() > 10) { std::cout << "ratio: " << pratio << " - " << sratio << " = " << std::abs(pratio - sratio) << " "; }
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) { std::cout << "ratio: " << pratio << " - " << sratio << " = " << std::abs(pratio - sratio) << " "; }
                if(std::abs(pratio - sratio) > 0.02) {
-                  if(TSourceCalibration::VerboseLevel() > 10) { std::cout << "skipping" << std::endl; }
+                  if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) { std::cout << "skipping" << std::endl; }
                   continue;
                }
-               if(TSourceCalibration::VerboseLevel() > 10) { std::cout << std::endl; }
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) { std::cout << std::endl; }
             }
 
             fitter.ClearPoints();
@@ -107,7 +107,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
             fitter.Eval();
 
             if(std::abs(fitter.GetParameter(0)) > 10) {
-               if(TSourceCalibration::VerboseLevel() > 3) {
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
                   std::cout << fitter.GetParameter(0) << " too big, clearing map with " << tmpMap.size() << " points: ";
                   for(auto iter : tmpMap) { std::cout << iter.first << " - " << iter.second << "; "; }
                   std::cout << std::endl;
@@ -130,7 +130,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
             //result[*(std::find_if(peaks.begin(),   peaks.end(),   [&iter](std::tuple<double, double, double, double>& item) { return iter.first  == std::get<0>(item); }))] =
             //       *(std::find_if(sources.begin(), sources.end(), [&iter](std::tuple<double, double, double, double>& item) { return iter.second == std::get<0>(item); }));
          }
-         if(TSourceCalibration::VerboseLevel() > 2) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Matched " << num_data_points << " data points from " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl;
             std::cout << "Returning map with " << result.size() << " points: ";
             for(auto iter : result) { std::cout << iter.first->Centroid() << " - " << std::get<0>(iter.second) << "; "; }
@@ -149,8 +149,8 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
    /// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
    /// It does so in slightly smarter way than the brute force method `Match`, by taking the reported intensity of the source peaks into account.
 
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << RESET_COLOR << "\"Smart\" matching " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl; }
-   if(TSourceCalibration::VerboseLevel() > 3) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << RESET_COLOR << "\"Smart\" matching " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
       for(size_t i = 0; i < peaks.size() || i < sources.size(); ++i) {
          std::cout << i << ".: " << std::setw(8);
          if(i < peaks.size()) {
@@ -187,7 +187,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
    std::map<double, double> tmpMap;
 
    for(size_t num_data_points = std::min(peakValues.size(), sourceValues.size()); num_data_points > 0; num_data_points--) {
-      if(TSourceCalibration::VerboseLevel() > 2) { std::cout << num_data_points << " data points:" << std::endl; }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << num_data_points << " data points:" << std::endl; }
       double best_chi2 = DBL_MAX;
       int    iteration = 0;
       for(auto peak_values : combinations(peakValues, num_data_points)) {
@@ -201,7 +201,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
          std::sort(sourceValues.begin(), sourceValues.end());
          sourceValues.push_back(0);
 
-         if(TSourceCalibration::VerboseLevel() > 6) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) {
             for(size_t i = 0; i < peak_values.size(); ++i) {
                std::cout << i << ".: " << std::setw(8) << peak_values[i] << " - " << std::setw(8) << sourceValues[i] << std::endl;
             }
@@ -209,9 +209,9 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
          if(peakValues.size() > 3) {
             double pratio = peak_values.front() / peak_values.at(peak_values.size() - 2);
             double sratio = sourceValues.front() / sourceValues.at(sourceValues.size() - 2);
-            if(TSourceCalibration::VerboseLevel() > 10) { std::cout << "ratio: " << pratio << " - " << sratio << " = " << std::abs(pratio - sratio) << std::endl; }
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) { std::cout << "ratio: " << pratio << " - " << sratio << " = " << std::abs(pratio - sratio) << std::endl; }
             if(std::abs(pratio - sratio) > 0.02) {
-               if(TSourceCalibration::VerboseLevel() > 10) { std::cout << "skipping" << std::endl; }
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) { std::cout << "skipping" << std::endl; }
                continue;
             }
          }
@@ -249,8 +249,8 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
             fitter.Eval();
 
             if(std::abs(fitter.GetParameter(0)) > 10) {
-               if(TSourceCalibration::VerboseLevel() > 3) {
-                  std::cout << fitter.GetParameter(0) << " too big, clearing map with " << tmpMap.size() << " points: ";
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+                  std::cout << fitter.GetParameter(0) << " too big an offset, clearing map with " << tmpMap.size() << " points: ";
                   for(auto iter : tmpMap) { std::cout << iter.first << " - " << iter.second << "; "; }
                   std::cout << std::endl;
                }
@@ -272,7 +272,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
             result[*(std::find_if(peaks.begin(), peaks.end(), [&iter](auto& item) { return iter.first == item->Centroid(); }))] =
                *(std::find_if(sources.begin(), sources.end(), [&iter](auto& item) { return iter.second == std::get<0>(item); }));
          }
-         if(TSourceCalibration::VerboseLevel() > 2) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Smart matched " << num_data_points << " data points from " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl;
             std::cout << "Returning map with " << result.size() << " points: ";
             for(auto iter : result) { std::cout << iter.first->Centroid() << " - " << std::get<0>(iter.second) << "; "; }
@@ -310,7 +310,7 @@ TSourceTab::TSourceTab(TChannelTab* parent, TGCompositeFrame* frame, GH1D* proje
 
 TSourceTab::TSourceTab(const TSourceTab& rhs)
 {
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fParent           = rhs.fParent;
    fSourceFrame      = rhs.fSourceFrame;
    fProjectionCanvas = rhs.fProjectionCanvas;
@@ -338,11 +338,11 @@ TSourceTab::~TSourceTab()
 void TSourceTab::BuildInterface()
 {
    // frame with canvas and status bar
-   fProjectionCanvas = new TRootEmbeddedCanvas(Form("ProjectionCanvas%s", fProjection->GetName()), fSourceFrame, 600, 400);
+   fProjectionCanvas = new TRootEmbeddedCanvas(Form("ProjectionCanvas%s", fProjection->GetName()), fSourceFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
 
    fSourceFrame->AddFrame(fProjectionCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-   fSourceStatusBar         = new TGStatusBar(fSourceFrame, 600, 50);
+   fSourceStatusBar         = new TGStatusBar(fSourceFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
    std::array<int, 3> parts = {35, 50, 15};
    fSourceStatusBar->SetParts(parts.data(), parts.size());
 
@@ -370,18 +370,18 @@ void TSourceTab::ProjectionStatus(Event_t* event)
    // kClientMessage  = 14, kSelectionClear    = 15, kSelectionRequest = 16, kSelectionNotify = 17,
    // kColormapNotify = 18, kButtonDoubleClick = 19, kOtherEvent       = 20
    // };
-   if(TSourceCalibration::VerboseLevel() > 4) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) {
       std::cout << __PRETTY_FUNCTION__ << ": code " << event->fCode << ", count " << event->fCount << ", state " << event->fState << ", type " << event->fType << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       if(event->fType == kClientMessage) {
          std::cout << "Client message: " << event->fUser[0] << ", " << event->fUser[1] << ", " << event->fUser[2] << std::endl;
       }
    }
    if(event->fType == kEnterNotify) {
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << "Entered source tab => changing gPad from " << gPad->GetName();
       }
       gPad = fProjectionCanvas->GetCanvas();
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " to " << gPad->GetName() << std::endl;
       }
    }
@@ -408,7 +408,7 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
    switch(event) {
    case kButton1Down:
       if(selected == fProjection) {
-         if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DCYAN << "Adding new marker at " << px << ", " << py << " (pixel to user: " << fProjectionCanvas->GetCanvas()->PixeltoX(px) << ", " << fProjectionCanvas->GetCanvas()->PixeltoY(py - fProjectionCanvas->GetCanvas()->GetWh()) << ", abs pixel to user: " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) << ", " << fProjectionCanvas->GetCanvas()->AbsPixeltoY(py) << ")" << std::endl; }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DCYAN << "Adding new marker at " << px << ", " << py << " (pixel to user: " << fProjectionCanvas->GetCanvas()->PixeltoX(px) << ", " << fProjectionCanvas->GetCanvas()->PixeltoY(py - fProjectionCanvas->GetCanvas()->GetWh()) << ", abs pixel to user: " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) << ", " << fProjectionCanvas->GetCanvas()->AbsPixeltoY(py) << ")" << std::endl; }
          auto* polym = static_cast<TPolyMarker*>(fProjection->GetListOfFunctions()->FindObject("TPolyMarker"));
          if(polym == nullptr) {
             std::cerr << "No peaks defined yet?" << std::endl;
@@ -423,7 +423,7 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
          //fPeakFitter.Fit(fProjection, "qretryfit");
          if(peak->Area() > 0) {
             fPeaks.push_back(peak);
-            if(TSourceCalibration::VerboseLevel() > 1) { std::cout << "Fitted peak " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range << " - " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range << " -> centroid " << peak->Centroid() << std::endl; }
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << "Fitted peak " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range << " - " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range << " -> centroid " << peak->Centroid() << std::endl; }
          } else {
             std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
          }
@@ -480,7 +480,7 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
    case kMouseLeave:
       break;
    default:
-      if(TSourceCalibration::VerboseLevel() > 3) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
          std::cout << "unprocessed event " << event << " with px, py " << px << ", " << py << " selected object is a " << selected->ClassName() << " with name " << selected->GetName() << " and title " << selected->GetTitle() << " object info is " << selected->GetObjectInfo(px, py) << std::endl;
       }
       break;
@@ -489,20 +489,20 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
 
 void TSourceTab::UpdateRegions()
 {
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "UpdateRegions: clearing " << fRegions.size() << " regions" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "UpdateRegions: clearing " << fRegions.size() << " regions" << std::endl; }
    fRegions.clear();
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "projection has " << fProjection->ListOfRegions()->GetEntries() << " regions:" << std::endl;
       fProjection->ListOfRegions()->Print();
    }
-   if(TSourceCalibration::VerboseLevel() > 3) { fProjection->Print(); }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { fProjection->Print(); }
    for(auto* obj : *(fProjection->ListOfRegions())) {
       if(obj->InheritsFrom(TRegion::Class())) {
          auto* region = static_cast<TRegion*>(obj);
-         if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "UpdateRegions: found " << fRegions.size() << ". region: " << std::min(region->GetX1(), region->GetX2()) << " - " << std::max(region->GetX1(), region->GetX2()) << std::endl; }
-         if(TSourceCalibration::VerboseLevel() > 3) { region->Print(); }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "UpdateRegions: found " << fRegions.size() << ". region: " << std::min(region->GetX1(), region->GetX2()) << " - " << std::max(region->GetX1(), region->GetX2()) << std::endl; }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { region->Print(); }
          fRegions.emplace_back(std::min(region->GetX1(), region->GetX2()), std::max(region->GetX1(), region->GetX2()));
-      } else if(TSourceCalibration::VerboseLevel() > 3) {
+      } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
          std::cout << obj->GetName() << " is not a TRegion but a " << obj->ClassName() << std::endl;
       }
    }
@@ -514,13 +514,13 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
    /// This list is then used to find all peaks that lie on a straight line.
 
    if(fPeakRatio != peakRatio) {
-      if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DCYAN << __PRETTY_FUNCTION__ << ": updating peak ratio from " << fPeakRatio << " to " << peakRatio << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DCYAN << __PRETTY_FUNCTION__ << ": updating peak ratio from " << fPeakRatio << " to " << peakRatio << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fPeakRatio = peakRatio;
    }
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DCYAN << __PRETTY_FUNCTION__ << std::flush << " " << fProjection->GetName() << ": got " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DCYAN << __PRETTY_FUNCTION__ << std::flush << " " << fProjection->GetName() << ": got " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
    if(fPeaks.empty() || fData == nullptr || sigma != fSigma || threshold != fThreshold || force) {
-      if(TSourceCalibration::VerboseLevel() > 2) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << __PRETTY_FUNCTION__ << ": # peaks " << fPeaks.size() << ", sigma (" << sigma << "/" << fSigma << "), or threshold (" << threshold << "/" << fThreshold << ") have changed?" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       }
       fSigma     = sigma;
@@ -528,7 +528,7 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       fPeaks.clear();
       // Remove all associated functions from projection.
       // These are the poly markers, fits, and the pave stat
-      if(TSourceCalibration::VerboseLevel() > 4) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
          TList* functions = fProjection->GetListOfFunctions();
          std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << " before clearing" << std::endl;
          for(auto* obj : *functions) {
@@ -541,13 +541,13 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       std::vector<double> peakPos;
       UpdateRegions();
       if(fRegions.empty()) {
-         if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "No regions found, using whole spectrum" << std::endl; }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "No regions found, using whole spectrum" << std::endl; }
          spectrum.Search(fProjection, fSigma, "", fThreshold);
          nofPeaks = spectrum.GetNPeaks();
          if(nofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
-            if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "Reducing # of peaks from " << nofPeaks; }
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << nofPeaks; }
             nofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
-            if(TSourceCalibration::VerboseLevel() > 2) { std::cout << " to " << nofPeaks << std::endl; }
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << nofPeaks << std::endl; }
          }
          peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + nofPeaks);
       } else {
@@ -556,17 +556,17 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
             spectrum.Search(fProjection, fSigma, "", fThreshold);
             int tmpNofPeaks = spectrum.GetNPeaks();
             if(tmpNofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
-               if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "Reducing # of peaks from " << tmpNofPeaks; }
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << tmpNofPeaks; }
                tmpNofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
-               if(TSourceCalibration::VerboseLevel() > 2) { std::cout << " to " << tmpNofPeaks << std::endl; }
+               if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << tmpNofPeaks << std::endl; }
             }
             peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + tmpNofPeaks);
             nofPeaks += spectrum.GetNPeaks();
-            if(TSourceCalibration::VerboseLevel() > 2) { std::cout << __PRETTY_FUNCTION__ << ": found " << spectrum.GetNPeaks() << " peaks in region " << region.first << " - " << region.second << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": found " << spectrum.GetNPeaks() << " peaks in region " << region.first << " - " << region.second << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
          }
          fProjection->GetXaxis()->UnZoom();
       }
-      if(TSourceCalibration::VerboseLevel() > 2) { std::cout << __PRETTY_FUNCTION__ << ": found " << nofPeaks << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": found " << nofPeaks << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       //fPeakFitter.RemoveAllPeaks();
       for(int i = 0; i < nofPeaks; i++) {
          double range = 4 * fSigma * fProjection->GetXaxis()->GetBinWidth(1);
@@ -577,15 +577,15 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
          //fPeakFitter.Fit(fProjection, "qretryfit");
          if(peak->Area() > 0) {
             fPeaks.push_back(peak);
-            if(TSourceCalibration::VerboseLevel() > 2) {
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << "Fitted peak " << peakPos[i] - range << " - " << peakPos[i] + range << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
             }
-         } else if(TSourceCalibration::VerboseLevel() > 2) {
+         } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
          }
          //fProjection->GetListOfFunctions()->Remove(peak);
       }
-      if(TSourceCalibration::VerboseLevel() > 2) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fProjection->Sumw2(false);                                                                                                                 // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
       fProjectionCanvas->GetCanvas()->cd();
@@ -608,7 +608,7 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       // update status
       Status(Form("%d/%d", static_cast<int>(fData->GetN()), nofPeaks), 2);
    }
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       Double_t* x = fData->GetX();
       Double_t* y = fData->GetY();
@@ -621,7 +621,7 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
 
 void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>> map)
 {
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
    }
    if(fData == nullptr) {
@@ -651,11 +651,11 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
       auto energyErr   = std::get<1>(iter->second);
       // drop this peak if the uncertainties in area or position are too large
       if(peakPosErr > 0.1 * peakPos || peakAreaErr > peakArea || std::isnan(peakPosErr) || std::isnan(peakAreaErr)) {
-         if(TSourceCalibration::VerboseLevel() > 1) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
             std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
          }
          iter = map.erase(iter);
-         if(TSourceCalibration::VerboseLevel() > 2) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Erasing peak returned iterator " << std::distance(map.begin(), iter) << std::endl;
          }
       } else {
@@ -663,14 +663,14 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
          fData->SetPointError(i, peakPosErr, energyErr);
          fFwhm->SetPoint(i, peakPos, fwhm);
          fFwhm->SetPointError(i, peakPosErr, fwhmErr);
-         if(TSourceCalibration::VerboseLevel() > 2) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Using peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
          }
          ++iter;
          ++i;
       }
    }
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << "Accepted " << map.size() << " peaks" << std::endl;
    }
    // if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
@@ -678,7 +678,7 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
    fFwhm->Set(map.size());
    // split poly marker into those peaks that were used, and those that weren't
    TList* functions = fProjection->GetListOfFunctions();
-   if(TSourceCalibration::VerboseLevel() > 4) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
       std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
       for(auto* obj : *functions) {
          std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
@@ -713,9 +713,9 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
       unusedMarkers->SetMarkerStyle(23);   // triangle down
       unusedMarkers->SetMarkerColor(16);   // light grey
       functions->Add(unusedMarkers);
-      if(TSourceCalibration::VerboseLevel() > 2) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << fProjection->GetTitle() << ": " << size << " peaks founds total, " << polym->GetN() << " used, and " << unusedMarkers->GetN() << " unused" << std::endl;
-         if(TSourceCalibration::VerboseLevel() > 3) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
             std::cout << "Used: ";
             for(size_t m = 0; m < newX.size(); ++m) { std::cout << newX[m] << " - " << newY[m] << ";"; }
             std::cout << std::endl;
@@ -723,7 +723,7 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
             for(size_t m = 0; m < unusedX.size(); ++m) { std::cout << unusedX[m] << " - " << unusedY[m] << ";"; }
             std::cout << std::endl;
          }
-         if(TSourceCalibration::VerboseLevel() > 4) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
             std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
             for(auto* obj : *functions) {
                std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
@@ -760,14 +760,14 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
 
 void TSourceTab::RemovePoint(Int_t px, Int_t py)
 {
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << DCYAN << __PRETTY_FUNCTION__ << ": px " << px << ", py " << py << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    // we removed a point of the calibration graph at px, py, where px is the channel and py is the energy
    // so we try and find a peak with its centroid close to px
    for(auto it = fPeaks.begin(); it != fPeaks.end(); ++it) {
       if(TMath::Abs((*it)->Centroid() - px) < fSigma) {
-         if(TSourceCalibration::VerboseLevel() > 1) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
             std::cout << DCYAN << "Erasing peak " << TMath::Abs((*it)->Centroid() - px) << " < " << fSigma << std::endl;
             (*it)->Print();
          }
@@ -785,7 +785,7 @@ void TSourceTab::RemovePoint(Int_t px, Int_t py)
             centroid = static_cast<GPeak*>(item)->Centroid();
          }
          if(TMath::Abs(centroid - px) < fSigma) {
-            if(TSourceCalibration::VerboseLevel() > 1) {
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
                std::cout << DCYAN << "Removing function " << TMath::Abs(centroid - px) << " < " << fSigma << std::endl;
                item->Print();
             }
@@ -823,7 +823,7 @@ void TSourceTab::RemovePoint(Int_t px, Int_t py)
 
 void TSourceTab::RemoveResidualPoint(Int_t px, Int_t py)
 {
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << DCYAN << __PRETTY_FUNCTION__ << ": px " << px << ", py " << py << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    // we removed a point of the residual graph at px, py, where px is the residual and py is the energy
@@ -849,9 +849,9 @@ void TSourceTab::PrintLayout() const
 
 //////////////////////////////////////// TChannelTab ////////////////////////////////////////
 TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, double sigma, double threshold, int degree, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar)
-   : fChannelFrame(frame), fSourceTab(new TGTab(frame, 600, 500)), fCanvasTab(new TGTab(frame, 600, 500)), fProgressBar(progressBar), fParent(parent), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSigma(sigma), fThreshold(threshold), fDegree(degree), fSourceEnergies(std::move(sourceEnergies))
+   : fChannelFrame(frame), fSourceTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fCanvasTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fProgressBar(progressBar), fParent(parent), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSigma(sigma), fThreshold(threshold), fDegree(degree), fSourceEnergies(std::move(sourceEnergies))
 {
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << DYELLOW << "========================================" << std::endl;
       std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
                 << " name = " << fName << ", fData = " << fData << std::endl;
@@ -861,7 +861,7 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
    fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
 
    fSources.resize(fNuclei.size(), nullptr);
-   //if(TSourceCalibration::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    for(size_t source = 0; source < fNuclei.size(); ++source) {
       CreateSourceTab(source);
    }
@@ -876,15 +876,15 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
 
    fCalibrationFrame = fCanvasTab->AddTab("Calibration");
    fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
-   fCalibrationCanvas = new TRootEmbeddedCanvas("ChannelCalibrationCanvas", fCalibrationFrame, 600, 400);
+   fCalibrationCanvas = new TRootEmbeddedCanvas("ChannelCalibrationCanvas", fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
    fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-   fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, 600, 50);
+   fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
    std::array<int, 3> parts = {25, 35, 40};
    fChannelStatusBar->SetParts(parts.data(), parts.size());
    fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
    fFwhmFrame = fCanvasTab->AddTab("FWHM");
    fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
-   fFwhmCanvas = new TRootEmbeddedCanvas("ChannelFwhmCanvas", fFwhmFrame, 600, 400);
+   fFwhmCanvas = new TRootEmbeddedCanvas("ChannelFwhmCanvas", fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
    fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
    //fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
    fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
@@ -912,7 +912,7 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
    fFwhm->DrawCalibration("*");
    fLegend->Draw();
 
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << DYELLOW << "----------------------------------------" << std::endl;
       std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
                 << " channel " << fName << " done" << std::endl;
@@ -944,7 +944,7 @@ TChannelTab::~TChannelTab()
 void TChannelTab::CreateSourceTab(size_t source)
 {
    if(fProjections[source]->GetEntries() > 1000) {
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << DYELLOW << "Creating source tab " << source << ", using fParent " << fParent << std::flush;
          if(fParent != nullptr) {
             std::cout << ", peak ratio " << fParent->PeakRatio();
@@ -956,11 +956,11 @@ void TChannelTab::CreateSourceTab(size_t source)
       fProgressBar->Increment(1);
    } else {
       fSources[source] = nullptr;
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << DYELLOW << "Skipping projection of source " << source << " = " << fProjections[source]->GetName() << ", only " << fProjections[source]->GetEntries() << " entries" << std::endl;
       }
    }
-   if(TSourceCalibration::VerboseLevel() > 1) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
       std::cout << __PRETTY_FUNCTION__ << " source " << source << " done" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
 }
@@ -991,9 +991,9 @@ void TChannelTab::Disconnect()
 void TChannelTab::SelectedTab(Int_t id)
 {
    /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fActiveSourceTab = id;
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
    if(fSources[fActiveSourceTab] == nullptr) {
       std::cout << "Failed to get fSources[" << fActiveSourceTab << "]" << RESET_COLOR << std::endl;
       return;
@@ -1006,20 +1006,20 @@ void TChannelTab::SelectedTab(Int_t id)
       std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
       return;
    }
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
    gPad = fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas();
    fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas()->cd();
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TChannelTab::SelectCanvas(Event_t* event)
 {
    if(event->fType == kEnterNotify) {
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << "Entered channel tab => changing gPad from " << gPad->GetName();
       }
       gPad = fCalibrationCanvas->GetCanvas();
-      if(TSourceCalibration::VerboseLevel() > 1) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) {
          std::cout << " to " << gPad->GetName() << std::endl;
       }
    }
@@ -1054,7 +1054,7 @@ void TChannelTab::CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* se
          fChannelStatusBar->SetText("pad nullptr");
          return;
       }
-      //if(TSourceCalibration::VerboseLevel() > 3) {
+      //if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
       //	std::cout << "px " << px << ", py " << py << ";    gPad: px " << gPad->AbsPixeltoX(px) << ", py " << gPad->AbsPixeltoY(py) << ";    fCalibrationCanvas: px " << fCalibrationCanvas->GetCanvas()->AbsPixeltoX(px) << ", py " << fCalibrationCanvas->GetCanvas()->AbsPixeltoY(py) << ";    fResidualPad: px " << fResidualPad->AbsPixeltoX(px) << ", py " << fResidualPad->AbsPixeltoY(py) << ";    fCalibrationPad: px " << fCalibrationPad->AbsPixeltoX(px) << ", py " << fCalibrationPad->AbsPixeltoY(py) << ";    pad: px " << pad->AbsPixeltoX(px) << ", py " << pad->AbsPixeltoY(py) << std::endl;
       //}
 
@@ -1065,15 +1065,15 @@ void TChannelTab::CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* se
 void TChannelTab::UpdateData()
 {
    /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fData == nullptr) {
       fData = new TCalibrationGraphSet("ADC channel", "Energy [keV]");
-      if(TSourceCalibration::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    fData->Clear();
 
    fData->SetName(Form("data%s", fName.c_str()));
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "set name of fData using " << fName.c_str() << ": " << fData->GetName() << std::endl;
       std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -2) << " data points after creation" << std::endl;
       std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
@@ -1087,7 +1087,7 @@ void TChannelTab::UpdateData()
          }
       }
    }
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
       fData->Print();
    }
@@ -1096,15 +1096,15 @@ void TChannelTab::UpdateData()
 void TChannelTab::UpdateFwhm()
 {
    /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fFwhm == nullptr) {
       fFwhm = new TCalibrationGraphSet("ADC channel", "FWHM [ADC channel]");
-      if(TSourceCalibration::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    fFwhm->Clear();
 
    fFwhm->SetName(Form("fwhm%s", fName.c_str()));
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "set name of fFwhm using " << fName.c_str() << ": " << fFwhm->GetName() << std::endl;
       std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -2) << " data points after creation" << std::endl;
       std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
@@ -1118,7 +1118,7 @@ void TChannelTab::UpdateFwhm()
          }
       }
    }
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
       fFwhm->Print();
    }
@@ -1127,7 +1127,7 @@ void TChannelTab::UpdateFwhm()
 void TChannelTab::Calibrate(const int& degree, const bool& force)
 {
    if(degree != fDegree || force) {
-      if(TSourceCalibration::VerboseLevel() > 2) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << DYELLOW;
          if(force) {
             std::cout << "forced calibration" << std::endl;
@@ -1137,7 +1137,7 @@ void TChannelTab::Calibrate(const int& degree, const bool& force)
       }
       fDegree = degree;
       Calibrate();
-   } else if(TSourceCalibration::VerboseLevel() > 2) {
+   } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << degree << " == " << fDegree << " and not forcing (" << force << "): not fitting channel " << fName << std::endl;
    }
 }
@@ -1147,14 +1147,14 @@ void TChannelTab::Calibrate()
    /// This function fit's the final data of the given channel. It requires all other elements to have been created already.
    TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fDegree + 2);
    calibration->FixParameter(0, fDegree);
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DYELLOW << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points being fit" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DYELLOW << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points being fit" << std::endl; }
    fData->Fit(calibration, "Q");
    TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
    for(int i = 2; i <= fDegree; ++i) {
       text.Append(Form(" + %.6f*x^%d", calibration->GetParameter(i + 1), i));
    }
    fChannelStatusBar->SetText(text.Data(), 2);
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
    // re-calculate the residuals
    fData->SetResidual(true);
 
@@ -1162,7 +1162,7 @@ void TChannelTab::Calibrate()
    fCalibrationPad->cd();
    fData->DrawCalibration("*", fLegend);
    fLegend->Draw();
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "set chi2 label" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "set chi2 label" << std::endl; }
    // calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
    // we position it in the top left corner about 50% of the width and 10% of the height of the graph
    double left   = fData->GetMinimumX();
@@ -1175,14 +1175,14 @@ void TChannelTab::Calibrate()
    } else {
       fChi2Label->Clear();
    }
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
       fData->Print("e");
    }
    fChi2Label->AddText(Form("#chi^{2}/NDF = %f", calibration->GetChisquare() / calibration->GetNDF()));
-   fChi2Label->SetFillColor(10);
+   fChi2Label->SetFillColor(kWhite);
    fChi2Label->Draw();
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "fChi2Label set to:" << std::endl;
       fChi2Label->GetListOfLines()->Print();
       std::cout << "Text size " << fChi2Label->GetTextSize() << std::endl;
@@ -1195,18 +1195,18 @@ void TChannelTab::Calibrate()
 
    delete calibration;
 
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TChannelTab::UpdateChannel()
 {
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    // write the actual parameters of the fit
    std::stringstream str;
    str << std::hex << fName;
    int address = 0;
    str >> address;
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
    TF1* calibration = fData->FitFunction();
    if(calibration == nullptr) {
       std::cout << "Failed to find calibration in fData" << std::endl;
@@ -1220,7 +1220,7 @@ void TChannelTab::UpdateChannel()
    TChannel* channel = TChannel::GetChannel(address, false);
    if(channel == nullptr) {
       std::cerr << "Failed to get channel for address " << hex(address, 4) << std::endl;
-      if(TSourceCalibration::VerboseLevel() > 1) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       return;
    }
    channel->SetENGCoefficients(parameters);
@@ -1228,19 +1228,19 @@ void TChannelTab::UpdateChannel()
    if(fParent->WriteNonlinearities()) {
       double* x = fData->GetX();
       double* y = fData->GetY();
-      if(TSourceCalibration::VerboseLevel() > 2) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
       for(int i = 0; i < fData->GetN(); ++i) {
          // nonlinearity expects y to be the true source energy minus the calibrated energy of the peak
          // the source energy is y, the peak is x
          channel->AddEnergyNonlinearityPoint(y[i], y[i] - calibration->Eval(x[i]));
-         if(TSourceCalibration::VerboseLevel() > 3) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
       }
    }
 }
 
 void TChannelTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
 {
-   if(TSourceCalibration::VerboseLevel() > 2) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << DYELLOW << "Finding peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
       fSourceTab->Print();
       for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
@@ -1256,10 +1256,10 @@ void TChannelTab::Write(TFile* output)
 {
    /// Write graphs to output.
    output->cd();
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << DYELLOW << "writing " << fName << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "writing " << fName << std::endl; }
    fData->Write(Form("calGraph_%s", fName.c_str()), TObject::kOverwrite);
    fFwhm->Write(Form("fwhm_%s", fName.c_str()), TObject::kOverwrite);
-   if(TSourceCalibration::VerboseLevel() > 2) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
 }
 
 void TChannelTab::ZoomX()
@@ -1275,7 +1275,7 @@ void TChannelTab::ZoomX()
    }
    if(hist1 == nullptr) {
       std::cout << "ZoomX - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-      if(TSourceCalibration::VerboseLevel() > 3) { gPad->GetListOfPrimitives()->Print(); }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
       return;
    }
 
@@ -1319,7 +1319,7 @@ void TChannelTab::ZoomX()
    }
    if(hist2 == nullptr) {
       std::cout << "ZoomX - Failed to find histogram for partner pad " << newName << std::endl;
-      if(TSourceCalibration::VerboseLevel() > 3) { pad2->GetListOfPrimitives()->Print(); }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
       return;
    }
 
@@ -1349,7 +1349,7 @@ void TChannelTab::ZoomY()
    }
    if(hist1 == nullptr) {
       std::cout << "ZoomY - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-      if(TSourceCalibration::VerboseLevel() > 3) { gPad->GetListOfPrimitives()->Print(); }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
       return;
    }
 
@@ -1393,7 +1393,7 @@ void TChannelTab::ZoomY()
    }
    if(hist2 == nullptr) {
       std::cout << "ZoomY - Failed to find histogram for partner pad " << newName << std::endl;
-      if(TSourceCalibration::VerboseLevel() > 3) { pad2->GetListOfPrimitives()->Print(); }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
       return;
    }
 
@@ -1418,10 +1418,16 @@ void TChannelTab::PrintLayout() const
 }
 
 //////////////////////////////////////// TSourceCalibration ////////////////////////////////////////
-int TSourceCalibration::fVerboseLevel = 0;
+EVerbosity TSourceCalibration::fVerboseLevel = EVerbosity::kQuiet;
+int TSourceCalibration::fPanelWidth = 600;
+int TSourceCalibration::fPanelHeight = 400;
+int TSourceCalibration::fStatusbarHeight = 50;
+int TSourceCalibration::fSourceboxWidth = 100;
+int TSourceCalibration::fParameterHeight = 200;
+int TSourceCalibration::fDigitWidth = 5;
 
 TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degree, double peakRatio, int count...)
-   : TGMainFrame(nullptr, 1200, 600), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree), fDefaultPeakRatio(peakRatio)
+   : TGMainFrame(nullptr, 2*fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree), fDefaultPeakRatio(peakRatio)
 {
    TH1::AddDirectory(false);   // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
 
@@ -1435,7 +1441,7 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
       }
    }
    va_end(args);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fVerboseLevel > 0) {
+   if(fVerboseLevel > EVerbosity::kQuiet) {
       std::cout << DGREEN << __PRETTY_FUNCTION__ << ": verbose level " << fVerboseLevel << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
                 << "using " << count << "/" << fMatrices.size() << " matrices:" << std::endl;
       for(auto* mat : fMatrices) {
@@ -1457,10 +1463,10 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
          fActiveBins.push_back(bin);
          channelToIndex[bin] = fNofBins;   // this map simply stores which bin ends up at which index
          fChannelLabel.push_back(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-         if(fVerboseLevel > 1) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
+         if(fVerboseLevel > EVerbosity::kBasic) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
          ++fNofBins;
       } else {
-         if(fVerboseLevel > 1) { std::cout << "skipping bin " << bin << std::endl; }
+         if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "skipping bin " << bin << std::endl; }
       }
    }
    // now loop over all other matrices and check vs. the first one
@@ -1490,7 +1496,7 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
       }
    }
 
-   if(fVerboseLevel > 0) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kQuiet) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
 
    fOutput = new TFile("TSourceCalibration.root", "recreate");
    if(!fOutput->IsOpen()) {
@@ -1527,14 +1533,14 @@ void TSourceCalibration::BuildFirstInterface()
    /// Build initial interface with histogram <-> source assignment
 
    auto* layoutManager = new TGTableLayout(this, fMatrices.size() + 1, 2, true, 5);
-   if(fVerboseLevel > 1) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
    SetLayoutManager(layoutManager);
 
    // The matrices and source selection boxes
    size_t i = 0;
    for(i = 0; i < fMatrices.size(); ++i) {
       fMatrixNames.push_back(new TGLabel(this, fMatrices[i]->GetName()));
-      if(fVerboseLevel > 2) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
       fSource.push_back(nullptr);
       fSourceEnergy.emplace_back();
       fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
@@ -1551,18 +1557,18 @@ void TSourceCalibration::BuildFirstInterface()
       for(const auto& file : std::filesystem::directory_iterator(path)) {
          if(file.is_regular_file() && file.path().extension().compare(".sou") == 0) {
             fSourceBox.back()->AddEntry(file.path().stem().c_str(), index);
-            if(fVerboseLevel > 2) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
+            if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
             if(std::strstr(fMatrices[i]->GetName(), file.path().stem().c_str()) != nullptr) {
                fSourceBox.back()->Select(index);
                SetSource(kSourceBox + fSourceBox.size() - 1, index);
-               if(fVerboseLevel > 2) { std::cout << i << ": selected source " << index << std::endl; }
-            } else if(fVerboseLevel > 2) {
+               if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": selected source " << index << std::endl; }
+            } else if(fVerboseLevel > EVerbosity::kSubroutines) {
                std::cout << "matrix name " << fMatrices[i]->GetName() << " not matching " << file.path().stem().c_str() << std::endl;
             }
             ++index;
          }
       }
-      if(fVerboseLevel > 2) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
 #else
       fSourceBox.back()->AddEntry("22Na", index);
       if(std::strstr(fMatrices[i]->GetName(), "22Na") != nullptr) {
@@ -1601,18 +1607,18 @@ void TSourceCalibration::BuildFirstInterface()
       }
 #endif
 
-      fSourceBox.back()->SetMinHeight(200);
+      fSourceBox.back()->SetMinHeight(fPanelHeight/2);
 
-      fSourceBox.back()->Resize(100, fLineHeight);
-      if(fVerboseLevel > 2) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
+      fSourceBox.back()->Resize(fSourceboxWidth, fLineHeight);
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
       AddFrame(fMatrixNames.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
       AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
    }
 
    // The buttons
-   if(fVerboseLevel > 1) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
    fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
-   if(fVerboseLevel > 1) { std::cout << "start button " << fStartButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << "start button " << fStartButton << std::endl; }
    AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
    Layout();
 }
@@ -1659,13 +1665,13 @@ void TSourceCalibration::DeleteFirst()
    }
    fSourceBox.clear();
    DeleteElement(fStartButton);
-   if(fVerboseLevel > 2) { std::cout << "Deleted start button " << fStartButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
 }
 
 void TSourceCalibration::SetSource(Int_t windowId, Int_t entryId)
 {
    int index = windowId - kSourceBox;
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    delete fSource[index];
    auto* nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
    TIter iter(nucleus->GetTransitionList());
@@ -1678,7 +1684,7 @@ void TSourceCalibration::SetSource(Int_t windowId, Int_t entryId)
 
 void TSourceCalibration::HandleTimer()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fEmitter == fStartButton) {
       SecondWindow();
    } else if(fEmitter == fAcceptAllButton) {
@@ -1697,16 +1703,16 @@ void TSourceCalibration::HandleTimer()
 
 void TSourceCalibration::Start()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fEmitter == nullptr) {                                                                                                                    // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
       fEmitter = fStartButton;
-      TTimer::SingleShot(100, "TSourceCalibration", this, "HandleTimer()");
+      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
    }
 }
 
 void TSourceCalibration::SecondWindow()
 {
-   if(fVerboseLevel > 1) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    // check that all sources have been set
    for(size_t i = 0; i < fSource.size(); ++i) {
       if(fSource[i] == nullptr) {
@@ -1732,17 +1738,17 @@ void TSourceCalibration::SecondWindow()
    SetLayoutManager(new TGVerticalLayout(this));
 
    // create intermediate progress bar
-   fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, 600);
+   fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
    fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
    fProgressBar->Percent(true);
-   if(fVerboseLevel > 2) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
    AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
    // Map all subwindows of main frame
    MapSubwindows();
 
    // Initialize the layout algorithm
-   Resize(TGDimension(600, fLineHeight));
+   Resize(TGDimension(fPanelWidth, fLineHeight));
 
    // Map main frame
    MapWindow();
@@ -1758,17 +1764,17 @@ void TSourceCalibration::SecondWindow()
    MapSubwindows();
 
    // Initialize the layout algorithm
-   Resize(TGDimension(1200, 600));
+   Resize(TGDimension(2*fPanelWidth, fPanelHeight + 2 * fStatusbarHeight));
 
    // Map main frame
    MapWindow();
-   if(fVerboseLevel > 2) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TSourceCalibration::BuildSecondInterface()
 {
    SetLayoutManager(new TGVerticalLayout(this));
-   fTab = new TGTab(this, 1200, 600);
+   fTab = new TGTab(this, 2*fPanelWidth, fPanelHeight + 2 * fStatusbarHeight);
 
    fChannelTab.resize(fMatrices[0]->GetNbinsX());
    for(auto& bin : fActiveBins) {
@@ -1782,51 +1788,51 @@ void TSourceCalibration::BuildSecondInterface()
       fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin)), fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
    }
 
-   //if(fVerboseLevel > 1) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
+   //if(fVerboseLevel > EVerbosity::kBasic) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
 
    //for(int i = 0; i < fChannelTab[0]->SourceTab()->GetNumberOfTabs(); ++i) {
-   //if(fVerboseLevel > 2) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
+   //if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
    //}
 
    AddFrame(fTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
    // bottom frame with navigation button group, text entries, etc.
-   fBottomFrame = new TGHorizontalFrame(this, 1200, 50);
+   fBottomFrame = new TGHorizontalFrame(this, 2*fPanelWidth, TSourceCalibration::StatusbarHeight());
 
-   fLeftFrame       = new TGVerticalFrame(fBottomFrame, 600, 200);
+   fLeftFrame       = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
    fNavigationGroup = new TGHButtonGroup(fLeftFrame, "");
    fPreviousButton  = new TGTextButton(fNavigationGroup, "Previous");
-   if(fVerboseLevel > 2) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
    fPreviousButton->SetEnabled(false);
    fFindPeaksButton     = new TGTextButton(fNavigationGroup, "Find Peaks");
    fFindPeaksFastButton = new TGTextButton(fNavigationGroup, "Find Peaks Fast");
-   if(fVerboseLevel > 2) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
    fCalibrateButton = new TGTextButton(fNavigationGroup, "Calibrate");
-   if(fVerboseLevel > 2) { std::cout << "cal button " << fCalibrateButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
    fDiscardButton = new TGTextButton(fNavigationGroup, "Discard");
-   if(fVerboseLevel > 2) { std::cout << "discard button " << fDiscardButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
    fAcceptButton = new TGTextButton(fNavigationGroup, "Accept");
-   if(fVerboseLevel > 2) { std::cout << "accept button " << fAcceptButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept button " << fAcceptButton << std::endl; }
    fAcceptAllButton = new TGTextButton(fNavigationGroup, "Accept All && Finish");
-   if(fVerboseLevel > 2) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
    fNextButton = new TGTextButton(fNavigationGroup, "Next");
-   if(fVerboseLevel > 2) { std::cout << "next button " << fNextButton << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
 
    fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
 
    fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
 
-   fRightFrame     = new TGVerticalFrame(fBottomFrame, 600, 200);
+   fRightFrame     = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
    fParameterFrame = new TGGroupFrame(fRightFrame, "Parameters", kHorizontalFrame);
    fParameterFrame->SetLayoutManager(new TGMatrixLayout(fParameterFrame, 0, 4, 2));
    fSigmaLabel          = new TGLabel(fParameterFrame, "Sigma");
-   fSigmaEntry          = new TGNumberEntry(fParameterFrame, fDefaultSigma, 5, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+   fSigmaEntry          = new TGNumberEntry(fParameterFrame, fDefaultSigma, fDigitWidth, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
    fThresholdLabel      = new TGLabel(fParameterFrame, "Threshold");
-   fThresholdEntry      = new TGNumberEntry(fParameterFrame, fDefaultThreshold, 5, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
+   fThresholdEntry      = new TGNumberEntry(fParameterFrame, fDefaultThreshold, fDigitWidth, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
    fDegreeLabel         = new TGLabel(fParameterFrame, "Degree of polynomial");
    fDegreeEntry         = new TGNumberEntry(fParameterFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger, TGNumberFormat::EAttribute::kNEAPositive);
    fPeakRatioLabel      = new TGLabel(fParameterFrame, "Ratio foundsource peaks");
-   fPeakRatioEntry      = new TGNumberEntry(fParameterFrame, fDefaultPeakRatio, 5, kPeakRatioEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+   fPeakRatioEntry      = new TGNumberEntry(fParameterFrame, fDefaultPeakRatio, fDigitWidth, kPeakRatioEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
    fWriteNonlinearities = new TGCheckButton(fParameterFrame, "Write nonlinearities", kWriteNonlinearities);
    fWriteNonlinearities->SetState(kButtonUp);
 
@@ -1848,12 +1854,12 @@ void TSourceCalibration::BuildSecondInterface()
 
    SelectedTab(0);
 
-   if(fVerboseLevel > 2) { std::cout << DGREEN << "Second interface done" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
 }
 
 void TSourceCalibration::MakeSecondConnections()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
    fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
    // we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
@@ -1866,7 +1872,7 @@ void TSourceCalibration::MakeSecondConnections()
 
 void TSourceCalibration::DisconnectSecond()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
    fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
    for(auto* sourceTab : fChannelTab) {
@@ -1884,23 +1890,23 @@ void TSourceCalibration::Navigate(Int_t id)
    int currentChannelId = fTab->GetCurrent();
    int actualChannelId  = fActualChannelId[currentChannelId];
    int nofTabs          = fTab->GetNumberOfTabs();
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
    switch(id) {
-   case 1:   // previous
+	case ENavigate::kPrevious:   // previous
       fTab->SetTab(currentChannelId - 1);
       SelectedTab(currentChannelId - 1);
       break;
-   case 2:   // find peaks
+	case ENavigate::kFindPeaks:   // find peaks
       FindPeaks();
       break;
-   case 3:   // find peaks fast
+	case ENavigate::kFindPeaksFast:   // find peaks fast
       FindPeaksFast();
       break;
-   case 4:   // calibrate
+	case ENavigate::kCalibrate:   // calibrate
       Calibrate();
       break;
-   case 5:   // discard
+	case ENavigate::kDiscard:   // discard
       // select the next (or if we are on the last tab, the previous) tab
       if(currentChannelId < nofTabs - 1) {
          fTab->SetTab(currentChannelId + 1);
@@ -1910,28 +1916,28 @@ void TSourceCalibration::Navigate(Int_t id)
       // remove the original active tab
       fTab->RemoveTab(currentChannelId);
       break;
-   case 6:   // accept
+	case ENavigate::kAccept:   // accept
       AcceptChannel(currentChannelId);
       break;
-   case 7:   // accept all (no argument = -1 = all)
+	case ENavigate::kAcceptAll:   // accept all (no argument = -1 = all)
       AcceptChannel();
       return;
       break;
-   case 8:   // next
+	case ENavigate::kNext:   // next
       fTab->SetTab(currentChannelId + 1);
       SelectedTab(currentChannelId + 1);
       break;
    default:
       break;
    }
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
 }
 
 void TSourceCalibration::SelectedTab(Int_t id)
 {
    /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
    /// Also sets gPad to the projection of the source selected in this tab.
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(id < 0) { return; }
    if(id == 0) {
       fPreviousButton->SetEnabled(false);
@@ -1945,7 +1951,7 @@ void TSourceCalibration::SelectedTab(Int_t id)
       fNextButton->SetEnabled(true);
    }
 
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
 
    if(fChannelTab[fActiveBins[id] - 1] == nullptr) {
       std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]" << RESET_COLOR << std::endl;
@@ -1963,15 +1969,15 @@ void TSourceCalibration::SelectedTab(Int_t id)
       std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
       return;
    }
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
    gPad = fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas();
    fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()->cd();
-   if(TSourceCalibration::VerboseLevel() > 1) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasic) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TSourceCalibration::AcceptChannel(const int& channelId)
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
    // select the next (or if we are on the last tab, the previous) tab
    int nofTabs    = fTab->GetNumberOfTabs();
@@ -1983,10 +1989,10 @@ void TSourceCalibration::AcceptChannel(const int& channelId)
    }
 
    // we need to loop backward, because removing the first channel would make the second one the new first and so on
-   if(fVerboseLevel > 2) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    for(int currentChannelId = maxChannel; currentChannelId >= minChannel; --currentChannelId) {
       int actualChannelId = fActualChannelId[currentChannelId];
-      if(fVerboseLevel > 3) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(fVerboseLevel > EVerbosity::kLoops) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       if(minChannel == maxChannel) {                                                                                                                                                                                                                                                 // we don't need to select the tab if we close all
          if(currentChannelId < maxChannel) {
             fTab->SetTab(currentChannelId + 1);
@@ -1999,69 +2005,69 @@ void TSourceCalibration::AcceptChannel(const int& channelId)
       fActualChannelId.erase(fActualChannelId.begin() + currentChannelId);
       fActiveBins.erase(fActiveBins.begin() + currentChannelId);
    }
-   if(fVerboseLevel > 2) { std::cout << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    // check if this changes which buttons are enabled or not (not using the variables from the beginning of this block because they might have changed by now!)
    SelectedTab(fTab->GetCurrent());
    // if this was also the last source vector we initiate the last screen
    if(fActualChannelId.empty() || fActiveBins.empty()) {
-      if(fVerboseLevel > 2) { std::cout << "last channel tab done - writing files now" << std::endl; }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "last channel tab done - writing files now" << std::endl; }
       fEmitter = fAcceptAllButton;
-      TTimer::SingleShot(100, "TSourceCalibration", this, "HandleTimer()");
+      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
    }
-   if(fVerboseLevel > 1) { std::cout << RESET_COLOR << std::flush; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindPeaks()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
       fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(Sigma(), Threshold(), PeakRatio(), true, false);   // force = true, fast = false
       Calibrate();
    } else {
       std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
-   if(fVerboseLevel > 1) { std::cout << RESET_COLOR << std::flush; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindPeaksFast()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
       fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(Sigma(), Threshold(), PeakRatio(), true, true);   // force = true, fast = true
       Calibrate();
    } else {
       std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
-   if(fVerboseLevel > 1) { std::cout << RESET_COLOR << std::flush; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::Calibrate()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
       fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate(Degree(), true);
    } else {
       std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
-   if(fVerboseLevel > 1) { std::cout << RESET_COLOR << std::flush; }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::WriteCalibration()
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    std::ostringstream fileName;
    for(auto* source : fSource) {
       fileName << source->GetName();
    }
    fileName << ".cal";
    TChannel::WriteCalFile(fileName.str());
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fVerboseLevel > 2) { TChannel::WriteCalFile(); }
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { TChannel::WriteCalFile(); }
 }
 
 void TSourceCalibration::PrintLayout() const
 {
-   if(fVerboseLevel > 1) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasic) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
    Print();
    if(fBottomFrame != nullptr) { fBottomFrame->Print(); }

--- a/thisgrsi.sh
+++ b/thisgrsi.sh
@@ -45,12 +45,23 @@ fi
 
 if [ -e "$GRSISYS/GRSIData" ] ; then
 	export GRSIDATA=$GRSISYS/GRSIData
+else
+	unset GRSIDATA
+fi
+if [ -e "$GRSISYS/HILData" ] ; then
+	export HILDATA=$GRSISYS/HILData
+else
+	unset HILDATA
 fi
 if [ -e "$GRSISYS/ILLData" ] ; then
 	export ILLDATA=$GRSISYS/ILLData
+else
+	unset ILLDATA
 fi
 if [ -e "$GRSISYS/iThembaData" ] ; then
 	export ITHEMBADATA=$GRSISYS/iThembaData
+else
+	unset ITHEMBADATA
 fi
 
 if [ -n "${old_grsisys}" ] ; then
@@ -62,6 +73,8 @@ if [ -n "${old_grsisys}" ] ; then
       drop_from_path "$LD_LIBRARY_PATH" "${old_grsisys}/lib"
       LD_LIBRARY_PATH=$newpath
 		drop_from_path "$LD_LIBRARY_PATH" "${old_grsisys}/GRSIData/lib"
+      LD_LIBRARY_PATH=$newpath
+		drop_from_path "$LD_LIBRARY_PATH" "${old_grsisys}/HILData/lib"
       LD_LIBRARY_PATH=$newpath
 		drop_from_path "$LD_LIBRARY_PATH" "${old_grsisys}/ILLData/lib"
       LD_LIBRARY_PATH=$newpath


### PR DESCRIPTION
Also changed those classes that do already use a `VerboseLevel` to implement that as a static member (with static setters and getters) using said enum.
Added more static parameters (like window width and height) to `TSourceCalibration` to have less hard-coded numbers in the code.