### PR TITLE
Various improvements around TSourceCalibration

### DIFF
--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -132,6 +132,7 @@ public:
    TCalibrationGraph* Graph(size_t index) { return &(fGraphs.at(index)); }
    TCalibrationGraph* Residual(size_t index) { return &(fResidualGraphs.at(index)); }
 
+   void Draw(Option_t* opt = "") override { DrawCalibration(opt, nullptr); }
    void DrawCalibration(Option_t* opt = "", TLegend* legend = nullptr);
    void DrawResidual(Option_t* opt = "", TLegend* legend = nullptr);
 
@@ -140,8 +141,9 @@ public:
       fGraphs.erase(fGraphs.begin() + index);
       ResetTotalGraph();
    }
-   Int_t RemovePoint(const Int_t& px, const Int_t& py);           //*SIGNAL*
-   Int_t RemoveResidualPoint(const Int_t& px, const Int_t& py);   //*SIGNAL*
+   Int_t RemovePoint(const Int_t& px, const Int_t& py);                        //*SIGNAL*
+   Int_t RemoveResidualPoint(const Int_t& px, const Int_t& py);                //*SIGNAL*
+   Int_t RemovePoint(TGraphErrors* graph, const Int_t& px, const Int_t& py);   //*SIGNAL*
 
    void XAxisLabel(const std::string& xAxisLabel) { fXAxisLabel = xAxisLabel; }
    void YAxisLabel(const std::string& yAxisLabel) { fYAxisLabel = yAxisLabel; }
@@ -150,6 +152,8 @@ public:
    std::string YAxisLabel() { return fYAxisLabel; }
 
    void Scale(bool useAllPrevious = true);
+
+	void Sort();
 
    void Print(Option_t* opt = "") const override;
 

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -26,7 +26,6 @@
 ///
 /////////////////////////////////////////////////////////////////
 class TSinglePeak;
-using MultiplePeak_t = std::list<TSinglePeak*>;
 
 class TPeakFitter : public TObject {
 public:
@@ -37,7 +36,7 @@ public:
    TPeakFitter(TPeakFitter&&) noexcept            = default;
    TPeakFitter& operator=(const TPeakFitter&)     = default;
    TPeakFitter& operator=(TPeakFitter&&) noexcept = default;
-   ~TPeakFitter()                                 = default;
+   ~TPeakFitter();
 
    void AddPeak(TSinglePeak* peak)
    {
@@ -62,8 +61,8 @@ public:
    void Print(Option_t* opt = "") const override;
    void PrintParameters() const;
 
-   TF1*          GetBackground() { return fBGToFit; }
-   TF1*          GetFitFunction() { return fTotalFitFunction; }
+   TF1*          GetBackground() const { return fBGToFit; }
+   TF1*          GetFitFunction() const { return fTotalFitFunction; }
    void          SetRange(const Double_t& low, const Double_t& high);
    Int_t         GetNParameters() const;
    TFitResultPtr Fit(TH1* fit_hist, Option_t* opt = "");
@@ -73,20 +72,21 @@ public:
 
    void SetColorIndex(const int& index) { fColorIndex = index; }
 
+   static void       VerboseLevel(EVerbosity val) { fVerboseLevel = val; }
+   static EVerbosity VerboseLevel() { return fVerboseLevel; }
+
 private:
    void     UpdateFitterParameters();
    void     UpdatePeakParameters(const TFitResultPtr& fit_res, TH1* fit_hist);
    Double_t DefaultBackgroundFunction(Double_t* dim, Double_t* par);
    void     ResetTotalFitFunction()
    {
-      if(fTotalFitFunction != nullptr) {
-         delete fTotalFitFunction;
-         fTotalFitFunction = nullptr;
-      }
+		delete fTotalFitFunction;
+		fTotalFitFunction = nullptr;
    }
 
-   MultiplePeak_t fPeaksToFit;
-   TF1*           fBGToFit{nullptr};
+   std::list<TSinglePeak*> fPeaksToFit;
+   TF1*                    fBGToFit{nullptr};
 
    TF1* fTotalFitFunction{nullptr};
 
@@ -101,6 +101,8 @@ private:
    TH1* fLastHistFit{nullptr};
 
    int fColorIndex{0};   ///< this index is added to the colors kRed for the total function and kMagenta for the individual peaks
+
+	static EVerbosity fVerboseLevel; ///< Changes verbosity of code.
 
    /// \cond CLASSIMP
    ClassDefOverride(TPeakFitter, 2)   // NOLINT(readability-else-after-return)

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -94,6 +94,9 @@ public:
 
    bool ParameterSetByUser(int par);
 
+   void SetLineColor(Color_t color) { fTotalFunction->SetLineColor(color); }
+   void SetLineStyle(Style_t style) { fTotalFunction->SetLineColor(style); }
+
 protected:
    Double_t         TotalFunction(Double_t* dim, Double_t* par);
    virtual Double_t BackgroundFunction(Double_t*, Double_t*) { return 0.0; }

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -13,12 +13,12 @@ TPeakFitter::TPeakFitter(const Double_t& rangeLow, const Double_t& rangeHigh)
    fBGToFit = new TF1("fbg", this, &TPeakFitter::DefaultBackgroundFunction, fRangeLow, fRangeHigh, 4, "TPeakFitter", "DefaultBackgroundFunction");
    fBGToFit->FixParameter(3, 0);
    fBGToFit->SetLineColor(static_cast<Color_t>(kRed + fColorIndex));
-	if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": constructed peak fitter " << this << " using range " << fRangeLow << " - " << fRangeHigh << std::endl; }
+   if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": constructed peak fitter " << this << " using range " << fRangeLow << " - " << fRangeHigh << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 TPeakFitter::~TPeakFitter()
 {
-	if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": destroying peak fitter " << this << " for range " << fRangeLow << " - " << fRangeHigh << std::endl; }
+	if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": destroying peak fitter " << this << " for range " << fRangeLow << " - " << fRangeHigh << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TPeakFitter::Print(Option_t* opt) const
@@ -325,7 +325,7 @@ Double_t TPeakFitter::FitFunction(Double_t* dim, Double_t* par)
    // I want to use the EvalPar command here in order to get the individual peaks
    Double_t sum           = 0;
    Int_t    params_so_far = 0;
-	if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": this " << this << " has " << fPeaksToFit.size() << " peaks to be evaluated at x = " << dim[0] << std::endl; }
+	if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": this " << this << " has " << fPeaksToFit.size() << " peaks to be evaluated at x = " << dim[0] << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    for(auto* p_it : fPeaksToFit) {
       TF1* peakFunction = p_it->GetFitFunction();
 		if(peakFunction == nullptr) {

--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -362,7 +362,7 @@ Int_t TCalibrationGraphSet::RemovePoint(TGraphErrors* graph, const Int_t& px, co
 	if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
 
 	// emit signal that this point has been removed
-   std::array<Longptr_t, 2> args = {static_cast<long int>(oldGraph), static_cast<long int>(fPointIndex[point])};
+   std::array<Longptr_t, 2> args = {static_cast<int64_t>(oldGraph), static_cast<int64_t>(fPointIndex[point])};
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemovePoint(Int_t, Int_t) with " << args[0] << ", " << args[1] << " - " << args.data() << std::endl; }
    Emit("RemovePoint(Int_t, Int_t)", args.data());
 

--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -140,6 +140,10 @@ bool TCalibrationGraphSet::SetResidual(const bool& force)
    if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " gpad " << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    TF1* calibration = FitFunction();
    if(calibration != nullptr && (!fResidualSet || force)) {
+		if(fVerboseLevel > EVerbosity::kBasicFlow) {
+         std::cout << "calibration " << calibration << ", fResidualSet " << (fResidualSet ? "true" : "false") << ", force " << (force ? "true" : "false") << ", calibration: " << std::endl;
+         calibration->Print();
+		}
       double* x  = fTotalGraph->GetX();
       double* y  = fTotalGraph->GetY();
       double* ex = fTotalGraph->GetEX();
@@ -149,33 +153,42 @@ bool TCalibrationGraphSet::SetResidual(const bool& force)
          fTotalResidualGraph->SetPoint(i, y[i] - calibration->Eval(x[i]), y[i]);
          fTotalResidualGraph->SetPointError(i, TMath::Sqrt(TMath::Power(ey[i], 2) + TMath::Power(ex[i] * calibration->Derivative(x[i]), 2)), ey[i]);
       }
-      for(size_t g = 0; g < fGraphs.size(); ++g) {
-         x  = fGraphs[g].GetX();
-         y  = fGraphs[g].GetY();
-         ex = fGraphs[g].GetEX();
-         ey = fGraphs[g].GetEY();
-         fResidualGraphs[g].Set(fGraphs[g].GetN());
-         for(int i = 0; i < fGraphs[g].GetN(); ++i) {
-            fResidualGraphs[g].SetPoint(i, y[i] - calibration->Eval(x[i]), y[i]);
-            fResidualGraphs[g].SetPointError(i, TMath::Sqrt(TMath::Power(ey[i], 2) + TMath::Power(ex[i] * calibration->Derivative(x[i]), 2)), ey[i]);
-         }
-      }
-      fResidualSet = true;
-      auto* mother = gPad->GetMother();
-      int   pad    = 0;
-      while(mother->GetPad(pad) != nullptr) {
-         mother->GetPad(pad)->Modified();
-         mother->GetPad(pad)->Update();
-         mother->cd(pad);
-         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
-         pad++;
-      }
-   } else {
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": didn't find calibration (" << calibration << "), or the residual was already set (" << (fResidualSet ? "true" : "false") << ") and we don't force it (" << (force ? "true" : "false") << ")" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      if(calibration == nullptr) { fResidualSet = false; }
-   }
-   if(fVerboseLevel > EVerbosity::kSubroutines) { Print(); }
-   return fResidualSet;
+      if(fVerboseLevel > EVerbosity::kBasicFlow) {
+         std::cout << "Done calculating total residual graph with " << fTotalResidualGraph->GetN() << " points" << std::endl;
+		}
+		for(size_t g = 0; g < fGraphs.size(); ++g) {
+			x  = fGraphs[g].GetX();
+			y  = fGraphs[g].GetY();
+			ex = fGraphs[g].GetEX();
+			ey = fGraphs[g].GetEY();
+			fResidualGraphs[g].Set(fGraphs[g].GetN());
+			for(int i = 0; i < fGraphs[g].GetN(); ++i) {
+				fResidualGraphs[g].SetPoint(i, y[i] - calibration->Eval(x[i]), y[i]);
+				fResidualGraphs[g].SetPointError(i, TMath::Sqrt(TMath::Power(ey[i], 2) + TMath::Power(ex[i] * calibration->Derivative(x[i]), 2)), ey[i]);
+			}
+		}
+      if(fVerboseLevel > EVerbosity::kBasicFlow) {
+         std::cout << "Done calculating all " << fGraphs.size() << " individual residual graphs" << std::endl;
+		}
+		fResidualSet = true;
+		auto* mother = gPad->GetMother();
+		int   pad    = 0;
+		while(mother->GetPad(pad) != nullptr) {
+			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "pad " << pad << " = " << std::flush << mother->GetPad(pad) << " = " << std::flush << mother->GetPad(pad)->GetName() << ": modifying, " << std::flush; }
+			mother->GetPad(pad)->Modified();
+			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "updating, " << std::flush; }
+			mother->GetPad(pad)->Update();
+			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "changing to pad, " << std::flush; }
+			mother->cd(pad);
+			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "done!" << std::endl; }
+			pad++;
+		}
+	} else {
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": didn't find calibration (" << calibration << "), or the residual was already set (" << (fResidualSet ? "true" : "false") << ") and we don't force it (" << (force ? "true" : "false") << ")" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		if(calibration == nullptr) { fResidualSet = false; }
+	}
+	if(fVerboseLevel > EVerbosity::kSubroutines) { Print(); }
+	return fResidualSet;
 }
 
 void TCalibrationGraphSet::SetAxisTitle(const char* title)
@@ -197,6 +210,7 @@ void TCalibrationGraphSet::DrawCalibration(Option_t* opt, TLegend* legend)
    } else {
       options.Append("a");
    }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " drawing total graph with option \"" << options.Data() << "\"" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fTotalGraph->Draw(options.Data());
 
    if(fTotalGraph->GetHistogram() != nullptr) {
@@ -213,6 +227,10 @@ void TCalibrationGraphSet::DrawCalibration(Option_t* opt, TLegend* legend)
          legend->AddEntry(&(fGraphs[i]), fLabel[i].c_str());
       }
    }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " drawing legend " << legend << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(legend != nullptr) {
+		legend->Draw();
+	}
 }
 
 void TCalibrationGraphSet::DrawResidual(Option_t* opt, TLegend* legend)
@@ -220,6 +238,7 @@ void TCalibrationGraphSet::DrawResidual(Option_t* opt, TLegend* legend)
    TString options = opt;
    options.ToLower();
    options.Append("a");
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " drawing total residual graph with option \"" << options.Data() << "\"" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fTotalResidualGraph->Draw(options.Data());
    auto* hist = fTotalResidualGraph->GetHistogram();
    if(hist != nullptr) {
@@ -236,320 +255,299 @@ void TCalibrationGraphSet::DrawResidual(Option_t* opt, TLegend* legend)
          legend->AddEntry(&(fResidualGraphs[i]), fLabel[i].c_str());
       }
    }
+	if(legend != nullptr) {
+		legend->Draw();
+	}
 }
 
 Int_t TCalibrationGraphSet::RemovePoint(const Int_t& px, const Int_t& py)
 {
-   /// This function is primarily a copy of TGraph::RemovePoint with some added bits to remove a point that has been selected in the calibration graph from it and the corresponding point from the residual graph and the total graphs
-
+	/// This function calls RemovePoint on the total graph.
+	
    if(fVerboseLevel > EVerbosity::kBasicFlow) {
       std::cout << __PRETTY_FUNCTION__ << ": point " << px << ", " << py << "; gPad " << gPad->GetName() << ": " << gPad->AbsPixeltoX(px) << ", " << gPad->AbsPixeltoY(py) << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      Print();
    }
 
+	return RemovePoint(fTotalGraph, px, py);
+}
+
+Int_t TCalibrationGraphSet::RemoveResidualPoint(const Int_t& px, const Int_t& py)
+{
+	/// This function calls RemovePoint on the total graph.
+	
+   if(fVerboseLevel > EVerbosity::kBasicFlow) {
+      std::cout << __PRETTY_FUNCTION__ << ": point " << px << ", " << py << "; gPad " << gPad->GetName() << ": " << gPad->AbsPixeltoX(px) << ", " << gPad->AbsPixeltoY(py) << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+
+	return RemovePoint(fTotalResidualGraph, px, py);
+}
+
+Int_t TCalibrationGraphSet::RemovePoint(TGraphErrors* graph, const Int_t& px, const Int_t& py)
+{
+   /// This function is primarily a copy of TGraph::RemovePoint with some added bits to remove a point that has been selected in the residual graph from it and the corresponding point from the calibration graph and the total graphs
+	
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
+
    // localize point to be deleted
-   Int_t ipoint = -2;
+   Int_t point = -2;
    Int_t i      = 0;
    // start with a small window (in case the mouse is very close to one point)
-   double* x = fTotalGraph->GetX();
-   double* y = fTotalGraph->GetY();
-   for(i = 0; i < fTotalGraph->GetN(); i++) {
+   double* x = graph->GetX();
+   double* y = graph->GetY();
+   for(i = 0; i < graph->GetN(); i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(x[i]));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(y[i]));
       // TODO replace 100 with member variable?
       if(dpx * dpx + dpy * dpy < 100) {
          if(fVerboseLevel > EVerbosity::kSubroutines) {
-            std::cout << i << ": dpx = " << dpx << " = " << px << " - " << gPad->XtoAbsPixel(gPad->XtoPad(x[i])) << ", dpy = " << dpy << " = " << py << " - " << gPad->YtoAbsPixel(gPad->YtoPad(y[i])) << " this is the point we're looking for" << std::endl;
+            std::cout << i << ": dpx = " << dpx << " = " << px << " - " << gPad->XtoAbsPixel(gPad->XtoPad(x[i])) << ", dpy = " << dpy << " = " << py << " - " << gPad->YtoAbsPixel(gPad->YtoPad(y[i])) << " this is the point we're looking for at " << x[i] << ", " << y[i] << std::endl;
          }
-         ipoint = i;
+         point = i;
          break;
       }
       if(fVerboseLevel > EVerbosity::kSubroutines) {
          std::cout << i << ": dpx = " << dpx << " = " << px << " - " << gPad->XtoAbsPixel(gPad->XtoPad(x[i])) << ", dpy = " << dpy << " = " << py << " - " << gPad->YtoAbsPixel(gPad->YtoPad(y[i])) << " not the point we're looking for" << std::endl;
       }
    }
-   if(ipoint < 0) {
-      std::cout << "Failed to find point close to " << px << ", " << py << std::endl;
-      if(fVerboseLevel > EVerbosity::kSubroutines) {
-         std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-         Print();
-      }
-      return ipoint;
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) {
-      Print();
-   }
-   fTotalGraph->RemovePoint(ipoint);
-   if(fTotalResidualGraph->RemovePoint(ipoint) < 0) {
-      // we failed to remove the point in the residual, so we assume it's out of whack
-      fResidualSet = false;
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " didn't removed residual point" << std::endl; }
-   } else if(fVerboseLevel > EVerbosity::kSubroutines) {
-      std::cout << ipoint << " removed residual point" << std::endl;
-   }
-   // need to find which of the graphs we have to remove this point from -> use fGraphIndex[ipoint]
-   // and also which point this is of the graph -> use fPointIndex[ipoint]
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
-   if(fGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1 || fResidualGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1) {
-      std::cout << "point " << ipoint << " out of range?" << std::endl;
-   }
-   // and now also remove the points from the indices - also need to update all points after this point!
-   auto& oldGraph = fGraphIndex[ipoint];
-   auto& oldPoint = fPointIndex[ipoint];
-   fGraphIndex.erase(fGraphIndex.begin() + ipoint);
-   fPointIndex.erase(fPointIndex.begin() + ipoint);
-   for(size_t p = 0; p < fGraphIndex.size(); ++p) {
-      if(fGraphIndex[p] == oldGraph && fPointIndex[p] > oldPoint) {
-         --fPointIndex[p];
-      }
-   }
-   auto* mother = gPad->GetMother();
-   int   pad    = 0;
-   while(mother->GetPad(pad) != nullptr) {
-      mother->GetPad(pad)->Modified();
-      mother->GetPad(pad)->Update();
-      mother->cd(pad);
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified and updated pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
-      pad++;
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
-   std::array<Longptr_t, 2> args = {px, py};
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemovePoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
+
+	if(point < 0) {
+		if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Failed to find point close to " << px << ", " << py << std::endl; }
+		if(fVerboseLevel > EVerbosity::kSubroutines) {
+			std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			Print();
+		}
+		return point;
+	}
+	if(fVerboseLevel > EVerbosity::kSubroutines) {
+		Print();
+	}
+
+	// now that we have the point we want to delete, remove it from the total graphs
+	fTotalGraph->RemovePoint(point);
+	if(fTotalResidualGraph->RemovePoint(point) < 0) {
+		// we failed to remove the point in the residual, so we assume it's out of whack
+		fResidualSet = false;
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << point << " didn't removed residual point" << std::endl; }
+	} else if(fVerboseLevel > EVerbosity::kSubroutines) {
+		std::cout << point << " removed residual point" << std::endl;
+	}
+
+	// need to find which of the graphs we have to remove this point from -> use fGraphIndex[point]
+	// and also which point this is of the graph -> use fPointIndex[point]
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << point << " - " << fGraphIndex[point] << ", " << fPointIndex[point] << std::endl; }
+	if(fGraphs[fGraphIndex[point]].RemovePoint(fPointIndex[point]) == -1 || fResidualGraphs[fGraphIndex[point]].RemovePoint(fPointIndex[point]) == -1) {
+		std::cout << "point " << point << " out of range?" << std::endl;
+	}
+
+	// now we need to update the indices by removing this one, and updating all that come after it
+	auto& oldGraph = fGraphIndex[point];
+	auto& oldPoint = fPointIndex[point];
+	fGraphIndex.erase(fGraphIndex.begin() + point);
+	fPointIndex.erase(fPointIndex.begin() + point);
+	for(size_t p = 0; p < fGraphIndex.size(); ++p) {
+		if(fGraphIndex[p] == oldGraph && fPointIndex[p] >= oldPoint) {
+			--fPointIndex[p];
+		}
+	}
+
+	// update the graphics
+	auto* mother = gPad->GetMother();
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Got mother pad " << mother->GetName() << " from pad " << gPad->GetName() << std::endl; }
+	int pad = 0;
+	while(mother->GetPad(pad) != nullptr) {
+		mother->GetPad(pad)->Modified(); // one version also used Update and cd(pad)?
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
+		pad++;
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
+
+	// emit signal that this point has been removed
+   std::array<Longptr_t, 2> args = {static_cast<long int>(oldGraph), static_cast<long int>(fPointIndex[point])};
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemovePoint(Int_t, Int_t) with " << args[0] << ", " << args[1] << " - " << args.data() << std::endl; }
    Emit("RemovePoint(Int_t, Int_t)", args.data());
-   return ipoint;
+
+	return point;
 }
 
-Int_t TCalibrationGraphSet::RemoveResidualPoint(const Int_t& px, const Int_t& py)
+void TCalibrationGraphSet::Sort()
 {
-   /// This function is primarily a copy of TGraph::RemovePoint with some added bits to remove a point that has been selected in the residual graph from it and the corresponding point from the calibration graph and the total graphs
-
-   // localize point to be deleted
-   Int_t ipoint = -2;
-   Int_t i      = 0;
-   // start with a small window (in case the mouse is very close to one point)
-   double* x = fTotalResidualGraph->GetX();
-   double* y = fTotalResidualGraph->GetY();
-   for(i = 0; i < fTotalResidualGraph->GetN(); i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(x[i]));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(y[i]));
-      // TODO replace 100 with member variable?
-      if(dpx * dpx + dpy * dpy < 100) {
-         ipoint = i;
-         break;
-      }
-   }
-   if(ipoint < 0) {
-      if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Failed to find point close to " << px << ", " << py << std::endl; }
-      if(fVerboseLevel > EVerbosity::kSubroutines) {
-         std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-         Print();
-      }
-      return ipoint;
-   }
-   if(fVerboseLevel > EVerbosity::kSubroutines) {
-      std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      Print();
-   }
-   // no need to check if we can remove the residual point in this case
-   // need to find which of the graphs we have to remove this point from -> use fGraphIndex[ipoint]
-   // and also which point this is of the graph -> use fPointIndex[ipoint]
-   fTotalGraph->RemovePoint(ipoint);
-   fTotalResidualGraph->RemovePoint(ipoint);
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << ipoint << " - " << fGraphIndex[ipoint] << ", " << fPointIndex[ipoint] << std::endl; }
-   if(fGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1 || fResidualGraphs[fGraphIndex[ipoint]].RemovePoint(fPointIndex[ipoint]) == -1) {
-      std::cout << "point " << ipoint << " out of range?" << std::endl;
-   }
-   // and now also remove the points from the indices - also need to update all points after this point!
-   auto& oldGraph = fGraphIndex[ipoint];
-   auto& oldPoint = fPointIndex[ipoint];
-   fGraphIndex.erase(fGraphIndex.begin() + ipoint);
-   fPointIndex.erase(fPointIndex.begin() + ipoint);
-   for(size_t p = 0; p < fGraphIndex.size(); ++p) {
-      if(fGraphIndex[p] == oldGraph && fPointIndex[p] > oldPoint) {
-         --fPointIndex[p];
-      }
-   }
-   auto* mother = gPad->GetMother();
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Got mother pad " << mother->GetName() << " from pad " << gPad->GetName() << std::endl; }
-   int pad = 0;
-   while(mother->GetPad(pad) != nullptr) {
-      mother->GetPad(pad)->Modified();
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Modified pad " << pad << " = " << mother->GetPad(pad)->GetName() << std::endl; }
-      pad++;
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
-   std::array<Longptr_t, 2> args = {px, py};
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Emitting RemoveResidualPoint(Int_t, Int_t) with " << px << ", " << py << " - " << args.data() << std::endl; }
-   Emit("RemoveResidualPoint(Int_t, Int_t)", args.data());
-   return ipoint;
+	for(auto& graph : fGraphs) {
+		graph.Sort();
+	}
+	for(auto& graph : fResidualGraphs) {
+		// residuals plot energy vs. residual, so we want to sort by y, not x!
+		graph.Sort(&TGraph::CompareY);
+	}
 }
 
 void TCalibrationGraphSet::Scale(bool useAllPrevious)
 {
-   /// Scale all graphs to fit each other (based on the first "previous" graph found or just the first graph).
-   /// If no overlap is being found between the graph that is being scaled and the first graph (or all graphs before this one),
-   /// the current graph isn't being scaled and we continue with the next graph.
-   if(fVerboseLevel > EVerbosity::kBasicFlow) {
-      std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      Print();
-   }
-   for(size_t g = 1; g < fGraphs.size(); ++g) {
-      auto& graph = fGraphs[g];
-      if(graph.GetN() == 0) {
-         std::cout << "No entries in " << g << ". graph" << std::endl;
-      }
-      graph.Sort();
-      double* x = graph.GetX();
-      double* y = graph.GetY();
-      // loop over all other graphs before this one and use the first one with an overlap (should this be extended to use all possible ones before this one?)
-      size_t g2 = 0;
-      for(g2 = 0; (useAllPrevious ? g2 < g : g2 < 1); ++g2) {
-         double minRef = fGraphs[g2].GetX()[0];
-         double maxRef = fGraphs[g2].GetX()[fGraphs[g2].GetN() - 1];
-         if(fVerboseLevel > EVerbosity::kBasicFlow) {
-            std::cout << "Checking overlap between " << g2 << ". graph (" << fGraphs[g2].GetN() << ": " << minRef << " - " << maxRef << ") and " << g << ". graph (" << graph.GetN() << std::flush << ": " << x[0] << " - " << x[graph.GetN() - 1] << ")" << std::endl;
-         }
-         if(maxRef < x[0] || x[graph.GetN() - 1] < minRef) {
-            // no overlap between the two graphs, for now we just skip this one, but we could try and compare it to all the other ones?
-            std::cout << "No overlap between " << g2 << ". graph (" << fGraphs[g2].GetN() << ": " << minRef << " - " << maxRef << ") and " << g << ". graph (" << graph.GetN() << ": " << x[0] << " - " << x[graph.GetN() - 1] << ")" << std::endl;
-            continue;
-         }
-         // we have an overlap, so we calculate the scaling factor for each point and take the average (maybe should add some weight from the errors bars)
-         int    count = 0;
-         double sum   = 0.;
-         for(int p = 0; p < graph.GetN(); ++p) {
-            if(minRef < x[p] && x[p] < maxRef) {
-               sum += fGraphs[g2].Eval(x[p]) / y[p];
-               ++count;
-               if(fVerboseLevel > EVerbosity::kLoops) { std::cout << g << ", " << p << ": " << count << " - " << sum << ", " << fGraphs[g2].Eval(x[p]) / y[p] << std::endl; }
-            }
-         }
-         sum /= count;
-         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << g << ": scaling with " << sum << std::endl; }
-         graph.Scale(sum);
-         break;
-      }
-      if(g2 == g && fVerboseLevel > EVerbosity::kQuiet) {
-         std::cout << "No overlap(s) between 0. to " << g2 - 1 << ". graph and " << g << ". graph (" << graph.GetN() << ": " << x[0] << " - " << x[graph.GetN() - 1] << "), not scaling this one!" << std::endl;
-      }
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
-   ResetTotalGraph();
+	/// Scale all graphs to fit each other (based on the first "previous" graph found or just the first graph).
+	/// If no overlap is being found between the graph that is being scaled and the first graph (or all graphs before this one),
+	/// the current graph isn't being scaled and we continue with the next graph.
+	if(fVerboseLevel > EVerbosity::kBasicFlow) {
+		std::cout << __PRETTY_FUNCTION__ << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		Print();
+	}
+	Sort();
+	for(size_t g = 1; g < fGraphs.size(); ++g) {
+		auto& graph = fGraphs[g];
+		if(graph.GetN() == 0) {
+			std::cout << "No entries in " << g << ". graph" << std::endl;
+		}
+		double* x = graph.GetX();
+		double* y = graph.GetY();
+		// loop over all other graphs before this one and use the first one with an overlap (should this be extended to use all possible ones before this one?)
+		size_t g2 = 0;
+		for(g2 = 0; (useAllPrevious ? g2 < g : g2 < 1); ++g2) {
+			double minRef = fGraphs[g2].GetX()[0];
+			double maxRef = fGraphs[g2].GetX()[fGraphs[g2].GetN() - 1];
+			if(fVerboseLevel > EVerbosity::kBasicFlow) {
+				std::cout << "Checking overlap between " << g2 << ". graph (" << fGraphs[g2].GetN() << ": " << minRef << " - " << maxRef << ") and " << g << ". graph (" << graph.GetN() << std::flush << ": " << x[0] << " - " << x[graph.GetN() - 1] << ")" << std::endl;
+			}
+			if(maxRef < x[0] || x[graph.GetN() - 1] < minRef) {
+				// no overlap between the two graphs, for now we just skip this one, but we could try and compare it to all the other ones?
+				std::cout << "No overlap between " << g2 << ". graph (" << fGraphs[g2].GetN() << ": " << minRef << " - " << maxRef << ") and " << g << ". graph (" << graph.GetN() << ": " << x[0] << " - " << x[graph.GetN() - 1] << ")" << std::endl;
+				continue;
+			}
+			// we have an overlap, so we calculate the scaling factor for each point and take the average (maybe should add some weight from the errors bars)
+			int    count = 0;
+			double sum   = 0.;
+			for(int p = 0; p < graph.GetN(); ++p) {
+				if(minRef < x[p] && x[p] < maxRef) {
+					sum += fGraphs[g2].Eval(x[p]) / y[p];
+					++count;
+					if(fVerboseLevel > EVerbosity::kLoops) { std::cout << g << ", " << p << ": " << count << " - " << sum << ", " << fGraphs[g2].Eval(x[p]) / y[p] << std::endl; }
+				}
+			}
+			sum /= count;
+			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << g << ": scaling with " << sum << std::endl; }
+			graph.Scale(sum);
+			break;
+		}
+		if(g2 == g && fVerboseLevel > EVerbosity::kQuiet) {
+			std::cout << "No overlap(s) between 0. to " << g2 - 1 << ". graph and " << g << ". graph (" << graph.GetN() << ": " << x[0] << " - " << x[graph.GetN() - 1] << "), not scaling this one!" << std::endl;
+		}
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { Print(); }
+	ResetTotalGraph();
 }
 
 void TCalibrationGraphSet::ResetTotalGraph()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fGraphs.empty()) {
-      std::cerr << "No graphs added yet, makes no sense to reset total graph?" << std::endl;
-      return;
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fGraphs.empty()) {
+		std::cerr << "No graphs added yet, makes no sense to reset total graph?" << std::endl;
+		return;
+	}
 
-   size_t newSize = 0;
-   for(auto& graph : fGraphs) {
-      newSize += graph.GetN();
-   }
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "creating graph with " << newSize << " points" << std::endl; }
-   // create one vector with x, y, ex, ey, index of graph, and index of point that we can use to sort the data
-   std::vector<std::tuple<double, double, double, double, size_t, size_t>> data(newSize);
-   size_t                                                                  counter = 0;
-   for(size_t i = 0; i < fGraphs.size(); ++i) {
-      // get points and error bars from graph
-      double* x  = fGraphs[i].GetX();
-      double* y  = fGraphs[i].GetY();
-      double* eX = fGraphs[i].GetEX();
-      double* eY = fGraphs[i].GetEY();
-      for(int p = 0; p < fGraphs[i].GetN(); ++p, ++counter) {
-         if(fVerboseLevel > EVerbosity::kLoops) { std::cout << "filling point " << counter << " of vector of size " << newSize << std::endl; }
-         data[counter] = std::make_tuple(x[p], y[p], eX[p], eY[p], i, p);
-      }
-   }
+	size_t newSize = 0;
+	for(auto& graph : fGraphs) {
+		newSize += graph.GetN();
+	}
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "creating graph with " << newSize << " points" << std::endl; }
+	// create one vector with x, y, ex, ey, index of graph, and index of point that we can use to sort the data
+	std::vector<std::tuple<double, double, double, double, size_t, size_t>> data(newSize);
+	size_t                                                                  counter = 0;
+	for(size_t i = 0; i < fGraphs.size(); ++i) {
+		// get points and error bars from graph
+		double* x  = fGraphs[i].GetX();
+		double* y  = fGraphs[i].GetY();
+		double* eX = fGraphs[i].GetEX();
+		double* eY = fGraphs[i].GetEY();
+		for(int p = 0; p < fGraphs[i].GetN(); ++p, ++counter) {
+			if(fVerboseLevel > EVerbosity::kLoops) { std::cout << "filling point " << counter << " of vector of size " << newSize << std::endl; }
+			data[counter] = std::make_tuple(x[p], y[p], eX[p], eY[p], i, p);
+		}
+	}
 
-   std::sort(data.begin(), data.end());
+	std::sort(data.begin(), data.end());
 
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "sorted vector, setting graph sizes" << std::endl; }
 
-   fTotalGraph->Set(data.size());
-   fTotalResidualGraph->Set(data.size());
-   fGraphIndex.resize(data.size());
-   fPointIndex.resize(data.size());
+	fTotalGraph->Set(data.size());
+	fTotalResidualGraph->Set(data.size());
+	fGraphIndex.resize(data.size());
+	fPointIndex.resize(data.size());
 
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
-   for(size_t i = 0; i < data.size(); ++i) {
-      fTotalGraph->SetPoint(i, std::get<0>(data[i]), std::get<1>(data[i]));
-      fTotalGraph->SetPointError(i, std::get<2>(data[i]), std::get<3>(data[i]));
-      fGraphIndex[i] = std::get<4>(data[i]);
-      fPointIndex[i] = std::get<5>(data[i]);
-   }
-   // doesn't really make sense to calculate the residual here, as we don't have a fit of all the data yet
-   fResidualSet = false;
-   // set the new minima and maxima (always assuming the first and last points are minima and maxima, respectively)
-   fMinimumX = std::get<0>(data[0]);
-   fMinimumY = std::get<1>(data[0]);
-   fMaximumX = std::get<0>(data.back());
-   fMaximumY = std::get<1>(data.back());
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Filling fTotalGraph, fGraphIndex, and fPointIndex with " << data.size() << " points" << std::endl; }
+	for(size_t i = 0; i < data.size(); ++i) {
+		fTotalGraph->SetPoint(i, std::get<0>(data[i]), std::get<1>(data[i]));
+		fTotalGraph->SetPointError(i, std::get<2>(data[i]), std::get<3>(data[i]));
+		fGraphIndex[i] = std::get<4>(data[i]);
+		fPointIndex[i] = std::get<5>(data[i]);
+	}
+	// doesn't really make sense to calculate the residual here, as we don't have a fit of all the data yet
+	fResidualSet = false;
+	// set the new minima and maxima (always assuming the first and last points are minima and maxima, respectively)
+	fMinimumX = std::get<0>(data[0]);
+	fMinimumY = std::get<1>(data[0]);
+	fMaximumX = std::get<0>(data.back());
+	fMaximumY = std::get<1>(data.back());
 }
 
 void TCalibrationGraphSet::Print(Option_t* opt) const
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) {
-      std::cout << __PRETTY_FUNCTION__ << ", fTotalGraph " << fTotalGraph << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) {
+		std::cout << __PRETTY_FUNCTION__ << ", fTotalGraph " << fTotalGraph << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
 
-   std::cout << "TCalibrationGraphSet " << this << " - " << GetName() << ": " << fGraphs.size() << " calibration graphs, " << fResidualGraphs.size() << " residual graphs, " << fLabel.size() << " labels, ";
-   if(fTotalGraph != nullptr) {
-      std::cout << fTotalGraph->GetN() << " calibration points, and ";
-   } else {
-      std::cout << " no calibration points, and ";
-   }
-   if(fTotalResidualGraph != nullptr) {
-      std::cout << fTotalResidualGraph->GetN() << " residual points" << std::endl;
-   } else {
-      std::cout << " no residual points" << std::endl;
-   }
-   TString options = opt;
-   bool    errors  = options.Contains("e", TString::ECaseCompare::kIgnoreCase);
-   for(const auto& g : fGraphs) {
-      double* x  = g.GetX();
-      double* y  = g.GetY();
-      double* ex = g.GetEX();
-      double* ey = g.GetEY();
-      for(int p = 0; p < g.GetN(); ++p) {
-         if(errors) {
-            std::cout << p << " - " << x[p] << "(" << ex[p] << "), " << y[p] << "(" << ey[p] << "); ";
-         } else {
-            std::cout << p << " - " << x[p] << ", " << y[p] << "; ";
-         }
-      }
-      std::cout << std::endl;
-   }
-   std::cout << fGraphIndex.size() << " graph indices: ";
-   for(const auto& i : fGraphIndex) { std::cout << i << " "; }
-   std::cout << std::endl;
-   std::cout << fPointIndex.size() << " point indices: ";
-   for(const auto& i : fPointIndex) { std::cout << i << " "; }
-   std::cout << std::endl;
-   std::cout << "---- total graph ----" << std::endl;
-   double* x = fTotalGraph->GetX();
-   double* y = fTotalGraph->GetY();
-   for(int p = 0; p < fTotalGraph->GetN(); ++p) {
-      std::cout << p << " - " << x[p] << ", " << y[p] << "; ";
-   }
-   std::cout << std::endl;
-   std::cout << "---------------------" << std::endl;
+	std::cout << "TCalibrationGraphSet " << this << " - " << GetName() << ": " << fGraphs.size() << " calibration graphs, " << fResidualGraphs.size() << " residual graphs, " << fLabel.size() << " labels, ";
+	if(fTotalGraph != nullptr) {
+		std::cout << fTotalGraph->GetN() << " calibration points, and ";
+	} else {
+		std::cout << " no calibration points, and ";
+	}
+	if(fTotalResidualGraph != nullptr) {
+		std::cout << fTotalResidualGraph->GetN() << " residual points" << std::endl;
+	} else {
+		std::cout << " no residual points" << std::endl;
+	}
+	TString options = opt;
+	bool    errors  = options.Contains("e", TString::ECaseCompare::kIgnoreCase);
+	for(const auto& g : fGraphs) {
+		double* x  = g.GetX();
+		double* y  = g.GetY();
+		double* ex = g.GetEX();
+		double* ey = g.GetEY();
+		for(int p = 0; p < g.GetN(); ++p) {
+			if(errors) {
+				std::cout << p << " - " << x[p] << "(" << ex[p] << "), " << y[p] << "(" << ey[p] << "); ";
+			} else {
+				std::cout << p << " - " << x[p] << ", " << y[p] << "; ";
+			}
+		}
+		std::cout << std::endl;
+	}
+	std::cout << fGraphIndex.size() << " graph indices: ";
+	for(const auto& i : fGraphIndex) { std::cout << i << " "; }
+	std::cout << std::endl;
+	std::cout << fPointIndex.size() << " point indices: ";
+	for(const auto& i : fPointIndex) { std::cout << i << " "; }
+	std::cout << std::endl;
+	std::cout << "---- total graph ----" << std::endl;
+	double* x = fTotalGraph->GetX();
+	double* y = fTotalGraph->GetY();
+	for(int p = 0; p < fTotalGraph->GetN(); ++p) {
+		std::cout << p << " - " << x[p] << ", " << y[p] << "; ";
+	}
+	std::cout << std::endl;
+	std::cout << "---------------------" << std::endl;
 }
 
 void TCalibrationGraphSet::Clear(Option_t* option)
 {
-   fGraphs.clear();
-   fResidualGraphs.clear();
-   fLabel.clear();
-   fGraphIndex.clear();
-   fPointIndex.clear();
-   fResidualSet = false;
-   fMinimumX    = 0.;
-   fMaximumX    = 0.;
-   fMinimumY    = 0.;
-   fMaximumY    = 0.;
-   TNamed::Clear(option);
+	fGraphs.clear();
+	fResidualGraphs.clear();
+	fLabel.clear();
+	fGraphIndex.clear();
+	fPointIndex.clear();
+	fResidualSet = false;
+	fMinimumX    = 0.;
+	fMaximumX    = 0.;
+	fMinimumY    = 0.;
+	fMaximumY    = 0.;
+	TNamed::Clear(option);
+	fTotalGraph->Set(0);
+	fTotalResidualGraph->Set(0);
 }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -1531,7 +1531,7 @@ void TChannelTab::Iterate(const double& maxResidual)
 	}
 
    for(source = 1; source < fData->NumberOfGraphs(); ++source) {
-      auto tmp = std::max_element(fData->Residual(source)->GetX(), fData->Residual(source)->GetX() + fData->Residual(source)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+      auto* tmp = std::max_element(fData->Residual(source)->GetX(), fData->Residual(source)->GetX() + fData->Residual(source)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
       if(*tmp > *maxElement) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "found larger residual in residual graph " << source << ": " << *tmp << " > " << *maxElement << ", was position " << index << std::flush; }
          maxElement = tmp;

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -26,7 +26,7 @@
 #include "combinations.h"
 #include "Globals.h"
 
-std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<GPeak*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab)
+std::map<TGauss*, std::tuple<double, double, double, double>> Match(std::vector<TGauss*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab)
 {
    /// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
    /// It does so in a brute force fashion where we try all combinations of channels and energies, do a linear fit through them, and keep the one with the best chi square.
@@ -45,8 +45,8 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
 		std::cout << std::endl;
 	}
 
-   std::map<GPeak*, std::tuple<double, double, double, double>> result;
-   std::sort(peaks.begin(), peaks.end(), [](const GPeak* a, const GPeak* b) { return a->Centroid() < b->Centroid(); });
+   std::map<TGauss*, std::tuple<double, double, double, double>> result;
+   std::sort(peaks.begin(), peaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
    std::sort(sources.begin(), sources.end());
 
    auto maxSize = peaks.size();
@@ -94,6 +94,12 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
                for(size_t i = 0; i < num_data_points; i++) {
                   tmpMap[peak_values[i]] = source_values[i];
                }
+               if(TSourceCalibration::VerboseLevel() == EVerbosity::kAll) { 
+						std::cout << "Chi^2 " << fitter.GetChisquare() << " better than " << best_chi2 << ":" << std::endl;
+						for(auto iter : tmpMap) {
+							std::cout << std::setw(10) << iter.first << " - " << iter.second << std::endl;
+						}
+					}
                best_chi2 = fitter.GetChisquare();
             }
          }
@@ -157,7 +163,7 @@ std::map<GPeak*, std::tuple<double, double, double, double>> Match(std::vector<G
    return result;
 }
 
-std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vector<GPeak*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab)
+std::map<TGauss*, std::tuple<double, double, double, double>> SmartMatch(std::vector<TGauss*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab)
 {
    /// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
    /// It does so in slightly smarter way than the brute force method `Match`, by taking the reported intensity of the source peaks into account.
@@ -181,8 +187,8 @@ std::map<GPeak*, std::tuple<double, double, double, double>> SmartMatch(std::vec
       }
    }
 
-   std::map<GPeak*, std::tuple<double, double, double, double>> result;
-   std::sort(peaks.begin(), peaks.end(), [](const GPeak* a, const GPeak* b) { return a->Centroid() < b->Centroid(); });
+   std::map<TGauss*, std::tuple<double, double, double, double>> result;
+   std::sort(peaks.begin(), peaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
    std::sort(sources.begin(), sources.end(), [](const std::tuple<double, double, double, double>& a, const std::tuple<double, double, double, double>& b) { return std::get<2>(a) > std::get<2>(b); });
 
    auto maxSize = peaks.size();
@@ -319,7 +325,7 @@ TSourceTab::TSourceTab(TChannelTab* parent, TGCompositeFrame* frame, GH1D* proje
    : fParent(parent), fSourceFrame(frame), fProjection(projection), fSigma(sigma), fThreshold(threshold), fPeakRatio(peakRatio), fSourceEnergy(std::move(sourceEnergy))
 {
    BuildInterface();
-   FindPeaks(fSigma, fThreshold, fPeakRatio);
+   FindPeaks(fSigma, fThreshold, fPeakRatio, true, TSourceCalibration::Fast());
 }
 
 TSourceTab::TSourceTab(const TSourceTab& rhs)
@@ -336,17 +342,34 @@ TSourceTab::TSourceTab(const TSourceTab& rhs)
    fSigma      = rhs.fSigma;
    fThreshold  = rhs.fThreshold;
    fPeakRatio  = rhs.fPeakRatio;
+	// ? not sure what to do here, clearing the vectors seems unnecessary since we never filled them
+	// but we also can't just simply copy them, we would need a deep copy, which might not make sense?
+	// does is make sense in general to have assignment constructors for this class?
+	fFits.clear();
+	fBadFits.clear();
    fPeaks.clear();
 }
 
 TSourceTab::~TSourceTab()
 {
+   for(auto* fit : fFits) {
+      delete fit;
+   }
+   fFits.clear();
+   for(auto* fit : fBadFits) {
+      delete fit;
+   }
+   fBadFits.clear();
    for(auto* peak : fPeaks) {
       delete peak;
    }
    fPeaks.clear();
+	delete fSourceFrame;
    delete fProjectionCanvas;
    delete fSourceStatusBar;
+	//delete fProjection;
+	//delete fData;
+	//delete fFwhm;
 }
 
 void TSourceTab::BuildInterface()
@@ -384,7 +407,7 @@ void TSourceTab::ProjectionStatus(Event_t* event)
    // kClientMessage  = 14, kSelectionClear    = 15, kSelectionRequest = 16, kSelectionNotify = 17,
    // kColormapNotify = 18, kButtonDoubleClick = 19, kOtherEvent       = 20
    // };
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kAll) {
+   if(TSourceCalibration::VerboseLevel() == EVerbosity::kAll) {
       std::cout << __PRETTY_FUNCTION__ << ": code " << event->fCode << ", count " << event->fCount << ", state " << event->fState << ", type " << event->fType << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       if(event->fType == kClientMessage) {
          std::cout << "Client message: " << event->fUser[0] << ", " << event->fUser[1] << ", " << event->fUser[2] << std::endl;
@@ -437,13 +460,13 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
          }
          polym->SetNextPoint(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px), fProjectionCanvas->GetCanvas()->AbsPixeltoX(py));
          double range = 4 * fSigma;   // * fProjection->GetXaxis()->GetBinWidth(1);
-         GPeak* peak  = PhotoPeakFit(fProjection, fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range, fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range, "qretryfit");
-         //fPeakFitter.SetRange(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range, fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range);
-         //auto peak = new TRWPeak(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px));
-         //fPeakFitter.AddPeak(peak);
-         //fPeakFitter.Fit(fProjection, "qretryfit");
+         auto* pf = new TPeakFitter(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range, fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range);
+         auto* peak = new TGauss(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px));
+         pf->AddPeak(peak);
+         pf->Fit(fProjection, "qnretryfit");
          if(peak->Area() > 0) {
             fPeaks.push_back(peak);
+				fFits.push_back(pf);
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Fitted peak " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range << " - " << fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range << " -> centroid " << peak->Centroid() << std::endl; }
          } else {
             std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
@@ -451,13 +474,7 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
          fProjection->GetListOfFunctions()->Remove(peak);
          fProjection->Sumw2(false);   // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
-         //// redo matching of found peaks to source energies
-         //std::vector<std::tuple<double, double, double, double>> peaks;
-         //for(auto* foundPeak : fPeaks) {
-         //   peaks.emplace_back(foundPeak->Centroid(), foundPeak->CentroidErr(), foundPeak->Area(), foundPeak->AreaErr());
-         //}
-
-			std::sort(fPeaks.begin(), fPeaks.end(), [](const GPeak* a, const GPeak* b) { return a->Centroid() < b->Centroid(); });
+			std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
 
          auto map = Match(fPeaks, fSourceEnergy, this);
          Add(map);
@@ -531,6 +548,41 @@ void TSourceTab::UpdateRegions()
    }
 }
 
+bool TSourceTab::Good(TGauss* peak) {
+	return TSourceCalibration::AcceptBadFits() || (peak->CentroidErr() < 0.1 * peak->Centroid() && peak->AreaErr() < peak->Area() && !std::isnan(peak->CentroidErr()) && !std::isnan(peak->AreaErr()));
+}
+
+void TSourceTab::UpdateFits()
+{
+	/// This functions removes all fits named "gauss_total" from the histogram and adds instead the fit functions from all good and bad peaks to it.
+	TList* functions = fProjection->GetListOfFunctions();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "Updating functions for histogram " << fProjection->GetName() << " by deleting " << functions->GetEntries() << " functions:" << std::endl; 
+		for(auto* obj : *functions) {
+			std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+		}
+	}
+	// remove all old fits (all have the same name/title of "gauss_total")
+	// alternative: clone the peaks with indices in their names, that would also allow us to add a function to replace a single fit
+	TObject* fit = nullptr;
+	while((fit = functions->FindObject("gauss_total")) != nullptr) {
+		functions->Remove(fit);
+	}
+	// add all the fit functions of the good and the bad peaks
+	for(auto* obj : fFits) {
+		functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
+	}
+	for(auto* obj : fBadFits) {
+		functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "And adding " << functions->GetEntries() << " functions instead:" << std::endl; 
+		for(auto* obj : *functions) {
+			std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+		}
+	}
+}
+
 void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
 {
    /// This functions finds the peaks in the histogram, fits them, and adds the fits to the list of peaks.
@@ -549,6 +601,8 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       fSigma     = sigma;
       fThreshold = threshold;
       fPeaks.clear();
+		fFits.clear();
+		fBadFits.clear();
       // Remove all associated functions from projection.
       // These are the poly markers, fits, and the pave stat
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
@@ -590,46 +644,49 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
          fProjection->GetXaxis()->UnZoom();
       }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": found " << nofPeaks << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      //fPeakFitter.RemoveAllPeaks();
       for(int i = 0; i < nofPeaks; i++) {
          double range = TSourceCalibration::FitRange() * fSigma;
          // if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
-         GPeak* peak = nullptr;
-			// our range is symmetric so we can use the simple PhotoPeakFit form w/o the centroid
+			auto* pf = new TPeakFitter(peakPos[i] - range, peakPos[i] + range);
+         auto* peak = new TGauss(peakPos[i]);
+         pf->AddPeak(peak);
          if(TSourceCalibration::LogFile().empty()) {
             TRedirect redirect("/dev/null");
-            peak = PhotoPeakFit(fProjection, peakPos[i] - range, peakPos[i] + range, "qretryfit");
+				pf->Fit(fProjection, "qnretryfit");
          } else {
-            peak = PhotoPeakFit(fProjection, peakPos[i] - range, peakPos[i] + range, "retryfit");
+				pf->Fit(fProjection, "nretryfit");
          }
          if(peak->Area() > 0) {
 				// check if we accept bad fits (and if it was a bad fit)
-				if(TSourceCalibration::AcceptBadFits() || (peak->CentroidErr() < 0.1 * peak->Centroid() && peak->AreaErr() < peak->Area() && !std::isnan(peak->CentroidErr()) && !std::isnan(peak->AreaErr()))) {
+				if(Good(peak)) {
+					peak->SetLineColor(kRed);
 					fPeaks.push_back(peak);
+					fFits.push_back(pf);
 					if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
 						std::cout << "Fitted peak " << peakPos[i] - range << " - " << peakPos[i] + range << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
 					}
-				} else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-					std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+				} else {
+					peak->SetLineColor(kGray);
+					fBadFits.push_back(pf);
+					if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+						std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+					}
 				}
          } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
+				//delete peak;
          }
-         //fProjection->GetListOfFunctions()->Remove(peak);
       }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fProjection->Sumw2(false);                                                                                                                                        // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
       fProjectionCanvas->GetCanvas()->cd();
+		UpdateFits();
       fProjection->Draw();   // seems like hist + samefunc does not work. Could use hist + loop over list of functions (with same)
 
-      //// get a list of peaks positions and areas
-      //std::vector<std::tuple<double, double, double, double>> peaks;
-      //for(auto* peak : fPeaks) {
-      //   peaks.emplace_back(peak->Centroid(), peak->CentroidErr(), peak->Area(), peak->AreaErr());
-      //}
-
-		std::sort(fPeaks.begin(), fPeaks.end(), [](const GPeak* a, const GPeak* b) { return a->Centroid() < b->Centroid(); });
+		std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
+		std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
+		std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
 
       if(fast) {
          auto map = SmartMatch(fPeaks, fSourceEnergy, this);
@@ -653,7 +710,101 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
    }
 }
 
-void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>> map)
+void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
+{
+   /// This functions finds uses the existing calibration to find all peaks from the list of source energies.
+
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << std::flush << " " << fProjection->GetName() << ": using calibration " << calibration << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+
+	if(calibration == nullptr) {
+		std::cerr <<  __PRETTY_FUNCTION__ << ": provided calibration is nullptr, this function can only be called after an initial calibration has been made!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		return;
+	}
+
+	fPeaks.clear();
+	fFits.clear();
+	fBadFits.clear();
+	// Remove all associated functions from projection.
+	// These are the poly markers, fits, and the pave stat
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+		TList* functions = fProjection->GetListOfFunctions();
+		std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << " before clearing" << std::endl;
+		for(auto* obj : *functions) {
+			std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+		}
+	}
+	fProjection->GetListOfFunctions()->Clear();
+
+	// loop over all source energies
+	for(auto iter : fSourceEnergy) {
+		if(std::get<2>(iter) < TSourceCalibration::MinIntensity()) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Skipping peak at " << std::get<0>(iter) << " keV with intensity " << std::get<2>(iter) << " below required minimum intensity " << TSourceCalibration::MinIntensity() << std::endl;
+			}
+			continue;
+		}
+		double range = TSourceCalibration::FitRange() * fSigma;
+		double peakPos = calibration->GetX(std::get<0>(iter));
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << "Trying to fit peak " << peakPos << " (" << std::get<0>(iter) << " keV) in range " << peakPos - range << " - " << peakPos + range << std::endl;
+		}
+		// if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
+		auto* pf = new TPeakFitter(peakPos - range, peakPos + range);
+		auto* peak = new TGauss(peakPos);
+		pf->AddPeak(peak);
+		if(TSourceCalibration::LogFile().empty()) {
+			TRedirect redirect("/dev/null");
+			pf->Fit(fProjection, "qnretryfit");
+		} else {
+			pf->Fit(fProjection, "nretryfit");
+		}
+		if(peak->Area() > 0) {
+			// check if we accept bad fits (and if it was a bad fit)
+			if(Good(peak)) {
+				peak->SetLineColor(kRed);
+				fPeaks.push_back(peak);
+				fFits.push_back(pf);
+				if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+					std::cout << "Fitted peak " << peakPos - range << " - " << peakPos + range << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+				}
+			} else {
+				peak->SetLineColor(kGray);
+				fBadFits.push_back(pf);
+				if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+					std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+				}
+			}
+		} else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
+		}
+	}
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks (" << fSourceEnergy.size() << " source energies)" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	fProjection->Sumw2(false);                                                                                                                                        // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
+
+	fProjectionCanvas->GetCanvas()->cd();
+	UpdateFits();
+	fProjection->Draw();   // seems like hist + samefunc does not work. Could use hist + loop over list of functions (with same)
+
+	std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
+	std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
+	std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
+
+	auto map = Match(fPeaks, fSourceEnergy, this);
+	Add(map);
+
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      Double_t* x = fData->GetX();
+      Double_t* y = fData->GetY();
+      for(int i = 0; i < fData->GetN(); ++i) {
+         std::cout << " - " << x[i] << ", " << y[i];
+      }
+      std::cout << std::endl;
+   }
+}
+
+void TSourceTab::Add(std::map<TGauss*, std::tuple<double, double, double, double>> map)
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
       std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
@@ -684,7 +835,7 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
       auto energy      = std::get<0>(iter->second);
       auto energyErr   = std::get<1>(iter->second);
       // drop this peak if the uncertainties in area or position are too large
-      if(peakPosErr > 0.1 * peakPos || peakAreaErr > peakArea || std::isnan(peakPosErr) || std::isnan(peakAreaErr)) {
+      if(!Good(iter->first)) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
             std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
          }
@@ -710,10 +861,12 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
    // if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
    fData->Set(map.size());
    fFwhm->Set(map.size());
+	fData->Sort();
+	fFwhm->Sort();
    // split poly marker into those peaks that were used, and those that weren't
    TList* functions = fProjection->GetListOfFunctions();
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-      std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
+      std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << std::endl;
       for(auto* obj : *functions) {
          std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
       }
@@ -766,16 +919,16 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
       }
    }
 
-   // remove fit functions for unused peaks
+   // change color of fit functions for unused peaks
    TIter    iter(functions);
    TObject* item = nullptr;
    while((item = iter.Next()) != nullptr) {
-      if(item->IsA() == TF1::Class() || item->IsA() == GPeak::Class()) {   // if the item is a TF1 or GPeak we see if we can find the centroid in the map of used peaks
+      if(item->IsA() == TF1::Class() || item->IsA() == TGauss::Class()) {   // if the item is a TF1 or TGauss we see if we can find the centroid in the map of used peaks
          double centroid = 0.;
          if(item->IsA() == TF1::Class()) {
             centroid = static_cast<TF1*>(item)->GetParameter(1);
          } else {
-            centroid = static_cast<GPeak*>(item)->Centroid();
+            centroid = static_cast<TGauss*>(item)->Centroid();
          }
          bool found = false;
          for(auto point : map) {
@@ -786,7 +939,12 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
          }
          // remove the TF1 if it wasn't found in the map
          if(!found) {
-            functions->Remove(item);
+            //functions->Remove(item);
+				if(item->IsA() == TF1::Class()) {
+					static_cast<TF1*>(item)->SetLineColor(kGray);
+				} else {
+					static_cast<TGauss*>(item)->GetFitFunction()->SetLineColor(kGray);
+				}
          }
       }
    }
@@ -795,117 +953,96 @@ void TSourceTab::Add(std::map<GPeak*, std::tuple<double, double, double, double>
 void TSourceTab::ReplacePeak(const size_t& index, const double& channel)
 {
 	/// Replace the peak at the index with one centered at channel (calculated from an initial calibration and the source energy of this peak).
+	/// This replaces the TGauss* in fPeaks, and updates the values of this index in fData and fFwhm.
 	
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
       std::cout << DCYAN << __PRETTY_FUNCTION__ << ": index " << index << ", channel " << channel << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
+			std::cout << i << ": " << fPeaks[i]->Centroid() << " +- " << fPeaks[i]->CentroidErr() << " - " << fFits[i]->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+		}
    }
-	// get the old peak and then erase it from the vector
-	auto* oldPeak = fPeaks.at(index);
-	fPeaks.erase(fPeaks.begin() + index);
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << oldPeak->Centroid() << " with new peak at channel " << channel << std::endl; }
+	if(index >= fPeaks.size()) {
+		std::cerr << "Trying to replace peak at index " << index << " but there are only " << fPeaks.size() << " peaks!" << std::endl;
+		return;
+	}
+
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << fPeaks.at(index)->Centroid() << " with new peak at channel " << channel << std::endl; }
 
 	// calculate the fitting range (low to high) and adjust it so we ignore the old peak
 	double range = TSourceCalibration::FitRange() * fSigma;
 	double low = channel - range;
 	double high = channel + range;
-	if(oldPeak->Centroid() < channel) {
-		low = (oldPeak->Centroid() + channel) / 2.;
+	if(fPeaks.at(index)->Centroid() < channel) {
+		low = (fPeaks.at(index)->Centroid() + channel) / 2.;
 	} else {
-		high = (oldPeak->Centroid() + channel) / 2.;
+		high = (fPeaks.at(index)->Centroid() + channel) / 2.;
 	}
 	// if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
-	GPeak* peak = nullptr;
-	// our range might be asymmetric, so we need to also provide the centroid to PhotoPeakFit
+	auto* pf = new TPeakFitter(low, high);
+	auto* peak = new TGauss(channel);
+	pf->AddPeak(peak);
 	if(TSourceCalibration::LogFile().empty()) {
-		TRedirect redirect("/dev/null");
-		peak = PhotoPeakFit(fProjection, low, channel, high, "qretryfit");
+		//TRedirect redirect("/dev/null");
+		pf->Fit(fProjection, "retryfit");
 	} else {
-		peak = PhotoPeakFit(fProjection, low, channel, high, "retryfit");
+		pf->Fit(fProjection, "retryfit");
 	}
 	if(peak->Area() > 0) {
-		fPeaks.push_back(peak);
-		std::sort(fPeaks.begin(), fPeaks.end(), [](const GPeak* a, const GPeak* b) { return a->Centroid() < b->Centroid(); });
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+		if(Good(peak)) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << index << ". peak/fit out of " << fPeaks.size() << "/" << fFits.size() << " peaks/fits: " << std::flush << fPeaks.at(index)->Centroid() << "/" << fFits.at(index)->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+				std::cout << "Deleting " << index << ". peak " << fPeaks.at(index) << std::flush;
+			}
+			delete fPeaks.at(index);
+			fPeaks[index] = peak;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << " and setting it to " << fPeaks.at(index) << std::endl;
+			}
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Deleting " << index << ". fit " << fFits.at(index) << std::flush;
+			}
+			delete fFits.at(index);
+			fFits[index] = pf;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << " and setting it to " << fFits.at(index) << std::endl;
+			}
+			UpdateFits();
+         fData->SetPoint(index, peak->Centroid(), fData->GetPointY(index));
+         fData->SetPointError(index, peak->CentroidErr(), fData->GetErrorY(index));
+         fFwhm->SetPoint(index, peak->Centroid(), peak->FWHM());
+         fFwhm->SetPointError(index, peak->CentroidErr(), peak->FWHMErr());
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+			}
+		} else {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+			}
 		}
 	} else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
 		std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
 	}
- 
-	delete oldPeak;
 }
 
-void TSourceTab::RemovePoint(Int_t px, Int_t py)
+void TSourceTab::RemovePoint(Int_t oldPoint)
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": px " << px << ", py " << py << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
-   // we removed a point of the calibration graph at px, py, where px is the channel and py is the energy
-   // so we try and find a peak with its centroid close to px
-   for(auto it = fPeaks.begin(); it != fPeaks.end(); ++it) {
-      if(TMath::Abs((*it)->Centroid() - px) < fSigma) {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-            std::cout << DCYAN << "Erasing peak " << TMath::Abs((*it)->Centroid() - px) << " < " << fSigma << std::endl;
-            (*it)->Print();
-         }
-			delete *it;
-         fPeaks.erase(it);
-         break;
-      }
-   }
-   // remove the fit function of this peak
-   for(auto* item : *(fProjection->GetListOfFunctions())) {
-      if(item->IsA() == TF1::Class() || item->IsA() == GPeak::Class()) {   // if the item is a TF1 or GPeak we see if we can find the centroid in the map of used peaks
-         double centroid = 0.;
-         if(item->IsA() == TF1::Class()) {
-            centroid = static_cast<TF1*>(item)->GetParameter(1);
-         } else {
-            centroid = static_cast<GPeak*>(item)->Centroid();
-         }
-         if(TMath::Abs(centroid - px) < fSigma) {
-            if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-               std::cout << DCYAN << "Removing function " << TMath::Abs(centroid - px) << " < " << fSigma << std::endl;
-               item->Print();
-            }
-            fProjection->GetListOfFunctions()->Remove(item);
-            break;
-         }
-      }
-      // we also need to move the marker of this peak to the poly-marker of unused peaks (16 is light gray aka the color of the unused markers)
-      if(item->IsA() == TPolyMarker::Class()) { item->Print(); }   // && static_cast<TPolyMarker*>(item)->GetMarkerColor() != 16) {
-      //auto* polym = static_cast<TPolyMarker*>(item);
-      //double*             oldX = polym->GetX();
-      //double*             oldY = polym->GetY();
-      //int                 size = polym->GetN();
-      //std::vector<double> newX;
-      //std::vector<double> newY;
-      //std::vector<double> unusedX;
-      //std::vector<double> unusedY;
-      //for(i = 0; i < size; ++i) {
-      //	if(TMath::Abs(oldX[i] - px) < fSigma) {
-      //		unusedX.push_back(oldX[i]);
-      //		unusedY.push_back(oldY[i]);
-      //	} else {
-      //			newX.push_back(oldX[i]);
-      //			newY.push_back(oldY[i]);
-      //	}
-      //}
-      //polym->SetPolyMarker(newX.size(), newX.data(), newY.data());
-      //auto* unusedMarkers = new TPolyMarker(unusedX.size(), unusedX.data(), unusedY.data());
-      //unusedMarkers->SetMarkerStyle(23);   // triangle down
-      //unusedMarkers->SetMarkerColor(16);   // light grey
-      //functions->Add(unusedMarkers);
-      //}
-   }
-}
+	// first thing to do is check if the graph the point was removed from matches the id of this tab
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+	//auto erasedPeak = fPeaks.at(oldPoint);
+	fPeaks.erase(fPeaks.begin() + oldPoint);
+	auto* erasedFit = fFits.at(oldPoint);
+	fFits.erase(fFits.begin() + oldPoint);
+	fBadFits.push_back(erasedFit);
+	fData->RemovePoint(oldPoint);
 
-void TSourceTab::RemoveResidualPoint(Int_t px, Int_t py)
-{
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": px " << px << ", py " << py << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   // we removed a point of the residual graph at px, py, where px is the residual and py is the energy
+	UpdateFits();
+	// we also need to move the marker of this peak to the poly-marker of unused peaks (16 is light gray aka the color of the unused markers)
+	//if(item->IsA() == TPolyMarker::Class()) { item->Print(); }   // && static_cast<TPolyMarker*>(item)->GetMarkerColor() != 16) {
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
 }
 
 void TSourceTab::Status(const char* status, int position)
@@ -914,6 +1051,51 @@ void TSourceTab::Status(const char* status, int position)
    fSourceStatusBar->MapWindow();
    fSourceFrame->MapSubwindows();
    gVirtualX->Update();
+}
+
+void TSourceTab::Print() const
+{
+	std::cout << "Projection " << fProjection;
+	if(fProjection != nullptr) {
+		std::cout << " = " << fProjection->GetName() << "/" << fProjection->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
+
+	std::cout << "Data " << fData;
+	if(fData != nullptr) {
+		std::cout << " = " << fData->GetName() << "/" << fData->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
+
+	std::cout << "Fwhm " << fFwhm;
+	if(fFwhm != nullptr) {
+		std::cout << " = " << fFwhm->GetName() << "/" << fFwhm->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
+
+	std::cout << fFits.size() << " good fits:";
+	for(size_t i = 0; i < fFits.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+	}
+	std::cout << std::endl;
+
+	std::cout << fBadFits.size() << " bad fits:";
+	for(size_t i = 0; i < fBadFits.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fBadFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+	}
+	std::cout << std::endl;
+
+	std::cout << fPeaks.size() << " peaks:";
+	for(size_t i = 0; i < fPeaks.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fPeaks.at(i)->Centroid();
+	}
+	std::cout << std::endl;
 }
 
 void TSourceTab::PrintLayout() const
@@ -985,6 +1167,11 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
    fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
    Calibrate();   // also creates the residual and chi^2 label
 
+	// check whether we want to use this initial calibration to find more peaks
+	if(TSourceCalibration::UseCalibratedPeaks()) {
+		FindCalibratedPeaks();
+	}
+
    // get the fwhm graphs and plot them
    UpdateFwhm();
    fFwhmCanvas->GetCanvas()->cd();
@@ -1001,23 +1188,25 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
 
 TChannelTab::~TChannelTab()
 {
+	delete fChannelFrame;
    delete fSourceTab;
    for(auto* channel : fSources) {
       delete channel;
    }
-   delete fCalibrationCanvas;
-   delete fChannelStatusBar;
+   delete fCanvasTab;
    delete fCalibrationFrame;
+   delete fCalibrationCanvas;
+   delete fResidualPad;
+   delete fCalibrationPad;
+   delete fChannelStatusBar;
+   delete fLegend;
+   delete fChi2Label;
+   delete fFwhmFrame;
+   delete fFwhmCanvas;
+   delete fProgressBar;
+	// delete all fProjections and all fNuclei?
    delete fData;
    delete fFwhm;
-   delete fCalibrationPad;
-   delete fLegend;
-   delete fResidualPad;
-   delete fChi2Label;
-   delete fFwhmCanvas;
-   delete fFwhmFrame;
-   delete fCanvasTab;
-   delete fProgressBar;
 }
 
 void TChannelTab::CreateSourceTab(size_t source)
@@ -1049,22 +1238,14 @@ void TChannelTab::MakeConnections()
    fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
    fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
    fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
-   for(auto& source : fSources) {
-      source->MakeConnections();
-      fData->Connect("RemovePoint(const Int_t&, const Int_t&)", "TSourceTab", source, "RemovePoint(const Int_t&, const Int_t&)");
-      fData->Connect("RemoveResidualPoint(const Int_t&, const Int_t&)", "TSourceTab", source, "RemoveResidualPoint(const Int_t&, const Int_t&)");
-   }
+	fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
 }
 
 void TChannelTab::Disconnect()
 {
    fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
    fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
-   for(auto& source : fSources) {
-      source->Disconnect();
-      fData->Disconnect("RemovePoint(const Int_t&, const Int_t&)", source, "RemovePoint(const Int_t&, const Int_t&)");
-      fData->Disconnect("RemoveResidualPoint(const Int_t&, const Int_t&)", source, "RemoveResidualPoint(const Int_t&, const Int_t&)");
-   }
+	fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
 }
 
 void TChannelTab::SelectedTab(Int_t id)
@@ -1102,6 +1283,17 @@ void TChannelTab::SelectCanvas(Event_t* event)
          std::cout << " to " << gPad->GetName() << std::endl;
       }
    }
+}
+
+void TChannelTab::RemovePoint(Int_t oldGraph, Int_t oldPoint)
+{
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldGraph " << oldGraph << ", oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+	if(0 <= oldGraph && oldGraph < static_cast<int>(fSources.size())) {
+		return fSources[oldGraph]->RemovePoint(oldPoint);
+	}
+	std::cout << "Graph the point was removed from was " << oldGraph << ", but we only have " << fSources.size() << " source tabs?" << std::endl;
 }
 
 void TChannelTab::CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* selected)
@@ -1224,9 +1416,19 @@ void TChannelTab::Calibrate(const int& degree, const bool& force)
 void TChannelTab::Calibrate()
 {
    /// This function fit's the final data of the given channel. It requires all other elements to have been created already.
+   if(TSourceCalibration::VerboseLevel() == EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fDegree + 2);
    calibration->FixParameter(0, fDegree);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points being fit" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DYELLOW << "fData " << fData << ": ";
+		if(fData != nullptr) {
+			std::cout << fData->GetN() << " data points being fit, ";
+		}
+		double min = 0.;
+		double max = 0.;
+		calibration->GetRange(min, max);
+		std::cout << "range " << min << " - " << max << std::endl;
+	}
    fData->Fit(calibration, "Q");
    TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
    for(int i = 2; i <= fDegree; ++i) {
@@ -1272,6 +1474,18 @@ void TChannelTab::Calibrate()
 
    fCalibrationCanvas->GetCanvas()->Modified();
 
+	fData->FitFunction()->SetRange(0., 10000.);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		double min = 0.;
+		double max = 0.;
+		calibration->GetRange(min, max);
+		std::cout << DYELLOW << "calibration has range " << min << " - " << max;
+		if(fData->FitFunction() != nullptr) {
+			fData->FitFunction()->GetRange(min, max);
+			std::cout << ",  fit function has range " << min << " - " << max;
+		}
+		std::cout << std::endl;
+	}
    delete calibration;
 
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
@@ -1287,23 +1501,35 @@ void TChannelTab::Iterate(const double& maxResidual)
 
 	// Get the max residual in all the residual graphs
 	size_t source = 0;
-	auto maxElement = std::max_element(fData->Residual(source)->GetX(), fData->Residual(source)->GetX() + fData->Residual(source)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+	auto* maxElement = std::max_element(fData->Residual(source)->GetX(), fData->Residual(source)->GetX() + fData->Residual(source)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
 	auto index = std::distance(fData->Residual(source)->GetX(), maxElement);
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "found largest residual in first residual graph: " << *maxElement << ", position " << index << std::endl;
+		fData->Residual(source)->Print();
+	}
 	
-	for(source = 1; source < fData->NumberOfGraphs(); ++source) {
-		auto tmp = std::max_element(fData->Residual(source)->GetX(), fData->Residual(source)->GetX() + fData->Residual(source)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+	for(size_t s = 1; s < fData->NumberOfGraphs(); ++s) {
+		auto* tmp = std::max_element(fData->Residual(s)->GetX(), fData->Residual(s)->GetX() + fData->Residual(s)->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
 		if(*tmp > *maxElement) {
 			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "found larger residual in residual graph " << source << ": " << *tmp << " > " << *maxElement << ", was position " << index << std::flush; }
 			maxElement = tmp;
 			index = std::distance(fData->Residual(source)->GetX(), maxElement);
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " now at position " << index << std::endl; }
+			source = s;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << " now at position " << index << std::endl;
+				fData->Residual(s)->Print();
+			}
 		}
 	}
 	if(*maxElement < maxResidual) {
 		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "max. residual in residual graph " << source << " is " << *maxElement << " < " << maxResidual << "!" << std::endl; }
 		return;
 	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "found max. residual in residual graph " << source << " of " << *maxElement << " > " << maxResidual << ", at position " << index << std::endl; }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "found max. residual in residual graph " << source << " of " << *maxElement << " > " << maxResidual << ", at position " << index << std::endl;
+		fData->Residual(source)->Print();
+	}
 
 	// now that we have the source and the index of the point, we can get the energy of this peak and calculate the corresponding channel
 	double energy = fData->Graph(source)->GetY()[index];
@@ -1312,6 +1538,14 @@ void TChannelTab::Iterate(const double& maxResidual)
 	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "energy  = " << energy << " => channel =  " << channel << std::endl; }
 
 	fSources[source]->ReplacePeak(index, channel);
+
+	// update the data, re-calibrate, and then call Iterate again
+	UpdateData();
+	UpdateFwhm();
+	Calibrate();
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Iterate(" << maxResidual << ") is done, updated index " << index << " using channel =  " << channel << std::endl; }
+	Iterate(maxResidual);
 }
 
 void TChannelTab::UpdateChannel()
@@ -1367,6 +1601,21 @@ void TChannelTab::FindPeaks(const double& sigma, const double& threshold, const 
    UpdateData();
    UpdateFwhm();
 }
+
+void TChannelTab::FindCalibratedPeaks()
+{
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << DYELLOW << "Finding peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+      fSourceTab->Print();
+      for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
+         std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
+      }
+   }
+   fSources[fActiveSourceTab]->FindCalibratedPeaks(fData->FitFunction());
+   UpdateData();
+   UpdateFwhm();
+}
+
 
 void TChannelTab::Write(TFile* output)
 {
@@ -1534,17 +1783,20 @@ void TChannelTab::PrintLayout() const
 }
 
 //////////////////////////////////////// TSourceCalibration ////////////////////////////////////////
-EVerbosity  TSourceCalibration::fVerboseLevel    = EVerbosity::kQuiet;
-int         TSourceCalibration::fPanelWidth      = 600;
-int         TSourceCalibration::fPanelHeight     = 400;
-int         TSourceCalibration::fStatusbarHeight = 50;
-int         TSourceCalibration::fSourceboxWidth  = 100;
-int         TSourceCalibration::fParameterHeight = 200;
-int         TSourceCalibration::fDigitWidth      = 5;
 std::string TSourceCalibration::fLogFile;
-int         TSourceCalibration::fMaxIterations   = 50;
-int         TSourceCalibration::fFitRange        = 4;
-bool        TSourceCalibration::fAcceptBadFits   = false;
+EVerbosity  TSourceCalibration::fVerboseLevel       = EVerbosity::kQuiet;
+int         TSourceCalibration::fPanelWidth         = 600;
+int         TSourceCalibration::fPanelHeight        = 400;
+int         TSourceCalibration::fStatusbarHeight    = 50;
+int         TSourceCalibration::fSourceboxWidth     = 100;
+int         TSourceCalibration::fParameterHeight    = 200;
+int         TSourceCalibration::fDigitWidth         = 5;
+int         TSourceCalibration::fMaxIterations      = 50;
+int         TSourceCalibration::fFitRange           = 4;
+bool        TSourceCalibration::fAcceptBadFits      = false;
+bool        TSourceCalibration::fFast               = false;
+bool        TSourceCalibration::fUseCalibratedPeaks = false;
+double      TSourceCalibration::fMinIntensity       = 5.;
 
 TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degree, double peakRatio, int count...)
    : TGMainFrame(nullptr, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree), fDefaultPeakRatio(peakRatio)
@@ -1572,6 +1824,11 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
    fOldErrorLevel        = gErrorIgnoreLevel;
    gErrorIgnoreLevel     = kError;
    gPrintViaErrorHandler = true;   // redirects all printf's to root's normal message system
+
+   if(!fLogFile.empty()) {
+      fRedirect = new TRedirect(fLogFile.c_str());
+		std::cout << "Starting redirect to " << fLogFile << std::endl;
+   }
 
    // check matrices (# of filled bins and bin labels) and resize some vectors for later use
    // use the first matrix to get a reference for everything
@@ -1623,11 +1880,6 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
       throw std::runtime_error("Unable to open output file \"TSourceCalibration.root\"!");
    }
 
-   TRedirect* redirect = nullptr;
-   if(!fLogFile.empty()) {
-      redirect = new TRedirect(fLogFile.c_str());
-   }
-
    // build the first screen
    BuildFirstInterface();
    MakeFirstConnections();
@@ -1643,8 +1895,6 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
 
    // Map main frame
    MapWindow();
-
-   delete redirect;
 }
 
 TSourceCalibration::~TSourceCalibration()
@@ -1653,6 +1903,8 @@ TSourceCalibration::~TSourceCalibration()
    delete fOutput;
 
    gErrorIgnoreLevel = fOldErrorLevel;
+
+	delete fRedirect;
 }
 
 void TSourceCalibration::BuildFirstInterface()
@@ -1931,13 +2183,6 @@ void TSourceCalibration::BuildSecondInterface()
    fPreviousButton  = new TGTextButton(fNavigationGroup, "&Previous");
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
    fPreviousButton->SetEnabled(false);
-   fFindPeaksButton     = new TGTextButton(fNavigationGroup, "Find Peaks");
-   fFindPeaksFastButton = new TGTextButton(fNavigationGroup, "&Find Peaks Fast");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
-   fCalibrateButton = new TGTextButton(fNavigationGroup, "&Calibrate");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
-   fIterateButton = new TGTextButton(fNavigationGroup, "&Iterate");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "iter button " << fIterateButton << std::endl; }
    fDiscardButton = new TGTextButton(fNavigationGroup, "&Discard");
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
    fAcceptButton = new TGTextButton(fNavigationGroup, "&Accept");
@@ -1950,6 +2195,20 @@ void TSourceCalibration::BuildSecondInterface()
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
 
    fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+
+   fFittingGroup = new TGHButtonGroup(fLeftFrame, "");
+   fFindPeaksButton     = new TGTextButton(fFittingGroup, "Find Peaks");
+   fFindPeaksFastButton = new TGTextButton(fFittingGroup, "&Find Peaks Fast");
+   fFindPeaksCalButton = new TGTextButton(fFittingGroup, "&Use Calibration");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
+   fFindPeaksCalAllButton = new TGTextButton(fFittingGroup, "Use Calibration (All)");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find all peaks button " << fFindPeaksCalAllButton << std::endl; }
+   fIterateButton = new TGTextButton(fFittingGroup, "&Iterate");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "iterate button " << fIterateButton << std::endl; }
+   fCalibrateButton = new TGTextButton(fFittingGroup, "&Calibrate");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
+
+   fLeftFrame->AddFrame(fFittingGroup, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
    fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
 
@@ -1996,6 +2255,7 @@ void TSourceCalibration::MakeSecondConnections()
 {
    if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
+   fFittingGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Fitting(Int_t)");
    fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
    // we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
    for(auto* sourceTab : fChannelTab) {
@@ -2009,6 +2269,7 @@ void TSourceCalibration::DisconnectSecond()
 {
    if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
+   fFittingGroup->Disconnect("Clicked(Int_t)", this, "Fitting(Int_t)");
    fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
    for(auto* sourceTab : fChannelTab) {
       if(sourceTab != nullptr) {
@@ -2032,19 +2293,6 @@ void TSourceCalibration::Navigate(Int_t id)
       fTab->SetTab(currentChannelId - 1);
       SelectedTab(currentChannelId - 1);
       break;
-   case ENavigate::kFindPeaks:   // find peaks
-      FindPeaks();
-      break;
-   case ENavigate::kFindPeaksFast:   // find peaks fast
-      FindPeaksFast();
-      break;
-   case ENavigate::kCalibrate:   // calibrate
-      Calibrate();
-      break;
-   case ENavigate::kIterate:   // calibrate
-      Iterate();
-		Calibrate();
-      break;
    case ENavigate::kDiscard:   // discard
       // select the next (or if we are on the last tab, the previous) tab
       if(currentChannelId < nofTabs - 1) {
@@ -2067,6 +2315,41 @@ void TSourceCalibration::Navigate(Int_t id)
    case ENavigate::kNext:   // next
       fTab->SetTab(currentChannelId + 1);
       SelectedTab(currentChannelId + 1);
+      break;
+   default:
+      break;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+}
+
+void TSourceCalibration::Fitting(Int_t id)
+{
+   // we get the current source tab id and use it to get the channel tab from the right source tab
+   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+   int currentChannelId = fTab->GetCurrent();
+   int actualChannelId  = fActualChannelId[currentChannelId];
+   int nofTabs          = fTab->GetNumberOfTabs();
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   switch(id) {
+   case EFitting::kFindPeaks:   // find peaks
+      FindPeaks();
+      break;
+   case EFitting::kFindPeaksFast:   // find peaks fast
+      FindPeaksFast();
+      break;
+   case EFitting::kFindPeaksCal:   // find calibrated peaks
+      FindCalibratedPeaks();
+      break;
+   case EFitting::kFindPeaksCalAll:   // find all calibrated peaks
+      FindAllCalibratedPeaks();
+      break;
+   case EFitting::kCalibrate:   // calibrate
+      Calibrate();
+      break;
+   case EFitting::kIterate:   // iterate
+      Iterate(); // also calibrates the channel
       break;
    default:
       break;
@@ -2183,6 +2466,32 @@ void TSourceCalibration::FindPeaksFast()
    } else {
       std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+}
+
+void TSourceCalibration::FindCalibratedPeaks()
+{
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindCalibratedPeaks();
+      Calibrate();
+   } else {
+      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+}
+
+void TSourceCalibration::FindAllCalibratedPeaks()
+{
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	for(auto& bin : fActiveBins) {
+		if(fChannelTab[bin] != nullptr) {
+			fChannelTab[bin]->FindCalibratedPeaks();
+			fChannelTab[bin]->Calibrate(Degree(), true);
+		} else {
+			std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << bin << "] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		}
+	}
    if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 

--- a/makefile
+++ b/makefile
@@ -89,26 +89,29 @@ CFLAGS    += -MMD -MP $(INCLUDES)
 LINKFLAGS += -Llib $(addprefix -l,$(LIBRARY_NAMES)) -Wl,-rpath,\$$ORIGIN/../lib
 LINKFLAGS += $(shell root-config --glibs) -lSpectrum -lMinuit -lGuiHtml -lTreePlayer -lX11 -lXpm -lTMVA
 
+ROOT_LIBFLAGS := $(shell root-config --cflags --glibs) -lSpectrum -lMinuit -lGuiHtml -lTreePlayer -lX11 -lXpm -lTMVA
+
 # RCFLAGS are being used for rootcint
 ifeq ($(MATHMORE_INSTALLED),yes)
   CFLAGS += -DHAS_MATHMORE
   RCFLAGS += -DHAS_MATHMORE
   LINKFLAGS += -lMathMore
+  ROOT_LIBFLAGS += -lMathMore
 endif
 
 ifeq ($(XML_INSTALLED),yes)
   CFLAGS += -DHAS_XML
   RCFLAGS += -DHAS_XML
   LINKFLAGS += -lXMLParser -lXMLIO
+  ROOT_LIBFLAGS += -lXMLParser -lXMLIO
 endif
 
 ifeq ($(PROOF_INSTALLED),yes)
 	LINKFLAGS += -lProof
+	ROOT_LIBFLAGS += -lProof
 endif
 
 LINKFLAGS := $(LINKFLAGS_PREFIX) $(LINKFLAGS) $(LINKFLAGS_SUFFIX) $(CFLAGS)
-
-ROOT_LIBFLAGS := $(shell root-config --cflags --glibs)
 
 UTIL_O_FILES     := $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(wildcard util/*.$(SRC_SUFFIX)))
 #SANDBOX_O_FILES  := $(patsubst %.$(SRC_SUFFIX),.build/%.o,$(wildcard Sandbox/*.$(SRC_SUFFIX)))
@@ -186,7 +189,7 @@ include/GVersion.h:
 
 #include/GVersion.h: .git/HEAD .git/index util/gen_version.sh
 
-grsirc:
+grsirc: | include/GVersion.h
 	$(call run_and_test,util/gen_grsirc.sh,$@,$(COM_COLOR),$(BLD_STRING),$(OBJ_COLOR) )
 
 lib/lib%.so: .build/histos/%.o | include/GVersion.h lib


### PR DESCRIPTION
### TCalibrationGraphSet

- Overriding Draw function to call DrawCalibration (which is the actual
  function to draw the TCalibrationGraphSet).
- Added function to sort the whole set.
- Fixed how RemovePoint and RemoveResidualPoint work. They now both call
  RemovePoint, providing the graph to work on (data or residuals),
  removing code duplication. The emitted signal now isn't just repeating
  the coordinates (making it necessary to again find the right peak
  based on these), but the index of the removed point and the index of
  the graph this point belonged to.

### TPeakFitter

- Not releasing fixed parameters anymore when using retryfit, only those
  with parameter limits.
- Added static VerboseLevel functions to control verbosity of debuggin
  messages.
- Added check for missing fit functions when evaluating the fit
  function.

### TSinglePeak

- Added functions to set line color and style.

### TSourceCalibration

Lots of improvements, still missing a few things, mainly
multi-threading.

- Changed peak function from GPeak to TGauss, this should avoid cases
  where the fits consist mainly of the tail with an off-center peak.
- Added option to use the calibration from the first pass to try and
  find all peaks that are listed in the .sou-file and fit them. This
  seems like it will result in a much easier way to find all relevant
  peaks in sources like 133Ba and 56Co.
- In addition to saving a vector of GPeak* (now TGauss*), we now also
  save vectors of TPeakFitter* for good and bad fits.
- Connected the calibration graphs to the RemovePoint signal from
  TCalibrationGraphSet, so that when a peak is removed by right clicking
  on the graph, we can also remove the fit/move it to the bad fits. Not
  sure if this is fully working yet!
- Split the buttons up into two groups, one for "navigation" (previous
  channel, discard channel, accept channel, accept all, write, and next
  channel), and one for "fitting" (find peaks, find peaks fast, find
  peaks using the calibration for single channel/all channels), try and
  re-fit all peaks with bad residuals, and calibrate).
- Added static settings to use find peaks fast as default, automatically
  use the calibration from the initial pass to find peaks based on the
  energies in the .sou-file, and to set a minimum intensity for those
  peaks.

Next things to do is to implement multi-threading, check if we have
memory leaks, and verify all features work as intended (right now there
seems to be an issue when requesting automatical usage of the initial
calibration to find more peaks?).