### PR TITLE
Adding SRIMData to cmake build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ endif()
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/libraries/TAnalysis/SourceData DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/libraries/TAnalysis/SRIMData DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 #----------------------------------------------------------------------------
 # define all libraries and root dictionaries

--- a/include/TGRSIUtilities.h
+++ b/include/TGRSIUtilities.h
@@ -7,8 +7,9 @@
 
 #include "TGRSITypes.h"
 
-bool file_exists(const char* filename);
-bool all_files_exist(const std::vector<std::string>& filenames);
+bool FileExists(const char* filename);
+bool DirectoryExists(const char* dirname);
+bool AllFilesExist(const std::vector<std::string>& filenames);
 
 void trim(std::string& line, const std::string& trimChars = " \f\n\r\t\v");
 void trimWS(std::string& line);

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -32,6 +32,7 @@
 #include "TCalibrationGraph.h"
 #include "GH1D.h"
 #include "Globals.h"
+#include "TRedirect.h"
 
 class TSourceTab;
 
@@ -237,6 +238,12 @@ public:
    static void       VerboseLevel(EVerbosity val) { fVerboseLevel = val; }
    static EVerbosity VerboseLevel() { return fVerboseLevel; }
 
+	static void LogFile(std::string val) { fLogFile = std::move(val); }
+	static std::string LogFile() { return fLogFile; }
+
+	static void MaxIterations(int val) { fMaxIterations = val; }
+	static int MaxIterations() { return fMaxIterations; }
+
    static void ZoomX();
 
    void PrintLayout() const;
@@ -318,6 +325,8 @@ private:
    std::vector<TH2*> fMatrices;
    int               fNofBins{0};   ///< Number of filled bins in first matrix
 
+	static std::string fLogFile;     ///< name of log file, if empty no log file is written
+
    // graphic settings
    unsigned int fLineHeight{20};    ///< Height of text boxes and progress bar
    static int   fPanelWidth;        ///< Width of one panel
@@ -335,6 +344,7 @@ private:
    double fDefaultThreshold{0.05};   ///< The default threshold used for the peak finding algorithm, can be changed later. Co-56 source needs a much lower threshold, 0.01 or 0.02, but that makes it much slower too.
    int    fDefaultDegree{1};         ///< The default degree of the polynomial used for calibrating, can be changed later.
    double fDefaultPeakRatio{2.};     ///< The default ratio between found peaks and peaks in the source (per region).
+	static int fMaxIterations;        ///< Maximum iterations over combinations in Match and SmartMatch
 
    TFile* fOutput{nullptr};
 

--- a/libraries/GROOT/TLevelScheme.cxx
+++ b/libraries/GROOT/TLevelScheme.cxx
@@ -642,7 +642,7 @@ TLevelScheme::TLevelScheme(const std::string& filename, bool debug)
    // open the file and read the level scheme
    // still need to decide what format that should be
    if(!filename.empty()) {
-      if(!file_exists(filename.c_str())) {
+      if(!FileExists(filename.c_str())) {
          std::cout << "file " << filename << " does not exist or we don't have read permissions" << std::endl;
       } else {
          auto lastDot = filename.find_last_of('.');

--- a/libraries/TAnalysis/TSRIM/TSRIM.cxx
+++ b/libraries/TAnalysis/TSRIM/TSRIM.cxx
@@ -1,6 +1,7 @@
-#include "Globals.h"
-
 #include "TSRIM.h"
+
+#include "Globals.h"
+#include "TGRSIUtilities.h"
 
 #include <TVector3.h>
 #include <TMath.h>
@@ -31,7 +32,16 @@ void TSRIM::ReadEnergyLossFile(const char* filename, double emax, double emin, b
 
    std::string        grsipath = getenv("GRSISYS");
    std::ostringstream ostr;
-   ostr << grsipath << "/libraries/TAnalysis/SRIMData/" << fname;
+   ostr << grsipath << "/libraries/TAnalysis/SRIMData/";
+	if(!DirectoryExists(ostr.str().c_str())) {
+		ostr.clear();
+		ostr << grsipath << "/SRIMData/";
+	}
+	if(!DirectoryExists(ostr.str().c_str())) {
+      std::cout << std::endl
+                << "Failed to find directory with SRIM data, tried \"" << grsipath << "/libraries/TAnalysis/SRIMData/\" and \"" << grsipath << "/SRIMData/\"!" << std::endl;
+   }
+	ostr << fname;
    if(printfile) {
       std::cout << std::endl
                 << "Searching for " << ostr.str() << "..." << std::endl;

--- a/libraries/TFormat/TDataFrameLibrary.cxx
+++ b/libraries/TFormat/TDataFrameLibrary.cxx
@@ -49,7 +49,7 @@ void TDataFrameLibrary::Load()
       libraryPath.replace(dot, std::string::npos, ".so");
    }
 
-   if(!file_exists(libraryPath.c_str())) {
+   if(!FileExists(libraryPath.c_str())) {
       std::ostringstream str;
       str << DRED << "Library '" << libraryPath << "' does not exist or we do not have permissions to access it!" << RESET_COLOR;
       throw std::runtime_error(str.str());

--- a/libraries/TFormat/TGRSIUtilities.cxx
+++ b/libraries/TFormat/TGRSIUtilities.cxx
@@ -10,7 +10,7 @@
 #include "TPRegexp.h"
 #include "TString.h"
 
-bool file_exists(const char* filename)
+bool FileExists(const char* filename)
 {
    /// This checks if the path exist, and if it is a file and not a directory!
    struct stat buffer {};
@@ -23,9 +23,22 @@ bool file_exists(const char* filename)
    return !S_ISDIR(buffer.st_mode);
 }
 
-bool all_files_exist(const std::vector<std::string>& filenames)
+bool DirectoryExists(const char* dirname)
 {
-   return std::all_of(filenames.begin(), filenames.end(), [](auto filename) { return file_exists(filename.c_str()); });
+   /// This checks if the directory exists
+   struct stat buffer {};
+   int         state = stat(dirname, &buffer);
+   // state != 0 means we couldn't get file attributes. This doesn't necessary mean the file
+   // does not exist, we might just be missing permission to access it. But for our purposes
+   // this is the same as the file not existing.
+   if(state != 0) { return false; }
+   // we got the file attributes, so it exsist, we just need to check if it is a directory.
+   return S_ISDIR(buffer.st_mode);
+}
+
+bool AllFilesExist(const std::vector<std::string>& filenames)
+{
+   return std::all_of(filenames.begin(), filenames.end(), [](auto filename) { return FileExists(filename.c_str()); });
 }
 
 void trim(std::string& line, const std::string& trimChars)

--- a/libraries/TFormat/TParserLibrary.cxx
+++ b/libraries/TFormat/TParserLibrary.cxx
@@ -31,7 +31,7 @@ void TParserLibrary::Load()
       throw std::runtime_error(str.str());
    }
 
-   if(!file_exists(TGRSIOptions::Get()->ParserLibrary().c_str())) {
+   if(!FileExists(TGRSIOptions::Get()->ParserLibrary().c_str())) {
       std::ostringstream str;
       str << DRED << "Library '" << TGRSIOptions::Get()->ParserLibrary() << "' does not exist or we do not have permissions to access it!" << RESET_COLOR;
       throw std::runtime_error(str.str());

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -98,7 +98,7 @@ void TGRSIint::ApplyOptions()
       MakeBatch();
    }
 
-   bool missing_raw_file = !all_files_exist(opt->InputFiles());
+   bool missing_raw_file = !AllFilesExist(opt->InputFiles());
 
    LoadGROOTGraphics();
 
@@ -371,7 +371,7 @@ TFile* TGRSIint::OpenRootFile(const std::string& filename, Option_t* opt)
 TRawFile* TGRSIint::OpenRawFile(const std::string& filename)
 {
    /// Opens Raw input file and stores them in _raw if successfuly opened.
-   if(!file_exists(filename.c_str())) {
+   if(!FileExists(filename.c_str())) {
       std::cerr << R"(File ")" << filename << R"(" does not exist)" << std::endl;
       return nullptr;
    }
@@ -408,7 +408,7 @@ void TGRSIint::SetupPipeline()
 
    bool missing_raw_file = false;
    for(const auto& filename : opt->InputFiles()) {
-      if(!file_exists(filename.c_str())) {
+      if(!FileExists(filename.c_str())) {
          missing_raw_file = true;
          std::cerr << "File not found: " << filename << std::endl;
       }
@@ -671,7 +671,7 @@ void TGRSIint::SetupPipeline()
 void TGRSIint::RunMacroFile(const std::string& filename)
 {
    /// Runs a macro file. This happens when a .C file is provided on the command line
-   if(file_exists(filename.c_str())) {
+   if(FileExists(filename.c_str())) {
       const char* command = Form(".x %s", filename.c_str());
       ProcessLine(command);
    } else {
@@ -680,7 +680,7 @@ void TGRSIint::RunMacroFile(const std::string& filename)
       if(beginning_pos != std::string::npos && filename.back() == ')') {
          std::string trueFilename = filename.substr(0, beginning_pos);
          std::string arguments    = filename.substr(beginning_pos, std::string::npos);
-         if(file_exists(trueFilename.c_str())) {
+         if(FileExists(trueFilename.c_str())) {
             const char* command = Form(".L %s", trueFilename.c_str());
             ProcessLine(command);
             command = Form("%s%s", trueFilename.substr(0, filename.find_first_of('.')).c_str(), arguments.c_str());


### PR DESCRIPTION
This should fix #1493.

CMakeLists.txt now copies the SRIMData directory to the build directory and TSRIM checks if the directory `$GRSISYS/libraries/TAnalysis/SRIMData` exists and if not tries to use `$GRSISYS/SRIMData` instead.

Also added some small changes to TSourceCalibration.