### PR TITLE
Improved TSourceCalibration

### DIFF
--- a/include/TCalibrationGraph.h
+++ b/include/TCalibrationGraph.h
@@ -145,7 +145,7 @@ public:
    Int_t RemoveResidualPoint(const Int_t& px, const Int_t& py);                //*SIGNAL*
    Int_t RemovePoint(TGraphErrors* graph, const Int_t& px, const Int_t& py);   //*SIGNAL*
 
-	void RemovePoint(const int& point); //*SIGNAL*
+   void RemovePoint(const int& point);   //*SIGNAL*
 
    void XAxisLabel(const std::string& xAxisLabel) { fXAxisLabel = xAxisLabel; }
    void YAxisLabel(const std::string& yAxisLabel) { fYAxisLabel = yAxisLabel; }

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -56,6 +56,10 @@ public:
 	size_t NumberOfPeaks() { return fPeaksToFit.size(); }
 	std::list<TSinglePeak*>& Peaks() { return fPeaksToFit; }
 	TSinglePeak* Peak(const size_t& index) { 
+		if(index >= fPeaksToFit.size()) {
+			std::cerr << "Only " << fPeaksToFit.size() << " peaks in this peak fitter, can't access peak #" << index << std::endl;
+			return nullptr;
+		}
 		auto it = fPeaksToFit.begin();
 		std::advance(it, index);
 		return *it;

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -53,17 +53,18 @@ public:
       fPeaksToFit.clear();
       ResetTotalFitFunction();
    }
-	size_t NumberOfPeaks() { return fPeaksToFit.size(); }
-	std::list<TSinglePeak*>& Peaks() { return fPeaksToFit; }
-	TSinglePeak* Peak(const size_t& index) { 
-		if(index >= fPeaksToFit.size()) {
-			std::cerr << "Only " << fPeaksToFit.size() << " peaks in this peak fitter, can't access peak #" << index << std::endl;
-			return nullptr;
-		}
-		auto it = fPeaksToFit.begin();
-		std::advance(it, index);
-		return *it;
-	}
+   size_t                   NumberOfPeaks() { return fPeaksToFit.size(); }
+   std::list<TSinglePeak*>& Peaks() { return fPeaksToFit; }
+   TSinglePeak*             Peak(const size_t& index)
+   {
+      if(index >= fPeaksToFit.size()) {
+         std::cerr << "Only " << fPeaksToFit.size() << " peaks in this peak fitter, can't access peak #" << index << std::endl;
+         return nullptr;
+      }
+      auto it = fPeaksToFit.begin();
+      std::advance(it, index);
+      return *it;
+   }
 
    void SetBackground(TF1* bg_to_fit) { fBGToFit = bg_to_fit; }
    void InitializeParameters(TH1* fit_hist);

--- a/include/TPeakFitter.h
+++ b/include/TPeakFitter.h
@@ -53,7 +53,14 @@ public:
       fPeaksToFit.clear();
       ResetTotalFitFunction();
    }
-   //   void SetPeakToFit(TMultiplePeak*  peaks_to_fit) { fPeaksToFit = peaks_to_fit; }
+	size_t NumberOfPeaks() { return fPeaksToFit.size(); }
+	std::list<TSinglePeak*>& Peaks() { return fPeaksToFit; }
+	TSinglePeak* Peak(const size_t& index) { 
+		auto it = fPeaksToFit.begin();
+		std::advance(it, index);
+		return *it;
+	}
+
    void SetBackground(TF1* bg_to_fit) { fBGToFit = bg_to_fit; }
    void InitializeParameters(TH1* fit_hist);
    void InitializeBackgroundParameters(TH1* fit_hist);

--- a/include/TRedirect.h
+++ b/include/TRedirect.h
@@ -43,8 +43,10 @@ public:
    {
       fflush(stdout);
       dup2(fStdOutFileDescriptor, fileno(stdout));
+		close(fStdOutFileDescriptor);
       fflush(stderr);
       dup2(fStdErrFileDescriptor, fileno(stderr));
+		close(fStdErrFileDescriptor);
    }
 
    TRedirect(const TRedirect&) = delete;

--- a/include/TRedirect.h
+++ b/include/TRedirect.h
@@ -43,10 +43,10 @@ public:
    {
       fflush(stdout);
       dup2(fStdOutFileDescriptor, fileno(stdout));
-		close(fStdOutFileDescriptor);
+      close(fStdOutFileDescriptor);
       fflush(stderr);
       dup2(fStdErrFileDescriptor, fileno(stderr));
-		close(fStdErrFileDescriptor);
+      close(fStdErrFileDescriptor);
    }
 
    TRedirect(const TRedirect&) = delete;

--- a/include/TSinglePeak.h
+++ b/include/TSinglePeak.h
@@ -95,7 +95,10 @@ public:
    bool ParameterSetByUser(int par);
 
    void SetLineColor(Color_t color) { fTotalFunction->SetLineColor(color); }
-   void SetLineStyle(Style_t style) { fTotalFunction->SetLineColor(style); }
+   void SetLineStyle(Style_t style) { fTotalFunction->SetLineStyle(style); }
+
+   Color_t GetLineColor() { return fTotalFunction->GetLineColor(); }
+   Style_t GetLineStyle() { return fTotalFunction->GetLineStyle(); }
 
 protected:
    Double_t         TotalFunction(Double_t* dim, Double_t* par);

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -43,7 +43,7 @@
 
 class TSourceTab;
 
-std::map<double, std::tuple<double, double, double, double>> RoughCal(std::vector<double> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab);
+std::map<double, std::tuple<double, double, double, double>>  RoughCal(std::vector<double> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab);
 std::map<TGauss*, std::tuple<double, double, double, double>> Match(std::vector<TGauss*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab);
 std::map<TGauss*, std::tuple<double, double, double, double>> SmartMatch(std::vector<TGauss*> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab);
 
@@ -70,7 +70,7 @@ public:
    void ProjectionStatus(Event_t* event);
    void ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* selected);
 
-	void InitialCalibration(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast);
+   void InitialCalibration(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast);
    void Add(std::map<double, std::tuple<double, double, double, double>> map);
    void Add(std::map<TGauss*, std::tuple<double, double, double, double>> map);
    void FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force = false, const bool& fast = true);
@@ -84,7 +84,7 @@ public:
    TGraphErrors*        Data() const { return fData; }
    TGraphErrors*        Fwhm() const { return fFwhm; }
    TRootEmbeddedCanvas* ProjectionCanvas() const { return fProjectionCanvas; }
-	const char* SourceName() const { return fSourceName; }
+   const char*          SourceName() const { return fSourceName; }
 
    void RemovePoint(Int_t oldPoint);
 
@@ -93,7 +93,7 @@ public:
 
    void PrintCanvases() const;
 
-	void Draw();
+   void Draw();
 
 private:
    void BuildInterface();
@@ -111,7 +111,7 @@ private:
 
    // storage elements
    GH1D*                                                   fProjection{nullptr};
-	const char*                                             fSourceName;
+   const char*                                             fSourceName;
    TGraphErrors*                                           fData{nullptr};
    TGraphErrors*                                           fFwhm{nullptr};
    double                                                  fSigma{2.};
@@ -126,7 +126,7 @@ private:
 
 class TChannelTab {
 public:
-	TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, double sigma, double threshold, int degree, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar);
+   TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, double sigma, double threshold, int degree, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar);
    TChannelTab(const TChannelTab&)                = default;
    TChannelTab(TChannelTab&&) noexcept            = default;
    TChannelTab& operator=(const TChannelTab&)     = default;
@@ -135,7 +135,7 @@ public:
 
    void MakeConnections();
    void Disconnect();
-	void Initialize(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast);
+   void Initialize(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast);
 
    void CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* selected);
    void SelectCanvas(Event_t* event);
@@ -160,7 +160,7 @@ public:
    int           ActiveSourceTab() const { return fActiveSourceTab; }
    TSourceTab*   SelectedSourceTab() const { return fSources[fActiveSourceTab]; }
 
-	TSourceCalibration* Parent() const { return fParent; }
+   TSourceCalibration* Parent() const { return fParent; }
 
    static void ZoomX();
    static void ZoomY();
@@ -169,7 +169,7 @@ public:
 
    void PrintCanvases() const;
 
-	void Draw();
+   void Draw();
 
 private:
    void BuildInterface();
@@ -230,7 +230,7 @@ public:
    void Navigate(Int_t id);
    void Fitting(Int_t id);
    void Calibrate();
-	void Remove();
+   void Remove();
    void FindPeaks();
    void FindPeaksFast();
    void FindCalibratedPeaks();
@@ -270,7 +270,7 @@ public:
    void SecondWindow();
    void FinalWindow();
 
-	std::mutex& GraphicsMutex() { return fGraphicsMutex; }
+   std::mutex& GraphicsMutex() { return fGraphicsMutex; }
 
    static void PanelWidth(int val) { fPanelWidth = val; }
    static void PanelHeight(int val) { fPanelHeight = val; }
@@ -342,7 +342,7 @@ private:
       kFindPeaksCal    = 3,
       kFindPeaksCalAll = 4,
       kCalibrate       = 5,
-		kRemove          = 6
+      kRemove          = 6
    };
 
    void BuildFirstInterface();
@@ -404,7 +404,7 @@ private:
    std::vector<int>                                                     fActiveBins;
    std::vector<int>                                                     fActualChannelId;
    std::vector<const char*>                                             fChannelLabel;
-	std::queue<std::pair<int, std::future<TChannelTab*>>>                fFutures;
+   std::queue<std::pair<int, std::future<TChannelTab*>>>                fFutures;
 
    std::vector<TH2*> fMatrices;
    int               fNofBins{0};   ///< Number of filled bins in first matrix
@@ -438,8 +438,8 @@ private:
    static double fMinIntensity;             ///< Minimum intensity of source peaks to be considered when trying to find them in the spectrum.
    static size_t fNumberOfThreads;          ///< Maximum number of threads to run while creating the channel tabs
 
-	std::mutex    fGraphicsMutex;            ///< mutex to lock changes to graphics
-																															  
+   std::mutex fGraphicsMutex;   ///< mutex to lock changes to graphics
+
    TFile* fOutput{nullptr};
 
    static EVerbosity fVerboseLevel;   ///< Changes verbosity from kQuiet to kAll

--- a/include/TSourceCalibration.h
+++ b/include/TSourceCalibration.h
@@ -100,7 +100,7 @@ private:
    bool Good(TGauss* peak);
    bool Good(TGauss* peak, double lowRange, double highRange) { return Good(peak) && lowRange < peak->Centroid() && peak->Centroid() < highRange; }
    void UpdateFits();
-	void SetLineColors();
+   void SetLineColors();
 
    // parents
    TSourceCalibration* fSourceCalibration{nullptr};
@@ -226,7 +226,7 @@ public:
    void Fitting(Int_t id);
    void Calibrate();
    void Remove();
-	using TObject::RecursiveRemove;
+   using TObject::RecursiveRemove;
    void RecursiveRemove();
    void FindSourcePeaks();
    void FindChannelPeaks();
@@ -301,9 +301,9 @@ public:
    static void   MinIntensity(double val) { fMinIntensity = val; }
    static double MinIntensity() { return fMinIntensity; }
 
-	static void BadBins(const std::vector<int>& val) { fBadBins = val; }
-	static void BadBin(const int& val) { fBadBins.push_back(val); }
-	static void ResetBadBins() { fBadBins.clear(); }
+   static void BadBins(const std::vector<int>& val) { fBadBins = val; }
+   static void BadBin(const int& val) { fBadBins.push_back(val); }
+   static void ResetBadBins() { fBadBins.clear(); }
 
    static void ZoomX();
 
@@ -339,21 +339,21 @@ private:
       kRecursiveRemove  = 5
    };
 
-   void BuildFirstInterface();
-   void MakeFirstConnections();
-   void DisconnectFirst();
-   void DeleteFirst();
-   void BuildSecondInterface();
-   void MakeSecondConnections();
-   void AcceptChannel(const int& channelId = -1);
-   void DisconnectSecond();
-   void DeleteSecond();
-   void BuildThirdInterface();
-   void MakeThirdConnections();
-   void AcceptFinalChannel(const int& channelId = -1);
-   void DisconnectThird();
-   void DeleteElement(TGFrame* element);
-	TGTransientFrame* CreateProgressbar(const char* format);
+   void              BuildFirstInterface();
+   void              MakeFirstConnections();
+   void              DisconnectFirst();
+   void              DeleteFirst();
+   void              BuildSecondInterface();
+   void              MakeSecondConnections();
+   void              AcceptChannel(const int& channelId = -1);
+   void              DisconnectSecond();
+   void              DeleteSecond();
+   void              BuildThirdInterface();
+   void              MakeThirdConnections();
+   void              AcceptFinalChannel(const int& channelId = -1);
+   void              DisconnectThird();
+   void              DeleteElement(TGFrame* element);
+   TGTransientFrame* CreateProgressbar(const char* format);
 
    //TGHorizontalFrame* fTopFrame{nullptr};
    TGHorizontalFrame*        fBottomFrame{nullptr};
@@ -419,18 +419,18 @@ private:
 
    int fOldErrorLevel;   ///< Used to store old value of gErrorIgnoreLevel (set to kError for the scope of the class)
 
-   double        fDefaultSigma{2.};         ///< The default sigma used for the peak finding algorithm, can be changed later.
-   double        fDefaultThreshold{0.05};   ///< The default threshold used for the peak finding algorithm, can be changed later. Co-56 source needs a much lower threshold, 0.01 or 0.02, but that makes it much slower too.
-   int           fDefaultDegree{1};         ///< The default degree of the polynomial used for calibrating, can be changed later.
-   double        fDefaultMaxResidual{2.};   ///< The default maximum residual accepted when trying to iteratively find peaks
-   static int    fMaxIterations;            ///< Maximum iterations over combinations in Match and SmartMatch
-   static int    fFitRange;                 ///< range in sigma used for fitting peaks (peak position - range to peas position + range)
-   static bool   fAcceptBadFits;            ///< Do we accept peaks where the fit was bad (position or area uncertainties too large or not numbers)
-   static bool   fFast;                     ///< Do we use the fast peak finding method on startup or not.
-   static bool   fUseCalibratedPeaks;       ///< Do we use the initial calibration to find more peaks in the source spectra?
-   static double fMinIntensity;             ///< Minimum intensity of source peaks to be considered when trying to find them in the spectrum.
-   static size_t fNumberOfThreads;          ///< Maximum number of threads to run while creating the channel tabs
-	static std::vector<int> fBadBins;        ///< Bins of the 2D matrix to be ignored even if there are enough counts in them
+   double                  fDefaultSigma{2.};         ///< The default sigma used for the peak finding algorithm, can be changed later.
+   double                  fDefaultThreshold{0.05};   ///< The default threshold used for the peak finding algorithm, can be changed later. Co-56 source needs a much lower threshold, 0.01 or 0.02, but that makes it much slower too.
+   int                     fDefaultDegree{1};         ///< The default degree of the polynomial used for calibrating, can be changed later.
+   double                  fDefaultMaxResidual{2.};   ///< The default maximum residual accepted when trying to iteratively find peaks
+   static int              fMaxIterations;            ///< Maximum iterations over combinations in Match and SmartMatch
+   static int              fFitRange;                 ///< range in sigma used for fitting peaks (peak position - range to peas position + range)
+   static bool             fAcceptBadFits;            ///< Do we accept peaks where the fit was bad (position or area uncertainties too large or not numbers)
+   static bool             fFast;                     ///< Do we use the fast peak finding method on startup or not.
+   static bool             fUseCalibratedPeaks;       ///< Do we use the initial calibration to find more peaks in the source spectra?
+   static double           fMinIntensity;             ///< Minimum intensity of source peaks to be considered when trying to find them in the spectrum.
+   static size_t           fNumberOfThreads;          ///< Maximum number of threads to run while creating the channel tabs
+   static std::vector<int> fBadBins;                  ///< Bins of the 2D matrix to be ignored even if there are enough counts in them
 
    std::mutex fGraphicsMutex;   ///< mutex to lock changes to graphics
 

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -80,6 +80,9 @@ void TPeakFitter::SetRange(const Double_t& low, const Double_t& high)
 {
    fRangeLow  = low;
    fRangeHigh = high;
+	if(fTotalFitFunction != nullptr) {
+		fTotalFitFunction->SetTitle(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh));
+	}
 }
 
 TFitResultPtr TPeakFitter::Fit(TH1* fit_hist, Option_t* opt)
@@ -113,7 +116,7 @@ TFitResultPtr TPeakFitter::Fit(TH1* fit_hist, Option_t* opt)
    TVirtualFitter::SetMaxIterations(100000);
    TVirtualFitter::SetPrecision(1e-4);
    if(fTotalFitFunction == nullptr) {
-      fTotalFitFunction = new TF1("total_fit", this, &TPeakFitter::FitFunction, fRangeLow, fRangeHigh, GetNParameters(), "TPeakFitter", "FitFunction");
+      fTotalFitFunction = new TF1(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh), this, &TPeakFitter::FitFunction, fRangeLow, fRangeHigh, GetNParameters(), "TPeakFitter", "FitFunction");
    }
    fTotalFitFunction->SetLineColor(static_cast<Color_t>(kMagenta + fColorIndex));
    fTotalFitFunction->SetRange(fRangeLow, fRangeHigh);
@@ -255,7 +258,7 @@ void TPeakFitter::UpdatePeakParameters(const TFitResultPtr& fit_res, TH1* fit_hi
          p_it->SetArea(total_function_copy->Integral(p_it->Centroid() - p_it->Width() * 5., p_it->Centroid() + p_it->Width() * 5., 1e-8) / fit_hist->GetBinWidth(1));
          if(goodCovarianceMatrix) {
             p_it->SetAreaErr(total_function_copy->IntegralError(p_it->Centroid() - p_it->Width() * 5., p_it->Centroid() + p_it->Width() * 5., total_function_copy->GetParameters(), covariance_matrix.GetMatrixArray(), 1E-5) / fit_hist->GetBinWidth(1));
-         } else {
+         } else if(fVerboseLevel != EVerbosity::kQuiet) {
             std::cout << "Not setting area error because we don't have a good covariance matrix!" << std::endl;
          }
       }

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -80,9 +80,9 @@ void TPeakFitter::SetRange(const Double_t& low, const Double_t& high)
 {
    fRangeLow  = low;
    fRangeHigh = high;
-	if(fTotalFitFunction != nullptr) {
-		fTotalFitFunction->SetTitle(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh));
-	}
+   if(fTotalFitFunction != nullptr) {
+      fTotalFitFunction->SetTitle(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh));
+   }
 }
 
 TFitResultPtr TPeakFitter::Fit(TH1* fit_hist, Option_t* opt)

--- a/libraries/TGUI/TCalibrationGraph.cxx
+++ b/libraries/TGUI/TCalibrationGraph.cxx
@@ -346,9 +346,11 @@ Int_t TCalibrationGraphSet::RemovePoint(TGraphErrors* graph, const Int_t& px, co
    fPointIndex.erase(fPointIndex.begin() + point);
    for(size_t p = 0; p < fGraphIndex.size(); ++p) {
       if(fGraphIndex[p] == oldGraph && fPointIndex[p] >= oldPoint) {
-			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " == " << oldGraph << " && " << fPointIndex[p] << " >= " << oldPoint << ": decrementing index" << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " == " << oldGraph << " && " << fPointIndex[p] << " >= " << oldPoint << ": decrementing index" << std::endl; }
          --fPointIndex[p];
-      } else if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " != " << oldGraph << " || " << fPointIndex[p] << " < " << oldPoint << ": decrementing index" << std::endl; }
+      } else if(fVerboseLevel > EVerbosity::kSubroutines) {
+         std::cout << fGraphIndex[p] << " != " << oldGraph << " || " << fPointIndex[p] << " < " << oldPoint << ": decrementing index" << std::endl;
+      }
    }
 
    // update the graphics
@@ -400,9 +402,11 @@ void TCalibrationGraphSet::RemovePoint(const int& point)
    fPointIndex.erase(fPointIndex.begin() + point);
    for(size_t p = 0; p < fGraphIndex.size(); ++p) {
       if(fGraphIndex[p] == oldGraph && fPointIndex[p] >= oldPoint) {
-			if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " == " << oldGraph << " && " << fPointIndex[p] << " >= " << oldPoint << ": decrementing index" << std::endl; }
+         if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " == " << oldGraph << " && " << fPointIndex[p] << " >= " << oldPoint << ": decrementing index" << std::endl; }
          --fPointIndex[p];
-      } else if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << fGraphIndex[p] << " != " << oldGraph << " || " << fPointIndex[p] << " < " << oldPoint << ": decrementing index" << std::endl; }
+      } else if(fVerboseLevel > EVerbosity::kSubroutines) {
+         std::cout << fGraphIndex[p] << " != " << oldGraph << " || " << fPointIndex[p] << " < " << oldPoint << ": decrementing index" << std::endl;
+      }
    }
 
    // update the graphics

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -1916,10 +1916,11 @@ void TChannelTab::Initialize(const double& sigma, const double& threshold, const
       fCalLabel->Clear();
    }
    std::stringstream str;
-   str << "Fit function: " << fInit->FitFunction()->GetParameter(0);
-   for(int i = 1; i < fInit->FitFunction()->GetNpar(); ++i) {
-      str << " + " << fInit->FitFunction()->GetParameter(i) << " x^" << i;
-   }
+	if(fInit->FitFunction()->GetNpar() == 3) {
+		str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
+	} else {
+		str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
+	}
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
    }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -29,7 +29,7 @@
 
 std::map<double, std::tuple<double, double, double, double>> RoughCal(std::vector<double> peaks, std::vector<std::tuple<double, double, double, double>> sources, TSourceTab* sourceTab)
 {
-	/// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
+   /// This function tries to match a list of found peaks (channels) to a list of provided peaks (energies).
    /// It does so in slightly smarter way than the brute force method `Match`, by taking the reported intensity of the source peaks into account.
 
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << "\"Smart\" matching " << peaks.size() << " peaks with " << sources.size() << " source energies" << std::endl; }
@@ -518,40 +518,40 @@ TSourceTab::~TSourceTab()
 void TSourceTab::BuildInterface()
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to build interface " << std::endl; }
-	//std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
-	//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Got unique lock on graphics mutex!" << std::endl; }
+                                                                                                                                                //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to build interface " << std::endl; }
+                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
+                                                                                                                                                //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Got unique lock on graphics mutex!" << std::endl; }
    // frame with canvas and status bar
    fProjectionCanvas = new TRootEmbeddedCanvas(Form("ProjectionCanvas%s", fProjection->GetName()), fSourceFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-	
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Created projection canvas!" << std::endl; }
+
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Created projection canvas!" << std::endl; }
 
    fSourceFrame->AddFrame(fProjectionCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Added projection canvas to source frame!" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Added projection canvas to source frame!" << std::endl; }
 
    fSourceStatusBar         = new TGStatusBar(fSourceFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
    std::array<int, 3> parts = {35, 50, 15};
    fSourceStatusBar->SetParts(parts.data(), parts.size());
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Created status bar!" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Created status bar!" << std::endl; }
 
    fSourceFrame->AddFrame(fSourceStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after building interface" << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after building interface" << std::endl; }
 }
 
 void TSourceTab::MakeConnections()
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	//std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
+                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
    fProjectionCanvas->Connect("ProcessedEvent(Event_t*)", "TSourceTab", this, "ProjectionStatus(Event_t*)");
    fProjectionCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TSourceTab", this, "ProjectionStatus(Int_t,Int_t,Int_t,TObject*)");
 }
 
 void TSourceTab::Disconnect()
 {
-	//std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
+   //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
    fProjectionCanvas->Disconnect("ProcessedEvent(Event_t*)", this, "ProjectionStatus(Event_t*)");
    fProjectionCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "ProjectionStatus(Int_t,Int_t,Int_t,TObject*)");
 }
@@ -744,9 +744,9 @@ void TSourceTab::UpdateFits()
 
 void TSourceTab::Draw()
 {
-	fProjectionCanvas->GetCanvas()->cd();
-	fProjection->Draw();   // seems like hist + samefunc does not work. Could use hist + loop over list of functions (with same)
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": drew " << fProjection->GetName() << " on " << fProjectionCanvas->GetCanvas()->GetName() << "/" << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   fProjectionCanvas->GetCanvas()->cd();
+   fProjection->Draw();                                                                                                                                                                                                                           // seems like hist + samefunc does not work. Could use hist + loop over list of functions (with same)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": drew " << fProjection->GetName() << " on " << fProjectionCanvas->GetCanvas()->GetName() << "/" << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TSourceTab::InitialCalibration(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
@@ -767,8 +767,8 @@ void TSourceTab::InitialCalibration(const double& sigma, const double& threshold
       fSigma     = sigma;
       fThreshold = threshold;
       fPeaks.clear();
-		fFits.clear();
-		fBadFits.clear();
+      fFits.clear();
+      fBadFits.clear();
       // Remove all associated functions from projection.
       // These are the poly markers, fits, and the pave stat
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
@@ -811,14 +811,13 @@ void TSourceTab::InitialCalibration(const double& sigma, const double& threshold
       }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": found " << nofPeaks << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-		auto map = RoughCal(peakPos, fSourceEnergy, this);
-		Add(map);
+      auto map = RoughCal(peakPos, fSourceEnergy, this);
+      Add(map);
 
       // update status
       Status(Form("%d/%d", static_cast<int>(fData->GetN()), nofPeaks), 2);
    }
 }
-
 
 void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
 {
@@ -917,7 +916,7 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fProjection->Sumw2(false);                                                                                                                                        // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
-		UpdateFits();
+      UpdateFits();
 
       std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
       std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
@@ -1017,7 +1016,7 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks (" << fSourceEnergy.size() << " source energies)" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fProjection->Sumw2(false);                                                                                                                                                                                         // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
-	UpdateFits();
+   UpdateFits();
 
    std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
    std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
@@ -1052,19 +1051,19 @@ void TSourceTab::Add(std::map<double, std::tuple<double, double, double, double>
    int i = 0;
    for(auto iter = map.begin(); iter != map.end();) {
       // more readable variable names
-      auto peakPos     = iter->first;
-      auto energy      = std::get<0>(iter->second);
-		fData->SetPoint(i, peakPos, energy);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
-		}
-		++iter;
-		++i;
+      auto peakPos = iter->first;
+      auto energy  = std::get<0>(iter->second);
+      fData->SetPoint(i, peakPos, energy);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
+      }
+      ++iter;
+      ++i;
    }
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
       std::cout << "Accepted " << map.size() << " peaks" << std::endl;
    }
-	fData->Sort();
+   fData->Sort();
 }
 
 void TSourceTab::Add(std::map<TGauss*, std::tuple<double, double, double, double>> map)
@@ -1364,9 +1363,9 @@ void TSourceTab::PrintCanvases() const
 {
    std::cout << "TSourceTab " << fSourceName << " projection canvas:" << std::endl;
    fProjectionCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
+   for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
 }
 
 void TSourceTab::PrintLayout() const
@@ -1390,7 +1389,7 @@ TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nucl
       std::cout << "========================================" << std::endl;
    }
 
-	BuildInterface();
+   BuildInterface();
 
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
       std::cout << DYELLOW << "----------------------------------------" << std::endl;
@@ -1425,10 +1424,10 @@ TChannelTab::~TChannelTab()
 
 void TChannelTab::BuildInterface()
 {
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-		fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
-	}
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+      fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
+   }
 
    fSources.resize(fNuclei.size(), nullptr);
    //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
@@ -1442,65 +1441,65 @@ void TChannelTab::BuildInterface()
       }
    }
 
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-		fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+      fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fCalibrationFrame = fCanvasTab->AddTab("Calibration");
-		fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
-		fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-		fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
-		std::array<int, 3> parts = {25, 35, 40};
-		fChannelStatusBar->SetParts(parts.data(), parts.size());
-		fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
-		fFwhmFrame = fCanvasTab->AddTab("FWHM");
-		fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
-		fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-		//fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fCalibrationFrame = fCanvasTab->AddTab("Calibration");
+      fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
+      fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
+      std::array<int, 3> parts = {25, 35, 40};
+      fChannelStatusBar->SetParts(parts.data(), parts.size());
+      fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+      fFwhmFrame = fCanvasTab->AddTab("FWHM");
+      fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
+      fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      //fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fInitFrame = fCanvasTab->AddTab("Initial");
-		fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
-		fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fInitFrame = fCanvasTab->AddTab("Initial");
+      fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
+      fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-	}
+      fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+   }
 
    UpdateData();
 
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-		fCalibrationCanvas->GetCanvas()->cd();
-		fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
-		fCalibrationPad->SetNumber(1);
-		fCalibrationPad->Draw();
-		fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+      fCalibrationCanvas->GetCanvas()->cd();
+      fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
+      fCalibrationPad->SetNumber(1);
+      fCalibrationPad->Draw();
+      fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
 
-		fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
+      fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
 
-		fCalibrationCanvas->GetCanvas()->cd();
-		fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
-		fResidualPad->SetNumber(2);
-		fResidualPad->Draw();
-		fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
-	}
-	//Calibrate();   // also creates the residual and chi^2 label
+      fCalibrationCanvas->GetCanvas()->cd();
+      fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
+      fResidualPad->SetNumber(2);
+      fResidualPad->Draw();
+      fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
+   }
+   //Calibrate();   // also creates the residual and chi^2 label
 
-	// check whether we want to use this initial calibration to find more peaks
-	//if(TSourceCalibration::UseCalibratedPeaks()) {
-	//	FindCalibratedPeaks();
-	//}
+   // check whether we want to use this initial calibration to find more peaks
+   //if(TSourceCalibration::UseCalibratedPeaks()) {
+   //	FindCalibratedPeaks();
+   //}
 
    // get the fwhm graphs and plot them
    UpdateFwhm();
-	//{
-	//	std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-	//	fFwhmCanvas->GetCanvas()->cd();
-	//	fFwhm->DrawCalibration("*");
-	//	fLegend->Draw();
-	//}
+   //{
+   //	std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+   //	fFwhmCanvas->GetCanvas()->cd();
+   //	fFwhm->DrawCalibration("*");
+   //	fLegend->Draw();
+   //}
 }
 
 void TChannelTab::CreateSourceTab(size_t source)
@@ -1513,20 +1512,20 @@ void TChannelTab::CreateSourceTab(size_t source)
          }
          std::cout << std::endl;
       }
-		TGCompositeFrame* tmpTab = nullptr;
-		{
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
-			//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-			tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
-		}
+      TGCompositeFrame* tmpTab = nullptr;
+      {
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
+         //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+         tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
+      }
       fSources[source] = new TSourceTab(this, tmpTab, fProjections[source], fNuclei[source]->GetName(), fSigma, fThreshold, fParent->PeakRatio(), fSourceEnergies[source]);
-		{
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
-			//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-			fProgressBar->Increment(1);
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
-		}
+      {
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
+         //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+         fProgressBar->Increment(1);
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
+      }
    } else {
       fSources[source] = nullptr;
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
@@ -1540,24 +1539,24 @@ void TChannelTab::CreateSourceTab(size_t source)
 
 void TChannelTab::MakeConnections()
 {
-	//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+   //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
    fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
    fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
    fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
-	if(fData != nullptr) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			fData->Print();
-		}
-		fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
-	} else {
-		std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
-	}
+   if(fData != nullptr) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         fData->Print();
+      }
+      fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
+   } else {
+      std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
+   }
 }
 
 void TChannelTab::Disconnect()
 {
-	//std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
+   //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
    fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
    fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
    fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
@@ -1606,11 +1605,11 @@ void TChannelTab::RemovePoint(Int_t oldGraph, Int_t oldPoint)
       std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldGraph " << oldGraph << ", oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    }
    if(0 <= oldGraph && oldGraph < static_cast<int>(fSources.size())) {
-		if(oldPoint >= 0) {
-			return fSources[oldGraph]->RemovePoint(oldPoint);
-		} else {
-			std::cout << "Can't remove negative point " << oldPoint << " from graph " << oldGraph << std::endl;
-		}
+      if(oldPoint >= 0) {
+         return fSources[oldGraph]->RemovePoint(oldPoint);
+      } else {
+         std::cout << "Can't remove negative point " << oldPoint << " from graph " << oldGraph << std::endl;
+      }
    }
    std::cout << "Graph the point was removed from was " << oldGraph << ", but we only have " << fSources.size() << " source tabs?" << std::endl;
 }
@@ -1766,16 +1765,16 @@ void TChannelTab::Calibrate()
    // calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
    // we position it in the top left corner about 50% of the width and 10% of the height of the graph
    if(fChi2Label == nullptr) {
-		double left   = fData->GetMinimumX();
-		double right  = left + (fData->GetMaximumX() - left) * 0.5;
-		double top    = fData->GetMaximumY();
-		double bottom = top - (top - fData->GetMinimumY()) * 0.1;
+      double left   = fData->GetMinimumX();
+      double right  = left + (fData->GetMaximumX() - left) * 0.5;
+      double top    = fData->GetMaximumY();
+      double bottom = top - (top - fData->GetMinimumY()) * 0.1;
 
       fChi2Label = new TPaveText(left, bottom, right, top);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
-			fData->Print("e");
-		}
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
+         fData->Print("e");
+      }
    } else {
       fChi2Label->Clear();
    }
@@ -1817,17 +1816,17 @@ void TChannelTab::Remove(const double& maxResidual)
 
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-	// loop over all points of the total residual graph and remove those that are above the maximum acceptable value
-	// we only want to increment the point index if we do not remove the point, otherwise the same index needs to be checked again
-	for(int point = 0; point < fData->TotalResidualGraph()->GetN();) {
-		if(std::abs(fData->TotalResidualGraph()->GetX()[point]) > maxResidual) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] <<") > " << maxResidual << ": removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
-			fData->RemovePoint(point);
-		} else {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] <<") <= " << maxResidual << ": not removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
-			++point;
-		}
-	}
+   // loop over all points of the total residual graph and remove those that are above the maximum acceptable value
+   // we only want to increment the point index if we do not remove the point, otherwise the same index needs to be checked again
+   for(int point = 0; point < fData->TotalResidualGraph()->GetN();) {
+      if(std::abs(fData->TotalResidualGraph()->GetX()[point]) > maxResidual) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") > " << maxResidual << ": removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+         fData->RemovePoint(point);
+      } else {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") <= " << maxResidual << ": not removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+         ++point;
+      }
+   }
 
    // update the data, and re-calibrate
    UpdateData();
@@ -1879,57 +1878,57 @@ void TChannelTab::UpdateChannel()
 
 void TChannelTab::Initialize(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
 {
-	// loop through sources and get rough calibration for each
-	for(auto* source : fSources) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
-			source->Print();
-		}
-		source->InitialCalibration(sigma, threshold, peakRatio, force, fast);
-		fProgressBar->Increment(1);
-	}
-	// get this rough calibration data and calibrate
-	UpdateData();
-	Calibrate();
-	// copy the data to the initial data and draw it
-	fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
-		fInit->Print();
-	}
-	auto* oldPad = gPad;
-	fInitCanvas->GetCanvas()->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
+   // loop through sources and get rough calibration for each
+   for(auto* source : fSources) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
+         source->Print();
+      }
+      source->InitialCalibration(sigma, threshold, peakRatio, force, fast);
+      fProgressBar->Increment(1);
+   }
+   // get this rough calibration data and calibrate
+   UpdateData();
+   Calibrate();
+   // copy the data to the initial data and draw it
+   fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
+      fInit->Print();
+   }
+   auto* oldPad = gPad;
+   fInitCanvas->GetCanvas()->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
    fInit->DrawCalibration("*", fLegend);
-	// calculate the corners of the label from the minimum and maximum x/y-values of the graph
+   // calculate the corners of the label from the minimum and maximum x/y-values of the graph
    // we position it in the top left corner about 50% of the width and 10% of the height of the graph
-	if(fCalLabel == nullptr) {
-		double left   = fInit->GetMinimumX();
-		double right  = left + (fInit->GetMaximumX() - left) * 0.5;
-		double top    = fInit->GetMaximumY();
-		double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
+   if(fCalLabel == nullptr) {
+      double left   = fInit->GetMinimumX();
+      double right  = left + (fInit->GetMaximumX() - left) * 0.5;
+      double top    = fInit->GetMaximumY();
+      double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
 
-		fCalLabel = new TPaveText(left, bottom, right, top);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
-		}
-	} else {
-		fCalLabel->Clear();
-	}
-	std::stringstream str;
-	str << "Fit function: " << fInit->FitFunction()->GetParameter(0);
-	for(int i = 1; i < fInit->FitFunction()->GetNpar(); ++i) {
-		str << " + " << fInit->FitFunction()->GetParameter(i) << " x^" << i;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
-	}
+      fCalLabel = new TPaveText(left, bottom, right, top);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
+      }
+   } else {
+      fCalLabel->Clear();
+   }
+   std::stringstream str;
+   str << "Fit function: " << fInit->FitFunction()->GetParameter(0);
+   for(int i = 1; i < fInit->FitFunction()->GetNpar(); ++i) {
+      str << " + " << fInit->FitFunction()->GetParameter(i) << " x^" << i;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
+   }
 
    fCalLabel->AddText(str.str().c_str());
    fCalLabel->SetFillColor(kWhite);
    fCalLabel->Draw();
    oldPad->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
 }
 
 void TChannelTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
@@ -1951,19 +1950,19 @@ void TChannelTab::FindPeaks(const double& sigma, const double& threshold, const 
 
 void TChannelTab::FindAllPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
 {
-	for(auto* source : fSources) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << DYELLOW << "Finding peaks in source tab:" << std::endl;
-			source->Print();
-		}
-		source->FindPeaks(sigma, threshold, peakRatio, force, fast);
-		fProgressBar->Increment(1);
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in all source tabs, updating data" << std::endl; }
-	UpdateData();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
-	UpdateFwhm();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
+   for(auto* source : fSources) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << DYELLOW << "Finding peaks in source tab:" << std::endl;
+         source->Print();
+      }
+      source->FindPeaks(sigma, threshold, peakRatio, force, fast);
+      fProgressBar->Increment(1);
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in all source tabs, updating data" << std::endl; }
+   UpdateData();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
+   UpdateFwhm();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
 }
 
 void TChannelTab::FindCalibratedPeaks()
@@ -1980,7 +1979,7 @@ void TChannelTab::FindCalibratedPeaks()
    UpdateFwhm();
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << DYELLOW << "Done finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-	}
+   }
 }
 
 void TChannelTab::FindAllCalibratedPeaks()
@@ -1988,27 +1987,27 @@ void TChannelTab::FindAllCalibratedPeaks()
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << DYELLOW << "Finding calibrated peaks in all source tabs" << std::endl;
    }
-	for(auto* source : fSources) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
-		}
-		source->FindCalibratedPeaks(fData->FitFunction());
-	}
+   for(auto* source : fSources) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
+      }
+      source->FindCalibratedPeaks(fData->FitFunction());
+   }
    UpdateData();
    UpdateFwhm();
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << DYELLOW << "Done finding calibrated peaks in all source tabs" << std::endl;
-	}
+   }
 }
 
 void TChannelTab::Draw()
 {
-	fFwhmCanvas->GetCanvas()->cd();
-	fFwhm->DrawCalibration("*");
-	fLegend->Draw();
-	for(auto* source : fSources) {
-		source->Draw();
-	}
+   fFwhmCanvas->GetCanvas()->cd();
+   fFwhm->DrawCalibration("*");
+   fLegend->Draw();
+   for(auto* source : fSources) {
+      source->Draw();
+   }
 }
 
 void TChannelTab::Write(TFile* output)
@@ -2167,14 +2166,14 @@ void TChannelTab::PrintCanvases() const
 {
    std::cout << "TChannelTab " << Name() << " calibration canvas:" << std::endl;
    fCalibrationCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
+   for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
    std::cout << "TChannelTab fwhm canvas:" << std::endl;
-	fFwhmCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
+   fFwhmCanvas->GetCanvas()->Print();
+   for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
    for(auto* sourceTab : fSources) {
       sourceTab->PrintCanvases();
    }
@@ -2532,7 +2531,7 @@ void TSourceCalibration::SecondWindow()
    fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
    fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
    fProgressBar->Percent(true);
-	fProgressBar->ShowPosition(true, true, "Graphics: %.0f");
+   fProgressBar->ShowPosition(true, true, "Graphics: %.0f");
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
    AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
@@ -2577,32 +2576,32 @@ void TSourceCalibration::BuildSecondInterface()
          projections[index] = new GH1D(matrix->ProjectionY(Form("%s_%s", fSource[index]->GetName(), matrix->GetXaxis()->GetBinLabel(bin)), bin, bin));
          ++index;
       }
-		auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-		// create a new tab in a new thread
-		if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
-		fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
-		//// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
-		//fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
-		//				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
-		//				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
-		//				std::cout << "created new tab " << newTab << std::endl;
-		//				return newTab;
-		//				})));
-		//// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
-		//if(fFutures.size() >= fNumberOfThreads) {
-		//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-		//	auto tmp = fFutures.front().second.get();
-		//	fChannelTab[fFutures.front().first] = tmp;
-		//	fFutures.pop();
-		//}
+      auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
+      // create a new tab in a new thread
+      if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
+      fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
+      //// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
+      //fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
+      //				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
+      //				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
+      //				std::cout << "created new tab " << newTab << std::endl;
+      //				return newTab;
+      //				})));
+      //// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
+      //if(fFutures.size() >= fNumberOfThreads) {
+      //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+      //	auto tmp = fFutures.front().second.get();
+      //	fChannelTab[fFutures.front().first] = tmp;
+      //	fFutures.pop();
+      //}
    }
-	// wait for all remaining threads to finish
-	//while(!fFutures.empty()) {
-	//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-	//	auto tmp = fFutures.front().second.get();
-	//	fChannelTab[fFutures.front().first] = tmp;
-	//	fFutures.pop();
-	//}
+   // wait for all remaining threads to finish
+   //while(!fFutures.empty()) {
+   //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+   //	auto tmp = fFutures.front().second.get();
+   //	fChannelTab[fFutures.front().first] = tmp;
+   //	fFutures.pop();
+   //}
 
    //if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
 
@@ -2685,24 +2684,24 @@ void TSourceCalibration::BuildSecondInterface()
 
    SelectedTab(0);
 
-	fProgressBar->Reset();
-	fProgressBar->ShowPosition(true, true, "Peaks: %.0f");
+   fProgressBar->Reset();
+   fProgressBar->ShowPosition(true, true, "Peaks: %.0f");
    for(auto* channelTab : fChannelTab) {
       if(channelTab != nullptr) {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-		for(int i = 0; i < 5; ++i) {
-			std::cout << "================================================================================" << std::endl;
-		}
-		for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-	}
-			channelTab->Initialize(Sigma(), Threshold(), PeakRatio(), true, fFast);
-			channelTab->FindAllCalibratedPeaks();
-			channelTab->Calibrate();
-			channelTab->Draw();
-			channelTab->PrintCanvases();
-		}
-	}
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+            for(int i = 0; i < 5; ++i) {
+               std::cout << "================================================================================" << std::endl;
+            }
+            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+         }
+         channelTab->Initialize(Sigma(), Threshold(), PeakRatio(), true, fFast);
+         channelTab->FindAllCalibratedPeaks();
+         channelTab->Calibrate();
+         channelTab->Draw();
+         channelTab->PrintCanvases();
+      }
+   }
 
    if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
 }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -463,10 +463,12 @@ bool FilledBin(TH2* matrix, const int& bin)
 }
 
 //////////////////////////////////////// TSourceTab ////////////////////////////////////////
-TSourceTab::TSourceTab(TChannelTab* parent, TGCompositeFrame* frame, GH1D* projection, const char* sourceName, const double& sigma, const double& threshold, const double& peakRatio, std::vector<std::tuple<double, double, double, double>> sourceEnergy)
-   : fParent(parent), fSourceFrame(frame), fProjection(projection), fSourceName(sourceName), fSigma(sigma), fThreshold(threshold), fPeakRatio(peakRatio), fSourceEnergy(std::move(sourceEnergy))
+TSourceTab::TSourceTab(TSourceCalibration* sourceCal, TChannelTab* channel, TGCompositeFrame* frame, GH1D* projection, const char* sourceName, std::vector<std::tuple<double, double, double, double>> sourceEnergy)
+   : fSourceCalibration(sourceCal), fChannelTab(channel), fSourceFrame(frame), fProjection(projection), fSourceName(sourceName), fSourceEnergy(std::move(sourceEnergy))
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	// default sorting of tuples is by the first entry, which is the source energy here, so no need for a custom sort condition
+	std::sort(fSourceEnergy.begin(), fSourceEnergy.end());
    BuildInterface();
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << "interface built, finding peaks ... " << RESET_COLOR << std::endl; }
 }
@@ -474,7 +476,7 @@ TSourceTab::TSourceTab(TChannelTab* parent, TGCompositeFrame* frame, GH1D* proje
 TSourceTab::TSourceTab(const TSourceTab& rhs)
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   fParent           = rhs.fParent;
+   fChannelTab       = rhs.fChannelTab;
    fSourceFrame      = rhs.fSourceFrame;
    fProjectionCanvas = rhs.fProjectionCanvas;
    fSourceStatusBar  = rhs.fSourceStatusBar;
@@ -482,9 +484,6 @@ TSourceTab::TSourceTab(const TSourceTab& rhs)
    fProjection = rhs.fProjection;
    fData       = rhs.fData;
    fFwhm       = rhs.fFwhm;
-   fSigma      = rhs.fSigma;
-   fThreshold  = rhs.fThreshold;
-   fPeakRatio  = rhs.fPeakRatio;
    // ? not sure what to do here, clearing the vectors seems unnecessary since we never filled them
    // but we also can't just simply copy them, we would need a deep copy, which might not make sense?
    // does is make sense in general to have assignment constructors for this class?
@@ -519,7 +518,7 @@ void TSourceTab::BuildInterface()
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
                                                                                                                                                 //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to build interface " << std::endl; }
-                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
+                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
                                                                                                                                                 //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Got unique lock on graphics mutex!" << std::endl; }
    // frame with canvas and status bar
    fProjectionCanvas = new TRootEmbeddedCanvas(Form("ProjectionCanvas%s", fProjection->GetName()), fSourceFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
@@ -544,14 +543,14 @@ void TSourceTab::BuildInterface()
 void TSourceTab::MakeConnections()
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
-   fProjectionCanvas->Connect("ProcessedEvent(Event_t*)", "TSourceTab", this, "ProjectionStatus(Event_t*)");
+                                                                                                                                                //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
    fProjectionCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TSourceTab", this, "ProjectionStatus(Int_t,Int_t,Int_t,TObject*)");
+   fProjectionCanvas->Connect("ProcessedEvent(Event_t*)", "TSourceTab", this, "ProjectionStatus(Event_t*)");
 }
 
 void TSourceTab::Disconnect()
 {
-   //std::unique_lock<std::mutex> graphicsLock(fParent->Parent()->GraphicsMutex());
+   //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
    fProjectionCanvas->Disconnect("ProcessedEvent(Event_t*)", this, "ProjectionStatus(Event_t*)");
    fProjectionCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "ProjectionStatus(Int_t,Int_t,Int_t,TObject*)");
 }
@@ -565,12 +564,12 @@ void TSourceTab::ProjectionStatus(Event_t* event)
    // kClientMessage  = 14, kSelectionClear    = 15, kSelectionRequest = 16, kSelectionNotify = 17,
    // kColormapNotify = 18, kButtonDoubleClick = 19, kOtherEvent       = 20
    // };
-   if(TSourceCalibration::VerboseLevel() == EVerbosity::kAll) {
-      std::cout << __PRETTY_FUNCTION__ << ": code " << event->fCode << ", count " << event->fCount << ", state " << event->fState << ", type " << event->fType << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      if(event->fType == kClientMessage) {
-         std::cout << "Client message: " << event->fUser[0] << ", " << event->fUser[1] << ", " << event->fUser[2] << std::endl;
-      }
-   }
+   //if(TSourceCalibration::VerboseLevel() == EVerbosity::kAll) {
+   //   std::cout << __PRETTY_FUNCTION__ << ": code " << event->fCode << ", count " << event->fCount << ", state " << event->fState << ", type " << event->fType << std::endl;   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   //   if(event->fType == kClientMessage) {
+   //      std::cout << "Client message: " << event->fUser[0] << ", " << event->fUser[1] << ", " << event->fUser[2] << std::endl;
+   //   }
+   //}
    if(event->fType == kEnterNotify) {
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
          std::cout << "Entered source tab => changing gPad from " << gPad->GetName();
@@ -617,7 +616,7 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
             return;
          }
          polym->SetNextPoint(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px), fProjectionCanvas->GetCanvas()->AbsPixeltoX(py));
-         double range = 4 * fSigma;   // * fProjection->GetXaxis()->GetBinWidth(1);
+         double range = 4 * fSourceCalibration->Sigma();   // * fProjection->GetXaxis()->GetBinWidth(1);
          auto*  pf    = new TPeakFitter(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) - range, fProjectionCanvas->GetCanvas()->AbsPixeltoX(px) + range);
          auto*  peak  = new TGauss(fProjectionCanvas->GetCanvas()->AbsPixeltoX(px));
          pf->AddPeak(peak);
@@ -641,9 +640,9 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
          Status(Form("%d/%d", static_cast<int>(fData->GetN()), static_cast<int>(fPeaks.size())), 2);
 
          // update data and re-calibrate
-         fParent->UpdateData();
-         fParent->UpdateFwhm();
-         fParent->Calibrate();
+         fChannelTab->UpdateData();
+         fChannelTab->UpdateFwhm();
+         fChannelTab->Calibrate();
       }
       break;
    case kArrowKeyPress:
@@ -672,6 +671,20 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
    case kButton1Up:
       break;
    case kMouseMotion:
+		//{
+		//	auto* canvas = fProjectionCanvas->GetCanvas();
+		//	if(canvas == nullptr) {
+		//		Status("canvas nullptr", 0);
+		//		break;
+		//	}
+		//	auto* pad = canvas->GetSelectedPad();
+		//	if(pad == nullptr) {
+		//		Status("pad nullptr", 0);
+		//		break;
+		//	}
+
+		//	Status(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 0);
+		//}
       break;
    case kMouseEnter:
       break;
@@ -718,7 +731,13 @@ void TSourceTab::UpdateFits()
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Updating functions for histogram " << fProjection->GetName() << " by deleting " << functions->GetEntries() << " functions:" << std::endl;
       for(auto* obj : *functions) {
-         std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+         std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName();
+			if(obj->IsA() == TF1::Class()) {
+				std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
+			} else {
+				std::cout << " not a TF1";
+			}
+			std::cout << std::endl;
       }
    }
    // remove all old fits (all have the same name/title of "gauss_total")
@@ -730,6 +749,7 @@ void TSourceTab::UpdateFits()
    // add all the fit functions of the good and the bad peaks
    for(auto* obj : fFits) {
       functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Added clone of " << obj->GetFitFunction() << " = " << functions->Last() << std::endl; }
    }
    for(auto* obj : fBadFits) {
       functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
@@ -737,9 +757,16 @@ void TSourceTab::UpdateFits()
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "And adding " << functions->GetEntries() << " functions instead:" << std::endl;
       for(auto* obj : *functions) {
-         std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+         std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName();
+			if(obj->IsA() == TF1::Class()) {
+				std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
+			} else {
+				std::cout << " not a TF1";
+			}
+			std::cout << std::endl;
       }
    }
+	fProjectionCanvas->GetCanvas()->Modified();
 }
 
 void TSourceTab::Draw()
@@ -749,23 +776,17 @@ void TSourceTab::Draw()
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": drew " << fProjection->GetName() << " on " << fProjectionCanvas->GetCanvas()->GetName() << "/" << gPad->GetName() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
-void TSourceTab::InitialCalibration(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
+void TSourceTab::InitialCalibration(const bool& force)
 {
    /// This functions finds the peaks in the histogram, fits them, and adds the fits to the list of peaks.
    /// This list is then used to find all peaks that lie on a straight line.
 
-   if(fPeakRatio != peakRatio) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << ": updating peak ratio from " << fPeakRatio << " to " << peakRatio << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      fPeakRatio = peakRatio;
-   }
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << std::flush << " " << fProjection->GetName() << ": got " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   if(fPeaks.empty() || fData == nullptr || sigma != fSigma || threshold != fThreshold || force) {
+   if(fPeaks.empty() || fData == nullptr || force) {
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << __PRETTY_FUNCTION__ << ": # peaks " << fPeaks.size() << ", sigma (" << sigma << "/" << fSigma << "), or threshold (" << threshold << "/" << fThreshold << ") have changed?" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         std::cout << __PRETTY_FUNCTION__ << ": # peaks " << fPeaks.size() << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       }
-      fSigma     = sigma;
-      fThreshold = threshold;
       fPeaks.clear();
       fFits.clear();
       fBadFits.clear();
@@ -785,22 +806,22 @@ void TSourceTab::InitialCalibration(const double& sigma, const double& threshold
       UpdateRegions();
       if(fRegions.empty()) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "No regions found, using whole spectrum" << std::endl; }
-         spectrum.Search(fProjection, fSigma, "", fThreshold);
+         spectrum.Search(fProjection, fSourceCalibration->Sigma(), "", fSourceCalibration->Threshold());
          nofPeaks = spectrum.GetNPeaks();
-         if(nofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
+         if(nofPeaks > fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size())) {
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << nofPeaks; }
-            nofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
+            nofPeaks = static_cast<int>(fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size()));
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << nofPeaks << std::endl; }
          }
          peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + nofPeaks);
       } else {
          for(auto& region : fRegions) {
             fProjection->GetXaxis()->SetRangeUser(region.first, region.second);
-            spectrum.Search(fProjection, fSigma, "", fThreshold);
+            spectrum.Search(fProjection, fSourceCalibration->Sigma(), "", fSourceCalibration->Threshold());
             int tmpNofPeaks = spectrum.GetNPeaks();
-            if(tmpNofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
+            if(tmpNofPeaks > fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size())) {
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << tmpNofPeaks; }
-               tmpNofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
+               tmpNofPeaks = static_cast<int>(fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size()));
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << tmpNofPeaks << std::endl; }
             }
             peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + tmpNofPeaks);
@@ -819,23 +840,17 @@ void TSourceTab::InitialCalibration(const double& sigma, const double& threshold
    }
 }
 
-void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
+void TSourceTab::FindPeaks(const bool& force, const bool& fast)
 {
    /// This functions finds the peaks in the histogram, fits them, and adds the fits to the list of peaks.
    /// This list is then used to find all peaks that lie on a straight line.
 
-   if(fPeakRatio != peakRatio) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << ": updating peak ratio from " << fPeakRatio << " to " << peakRatio << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      fPeakRatio = peakRatio;
-   }
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << std::flush << " " << fProjection->GetName() << ": got " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   if(fPeaks.empty() || fData == nullptr || sigma != fSigma || threshold != fThreshold || force) {
+   if(fPeaks.empty() || fData == nullptr || force) {
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << __PRETTY_FUNCTION__ << ": # peaks " << fPeaks.size() << ", sigma (" << sigma << "/" << fSigma << "), or threshold (" << threshold << "/" << fThreshold << ") have changed?" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         std::cout << __PRETTY_FUNCTION__ << ": # peaks " << fPeaks.size() << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       }
-      fSigma     = sigma;
-      fThreshold = threshold;
       fPeaks.clear();
       fFits.clear();
       fBadFits.clear();
@@ -855,22 +870,22 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       UpdateRegions();
       if(fRegions.empty()) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "No regions found, using whole spectrum" << std::endl; }
-         spectrum.Search(fProjection, fSigma, "", fThreshold);
+         spectrum.Search(fProjection, fSourceCalibration->Sigma(), "", fSourceCalibration->Threshold());
          nofPeaks = spectrum.GetNPeaks();
-         if(nofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
+         if(nofPeaks > fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size())) {
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << nofPeaks; }
-            nofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
+            nofPeaks = static_cast<int>(fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size()));
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << nofPeaks << std::endl; }
          }
          peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + nofPeaks);
       } else {
          for(auto& region : fRegions) {
             fProjection->GetXaxis()->SetRangeUser(region.first, region.second);
-            spectrum.Search(fProjection, fSigma, "", fThreshold);
+            spectrum.Search(fProjection, fSourceCalibration->Sigma(), "", fSourceCalibration->Threshold());
             int tmpNofPeaks = spectrum.GetNPeaks();
-            if(tmpNofPeaks > fPeakRatio * static_cast<double>(fSourceEnergy.size())) {
+            if(tmpNofPeaks > fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size())) {
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Reducing # of peaks from " << tmpNofPeaks; }
-               tmpNofPeaks = static_cast<int>(fPeakRatio * static_cast<double>(fSourceEnergy.size()));
+               tmpNofPeaks = static_cast<int>(fSourceCalibration->PeakRatio() * static_cast<double>(fSourceEnergy.size()));
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << " to " << tmpNofPeaks << std::endl; }
             }
             peakPos.insert(peakPos.end(), spectrum.GetPositionX(), spectrum.GetPositionX() + tmpNofPeaks);
@@ -880,8 +895,9 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
          fProjection->GetXaxis()->UnZoom();
       }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": found " << nofPeaks << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		// peakPos is not sorted by x-value but rather by peak height
       for(int i = 0; i < nofPeaks; i++) {
-         double range = TSourceCalibration::FitRange() * fSigma;
+         double range = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
          // if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
          auto* pf   = new TPeakFitter(peakPos[i] - range, peakPos[i] + range);
          auto* peak = new TGauss(peakPos[i]);
@@ -894,15 +910,13 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
          }
          if(peak->Area() > 0) {
             // check if we accept bad fits (and if it was a bad fit)
-            if(Good(peak)) {
-               peak->SetLineColor(kRed);
+            if(Good(peak, peakPos[i] - range, peakPos[i] + range)) {
                fPeaks.push_back(peak);
                fFits.push_back(pf);
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
                   std::cout << "Fitted peak " << peakPos[i] - range << " - " << peakPos[i] + range << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
                }
             } else {
-               peak->SetLineColor(kGray);
                fBadFits.push_back(pf);
                if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
                   std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
@@ -916,11 +930,13 @@ void TSourceTab::FindPeaks(const double& sigma, const double& threshold, const d
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
       fProjection->Sumw2(false);                                                                                                                                        // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
-      UpdateFits();
-
       std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
       std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
       std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
+
+		SetLineColors();
+
+      UpdateFits();
 
       if(fast) {
          auto map = SmartMatch(fPeaks, fSourceEnergy, this);
@@ -961,6 +977,14 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    // Remove all associated functions from projection.
    // These are the poly markers, fits, and the pave stat
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+		std::cout << "calibration has " << calibration->GetNpar() << " parameters (";
+		for(int i = 0; i < calibration->GetNpar(); ++i) {
+			if(i != 0) {
+				std::cout << ", ";
+			}
+			std::cout << i << ": " << calibration->GetParameter(i);
+		}
+		std::cout << "), if linear offset is " << calibration->Eval(0) << " and gain is " << calibration->Eval(1) - calibration->Eval(0) << std::endl;
       TList* functions = fProjection->GetListOfFunctions();
       std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << " before clearing" << std::endl;
       for(auto* obj : *functions) {
@@ -969,22 +993,51 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    }
    fProjection->GetListOfFunctions()->Clear();
 
-   // loop over all source energies
-   for(auto iter : fSourceEnergy) {
-      if(std::get<2>(iter) < TSourceCalibration::MinIntensity()) {
+	std::map<TGauss*, std::tuple<double, double, double, double>> map;
+
+   // loop over all source energies and check if we want to use the peak or if it's too weak
+	// for each source energy we calculate the channel it would be at
+	std::vector<std::pair<std::tuple<double, double, double, double>, double>> channelPos;
+	for(auto& tuple : fSourceEnergy) {
+      if(std::get<2>(tuple) < TSourceCalibration::MinIntensity()) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "Skipping peak at " << std::get<0>(iter) << " keV with intensity " << std::get<2>(iter) << " below required minimum intensity " << TSourceCalibration::MinIntensity() << std::endl;
+            std::cout << "Skipping peak at " << std::get<0>(tuple) << " keV with intensity " << std::get<2>(tuple) << " below required minimum intensity " << TSourceCalibration::MinIntensity() << std::endl;
          }
          continue;
       }
-      double range   = TSourceCalibration::FitRange() * fSigma;
-      double peakPos = calibration->GetX(std::get<0>(iter));
+		channelPos.emplace_back(tuple, calibration->GetX(std::get<0>(tuple)));
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "Set channel position for " << channelPos.size() - 1 << ". peak to " << channelPos.back().second << " channels = " << std::get<0>(channelPos.back().first) << " keV" << std::endl;
+      }
+	}
+	// loop over channel positions and fit the peaks
+   for(size_t i = 0; i < channelPos.size(); ++i) {
+      double lowRange  = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
+      double highRange = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
+		// if the range for this peaks overlaps with the previous/next one, reduce the range but not more than half
+		// also check if the previous/next one is above the minimum intensity, because otherwise we would have skipped that one anyway
+		if(i > 0) {
+         if(channelPos[i].second - lowRange < channelPos[i - 1].second + highRange) {
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+					std::cout << channelPos[i].second - lowRange << " < " << channelPos[i - 1].second + highRange << ": changing low range from " << lowRange << " to " << std::max(lowRange/2., (channelPos[i].second - channelPos[i - 1].second)/2.) << " = std::max(" << lowRange/2. << ", " << (channelPos[i].second - channelPos[i - 1].second)/2. << " = (" << channelPos[i].second << " - " << channelPos[i - 1].second << "/2.)" << std::endl;
+				}
+				lowRange = std::max(lowRange/2., (channelPos[i].second - channelPos[i - 1].second)/2.);
+         }
+		}
+		if(i + 1 < channelPos.size()) {
+         if(channelPos[i].second + highRange > channelPos[i + 1].second - lowRange) {
+				if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+					std::cout << channelPos[i].second + highRange << " > " << channelPos[i + 1].second - lowRange << ": changing high range from " << highRange << " to " << std::max(highRange / 2., (channelPos[i + 1].second - channelPos[i].second) / 2.) << " = std::max(" << highRange / 2. << ", " << (channelPos[i + 1].second - channelPos[i].second) / 2. << " = (" << channelPos[i + 1].second << " - " << channelPos[i].second << "/2.)" << std::endl;
+				}
+            highRange = std::min(highRange/2., (channelPos[i + 1].second - channelPos[i].second)/2.);
+			}
+      }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << "Trying to fit peak " << peakPos << " (" << std::get<0>(iter) << " keV) in range " << peakPos - range << " - " << peakPos + range << std::endl;
+         std::cout << "Trying to fit peak " << channelPos[i].second << " in range " << channelPos[i].second - lowRange << " - " << channelPos[i].second + highRange << std::endl;
       }
       // if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
-      auto* pf   = new TPeakFitter(peakPos - range, peakPos + range);
-      auto* peak = new TGauss(peakPos);
+      auto* pf   = new TPeakFitter(channelPos[i].second - lowRange, channelPos[i].second + highRange);
+      auto* peak = new TGauss(channelPos[i].second);
       pf->AddPeak(peak);
       if(TSourceCalibration::LogFile().empty()) {
          TRedirect redirect("/dev/null");
@@ -994,15 +1047,14 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
       }
       if(peak->Area() > 0) {
          // check if we accept bad fits (and if it was a bad fit)
-         if(Good(peak)) {
-            peak->SetLineColor(kRed);
+         if(Good(peak, channelPos[i].second - lowRange, channelPos[i].second + highRange)) {
             fPeaks.push_back(peak);
             fFits.push_back(pf);
+				map[peak] = channelPos[i].first;
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-               std::cout << "Fitted peak " << peakPos - range << " - " << peakPos + range << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+               std::cout << "Fitted peak " << channelPos[i].second - lowRange << " - " << channelPos[i].second + highRange << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
             }
          } else {
-            peak->SetLineColor(kGray);
             fBadFits.push_back(pf);
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
@@ -1013,1999 +1065,2069 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
       }
    }
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks (" << fSourceEnergy.size() << " source energies)" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks (" << fSourceEnergy.size() << " source energies, " << channelPos.size() << " channel positions)" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
    fProjection->Sumw2(false);                                                                                                                                                                                         // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
-
-   UpdateFits();
 
    std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
    std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
    std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
 
-   auto map = Match(fPeaks, fSourceEnergy, this);
-   Add(map);
+	SetLineColors();
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      Double_t* x = fData->GetX();
-      Double_t* y = fData->GetY();
-      for(int i = 0; i < fData->GetN(); ++i) {
-         std::cout << " - " << x[i] << ", " << y[i];
-      }
-      std::cout << std::endl;
-   }
+   UpdateFits();
+
+	Add(map);
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		Double_t* x = fData->GetX();
+		Double_t* y = fData->GetY();
+		for(int i = 0; i < fData->GetN(); ++i) {
+			std::cout << "; " << x[i] << " - " << y[i];
+		}
+		std::cout << std::endl;
+	}
 }
 
 void TSourceTab::Add(std::map<double, std::tuple<double, double, double, double>> map)
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
-   }
-   if(fData == nullptr) {
-      fData = new TGraphErrors(map.size());
-   } else {
-      fData->Set(map.size());
-   }
-   fData->SetLineColor(2);
-   fData->SetMarkerColor(2);
-   int i = 0;
-   for(auto iter = map.begin(); iter != map.end();) {
-      // more readable variable names
-      auto peakPos = iter->first;
-      auto energy  = std::get<0>(iter->second);
-      fData->SetPoint(i, peakPos, energy);
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
-      }
-      ++iter;
-      ++i;
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << "Accepted " << map.size() << " peaks" << std::endl;
-   }
-   fData->Sort();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
+	}
+	if(fData == nullptr) {
+		fData = new TGraphErrors(map.size());
+	} else {
+		fData->Set(map.size());
+	}
+	fData->SetLineColor(2);
+	fData->SetMarkerColor(2);
+	int i = 0;
+	for(auto iter = map.begin(); iter != map.end();) {
+		// more readable variable names
+		auto peakPos = iter->first;
+		auto energy  = std::get<0>(iter->second);
+		fData->SetPoint(i, peakPos, energy);
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
+		}
+		++iter;
+		++i;
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << "Accepted " << map.size() << " peaks" << std::endl;
+	}
+	fData->Sort();
 }
 
 void TSourceTab::Add(std::map<TGauss*, std::tuple<double, double, double, double>> map)
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
-   }
-   if(fData == nullptr) {
-      fData = new TGraphErrors(map.size());
-   } else {
-      fData->Set(map.size());
-   }
-   fData->SetLineColor(2);
-   fData->SetMarkerColor(2);
-   if(fFwhm == nullptr) {
-      fFwhm = new TGraphErrors(map.size());
-   } else {
-      fFwhm->Set(map.size());
-   }
-   fFwhm->SetLineColor(4);
-   fFwhm->SetMarkerColor(4);
-   int i = 0;
-   for(auto iter = map.begin(); iter != map.end();) {
-      // more readable variable names
-      auto peakPos     = iter->first->Centroid();
-      auto peakPosErr  = iter->first->CentroidErr();
-      auto peakArea    = iter->first->Area();
-      auto peakAreaErr = iter->first->AreaErr();
-      auto fwhm        = iter->first->FWHM();
-      auto fwhmErr     = iter->first->FWHMErr();
-      auto energy      = std::get<0>(iter->second);
-      auto energyErr   = std::get<1>(iter->second);
-      // drop this peak if the uncertainties in area or position are too large
-      if(!Good(iter->first)) {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-            std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
-         }
-         iter = map.erase(iter);
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "Erasing peak returned iterator " << std::distance(map.begin(), iter) << std::endl;
-         }
-      } else {
-         fData->SetPoint(i, peakPos, energy);
-         fData->SetPointError(i, peakPosErr, energyErr);
-         fFwhm->SetPoint(i, peakPos, fwhm);
-         fFwhm->SetPointError(i, peakPosErr, fwhmErr);
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "Using peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
-         }
-         ++iter;
-         ++i;
-      }
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << "Accepted " << map.size() << " peaks" << std::endl;
-   }
-   // if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
-   fData->Set(map.size());
-   fFwhm->Set(map.size());
-   fData->Sort();
-   fFwhm->Sort();
-   // split poly marker into those peaks that were used, and those that weren't
-   TList* functions = fProjection->GetListOfFunctions();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-      std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << std::endl;
-      for(auto* obj : *functions) {
-         std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
-      }
-   }
-   auto* polym = static_cast<TPolyMarker*>(functions->FindObject("TPolyMarker"));
-   if(polym != nullptr) {
-      double*             oldX = polym->GetX();
-      double*             oldY = polym->GetY();
-      int                 size = polym->GetN();
-      std::vector<double> newX;
-      std::vector<double> newY;
-      std::vector<double> unusedX;
-      std::vector<double> unusedY;
-      for(i = 0; i < size; ++i) {
-         bool used = false;
-         for(auto point : map) {
-            if(TMath::Abs(oldX[i] - point.first->Centroid()) < fSigma) {
-               newX.push_back(oldX[i]);
-               newY.push_back(oldY[i]);
-               used = true;
-               break;
-            }
-         }
-         if(!used) {
-            unusedX.push_back(oldX[i]);
-            unusedY.push_back(oldY[i]);
-         }
-      }
-      polym->SetPolyMarker(newX.size(), newX.data(), newY.data());
-      auto* unusedMarkers = new TPolyMarker(unusedX.size(), unusedX.data(), unusedY.data());
-      unusedMarkers->SetMarkerStyle(23);   // triangle down
-      unusedMarkers->SetMarkerColor(16);   // light grey
-      functions->Add(unusedMarkers);
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << fProjection->GetTitle() << ": " << size << " peaks founds total, " << polym->GetN() << " used, and " << unusedMarkers->GetN() << " unused" << std::endl;
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-            std::cout << "Used: ";
-            for(size_t m = 0; m < newX.size(); ++m) { std::cout << newX[m] << " - " << newY[m] << ";"; }
-            std::cout << std::endl;
-            std::cout << "Unused: ";
-            for(size_t m = 0; m < unusedX.size(); ++m) { std::cout << unusedX[m] << " - " << unusedY[m] << ";"; }
-            std::cout << std::endl;
-         }
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-            std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
-            for(auto* obj : *functions) {
-               std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
-            }
-         }
-      }
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
+	}
+	if(fData == nullptr) {
+		fData = new TGraphErrors(map.size());
+	} else {
+		fData->Set(map.size());
+	}
+	fData->SetLineColor(2);
+	fData->SetMarkerColor(2);
+	if(fFwhm == nullptr) {
+		fFwhm = new TGraphErrors(map.size());
+	} else {
+		fFwhm->Set(map.size());
+	}
+	fFwhm->SetLineColor(4);
+	fFwhm->SetMarkerColor(4);
+	int i = 0;
+	for(auto iter = map.begin(); iter != map.end();) {
+		// more readable variable names
+		auto peakPos     = iter->first->Centroid();
+		auto peakPosErr  = iter->first->CentroidErr();
+		auto peakArea    = iter->first->Area();
+		auto peakAreaErr = iter->first->AreaErr();
+		auto fwhm        = iter->first->FWHM();
+		auto fwhmErr     = iter->first->FWHMErr();
+		auto energy      = std::get<0>(iter->second);
+		auto energyErr   = std::get<1>(iter->second);
+		// drop this peak if the uncertainties in area or position are too large
+		if(!Good(iter->first)) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+				std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
+			}
+			iter = map.erase(iter);
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Erasing peak returned iterator " << std::distance(map.begin(), iter) << std::endl;
+			}
+		} else {
+			fData->SetPoint(i, peakPos, energy);
+			fData->SetPointError(i, peakPosErr, energyErr);
+			fFwhm->SetPoint(i, peakPos, fwhm);
+			fFwhm->SetPointError(i, peakPosErr, fwhmErr);
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Using peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
+			}
+			++iter;
+			++i;
+		}
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << "Accepted " << map.size() << " peaks" << std::endl;
+	}
+	// if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
+	fData->Set(map.size());
+	fFwhm->Set(map.size());
+	fData->Sort();
+	fFwhm->Sort();
+	// split poly marker into those peaks that were used, and those that weren't
+	TList* functions = fProjection->GetListOfFunctions();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+		std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << std::endl;
+		for(auto* obj : *functions) {
+			std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+		}
+	}
+	auto* polym = static_cast<TPolyMarker*>(functions->FindObject("TPolyMarker"));
+	if(polym != nullptr) {
+		double*             oldX = polym->GetX();
+		double*             oldY = polym->GetY();
+		int                 size = polym->GetN();
+		std::vector<double> newX;
+		std::vector<double> newY;
+		std::vector<double> unusedX;
+		std::vector<double> unusedY;
+		for(i = 0; i < size; ++i) {
+			bool used = false;
+			for(auto point : map) {
+				if(TMath::Abs(oldX[i] - point.first->Centroid()) < fSourceCalibration->Sigma()) {
+					newX.push_back(oldX[i]);
+					newY.push_back(oldY[i]);
+					used = true;
+					break;
+				}
+			}
+			if(!used) {
+				unusedX.push_back(oldX[i]);
+				unusedY.push_back(oldY[i]);
+			}
+		}
+		polym->SetPolyMarker(newX.size(), newX.data(), newY.data());
+		auto* unusedMarkers = new TPolyMarker(unusedX.size(), unusedX.data(), unusedY.data());
+		unusedMarkers->SetMarkerStyle(23);   // triangle down
+		unusedMarkers->SetMarkerColor(16);   // light grey
+		functions->Add(unusedMarkers);
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << fProjection->GetTitle() << ": " << size << " peaks founds total, " << polym->GetN() << " used, and " << unusedMarkers->GetN() << " unused" << std::endl;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+				std::cout << "Used: ";
+				for(size_t m = 0; m < newX.size(); ++m) { std::cout << newX[m] << " - " << newY[m] << ";"; }
+				std::cout << std::endl;
+				std::cout << "Unused: ";
+				for(size_t m = 0; m < unusedX.size(); ++m) { std::cout << unusedX[m] << " - " << unusedY[m] << ";"; }
+				std::cout << std::endl;
+			}
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+				std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
+				for(auto* obj : *functions) {
+					std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+				}
+			}
+		}
+	}
 
-   // change color of fit functions for unused peaks
-   TIter    iter(functions);
-   TObject* item = nullptr;
-   while((item = iter.Next()) != nullptr) {
-      if(item->IsA() == TF1::Class() || item->IsA() == TGauss::Class()) {   // if the item is a TF1 or TGauss we see if we can find the centroid in the map of used peaks
-         double centroid = 0.;
-         if(item->IsA() == TF1::Class()) {
-            centroid = static_cast<TF1*>(item)->GetParameter(1);
-         } else {
-            centroid = static_cast<TGauss*>(item)->Centroid();
-         }
-         bool found = false;
-         for(auto point : map) {
-            if(TMath::Abs(centroid - point.first->Centroid()) < fSigma) {
-               found = true;
-               break;
-            }
-         }
-         // remove the TF1 if it wasn't found in the map
-         if(!found) {
-            //functions->Remove(item);
-            if(item->IsA() == TF1::Class()) {
-               static_cast<TF1*>(item)->SetLineColor(kGray);
-            } else {
-               static_cast<TGauss*>(item)->GetFitFunction()->SetLineColor(kGray);
-            }
-         }
-      }
-   }
+	// change color of fit functions for unused peaks
+	TIter    iter(functions);
+	TObject* item = nullptr;
+	while((item = iter.Next()) != nullptr) {
+		if(item->IsA() == TF1::Class() || item->IsA() == TGauss::Class()) {   // if the item is a TF1 or TGauss we see if we can find the centroid in the map of used peaks
+			double centroid = 0.;
+			if(item->IsA() == TF1::Class()) {
+				centroid = static_cast<TF1*>(item)->GetParameter(1);
+			} else {
+				centroid = static_cast<TGauss*>(item)->Centroid();
+			}
+			bool found = false;
+			for(auto point : map) {
+				if(TMath::Abs(centroid - point.first->Centroid()) < fSourceCalibration->Sigma()) {
+					found = true;
+					break;
+				}
+			}
+			// remove the TF1 if it wasn't found in the map
+			if(!found) {
+				//functions->Remove(item);
+				if(item->IsA() == TF1::Class()) {
+					static_cast<TF1*>(item)->SetLineColor(kGray);
+				} else {
+					static_cast<TGauss*>(item)->GetFitFunction()->SetLineColor(kGray);
+				}
+			}
+		}
+	}
 }
 
 void TSourceTab::ReplacePeak(const size_t& index, const double& channel)
 {
-   /// Replace the peak at the index with one centered at channel (calculated from an initial calibration and the source energy of this peak).
-   /// This replaces the TGauss* in fPeaks, and updates the values of this index in fData and fFwhm.
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": index " << index << ", channel " << channel << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
-         std::cout << i << ": " << fPeaks[i]->Centroid() << " +- " << fPeaks[i]->CentroidErr() << " - " << fFits[i]->GetFitFunction()->GetParameter("centroid_0") << std::endl;
-      }
-   }
+	/// Replace the peak at the index with one centered at channel (calculated from an initial calibration and the source energy of this peak).
+	/// This replaces the TGauss* in fPeaks, and updates the values of this index in fData and fFwhm.
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DCYAN << __PRETTY_FUNCTION__ << ": index " << index << ", channel " << channel << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
+			std::cout << i << ": " << fPeaks[i]->Centroid() << " +- " << fPeaks[i]->CentroidErr() << " - " << fFits[i]->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+		}
+	}
 
-   if(index >= fPeaks.size()) {
-      std::cerr << "Trying to replace peak at index " << index << " but there are only " << fPeaks.size() << " peaks!" << std::endl;
-      return;
-   }
+	if(index >= fPeaks.size()) {
+		std::cerr << "Trying to replace peak at index " << index << " but there are only " << fPeaks.size() << " peaks!" << std::endl;
+		return;
+	}
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << fPeaks.at(index)->Centroid() << " with new peak at channel " << channel << std::endl; }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << fPeaks.at(index)->Centroid() << " with new peak at channel " << channel << std::endl; }
 
-   // calculate the fitting range (low to high) and adjust it so we ignore the old peak
-   double range = TSourceCalibration::FitRange() * fSigma;
-   double low   = channel - range;
-   double high  = channel + range;
-   if(fPeaks.at(index)->Centroid() < channel) {
-      low = (fPeaks.at(index)->Centroid() + channel) / 2.;
-   } else {
-      high = (fPeaks.at(index)->Centroid() + channel) / 2.;
-   }
-   // if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
-   auto* pf   = new TPeakFitter(low, high);
-   auto* peak = new TGauss(channel);
-   pf->AddPeak(peak);
-   if(TSourceCalibration::LogFile().empty()) {
-      //TRedirect redirect("/dev/null");
-      pf->Fit(fProjection, "retryfit");
-   } else {
-      pf->Fit(fProjection, "retryfit");
-   }
-   if(peak->Area() > 0) {
-      if(Good(peak)) {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << index << ". peak/fit out of " << fPeaks.size() << "/" << fFits.size() << " peaks/fits: " << std::flush << fPeaks.at(index)->Centroid() << "/" << fFits.at(index)->GetFitFunction()->GetParameter("centroid_0") << std::endl;
-            std::cout << "Deleting " << index << ". peak " << fPeaks.at(index) << std::flush;
-         }
-         delete fPeaks.at(index);
-         fPeaks[index] = peak;
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << " and setting it to " << fPeaks.at(index) << std::endl;
-         }
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "Deleting " << index << ". fit " << fFits.at(index) << std::flush;
-         }
-         delete fFits.at(index);
-         fFits[index] = pf;
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << " and setting it to " << fFits.at(index) << std::endl;
-         }
-         UpdateFits();
-         fData->SetPoint(index, peak->Centroid(), fData->GetPointY(index));
-         fData->SetPointError(index, peak->CentroidErr(), fData->GetErrorY(index));
-         fFwhm->SetPoint(index, peak->Centroid(), peak->FWHM());
-         fFwhm->SetPointError(index, peak->CentroidErr(), peak->FWHMErr());
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
-         }
-      } else {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
-         }
-      }
-   } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
-   }
+	// calculate the fitting range (low to high) and adjust it so we ignore the old peak
+	double range = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
+	double low   = channel - range;
+	double high  = channel + range;
+	if(fPeaks.at(index)->Centroid() < channel) {
+		low = (fPeaks.at(index)->Centroid() + channel) / 2.;
+	} else {
+		high = (fPeaks.at(index)->Centroid() + channel) / 2.;
+	}
+	// if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
+	auto* pf   = new TPeakFitter(low, high);
+	auto* peak = new TGauss(channel);
+	pf->AddPeak(peak);
+	if(TSourceCalibration::LogFile().empty()) {
+		//TRedirect redirect("/dev/null");
+		pf->Fit(fProjection, "retryfit");
+	} else {
+		pf->Fit(fProjection, "retryfit");
+	}
+	if(peak->Area() > 0) {
+		if(Good(peak, low, high)) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << index << ". peak/fit out of " << fPeaks.size() << "/" << fFits.size() << " peaks/fits: " << std::flush << fPeaks.at(index)->Centroid() << "/" << fFits.at(index)->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+				std::cout << "Deleting " << index << ". peak " << fPeaks.at(index) << std::flush;
+			}
+			peak->SetLineColor(fPeaks.at(index)->GetLineColor());
+			delete fPeaks.at(index);
+			fPeaks[index] = peak;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << " and setting it to " << fPeaks.at(index) << std::endl;
+			}
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Deleting " << index << ". fit " << fFits.at(index) << std::flush;
+			}
+			pf->GetFitFunction()->SetLineColor(fFits.at(index)->GetFitFunction()->GetLineColor());
+			delete fFits.at(index);
+			fFits[index] = pf;
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << " and setting it to " << fFits.at(index) << std::endl;
+			}
+			UpdateFits();
+			fData->SetPoint(index, peak->Centroid(), fData->GetPointY(index));
+			fData->SetPointError(index, peak->CentroidErr(), fData->GetErrorY(index));
+			fFwhm->SetPoint(index, peak->Centroid(), peak->FWHM());
+			fFwhm->SetPointError(index, peak->CentroidErr(), peak->FWHMErr());
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+			}
+		} else {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+			}
+		}
+	} else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
+	}
 }
 
 void TSourceTab::RemovePoint(Int_t oldPoint)
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   // first thing to do is check if the graph the point was removed from matches the id of this tab
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
-   //auto erasedPeak = fPeaks.at(oldPoint);
-   fPeaks.erase(fPeaks.begin() + oldPoint);
-   auto* erasedFit = fFits.at(oldPoint);
-   fFits.erase(fFits.begin() + oldPoint);
-   fBadFits.push_back(erasedFit);
-   fData->RemovePoint(oldPoint);
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	// first thing to do is check if the graph the point was removed from matches the id of this tab
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+	//auto erasedPeak = fPeaks.at(oldPoint);
+	fPeaks.erase(fPeaks.begin() + oldPoint);
+	auto* erasedFit = fFits.at(oldPoint);
+	fFits.erase(fFits.begin() + oldPoint);
+	fBadFits.push_back(erasedFit);
+	fData->RemovePoint(oldPoint);
 
-   UpdateFits();
-   // we also need to move the marker of this peak to the poly-marker of unused peaks (16 is light gray aka the color of the unused markers)
-   //if(item->IsA() == TPolyMarker::Class()) { item->Print(); }   // && static_cast<TPolyMarker*>(item)->GetMarkerColor() != 16) {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+	SetLineColors();
+
+	UpdateFits();
+	
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+}
+
+void TSourceTab::SetLineColors()
+{
+	/// This function sets the line colors of good and bad fits to alternating colors.
+	/// Red and blue for the good fits, and grey and dark grey for the bad fits.
+	
+	// set colors of good fits alternating to red or blue (peaks themselves are set to darker versions of those colors)
+	for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
+		if(i%2 == 0) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) red for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
+			fPeaks[i]->SetLineColor(kRed + 2); 
+			fFits[i]->GetFitFunction()->SetLineColor(kRed);
+		} else {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) blue for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
+			fPeaks[i]->SetLineColor(kBlue + 2); 
+			fFits[i]->GetFitFunction()->SetLineColor(kBlue);
+		}
+	}
+
+	// set colors of bad fits alterating to grey and dark grey
+	for(size_t i = 0; i < fBadFits.size(); ++i) {
+		if(i%2 == 0) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
+			fBadFits[i]->GetFitFunction()->SetLineColor(kGray);
+		} else {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to dark grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
+			fBadFits[i]->GetFitFunction()->SetLineColor(kGray + 2);
+		}
+	}
 }
 
 void TSourceTab::Status(const char* status, int position)
 {
-   fSourceStatusBar->SetText(status, position);
-   fSourceStatusBar->MapWindow();
-   fSourceFrame->MapSubwindows();
-   gVirtualX->Update();
+	fSourceStatusBar->SetText(status, position);
+	fSourceStatusBar->MapWindow();
+	fSourceFrame->MapSubwindows();
+	gVirtualX->Update();
 }
 
 void TSourceTab::Print() const
 {
-   std::cout << "Projection " << fProjection;
-   if(fProjection != nullptr) {
-      std::cout << " = " << fProjection->GetName() << "/" << fProjection->GetTitle();
-   } else {
-      std::cout << " is null";
-   }
-   std::cout << std::endl;
+	std::cout << "Projection " << fProjection;
+	if(fProjection != nullptr) {
+		std::cout << " = " << fProjection->GetName() << "/" << fProjection->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
 
-   std::cout << "Data " << fData;
-   if(fData != nullptr) {
-      std::cout << " = " << fData->GetName() << "/" << fData->GetTitle();
-   } else {
-      std::cout << " is null";
-   }
-   std::cout << std::endl;
+	std::cout << "Data " << fData;
+	if(fData != nullptr) {
+		std::cout << " = " << fData->GetName() << "/" << fData->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
 
-   std::cout << "Fwhm " << fFwhm;
-   if(fFwhm != nullptr) {
-      std::cout << " = " << fFwhm->GetName() << "/" << fFwhm->GetTitle();
-   } else {
-      std::cout << " is null";
-   }
-   std::cout << std::endl;
+	std::cout << "Fwhm " << fFwhm;
+	if(fFwhm != nullptr) {
+		std::cout << " = " << fFwhm->GetName() << "/" << fFwhm->GetTitle();
+	} else {
+		std::cout << " is null";
+	}
+	std::cout << std::endl;
 
-   std::cout << fFits.size() << " good fits:";
-   for(size_t i = 0; i < fFits.size(); ++i) {
-      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
-   }
-   std::cout << std::endl;
+	std::cout << fFits.size() << " good fits:";
+	for(size_t i = 0; i < fFits.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+	}
+	std::cout << std::endl;
 
-   std::cout << fBadFits.size() << " bad fits:";
-   for(size_t i = 0; i < fBadFits.size(); ++i) {
-      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fBadFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
-   }
-   std::cout << std::endl;
+	std::cout << fBadFits.size() << " bad fits:";
+	for(size_t i = 0; i < fBadFits.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fBadFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+	}
+	std::cout << std::endl;
 
-   std::cout << fPeaks.size() << " peaks:";
-   for(size_t i = 0; i < fPeaks.size(); ++i) {
-      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fPeaks.at(i)->Centroid();
-   }
-   std::cout << std::endl;
+	std::cout << fPeaks.size() << " peaks:";
+	for(size_t i = 0; i < fPeaks.size(); ++i) {
+		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fPeaks.at(i)->Centroid();
+	}
+	std::cout << std::endl;
 }
 
 void TSourceTab::PrintCanvases() const
 {
-   std::cout << "TSourceTab " << fSourceName << " projection canvas:" << std::endl;
-   fProjectionCanvas->GetCanvas()->Print();
-   for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
-      obj->Print();
-   }
+	std::cout << "TSourceTab " << fSourceName << " projection canvas:" << std::endl;
+	fProjectionCanvas->GetCanvas()->Print();
+	for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
+		obj->Print();
+	}
 }
 
 void TSourceTab::PrintLayout() const
 {
-   std::cout << "TSourceTab frame:" << std::endl;
-   fSourceFrame->Print();
-   std::cout << "TSourceTab canvas:" << std::endl;
-   fProjectionCanvas->Print();
-   std::cout << "TSourceTab status bar:" << std::endl;
-   fSourceStatusBar->Print();
+	std::cout << "TSourceTab frame:" << std::endl;
+	fSourceFrame->Print();
+	std::cout << "TSourceTab canvas:" << std::endl;
+	fProjectionCanvas->Print();
+	std::cout << "TSourceTab status bar:" << std::endl;
+	fSourceStatusBar->Print();
 }
 
 //////////////////////////////////////// TChannelTab ////////////////////////////////////////
-TChannelTab::TChannelTab(TSourceCalibration* parent, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, double sigma, double threshold, int degree, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar)
-   : fChannelFrame(frame), fSourceTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fCanvasTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fProgressBar(progressBar), fParent(parent), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSigma(sigma), fThreshold(threshold), fDegree(degree), fSourceEnergies(std::move(sourceEnergies))
+TChannelTab::TChannelTab(TSourceCalibration* sourceCal, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar)
+	: fChannelFrame(frame), fSourceTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fCanvasTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fProgressBar(progressBar), fSourceCalibration(sourceCal), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSourceEnergies(std::move(sourceEnergies))
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DYELLOW << "========================================" << std::endl;
-      std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-                << " name = " << fName << ", fData = " << fData << std::endl;
-      std::cout << "========================================" << std::endl;
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DYELLOW << "========================================" << std::endl;
+		std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			<< " name = " << fName << ", fData = " << fData << std::endl;
+		std::cout << "========================================" << std::endl;
+	}
 
-   BuildInterface();
+	BuildInterface();
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DYELLOW << "----------------------------------------" << std::endl;
-      std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-                << " channel " << fName << " done" << std::endl;
-      std::cout << "----------------------------------------" << std::endl;
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DYELLOW << "----------------------------------------" << std::endl;
+		std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			<< " channel " << fName << " done" << std::endl;
+		std::cout << "----------------------------------------" << std::endl;
+	}
 }
 
 TChannelTab::~TChannelTab()
 {
-   delete fChannelFrame;
-   delete fSourceTab;
-   for(auto* channel : fSources) {
-      delete channel;
-   }
-   delete fCanvasTab;
-   delete fCalibrationFrame;
-   delete fCalibrationCanvas;
-   delete fResidualPad;
-   delete fCalibrationPad;
-   delete fChannelStatusBar;
-   delete fLegend;
-   delete fChi2Label;
-   delete fFwhmFrame;
-   delete fFwhmCanvas;
-   delete fProgressBar;
-   // delete all fProjections and all fNuclei?
-   delete fData;
-   delete fFwhm;
+	delete fChannelFrame;
+	delete fSourceTab;
+	for(auto* channel : fSources) {
+		delete channel;
+	}
+	delete fCanvasTab;
+	delete fCalibrationFrame;
+	delete fCalibrationCanvas;
+	delete fResidualPad;
+	delete fCalibrationPad;
+	delete fChannelStatusBar;
+	delete fLegend;
+	delete fChi2Label;
+	delete fFwhmFrame;
+	delete fFwhmCanvas;
+	delete fProgressBar;
+	// delete all fProjections and all fNuclei?
+	delete fData;
+	delete fFwhm;
 }
 
 void TChannelTab::BuildInterface()
 {
-   {
-      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-      fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
-   }
+	{
+		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+		fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
+	}
 
-   fSources.resize(fNuclei.size(), nullptr);
-   //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   for(size_t source = 0; source < fNuclei.size(); ++source) {
-      CreateSourceTab(source);
-   }
+	fSources.resize(fNuclei.size(), nullptr);
+	//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	for(size_t source = 0; source < fNuclei.size(); ++source) {
+		CreateSourceTab(source);
+	}
 
-   for(auto iter = fSources.begin(); iter != fSources.end(); ++iter) {
-      if(*iter == nullptr) {
-         fSources.erase(iter--);   // erase iterator and then go to the element before this one (and then the loop goes to the next one)
-      }
-   }
+	for(auto iter = fSources.begin(); iter != fSources.end(); ++iter) {
+		if(*iter == nullptr) {
+			fSources.erase(iter--);   // erase iterator and then go to the element before this one (and then the loop goes to the next one)
+		}
+	}
 
-   {
-      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-      fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+	{
+		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+		fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-      fCalibrationFrame = fCanvasTab->AddTab("Calibration");
-      fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
-      fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-      fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-      fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
-      std::array<int, 3> parts = {25, 35, 40};
-      fChannelStatusBar->SetParts(parts.data(), parts.size());
-      fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
-      fFwhmFrame = fCanvasTab->AddTab("FWHM");
-      fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
-      fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-      fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-      //fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+		fCalibrationFrame = fCanvasTab->AddTab("Calibration");
+		fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
+		fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+		fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+		fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
+		std::array<int, 3> parts = {25, 35, 40};
+		fChannelStatusBar->SetParts(parts.data(), parts.size());
+		fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+		fFwhmFrame = fCanvasTab->AddTab("FWHM");
+		fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
+		fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+		fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+		//fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-      fInitFrame = fCanvasTab->AddTab("Initial");
-      fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
-      fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-      fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+		fInitFrame = fCanvasTab->AddTab("Initial");
+		fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
+		fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+		fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-      fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-   }
+		fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+	}
 
-   UpdateData();
+	UpdateData();
 
-   {
-      //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-      fCalibrationCanvas->GetCanvas()->cd();
-      fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
-      fCalibrationPad->SetNumber(1);
-      fCalibrationPad->Draw();
-      fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
+	{
+		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+		fCalibrationCanvas->GetCanvas()->cd();
+		fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
+		fCalibrationPad->SetNumber(1);
+		fCalibrationPad->Draw();
+		fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
 
-      fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
+		fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
 
-      fCalibrationCanvas->GetCanvas()->cd();
-      fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
-      fResidualPad->SetNumber(2);
-      fResidualPad->Draw();
-      fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
-   }
-   //Calibrate();   // also creates the residual and chi^2 label
+		fCalibrationCanvas->GetCanvas()->cd();
+		fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
+		fResidualPad->SetNumber(2);
+		fResidualPad->Draw();
+		fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
+	}
+	//Calibrate();   // also creates the residual and chi^2 label
 
-   // check whether we want to use this initial calibration to find more peaks
-   //if(TSourceCalibration::UseCalibratedPeaks()) {
-   //	FindCalibratedPeaks();
-   //}
+	// check whether we want to use this initial calibration to find more peaks
+	//if(TSourceCalibration::UseCalibratedPeaks()) {
+	//	FindCalibratedPeaks();
+	//}
 
-   // get the fwhm graphs and plot them
-   UpdateFwhm();
-   //{
-   //	std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-   //	fFwhmCanvas->GetCanvas()->cd();
-   //	fFwhm->DrawCalibration("*");
-   //	fLegend->Draw();
-   //}
+	// get the fwhm graphs and plot them
+	UpdateFwhm();
+	//{
+	//	std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+	//	fFwhmCanvas->GetCanvas()->cd();
+	//	fFwhm->DrawCalibration("*");
+	//	fLegend->Draw();
+	//}
 }
 
 void TChannelTab::CreateSourceTab(size_t source)
 {
-   if(fProjections[source]->GetEntries() > 1000) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-         std::cout << DYELLOW << "Creating source tab " << source << ", using fParent " << fParent << std::flush;
-         if(fParent != nullptr) {
-            std::cout << ", peak ratio " << fParent->PeakRatio();
-         }
-         std::cout << std::endl;
-      }
-      TGCompositeFrame* tmpTab = nullptr;
-      {
-         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
-         //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-         tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
-         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
-      }
-      fSources[source] = new TSourceTab(this, tmpTab, fProjections[source], fNuclei[source]->GetName(), fSigma, fThreshold, fParent->PeakRatio(), fSourceEnergies[source]);
-      {
-         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
-         //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-         fProgressBar->Increment(1);
-         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
-      }
-   } else {
-      fSources[source] = nullptr;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-         std::cout << DYELLOW << "Skipping projection of source " << source << " = " << fProjections[source]->GetName() << ", only " << fProjections[source]->GetEntries() << " entries" << std::endl;
-      }
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << __PRETTY_FUNCTION__ << " source " << source << " done" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
+	if(fProjections[source]->GetEntries() > 1000) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+			std::cout << DYELLOW << "Creating source tab " << source << ", using fSourceCalibration " << fSourceCalibration << std::flush;
+			if(fSourceCalibration != nullptr) {
+				std::cout << ", peak ratio " << fSourceCalibration->PeakRatio();
+			}
+			std::cout << std::endl;
+		}
+		TGCompositeFrame* tmpTab = nullptr;
+		{
+			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
+			//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+			tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
+			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
+		}
+		fSources[source] = new TSourceTab(fSourceCalibration, this, tmpTab, fProjections[source], fNuclei[source]->GetName(), fSourceEnergies[source]);
+		{
+			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
+			//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+			fProgressBar->Increment(1);
+			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
+		}
+	} else {
+		fSources[source] = nullptr;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+			std::cout << DYELLOW << "Skipping projection of source " << source << " = " << fProjections[source]->GetName() << ", only " << fProjections[source]->GetEntries() << " entries" << std::endl;
+		}
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << __PRETTY_FUNCTION__ << " source " << source << " done" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
 }
 
 void TChannelTab::MakeConnections()
 {
-   //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-   fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
-   fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
-   fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
-   if(fData != nullptr) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-         std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-         fData->Print();
-      }
-      fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
-   } else {
-      std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
-   }
+	//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+	fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
+	for(auto* source : fSources) {
+		source->MakeConnections();
+	}
+	fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
+	fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
+	if(fData != nullptr) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+			std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			fData->Print();
+		}
+		fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
+	} else {
+		std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
+	}
 }
 
 void TChannelTab::Disconnect()
 {
-   //std::unique_lock<std::mutex> graphicsLock(fParent->GraphicsMutex());
-   fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
-   fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
-   fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
+	//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+	fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
+	for(auto* source : fSources) {
+		source->Disconnect();
+	}
+	fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
+	fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
 }
 
 void TChannelTab::SelectedTab(Int_t id)
 {
-   /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   fActiveSourceTab = id;
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
-   if(fSources[fActiveSourceTab] == nullptr) {
-      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(fSources[fActiveSourceTab]->ProjectionCanvas() == nullptr) {
-      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas() == nullptr) {
-      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
-   gPad = fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas();
-   fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas()->cd();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+	/// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	fActiveSourceTab = id;
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
+	if(fSources[fActiveSourceTab] == nullptr) {
+		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(fSources[fActiveSourceTab]->ProjectionCanvas() == nullptr) {
+		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas() == nullptr) {
+		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+	gPad = fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas();
+	fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas()->cd();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TChannelTab::SelectCanvas(Event_t* event)
 {
-   if(event->fType == kEnterNotify) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-         std::cout << "Entered channel tab => changing gPad from " << gPad->GetName();
-      }
-      gPad = fCalibrationCanvas->GetCanvas();
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-         std::cout << " to " << gPad->GetName() << std::endl;
-      }
-   }
+	if(event->fType == kEnterNotify) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+			std::cout << "Entered channel tab => changing gPad from " << gPad->GetName();
+		}
+		gPad = fCalibrationCanvas->GetCanvas();
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+			std::cout << " to " << gPad->GetName() << std::endl;
+		}
+	}
 }
 
 void TChannelTab::RemovePoint(Int_t oldGraph, Int_t oldPoint)
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldGraph " << oldGraph << ", oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(0 <= oldGraph && oldGraph < static_cast<int>(fSources.size())) {
-      if(oldPoint >= 0) {
-         return fSources[oldGraph]->RemovePoint(oldPoint);
-      } else {
-         std::cout << "Can't remove negative point " << oldPoint << " from graph " << oldGraph << std::endl;
-      }
-   }
-   std::cout << "Graph the point was removed from was " << oldGraph << ", but we only have " << fSources.size() << " source tabs?" << std::endl;
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldGraph " << oldGraph << ", oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(0 <= oldGraph && oldGraph < static_cast<int>(fSources.size())) {
+		if(oldPoint >= 0) {
+			return fSources[oldGraph]->RemovePoint(oldPoint);
+		}
+		std::cout << "Can't remove negative point " << oldPoint << " from graph " << oldGraph << std::endl;
+	}
+	std::cout << "Graph the point was removed from was " << oldGraph << ", but we only have " << fSources.size() << " source tabs?" << std::endl;
 }
 
 void TChannelTab::CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* selected)
 {
-   // looks like 51 is hovering over the object, 52 is moving the cursor over the object, and 53 is moving the cursort away from the object
-   // kButton1 = left mouse button, kButton2 = right mouse button
-   // enum EEventType {
-   //   kNoEvent       =  0,
-   //   kButton1Down   =  1, kButton2Down   =  2, kButton3Down   =  3, kKeyDown  =  4,
-   //   kWheelUp       =  5, kWheelDown     =  6, kButton1Shift  =  7, kButton1ShiftMotion  =  8,
-   //   kButton1Up     = 11, kButton2Up     = 12, kButton3Up     = 13, kKeyUp    = 14,
-   //   kButton1Motion = 21, kButton2Motion = 22, kButton3Motion = 23, kKeyPress = 24,
-   //   kArrowKeyPress = 25, kArrowKeyRelease = 26,
-   //   kButton1Locate = 41, kButton2Locate = 42, kButton3Locate = 43, kESC      = 27,
-   //   kMouseMotion   = 51, kMouseEnter    = 52, kMouseLeave    = 53,
-   //   kButton1Double = 61, kButton2Double = 62, kButton3Double = 63
-   //};
-   fChannelStatusBar->SetText(selected->GetName(), 0);
-   if(event == kKeyPress) {
-      fChannelStatusBar->SetText(Form("%c", static_cast<char>(px)), 1);
-   } else {
-      auto* canvas = fCalibrationCanvas->GetCanvas();
-      if(canvas == nullptr) {
-         fChannelStatusBar->SetText("canvas nullptr");
-         return;
-      }
-      auto* pad = canvas->GetSelectedPad();
-      if(pad == nullptr) {
-         fChannelStatusBar->SetText("pad nullptr");
-         return;
-      }
-      //if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-      //	std::cout << "px " << px << ", py " << py << ";    gPad: px " << gPad->AbsPixeltoX(px) << ", py " << gPad->AbsPixeltoY(py) << ";    fCalibrationCanvas: px " << fCalibrationCanvas->GetCanvas()->AbsPixeltoX(px) << ", py " << fCalibrationCanvas->GetCanvas()->AbsPixeltoY(py) << ";    fResidualPad: px " << fResidualPad->AbsPixeltoX(px) << ", py " << fResidualPad->AbsPixeltoY(py) << ";    fCalibrationPad: px " << fCalibrationPad->AbsPixeltoX(px) << ", py " << fCalibrationPad->AbsPixeltoY(py) << ";    pad: px " << pad->AbsPixeltoX(px) << ", py " << pad->AbsPixeltoY(py) << std::endl;
-      //}
+	// looks like 51 is hovering over the object, 52 is moving the cursor over the object, and 53 is moving the cursort away from the object
+	// kButton1 = left mouse button, kButton2 = right mouse button
+	// enum EEventType {
+	//   kNoEvent       =  0,
+	//   kButton1Down   =  1, kButton2Down   =  2, kButton3Down   =  3, kKeyDown  =  4,
+	//   kWheelUp       =  5, kWheelDown     =  6, kButton1Shift  =  7, kButton1ShiftMotion  =  8,
+	//   kButton1Up     = 11, kButton2Up     = 12, kButton3Up     = 13, kKeyUp    = 14,
+	//   kButton1Motion = 21, kButton2Motion = 22, kButton3Motion = 23, kKeyPress = 24,
+	//   kArrowKeyPress = 25, kArrowKeyRelease = 26,
+	//   kButton1Locate = 41, kButton2Locate = 42, kButton3Locate = 43, kESC      = 27,
+	//   kMouseMotion   = 51, kMouseEnter    = 52, kMouseLeave    = 53,
+	//   kButton1Double = 61, kButton2Double = 62, kButton3Double = 63
+	//};
+	fChannelStatusBar->SetText(selected->GetName(), 0);
+	if(event == kKeyPress) {
+		fChannelStatusBar->SetText(Form("%c", static_cast<char>(px)), 1);
+	} else {
+		auto* canvas = fCalibrationCanvas->GetCanvas();
+		if(canvas == nullptr) {
+			fChannelStatusBar->SetText("canvas nullptr");
+			return;
+		}
+		auto* pad = canvas->GetSelectedPad();
+		if(pad == nullptr) {
+			fChannelStatusBar->SetText("pad nullptr");
+			return;
+		}
+		//if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+		//	std::cout << "px " << px << ", py " << py << ";    gPad: px " << gPad->AbsPixeltoX(px) << ", py " << gPad->AbsPixeltoY(py) << ";    fCalibrationCanvas: px " << fCalibrationCanvas->GetCanvas()->AbsPixeltoX(px) << ", py " << fCalibrationCanvas->GetCanvas()->AbsPixeltoY(py) << ";    fResidualPad: px " << fResidualPad->AbsPixeltoX(px) << ", py " << fResidualPad->AbsPixeltoY(py) << ";    fCalibrationPad: px " << fCalibrationPad->AbsPixeltoX(px) << ", py " << fCalibrationPad->AbsPixeltoY(py) << ";    pad: px " << pad->AbsPixeltoX(px) << ", py " << pad->AbsPixeltoY(py) << std::endl;
+		//}
 
-      fChannelStatusBar->SetText(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 1);
-   }
+		fChannelStatusBar->SetText(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 1);
+	}
 }
 
 void TChannelTab::UpdateData()
 {
-   /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fData == nullptr) {
-      fData = new TCalibrationGraphSet("ADC channel", "Energy [keV]");
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   fData->Clear();
+	/// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fData == nullptr) {
+		fData = new TCalibrationGraphSet("ADC channel", "Energy [keV]");
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	fData->Clear();
 
-   fData->SetName(Form("data%s", fName.c_str()));
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "set name of fData using " << fName.c_str() << ": " << fData->GetName() << std::endl;
-      std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -2) << " data points after creation" << std::endl;
-      std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
-   }
-   for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
-      if(fSources[source]->Data() != nullptr && fSources[source]->Data()->GetN() > 0) {
-         int index = fData->Add(fSources[source]->Data(), fNuclei[source]->GetName());
-         if(index >= 0) {
-            fData->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
-            fData->SetMarkerColor(index, static_cast<Color_t>(source + 1));
-         }
-      }
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
-      fData->Print();
-   }
+	fData->SetName(Form("data%s", fName.c_str()));
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "set name of fData using " << fName.c_str() << ": " << fData->GetName() << std::endl;
+		std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -2) << " data points after creation" << std::endl;
+		std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
+	}
+	for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
+		if(fSources[source]->Data() != nullptr && fSources[source]->Data()->GetN() > 0) {
+			int index = fData->Add(fSources[source]->Data(), fNuclei[source]->GetName());
+			if(index >= 0) {
+				fData->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
+				fData->SetMarkerColor(index, static_cast<Color_t>(source + 1));
+			}
+		}
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
+		fData->Print();
+	}
 }
 
 void TChannelTab::UpdateFwhm()
 {
-   /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fFwhm == nullptr) {
-      fFwhm = new TCalibrationGraphSet("ADC channel", "FWHM [ADC channel]");
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   fFwhm->Clear();
+	/// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fFwhm == nullptr) {
+		fFwhm = new TCalibrationGraphSet("ADC channel", "FWHM [ADC channel]");
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	fFwhm->Clear();
 
-   fFwhm->SetName(Form("fwhm%s", fName.c_str()));
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "set name of fFwhm using " << fName.c_str() << ": " << fFwhm->GetName() << std::endl;
-      std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -2) << " data points after creation" << std::endl;
-      std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
-   }
-   for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
-      if(fSources[source]->Fwhm() != nullptr && fSources[source]->Fwhm()->GetN() > 0) {
-         int index = fFwhm->Add(fSources[source]->Fwhm(), fNuclei[source]->GetName());
-         if(index >= 0) {
-            fFwhm->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
-            fFwhm->SetMarkerColor(index, static_cast<Color_t>(source + 1));
-         }
-      }
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
-      fFwhm->Print();
-   }
-}
-
-void TChannelTab::Calibrate(const int& degree, const bool& force)
-{
-   if(degree != fDegree || force) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << DYELLOW;
-         if(force) {
-            std::cout << "forced calibration" << std::endl;
-         } else {
-            std::cout << "changed degree of polynomial: " << degree << " != " << fDegree << std::endl;
-         }
-      }
-      fDegree = degree;
-      Calibrate();
-   } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << degree << " == " << fDegree << " and not forcing (" << force << "): not fitting channel " << fName << std::endl;
-   }
+	fFwhm->SetName(Form("fwhm%s", fName.c_str()));
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "set name of fFwhm using " << fName.c_str() << ": " << fFwhm->GetName() << std::endl;
+		std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -2) << " data points after creation" << std::endl;
+		std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
+	}
+	for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
+		if(fSources[source]->Fwhm() != nullptr && fSources[source]->Fwhm()->GetN() > 0) {
+			int index = fFwhm->Add(fSources[source]->Fwhm(), fNuclei[source]->GetName());
+			if(index >= 0) {
+				fFwhm->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
+				fFwhm->SetMarkerColor(index, static_cast<Color_t>(source + 1));
+			}
+		}
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
+		fFwhm->Print();
+	}
 }
 
 void TChannelTab::Calibrate()
 {
-   /// This function fit's the final data of the given channel. It requires all other elements to have been created already.
-   if(TSourceCalibration::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fDegree + 2);
-   calibration->FixParameter(0, fDegree);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-      std::cout << DYELLOW << "fData " << fData << ": ";
-      if(fData != nullptr) {
-         std::cout << fData->GetN() << " data points being fit, ";
-      }
-      double min = 0.;
-      double max = 0.;
-      calibration->GetRange(min, max);
-      std::cout << "range " << min << " - " << max << std::endl;
-   }
-   fData->Fit(calibration, "Q");
-   TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
-   for(int i = 2; i <= fDegree; ++i) {
-      text.Append(Form(" + %.6f*x^%d", calibration->GetParameter(i + 1), i));
-   }
-   fChannelStatusBar->SetText(text.Data(), 2);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
-   // re-calculate the residuals
-   fData->SetResidual(true);
+	/// This function fit's the final data of the given channel. It requires all other elements to have been created already.
+	if(TSourceCalibration::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fSourceCalibration->Degree() + 2);
+	calibration->FixParameter(0, fSourceCalibration->Degree());
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+		std::cout << DYELLOW << "fData " << fData << ": ";
+		if(fData != nullptr) {
+			std::cout << fData->GetN() << " data points being fit, ";
+		}
+		double min = 0.;
+		double max = 0.;
+		calibration->GetRange(min, max);
+		std::cout << "range " << min << " - " << max << std::endl;
+	}
+	fData->Fit(calibration, "Q");
+	TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
+	for(int i = 2; i <= fSourceCalibration->Degree(); ++i) {
+		text.Append(Form(" + %.6f*x^%d", calibration->GetParameter(i + 1), i));
+	}
+	fChannelStatusBar->SetText(text.Data(), 2);
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
+	// re-calculate the residuals
+	fData->SetResidual(true);
 
-   fLegend->Clear();
-   fCalibrationPad->cd();
-   fData->DrawCalibration("*", fLegend);
-   fLegend->Draw();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "set chi2 label" << std::endl; }
-   // calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
-   // we position it in the top left corner about 50% of the width and 10% of the height of the graph
-   if(fChi2Label == nullptr) {
-      double left   = fData->GetMinimumX();
-      double right  = left + (fData->GetMaximumX() - left) * 0.5;
-      double top    = fData->GetMaximumY();
-      double bottom = top - (top - fData->GetMinimumY()) * 0.1;
+	fLegend->Clear();
+	fCalibrationPad->cd();
+	fData->DrawCalibration("*", fLegend);
+	fLegend->Draw();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "set chi2 label" << std::endl; }
+	// calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
+	// we position it in the top left corner about 50% of the width and 10% of the height of the graph
+	if(fChi2Label == nullptr) {
+		double left   = fData->GetMinimumX();
+		double right  = left + (fData->GetMaximumX() - left) * 0.5;
+		double top    = fData->GetMaximumY();
+		double bottom = top - (top - fData->GetMinimumY()) * 0.1;
 
-      fChi2Label = new TPaveText(left, bottom, right, top);
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
-         fData->Print("e");
-      }
-   } else {
-      fChi2Label->Clear();
-   }
-   fChi2Label->AddText(Form("#chi^{2}/NDF = %f", calibration->GetChisquare() / calibration->GetNDF()));
-   fChi2Label->SetFillColor(kWhite);
-   fChi2Label->Draw();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "fChi2Label set to:" << std::endl;
-      fChi2Label->GetListOfLines()->Print();
-      std::cout << "Text size " << fChi2Label->GetTextSize() << std::endl;
-   }
+		fChi2Label = new TPaveText(left, bottom, right, top);
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
+			fData->Print("e");
+		}
+	} else {
+		fChi2Label->Clear();
+	}
+	fChi2Label->AddText(Form("#chi^{2}/NDF = %f", calibration->GetChisquare() / calibration->GetNDF()));
+	fChi2Label->SetFillColor(kWhite);
+	fChi2Label->Draw();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "fChi2Label set to:" << std::endl;
+		fChi2Label->GetListOfLines()->Print();
+		std::cout << "Text size " << fChi2Label->GetTextSize() << std::endl;
+	}
 
-   fResidualPad->cd();
-   fData->DrawResidual("*");
+	fResidualPad->cd();
+	fData->DrawResidual("*");
 
-   fCalibrationCanvas->GetCanvas()->Modified();
+	fCalibrationCanvas->GetCanvas()->Modified();
 
-   fData->FitFunction()->SetRange(0., 10000.);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      double min = 0.;
-      double max = 0.;
-      calibration->GetRange(min, max);
-      std::cout << DYELLOW << "calibration has range " << min << " - " << max;
-      if(fData->FitFunction() != nullptr) {
-         fData->FitFunction()->GetRange(min, max);
-         std::cout << ",  fit function has range " << min << " - " << max;
-      }
-      std::cout << std::endl;
-   }
-   delete calibration;
+	fData->FitFunction()->SetRange(0., 10000.);
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		double min = 0.;
+		double max = 0.;
+		calibration->GetRange(min, max);
+		std::cout << DYELLOW << "calibration has range " << min << " - " << max;
+		if(fData->FitFunction() != nullptr) {
+			fData->FitFunction()->GetRange(min, max);
+			std::cout << ",  fit function has range " << min << " - " << max;
+		}
+		std::cout << std::endl;
+	}
+	delete calibration;
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TChannelTab::Remove(const double& maxResidual)
 {
-   /// This function goes through the residuals of the calibration and removes each point that is above the maxResidual parameter.
-   /// The function requires an initial calibration to have residuals available.
+	/// This function goes through the residuals of the calibration and removes each point that is above the maxResidual parameter.
+	/// The function requires an initial calibration to have residuals available.
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   // loop over all points of the total residual graph and remove those that are above the maximum acceptable value
-   // we only want to increment the point index if we do not remove the point, otherwise the same index needs to be checked again
-   for(int point = 0; point < fData->TotalResidualGraph()->GetN();) {
-      if(std::abs(fData->TotalResidualGraph()->GetX()[point]) > maxResidual) {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") > " << maxResidual << ": removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
-         fData->RemovePoint(point);
-      } else {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") <= " << maxResidual << ": not removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
-         ++point;
-      }
-   }
+	// loop over all points of the total residual graph and remove those that are above the maximum acceptable value
+	// we only want to increment the point index if we do not remove the point, otherwise the same index needs to be checked again
+	for(int point = 0; point < fData->TotalResidualGraph()->GetN();) {
+		if(std::abs(fData->TotalResidualGraph()->GetX()[point]) > maxResidual) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") > " << maxResidual << ": removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+			fData->RemovePoint(point);
+		} else {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << fData->TotalResidualGraph()->GetX()[point] << ") <= " << maxResidual << ": not removing point " << point << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+			++point;
+		}
+	}
 
-   // update the data, and re-calibrate
-   UpdateData();
-   UpdateFwhm();
-   Calibrate();
+	// update the data, and re-calibrate
+	UpdateData();
+	UpdateFwhm();
+	Calibrate();
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Remove(" << maxResidual << ") is done" << RESET_COLOR << std::endl; }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Remove(" << maxResidual << ") is done" << RESET_COLOR << std::endl; }
+}
+
+void TChannelTab::RecursiveRemove(const double& maxResidual)
+{
+	/// This function goes through the residuals of the calibration and recursively removes each point that is above the maxResidual parameter.
+	/// The function requires an initial calibration to have residuals available.
+	/// After each point that is removed, it re-calibrates the data, producing new residuals.
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+
+	// get the maximum residual
+	auto maxElement = std::max_element(fData->TotalResidualGraph()->GetX(), fData->TotalResidualGraph()->GetX() + fData->TotalResidualGraph()->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+	auto index = std::distance(fData->TotalResidualGraph()->GetX(), maxElement);
+
+	if(std::abs(*maxElement) < maxResidual) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "largest residual is " << *maxElement << " at position " << index << " and is smaller than max. residual " << maxResidual << ": stopping recursive remove" << std::endl; }
+		return;
+	}
+
+	// remove the index with the maximum residual
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << *maxElement << ") > " << maxResidual << ": removing index " << index << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+	fData->RemovePoint(index);
+
+	// update the data, and re-calibrate
+	UpdateData();
+	UpdateFwhm();
+	Calibrate();
+
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "RecursiveRemove(" << maxResidual << ") being called again" << RESET_COLOR << std::endl; }
+	RecursiveRemove(maxResidual);
 }
 
 void TChannelTab::UpdateChannel()
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   // write the actual parameters of the fit
-   std::stringstream str;
-   str << std::hex << fName;
-   int address = 0;
-   str >> address;
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
-   TF1* calibration = fData->FitFunction();
-   if(calibration == nullptr) {
-      std::cout << "Failed to find calibration in fData" << std::endl;
-      fData->TotalGraph()->GetListOfFunctions()->Print();
-      return;
-   }
-   std::vector<Float_t> parameters;
-   for(int i = 0; i <= calibration->GetParameter(0); ++i) {
-      parameters.push_back(static_cast<Float_t>(calibration->GetParameter(i + 1)));
-   }
-   TChannel* channel = TChannel::GetChannel(address, false);
-   if(channel == nullptr) {
-      std::cerr << "Failed to get channel for address " << hex(address, 4) << std::endl;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      return;
-   }
-   channel->SetENGCoefficients(parameters);
-   channel->DestroyEnergyNonlinearity();
-   if(fParent->WriteNonlinearities()) {
-      double* x = fData->GetX();
-      double* y = fData->GetY();
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
-      for(int i = 0; i < fData->GetN(); ++i) {
-         // nonlinearity expects y to be the true source energy minus the calibrated energy of the peak
-         // the source energy is y, the peak is x
-         channel->AddEnergyNonlinearityPoint(y[i], y[i] - calibration->Eval(x[i]));
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
-      }
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+																																											  // write the actual parameters of the fit
+	std::stringstream str;
+	str << std::hex << fName;
+	int address = 0;
+	str >> address;
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
+	TF1* calibration = fData->FitFunction();
+	if(calibration == nullptr) {
+		std::cout << "Failed to find calibration in fData" << std::endl;
+		fData->TotalGraph()->GetListOfFunctions()->Print();
+		return;
+	}
+	std::vector<Float_t> parameters;
+	for(int i = 0; i <= calibration->GetParameter(0); ++i) {
+		parameters.push_back(static_cast<Float_t>(calibration->GetParameter(i + 1)));
+	}
+	TChannel* channel = TChannel::GetChannel(address, false);
+	if(channel == nullptr) {
+		std::cerr << "Failed to get channel for address " << hex(address, 4) << std::endl;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		return;
+	}
+	channel->SetENGCoefficients(parameters);
+	channel->DestroyEnergyNonlinearity();
+	if(fSourceCalibration->WriteNonlinearities()) {
+		double* x = fData->GetX();
+		double* y = fData->GetY();
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
+		for(int i = 0; i < fData->GetN(); ++i) {
+			// nonlinearity expects y to be the true source energy minus the calibrated energy of the peak
+			// the source energy is y, the peak is x
+			channel->AddEnergyNonlinearityPoint(y[i], y[i] - calibration->Eval(x[i]));
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
+		}
+	}
 }
 
-void TChannelTab::Initialize(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
+void TChannelTab::Initialize(const bool& force)
 {
-   // loop through sources and get rough calibration for each
-   for(auto* source : fSources) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
-         source->Print();
-      }
-      source->InitialCalibration(sigma, threshold, peakRatio, force, fast);
-      fProgressBar->Increment(1);
-   }
-   // get this rough calibration data and calibrate
-   UpdateData();
-   Calibrate();
-   // copy the data to the initial data and draw it
-   fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
-      fInit->Print();
-   }
-   auto* oldPad = gPad;
-   fInitCanvas->GetCanvas()->cd();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
-   fInit->DrawCalibration("*", fLegend);
-   // calculate the corners of the label from the minimum and maximum x/y-values of the graph
-   // we position it in the top left corner about 50% of the width and 10% of the height of the graph
-   if(fCalLabel == nullptr) {
-      double left   = fInit->GetMinimumX();
-      double right  = left + (fInit->GetMaximumX() - left) * 0.5;
-      double top    = fInit->GetMaximumY();
-      double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
+	// loop through sources and get rough calibration for each
+	for(auto* source : fSources) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
+			source->Print();
+		}
+		source->InitialCalibration(force);
+		fProgressBar->Increment(1);
+	}
+	// get this rough calibration data and calibrate
+	UpdateData();
+	Calibrate();
+	// copy the data to the initial data and draw it
+	fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
+		fInit->Print();
+	}
+	auto* oldPad = gPad;
+	fInitCanvas->GetCanvas()->cd();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
+	fInit->DrawCalibration("*", fLegend);
+	// calculate the corners of the label from the minimum and maximum x/y-values of the graph
+	// we position it in the top left corner about 50% of the width and 10% of the height of the graph
+	if(fCalLabel == nullptr) {
+		double left   = fInit->GetMinimumX();
+		double right  = left + (fInit->GetMaximumX() - left) * 0.5;
+		double top    = fInit->GetMaximumY();
+		double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
 
-      fCalLabel = new TPaveText(left, bottom, right, top);
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
-      }
-   } else {
-      fCalLabel->Clear();
-   }
-   std::stringstream str;
-   if(fInit->FitFunction()->GetNpar() == 3) {
-      str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
-   } else {
-      str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
-   }
+		fCalLabel = new TPaveText(left, bottom, right, top);
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
+		}
+	} else {
+		fCalLabel->Clear();
+	}
+	std::stringstream str;
+	if(fInit->FitFunction()->GetNpar() == 3) {
+		str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
+	} else {
+		str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
+	}
 
-   fCalLabel->AddText(str.str().c_str());
-   fCalLabel->SetFillColor(kWhite);
-   fCalLabel->Draw();
-   oldPad->cd();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
+	fCalLabel->AddText(str.str().c_str());
+	fCalLabel->SetFillColor(kWhite);
+	fCalLabel->Draw();
+	oldPad->cd();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
 }
 
-void TChannelTab::FindPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
+void TChannelTab::FindPeaks(const bool& force, const bool& fast)
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << DYELLOW << "Finding peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-      fSourceTab->Print();
-      for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
-         std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
-      }
-   }
-   fSources[fActiveSourceTab]->FindPeaks(sigma, threshold, peakRatio, force, fast);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in source tab " << fActiveSourceTab << ", updating data" << std::endl; }
-   UpdateData();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
-   UpdateFwhm();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << DYELLOW << "Finding peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+		fSourceTab->Print();
+		for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
+			std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
+		}
+	}
+	fSources[fActiveSourceTab]->FindPeaks(force, fast);
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in source tab " << fActiveSourceTab << ", updating data" << std::endl; }
+	UpdateData();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
+	UpdateFwhm();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
 }
 
-void TChannelTab::FindAllPeaks(const double& sigma, const double& threshold, const double& peakRatio, const bool& force, const bool& fast)
+void TChannelTab::FindAllPeaks(const bool& force, const bool& fast)
 {
-   for(auto* source : fSources) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << DYELLOW << "Finding peaks in source tab:" << std::endl;
-         source->Print();
-      }
-      source->FindPeaks(sigma, threshold, peakRatio, force, fast);
-      fProgressBar->Increment(1);
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in all source tabs, updating data" << std::endl; }
-   UpdateData();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
-   UpdateFwhm();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
+	for(auto* source : fSources) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << DYELLOW << "Finding peaks in source tab:" << std::endl;
+			source->Print();
+		}
+		source->FindPeaks(force, fast);
+		fProgressBar->Increment(1);
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Found peaks in all source tabs, updating data" << std::endl; }
+	UpdateData();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Updating FWHM" << std::endl; }
+	UpdateFwhm();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "Source tab " << fActiveSourceTab << " done!" << std::endl; }
 }
 
 void TChannelTab::FindCalibratedPeaks()
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << DYELLOW << "Finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-      fSourceTab->Print();
-      for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
-         std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
-      }
-   }
-   fSources[fActiveSourceTab]->FindCalibratedPeaks(fData->FitFunction());
-   UpdateData();
-   UpdateFwhm();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << DYELLOW << "Done finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << DYELLOW << "Finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+		fSourceTab->Print();
+		for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
+			std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
+		}
+	}
+	fSources[fActiveSourceTab]->FindCalibratedPeaks(fData->FitFunction());
+	UpdateData();
+	UpdateFwhm();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << DYELLOW << "Done finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+	}
 }
 
 void TChannelTab::FindAllCalibratedPeaks()
 {
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << DYELLOW << "Finding calibrated peaks in all source tabs" << std::endl;
-   }
-   for(auto* source : fSources) {
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-         std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
-      }
-      source->FindCalibratedPeaks(fData->FitFunction());
-   }
-   UpdateData();
-   UpdateFwhm();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-      std::cout << DYELLOW << "Done finding calibrated peaks in all source tabs" << std::endl;
-   }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << DYELLOW << "Finding calibrated peaks in all source tabs" << std::endl;
+	}
+	for(auto* source : fSources) {
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+			std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
+		}
+		source->FindCalibratedPeaks(fData->FitFunction());
+	}
+	UpdateData();
+	UpdateFwhm();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+		std::cout << DYELLOW << "Done finding calibrated peaks in all source tabs" << std::endl;
+	}
 }
 
 void TChannelTab::Draw()
 {
-   fFwhmCanvas->GetCanvas()->cd();
-   fFwhm->DrawCalibration("*");
-   fLegend->Draw();
-   for(auto* source : fSources) {
-      source->Draw();
-   }
+	fFwhmCanvas->GetCanvas()->cd();
+	fFwhm->DrawCalibration("*");
+	fLegend->Draw();
+	for(auto* source : fSources) {
+		source->Draw();
+	}
 }
 
 void TChannelTab::Write(TFile* output)
 {
-   /// Write graphs to output.
-   output->cd();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "writing " << fName << std::endl; }
-   fData->Write(Form("calGraph_%s", fName.c_str()), TObject::kOverwrite);
-   fFwhm->Write(Form("fwhm_%s", fName.c_str()), TObject::kOverwrite);
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
+	/// Write graphs to output.
+	output->cd();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "writing " << fName << std::endl; }
+	fData->Write(Form("calGraph_%s", fName.c_str()), TObject::kOverwrite);
+	fFwhm->Write(Form("fwhm_%s", fName.c_str()), TObject::kOverwrite);
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
 }
 
 void TChannelTab::ZoomX()
 {
-   /// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's x-axis range to be the same as the selected graphs
-   // find the histogram in the current pad
-   TH1* hist1 = nullptr;
-   for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
-      if(obj->InheritsFrom(TGraph::Class())) {
-         hist1 = static_cast<TGraph*>(obj)->GetHistogram();
-         break;
-      }
-   }
-   if(hist1 == nullptr) {
-      std::cout << "ZoomX - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
-      return;
-   }
+	/// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's x-axis range to be the same as the selected graphs
+	// find the histogram in the current pad
+	TH1* hist1 = nullptr;
+	for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
+		if(obj->InheritsFrom(TGraph::Class())) {
+			hist1 = static_cast<TGraph*>(obj)->GetHistogram();
+			break;
+		}
+	}
+	if(hist1 == nullptr) {
+		std::cout << "ZoomX - Failed to find histogram for pad " << gPad->GetName() << std::endl;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
+		return;
+	}
 
-   // extract base name and channel from pad name
-   std::string padName     = gPad->GetName();
-   std::string baseName    = padName.substr(0, 3);
-   std::string channelName = padName.substr(4);
+	// extract base name and channel from pad name
+	std::string padName     = gPad->GetName();
+	std::string baseName    = padName.substr(0, 3);
+	std::string channelName = padName.substr(4);
 
-   // find the corresponding partner pad to the selected one
-   std::string newName;
-   if(baseName == "cal") {
-      newName = "res_" + channelName;
-   } else if(baseName == "res") {
-      newName = "cal_" + channelName;
-   } else {
-      std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
-      return;
-   }
-   auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
-   if(newObj == nullptr) {
-      std::cout << "Failed to find " << newName << std::endl;
-      return;
-   }
+	// find the corresponding partner pad to the selected one
+	std::string newName;
+	if(baseName == "cal") {
+		newName = "res_" + channelName;
+	} else if(baseName == "res") {
+		newName = "cal_" + channelName;
+	} else {
+		std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
+		return;
+	}
+	auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
+	if(newObj == nullptr) {
+		std::cout << "Failed to find " << newName << std::endl;
+		return;
+	}
 
-   if(newObj->IsA() != TPad::Class()) {
-      std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
-      return;
-   }
-   auto* pad2 = static_cast<TPad*>(newObj);
-   if(pad2 == nullptr) {
-      std::cout << "Failed to find partner pad " << newName << std::endl;
-      return;
-   }
-   // find the histogram in the partner pad
-   TH1* hist2 = nullptr;
-   for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
-      if(obj->InheritsFrom(TGraph::Class())) {
-         hist2 = static_cast<TGraph*>(obj)->GetHistogram();
-         break;
-      }
-   }
-   if(hist2 == nullptr) {
-      std::cout << "ZoomX - Failed to find histogram for partner pad " << newName << std::endl;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
-      return;
-   }
+	if(newObj->IsA() != TPad::Class()) {
+		std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
+		return;
+	}
+	auto* pad2 = static_cast<TPad*>(newObj);
+	if(pad2 == nullptr) {
+		std::cout << "Failed to find partner pad " << newName << std::endl;
+		return;
+	}
+	// find the histogram in the partner pad
+	TH1* hist2 = nullptr;
+	for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
+		if(obj->InheritsFrom(TGraph::Class())) {
+			hist2 = static_cast<TGraph*>(obj)->GetHistogram();
+			break;
+		}
+	}
+	if(hist2 == nullptr) {
+		std::cout << "ZoomX - Failed to find histogram for partner pad " << newName << std::endl;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
+		return;
+	}
 
-   TAxis*   axis1  = hist1->GetXaxis();
-   Int_t    binmin = axis1->GetFirst();
-   Int_t    binmax = axis1->GetLast();
-   Double_t xmin   = axis1->GetBinLowEdge(binmin);
-   Double_t xmax   = axis1->GetBinLowEdge(binmax);
-   TAxis*   axis2  = hist2->GetXaxis();
-   Int_t    newmin = axis2->FindBin(xmin);
-   Int_t    newmax = axis2->FindBin(xmax);
-   axis2->SetRange(newmin, newmax);
-   pad2->Modified();
-   pad2->Update();
+	TAxis*   axis1  = hist1->GetXaxis();
+	Int_t    binmin = axis1->GetFirst();
+	Int_t    binmax = axis1->GetLast();
+	Double_t xmin   = axis1->GetBinLowEdge(binmin);
+	Double_t xmax   = axis1->GetBinLowEdge(binmax);
+	TAxis*   axis2  = hist2->GetXaxis();
+	Int_t    newmin = axis2->FindBin(xmin);
+	Int_t    newmax = axis2->FindBin(xmax);
+	axis2->SetRange(newmin, newmax);
+	pad2->Modified();
+	pad2->Update();
 }
 
 void TChannelTab::ZoomY()
 {
-   /// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's y-axis range to be the same as the selected graphs
-   // find the histogram in the current pad
-   TH1* hist1 = nullptr;
-   for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
-      if(obj->InheritsFrom(TGraph::Class())) {
-         hist1 = static_cast<TGraph*>(obj)->GetHistogram();
-         break;
-      }
-   }
-   if(hist1 == nullptr) {
-      std::cout << "ZoomY - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
-      return;
-   }
+	/// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's y-axis range to be the same as the selected graphs
+	// find the histogram in the current pad
+	TH1* hist1 = nullptr;
+	for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
+		if(obj->InheritsFrom(TGraph::Class())) {
+			hist1 = static_cast<TGraph*>(obj)->GetHistogram();
+			break;
+		}
+	}
+	if(hist1 == nullptr) {
+		std::cout << "ZoomY - Failed to find histogram for pad " << gPad->GetName() << std::endl;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
+		return;
+	}
 
-   // extract base name and channel from pad name
-   std::string padName     = gPad->GetName();
-   std::string baseName    = padName.substr(0, 3);
-   std::string channelName = padName.substr(4);
+	// extract base name and channel from pad name
+	std::string padName     = gPad->GetName();
+	std::string baseName    = padName.substr(0, 3);
+	std::string channelName = padName.substr(4);
 
-   // find the corresponding partner pad to the selected one
-   std::string newName;
-   if(baseName == "cal") {
-      newName = "res_" + channelName;
-   } else if(baseName == "res") {
-      newName = "cal_" + channelName;
-   } else {
-      std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
-      return;
-   }
-   auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
-   if(newObj == nullptr) {
-      std::cout << "Failed to find " << newName << std::endl;
-      return;
-   }
+	// find the corresponding partner pad to the selected one
+	std::string newName;
+	if(baseName == "cal") {
+		newName = "res_" + channelName;
+	} else if(baseName == "res") {
+		newName = "cal_" + channelName;
+	} else {
+		std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
+		return;
+	}
+	auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
+	if(newObj == nullptr) {
+		std::cout << "Failed to find " << newName << std::endl;
+		return;
+	}
 
-   if(newObj->IsA() != TPad::Class()) {
-      std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
-      return;
-   }
-   auto* pad2 = static_cast<TPad*>(newObj);
-   if(pad2 == nullptr) {
-      std::cout << "Failed to find partner pad " << newName << std::endl;
-      return;
-   }
-   // find the histogram in the partner pad
-   TH1* hist2 = nullptr;
-   for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
-      if(obj->InheritsFrom(TGraph::Class())) {
-         hist2 = static_cast<TGraph*>(obj)->GetHistogram();
-         break;
-      }
-   }
-   if(hist2 == nullptr) {
-      std::cout << "ZoomY - Failed to find histogram for partner pad " << newName << std::endl;
-      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
-      return;
-   }
+	if(newObj->IsA() != TPad::Class()) {
+		std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
+		return;
+	}
+	auto* pad2 = static_cast<TPad*>(newObj);
+	if(pad2 == nullptr) {
+		std::cout << "Failed to find partner pad " << newName << std::endl;
+		return;
+	}
+	// find the histogram in the partner pad
+	TH1* hist2 = nullptr;
+	for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
+		if(obj->InheritsFrom(TGraph::Class())) {
+			hist2 = static_cast<TGraph*>(obj)->GetHistogram();
+			break;
+		}
+	}
+	if(hist2 == nullptr) {
+		std::cout << "ZoomY - Failed to find histogram for partner pad " << newName << std::endl;
+		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
+		return;
+	}
 
-   hist2->SetMinimum(hist1->GetMinimum());
-   hist2->SetMaximum(hist1->GetMaximum());
+	hist2->SetMinimum(hist1->GetMinimum());
+	hist2->SetMaximum(hist1->GetMaximum());
 
-   pad2->Modified();
-   pad2->Update();
+	pad2->Modified();
+	pad2->Update();
 }
 
 void TChannelTab::PrintCanvases() const
 {
-   std::cout << "TChannelTab " << Name() << " calibration canvas:" << std::endl;
-   fCalibrationCanvas->GetCanvas()->Print();
-   for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
-      obj->Print();
-   }
-   std::cout << "TChannelTab fwhm canvas:" << std::endl;
-   fFwhmCanvas->GetCanvas()->Print();
-   for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
-      obj->Print();
-   }
-   for(auto* sourceTab : fSources) {
-      sourceTab->PrintCanvases();
-   }
+	std::cout << "TChannelTab " << Name() << " calibration canvas:" << std::endl;
+	fCalibrationCanvas->GetCanvas()->Print();
+	for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
+		obj->Print();
+	}
+	std::cout << "TChannelTab fwhm canvas:" << std::endl;
+	fFwhmCanvas->GetCanvas()->Print();
+	for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
+		obj->Print();
+	}
+	for(auto* sourceTab : fSources) {
+		sourceTab->PrintCanvases();
+	}
 }
 
 void TChannelTab::PrintLayout() const
 {
-   std::cout << "TChannelTab frame:" << std::endl;
-   fChannelFrame->Print();
-   std::cout << "TChannelTab canvas:" << std::endl;
-   fCalibrationCanvas->Print();
-   std::cout << "TChannelTab status bar:" << std::endl;
-   //fChannelStatusBar->Print();
-   for(auto* sourceTab : fSources) {
-      sourceTab->PrintLayout();
-   }
+	std::cout << "TChannelTab frame:" << std::endl;
+	fChannelFrame->Print();
+	std::cout << "TChannelTab canvas:" << std::endl;
+	fCalibrationCanvas->Print();
+	std::cout << "TChannelTab status bar:" << std::endl;
+	//fChannelStatusBar->Print();
+	for(auto* sourceTab : fSources) {
+		sourceTab->PrintLayout();
+	}
 }
 
 //////////////////////////////////////// TSourceCalibration ////////////////////////////////////////
-std::string TSourceCalibration::fLogFile;
-EVerbosity  TSourceCalibration::fVerboseLevel       = EVerbosity::kQuiet;
-int         TSourceCalibration::fPanelWidth         = 600;
-int         TSourceCalibration::fPanelHeight        = 400;
-int         TSourceCalibration::fStatusbarHeight    = 50;
-int         TSourceCalibration::fSourceboxWidth     = 100;
-int         TSourceCalibration::fParameterHeight    = 200;
-int         TSourceCalibration::fDigitWidth         = 5;
-int         TSourceCalibration::fMaxIterations      = 50;
-int         TSourceCalibration::fFitRange           = 4;
-bool        TSourceCalibration::fAcceptBadFits      = false;
-bool        TSourceCalibration::fFast               = false;
-bool        TSourceCalibration::fUseCalibratedPeaks = false;
-double      TSourceCalibration::fMinIntensity       = 5.;
-size_t      TSourceCalibration::fNumberOfThreads    = 4;
+std::string      TSourceCalibration::fLogFile;
+EVerbosity       TSourceCalibration::fVerboseLevel       = EVerbosity::kQuiet;
+int              TSourceCalibration::fPanelWidth         = 600;
+int              TSourceCalibration::fPanelHeight        = 400;
+int              TSourceCalibration::fStatusbarHeight    = 50;
+int              TSourceCalibration::fSourceboxWidth     = 100;
+int              TSourceCalibration::fParameterHeight    = 200;
+int              TSourceCalibration::fDigitWidth         = 5;
+int              TSourceCalibration::fMaxIterations      = 50;
+int              TSourceCalibration::fFitRange           = 10;
+bool             TSourceCalibration::fAcceptBadFits      = false;
+bool             TSourceCalibration::fFast               = false;
+bool             TSourceCalibration::fUseCalibratedPeaks = false;
+double           TSourceCalibration::fMinIntensity       = 4.;
+size_t           TSourceCalibration::fNumberOfThreads    = 4;
+std::vector<int> TSourceCalibration::fBadBins;
 
 TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degree, double peakRatio, int count...)
-   : TGMainFrame(nullptr, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree), fDefaultPeakRatio(peakRatio)
+	: TGMainFrame(nullptr, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree), fDefaultPeakRatio(peakRatio)
 {
-   TH1::AddDirectory(false);   // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
+	TH1::AddDirectory(false);   // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
 
-   va_list args;
-   va_start(args, count);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   for(int i = 0; i < count; ++i) {
-      fMatrices.push_back(va_arg(args, TH2*));   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      if(fMatrices.back() == nullptr) {
-         std::cout << "Error, got nullptr as matrix input?" << std::endl;
-         fMatrices.pop_back();
-      }
-   }
-   va_end(args);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fVerboseLevel > EVerbosity::kQuiet) {
-      std::cout << DGREEN << __PRETTY_FUNCTION__ << ": verbose level " << fVerboseLevel << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-                << "using " << count << "/" << fMatrices.size() << " matrices:" << std::endl;
-      for(auto* mat : fMatrices) {
-         std::cout << mat << std::flush << " = " << mat->GetName() << std::endl;
-      }
-   }
+	va_list args;
+	va_start(args, count);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	for(int i = 0; i < count; ++i) {
+		fMatrices.push_back(va_arg(args, TH2*));   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		if(fMatrices.back() == nullptr) {
+			std::cout << "Error, got nullptr as matrix input?" << std::endl;
+			fMatrices.pop_back();
+		}
+	}
+	va_end(args);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fVerboseLevel > EVerbosity::kQuiet) {
+		std::cout << DGREEN << __PRETTY_FUNCTION__ << ": verbose level " << fVerboseLevel << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			<< "using " << count << "/" << fMatrices.size() << " matrices:" << std::endl;
+		for(auto* mat : fMatrices) {
+			std::cout << mat << std::flush << " = " << mat->GetName() << std::endl;
+		}
+	}
 
-   fOldErrorLevel        = gErrorIgnoreLevel;
-   gErrorIgnoreLevel     = kError;
-   gPrintViaErrorHandler = true;   // redirects all printf's to root's normal message system
+	fOldErrorLevel        = gErrorIgnoreLevel;
+	gErrorIgnoreLevel     = kError;
+	gPrintViaErrorHandler = true;   // redirects all printf's to root's normal message system
 
-   if(!fLogFile.empty()) {
-      fRedirect = new TRedirect(fLogFile.c_str());
-      std::cout << "Starting redirect to " << fLogFile << std::endl;
-   }
+	if(!fLogFile.empty()) {
+		fRedirect = new TRedirect(fLogFile.c_str());
+		std::cout << "Starting redirect to " << fLogFile << std::endl;
+	}
 
-   // check matrices (# of filled bins and bin labels) and resize some vectors for later use
-   // use the first matrix to get a reference for everything
-   fNofBins = 0;
-   std::map<int, int> channelToIndex;   // used to be a member, but only used here
-   for(int bin = 1; bin <= fMatrices[0]->GetNbinsX(); ++bin) {
-      if(FilledBin(fMatrices[0], bin)) {
-         fActualChannelId.push_back(fNofBins);   // at this point fNofBins is the index at which this projection will end up
-         fActiveBins.push_back(bin);
-         channelToIndex[bin] = fNofBins;   // this map simply stores which bin ends up at which index
-         fChannelLabel.push_back(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-         if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
-         ++fNofBins;
-      } else {
-         if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "skipping bin " << bin << std::endl; }
-      }
-   }
-   // now loop over all other matrices and check vs. the first one
-   for(size_t i = 1; i < fMatrices.size(); ++i) {
-      int tmpBins = 0;
-      for(int bin = 1; bin <= fMatrices[i]->GetNbinsX(); ++bin) {
-         if(FilledBin(fMatrices[i], bin)) {   // good bin in the current matrix
-            // current index is tmpBins, so we check if the bin agrees with what we have
-            if(channelToIndex.find(bin) == channelToIndex.end() || tmpBins != channelToIndex[bin]) {   // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
-               std::ostringstream error;
-               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (channelToIndex.find(bin) == channelToIndex.end() ? "not filled" : Form("%d", channelToIndex[bin])) << std::endl;
-               throw std::invalid_argument(error.str());
-            }
-            if(strcmp(fMatrices[0]->GetXaxis()->GetBinLabel(bin), fMatrices[i]->GetXaxis()->GetBinLabel(bin)) != 0) {   // bin is full and matches the bin in the first matrix so we check the labels
-               std::ostringstream error;
-               error << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
-               throw std::invalid_argument(error.str());
-            }
-            ++tmpBins;
-         } else {
-            if(channelToIndex.find(bin) != channelToIndex.end()) {   //found an empty bin that was full in the first matrix
-               std::ostringstream error;
-               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << channelToIndex[bin] << ". filled bin" << std::endl;
-               throw std::invalid_argument(error.str());
-            }
-         }
-      }
-   }
+	// check matrices (# of filled bins and bin labels) and resize some vectors for later use
+	// use the first matrix to get a reference for everything
+	fNofBins = 0;
+	std::map<int, int> channelToIndex;   // used to be a member, but only used here
+	for(int bin = 1; bin <= fMatrices[0]->GetNbinsX(); ++bin) {
+		if(FilledBin(fMatrices[0], bin) && std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {
+			fActualChannelId.push_back(fNofBins);   // at this point fNofBins is the index at which this projection will end up
+			fActiveBins.push_back(bin);
+			channelToIndex[bin] = fNofBins;   // this map simply stores which bin ends up at which index
+			fChannelLabel.push_back(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
+			if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
+			++fNofBins;
+		} else {
+			if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "skipping bin " << bin << std::endl; }
+		}
+	}
+	// now loop over all other matrices and check vs. the first one
+	for(size_t i = 1; i < fMatrices.size(); ++i) {
+		int tmpBins = 0;
+		for(int bin = 1; bin <= fMatrices[i]->GetNbinsX(); ++bin) {
+			if(FilledBin(fMatrices[i], bin), std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {   // good bin in the current matrix
+																																						// current index is tmpBins, so we check if the bin agrees with what we have
+				if(channelToIndex.find(bin) == channelToIndex.end() || tmpBins != channelToIndex[bin]) {   // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
+					std::ostringstream error;
+					error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (channelToIndex.find(bin) == channelToIndex.end() ? "not filled" : Form("%d", channelToIndex[bin])) << std::endl;
+					throw std::invalid_argument(error.str());
+				}
+				if(strcmp(fMatrices[0]->GetXaxis()->GetBinLabel(bin), fMatrices[i]->GetXaxis()->GetBinLabel(bin)) != 0) {   // bin is full and matches the bin in the first matrix so we check the labels
+					std::ostringstream error;
+					error << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
+					throw std::invalid_argument(error.str());
+				}
+				++tmpBins;
+			} else {
+				if(channelToIndex.find(bin) != channelToIndex.end()) {   //found an empty bin that was full in the first matrix
+					std::ostringstream error;
+					error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << channelToIndex[bin] << ". filled bin" << std::endl;
+					throw std::invalid_argument(error.str());
+				}
+			}
+		}
+	}
 
-   if(fVerboseLevel > EVerbosity::kQuiet) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
+	if(fVerboseLevel > EVerbosity::kQuiet) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
 
-   fOutput = new TFile("TSourceCalibration.root", "recreate");
-   if(!fOutput->IsOpen()) {
-      throw std::runtime_error("Unable to open output file \"TSourceCalibration.root\"!");
-   }
+	fOutput = new TFile("TSourceCalibration.root", "recreate");
+	if(!fOutput->IsOpen()) {
+		throw std::runtime_error("Unable to open output file \"TSourceCalibration.root\"!");
+	}
 
-   // build the first screen
-   BuildFirstInterface();
-   MakeFirstConnections();
+	// build the first screen
+	BuildFirstInterface();
+	MakeFirstConnections();
 
-   // Set a name to the main frame
-   SetWindowName("SourceCalibration");
+	// Set a name to the main frame
+	SetWindowName("SourceCalibration");
 
-   // Map all subwindows of main frame
-   MapSubwindows();
+	// Map all subwindows of main frame
+	MapSubwindows();
 
-   // Initialize the layout algorithm
-   Resize(GetDefaultSize());
+	// Initialize the layout algorithm
+	Resize(GetDefaultSize());
 
-   // Map main frame
-   MapWindow();
+	// Map main frame
+	MapWindow();
 }
 
 TSourceCalibration::~TSourceCalibration()
 {
-   fOutput->Close();
-   delete fOutput;
+	fOutput->Close();
+	delete fOutput;
 
-   gErrorIgnoreLevel = fOldErrorLevel;
+	gErrorIgnoreLevel = fOldErrorLevel;
 
-   delete fRedirect;
+	delete fRedirect;
 }
 
 void TSourceCalibration::BuildFirstInterface()
 {
-   /// Build initial interface with histogram <-> source assignment
+	/// Build initial interface with histogram <-> source assignment
 
-   auto* layoutManager = new TGTableLayout(this, fMatrices.size() + 1, 2, true, 5);
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
-   SetLayoutManager(layoutManager);
+	auto* layoutManager = new TGTableLayout(this, fMatrices.size() + 1, 2, true, 5);
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
+	SetLayoutManager(layoutManager);
 
-   // The matrices and source selection boxes
-   size_t i = 0;
-   for(i = 0; i < fMatrices.size(); ++i) {
-      fMatrixNames.push_back(new TGLabel(this, fMatrices[i]->GetName()));
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
-      fSource.push_back(nullptr);
-      fSourceEnergy.emplace_back();
-      fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
+	// The matrices and source selection boxes
+	size_t i = 0;
+	for(i = 0; i < fMatrices.size(); ++i) {
+		fMatrixNames.push_back(new TGLabel(this, fMatrices[i]->GetName()));
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
+		fSource.push_back(nullptr);
+		fSourceEnergy.emplace_back();
+		fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
 
-      int index = 0;
+		int index = 0;
 #if __cplusplus >= 201703L
-      // For some reasons getenv("GRSISYS") with strcat does not work (adds the "sub"-path twice).
-      // Have to do this by copying the getenv result into a c++-string.
-      if(std::getenv("GRSISYS") == nullptr) {
-         throw std::runtime_error("Failed to get environment variable $GRSISYS");
-      }
-      std::string path(std::getenv("GRSISYS"));
-      path += "/libraries/TAnalysis/SourceData/";
-      for(const auto& file : std::filesystem::directory_iterator(path)) {
-         if(file.is_regular_file() && file.path().extension().compare(".sou") == 0) {
-            fSourceBox.back()->AddEntry(file.path().stem().c_str(), index);
-            if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
-            if(std::strstr(fMatrices[i]->GetName(), file.path().stem().c_str()) != nullptr) {
-               fSourceBox.back()->Select(index);
-               SetSource(kSourceBox + fSourceBox.size() - 1, index);
-               if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": selected source " << index << std::endl; }
-            } else if(fVerboseLevel > EVerbosity::kSubroutines) {
-               std::cout << "matrix name " << fMatrices[i]->GetName() << " not matching " << file.path().stem().c_str() << std::endl;
-            }
-            ++index;
-         }
-      }
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
+		// For some reasons getenv("GRSISYS") with strcat does not work (adds the "sub"-path twice).
+		// Have to do this by copying the getenv result into a c++-string.
+		if(std::getenv("GRSISYS") == nullptr) {
+			throw std::runtime_error("Failed to get environment variable $GRSISYS");
+		}
+		std::string path(std::getenv("GRSISYS"));
+		path += "/libraries/TAnalysis/SourceData/";
+		for(const auto& file : std::filesystem::directory_iterator(path)) {
+			if(file.is_regular_file() && file.path().extension().compare(".sou") == 0) {
+				fSourceBox.back()->AddEntry(file.path().stem().c_str(), index);
+				if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
+				if(std::strstr(fMatrices[i]->GetName(), file.path().stem().c_str()) != nullptr) {
+					fSourceBox.back()->Select(index);
+					SetSource(kSourceBox + fSourceBox.size() - 1, index);
+					if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": selected source " << index << std::endl; }
+				} else if(fVerboseLevel > EVerbosity::kSubroutines) {
+					std::cout << "matrix name " << fMatrices[i]->GetName() << " not matching " << file.path().stem().c_str() << std::endl;
+				}
+				++index;
+			}
+		}
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
 #else
-      fSourceBox.back()->AddEntry("22Na", index);
-      if(std::strstr(fMatrices[i]->GetName(), "22Na") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
-      ++index;
-      fSourceBox.back()->AddEntry("56Co", index);
-      if(std::strstr(fMatrices[i]->GetName(), "56Co") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
-      ++index;
-      fSourceBox.back()->AddEntry("60Co", index);
-      if(std::strstr(fMatrices[i]->GetName(), "60Co") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
-      ++index;
-      fSourceBox.back()->AddEntry("133Ba", index);
-      if(std::strstr(fMatrices[i]->GetName(), "133Ba") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
-      ++index;
-      fSourceBox.back()->AddEntry("152Eu", index);
-      if(std::strstr(fMatrices[i]->GetName(), "152Eu") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
-      ++index;
-      fSourceBox.back()->AddEntry("241Am", index);
-      if(std::strstr(fMatrices[i]->GetName(), "241Am") != nullptr) {
-         fSourceBox.back()->Select(index);
-         SetSource(kSourceBox + fSourceBox.size() - 1, index);
-      }
+		fSourceBox.back()->AddEntry("22Na", index);
+		if(std::strstr(fMatrices[i]->GetName(), "22Na") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
+		++index;
+		fSourceBox.back()->AddEntry("56Co", index);
+		if(std::strstr(fMatrices[i]->GetName(), "56Co") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
+		++index;
+		fSourceBox.back()->AddEntry("60Co", index);
+		if(std::strstr(fMatrices[i]->GetName(), "60Co") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
+		++index;
+		fSourceBox.back()->AddEntry("133Ba", index);
+		if(std::strstr(fMatrices[i]->GetName(), "133Ba") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
+		++index;
+		fSourceBox.back()->AddEntry("152Eu", index);
+		if(std::strstr(fMatrices[i]->GetName(), "152Eu") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
+		++index;
+		fSourceBox.back()->AddEntry("241Am", index);
+		if(std::strstr(fMatrices[i]->GetName(), "241Am") != nullptr) {
+			fSourceBox.back()->Select(index);
+			SetSource(kSourceBox + fSourceBox.size() - 1, index);
+		}
 #endif
 
-      fSourceBox.back()->SetMinHeight(fPanelHeight / 2);
+		fSourceBox.back()->SetMinHeight(fPanelHeight / 2);
 
-      fSourceBox.back()->Resize(fSourceboxWidth, fLineHeight);
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
-      AddFrame(fMatrixNames.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
-      AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
-   }
+		fSourceBox.back()->Resize(fSourceboxWidth, fLineHeight);
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
+		AddFrame(fMatrixNames.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
+		AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
+	}
 
-   // The buttons
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
-   fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "start button " << fStartButton << std::endl; }
-   AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
-   Layout();
+	// The buttons
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
+	fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "start button " << fStartButton << std::endl; }
+	AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
+	Layout();
 }
 
 void TSourceCalibration::MakeFirstConnections()
 {
-   /// Create connections for the histogram <-> source assignment interface
+	/// Create connections for the histogram <-> source assignment interface
 
-   // Connect the selection of the source
-   for(auto* box : fSourceBox) {
-      box->Connect("Selected(Int_t, Int_t)", "TSourceCalibration", this, "SetSource(Int_t, Int_t)");
-   }
+	// Connect the selection of the source
+	for(auto* box : fSourceBox) {
+		box->Connect("Selected(Int_t, Int_t)", "TSourceCalibration", this, "SetSource(Int_t, Int_t)");
+	}
 
-   //Connect the clicking of buttons
-   fStartButton->Connect("Clicked()", "TSourceCalibration", this, "Start()");
+	//Connect the clicking of buttons
+	fStartButton->Connect("Clicked()", "TSourceCalibration", this, "Start()");
 }
 
 void TSourceCalibration::DisconnectFirst()
 {
-   /// Disconnect all signals from histogram <-> source assignment interface
-   for(auto* box : fSourceBox) {
-      box->Disconnect("Selected(Int_t, Int_t)", this, "SetSource(Int_t, Int_t)");
-   }
+	/// Disconnect all signals from histogram <-> source assignment interface
+	for(auto* box : fSourceBox) {
+		box->Disconnect("Selected(Int_t, Int_t)", this, "SetSource(Int_t, Int_t)");
+	}
 
-   fStartButton->Disconnect("Clicked()", this, "Start()");
+	fStartButton->Disconnect("Clicked()", this, "Start()");
 }
 
 void TSourceCalibration::DeleteElement(TGFrame* element)
 {
-   HideFrame(element);
-   RemoveFrame(element);
-   //delete element;
-   //element = nullptr;
+	HideFrame(element);
+	RemoveFrame(element);
+	//delete element;
+	//element = nullptr;
 }
 
 void TSourceCalibration::DeleteFirst()
 {
-   for(auto* name : fMatrixNames) {
-      DeleteElement(name);
-   }
-   fMatrixNames.clear();
-   for(auto* box : fSourceBox) {
-      DeleteElement(box);
-   }
-   fSourceBox.clear();
-   DeleteElement(fStartButton);
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
+	for(auto* name : fMatrixNames) {
+		DeleteElement(name);
+	}
+	fMatrixNames.clear();
+	for(auto* box : fSourceBox) {
+		DeleteElement(box);
+	}
+	fSourceBox.clear();
+	DeleteElement(fStartButton);
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
 }
 
 void TSourceCalibration::SetSource(Int_t windowId, Int_t entryId)
 {
-   int index = windowId - kSourceBox;
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   delete fSource[index];
-   auto* nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
-   TIter iter(nucleus->GetTransitionList());
-   fSourceEnergy[index].clear();
-   while(auto* transition = static_cast<TTransition*>(iter.Next())) {
-      fSourceEnergy[index].push_back(std::make_tuple(transition->GetEnergy(), transition->GetEnergyUncertainty(), transition->GetIntensity(), transition->GetIntensityUncertainty()));
-   }
-   fSource[index] = nucleus;
+	int index = windowId - kSourceBox;
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	delete fSource[index];
+	auto* nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
+	TIter iter(nucleus->GetTransitionList());
+	fSourceEnergy[index].clear();
+	while(auto* transition = static_cast<TTransition*>(iter.Next())) {
+		fSourceEnergy[index].push_back(std::make_tuple(transition->GetEnergy(), transition->GetEnergyUncertainty(), transition->GetIntensity(), transition->GetIntensityUncertainty()));
+	}
+	fSource[index] = nucleus;
 }
 
 void TSourceCalibration::HandleTimer()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fEmitter == fStartButton) {
-      SecondWindow();
-   } else if(fEmitter == fAcceptAllButton) {
-      for(auto& channelTab : fChannelTab) {
-         if(channelTab == nullptr) { continue; }
-         channelTab->UpdateChannel();
-         channelTab->Write(fOutput);
-      }
-      WriteCalibration();
-      std::cout << "Closing window" << std::endl;
-      CloseWindow();
-      std::cout << "all done" << std::endl;
-      exit(0);
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fEmitter == fStartButton) {
+		SecondWindow();
+	} else if(fEmitter == fAcceptAllButton) {
+		for(auto& channelTab : fChannelTab) {
+			if(channelTab == nullptr) { continue; }
+			channelTab->UpdateChannel();
+			channelTab->Write(fOutput);
+		}
+		WriteCalibration();
+		std::cout << "Closing window" << std::endl;
+		CloseWindow();
+		std::cout << "all done" << std::endl;
+		exit(0);
+	}
 }
 
 void TSourceCalibration::Start()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fEmitter == nullptr) {                                                                                                                                         // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
-      fEmitter = fStartButton;
-      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fEmitter == nullptr) {                                                                                                                                         // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
+		fEmitter = fStartButton;
+		TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
+	}
 }
 
 void TSourceCalibration::SecondWindow()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   // check that all sources have been set
-   for(size_t i = 0; i < fSource.size(); ++i) {
-      if(fSource[i] == nullptr) {
-         std::cerr << "Source " << i << " not set!" << std::endl;
-         return;
-      }
-   }
-   // now check that we don't have the same source twice (which wouldn't make sense)
-   for(size_t i = 0; i < fSource.size(); ++i) {
-      for(size_t j = i + 1; j < fSource.size(); ++j) {
-         if(*(fSource[i]) == *(fSource[j])) {
-            std::cerr << "Duplicate sources: " << i << " - " << fSource[i]->GetName() << " and " << j << " - " << fSource[j]->GetName() << std::endl;
-            return;
-         }
-      }
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+																																	// check that all sources have been set
+	for(size_t i = 0; i < fSource.size(); ++i) {
+		if(fSource[i] == nullptr) {
+			std::cerr << "Source " << i << " not set!" << std::endl;
+			return;
+		}
+	}
+	// now check that we don't have the same source twice (which wouldn't make sense)
+	for(size_t i = 0; i < fSource.size(); ++i) {
+		for(size_t j = i + 1; j < fSource.size(); ++j) {
+			if(*(fSource[i]) == *(fSource[j])) {
+				std::cerr << "Duplicate sources: " << i << " - " << fSource[i]->GetName() << " and " << j << " - " << fSource[j]->GetName() << std::endl;
+				return;
+			}
+		}
+	}
 
-   // disconnect signals of first screen and remove all elements
-   DisconnectFirst();
-   RemoveAll();
-   DeleteFirst();
+	// disconnect signals of first screen and remove all elements
+	DisconnectFirst();
+	RemoveAll();
+	DeleteFirst();
 
-   SetLayoutManager(new TGVerticalLayout(this));
+	SetLayoutManager(new TGVerticalLayout(this));
 
-   // create intermediate progress bar
-   fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
-   fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
-   fProgressBar->Percent(true);
-   fProgressBar->ShowPosition(true, true, "Graphics: %.0f");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
-   AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+	// create intermediate progress bar
+	fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
+	fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
+	fProgressBar->Percent(true);
+	fProgressBar->ShowPosition(true, true, "Graphics: %.0f");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
+	AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
-   // Map all subwindows of main frame
-   MapSubwindows();
+	// Map all subwindows of main frame
+	MapSubwindows();
 
-   // Initialize the layout algorithm
-   Resize(TGDimension(fPanelWidth, fLineHeight));
+	// Initialize the layout algorithm
+	Resize(TGDimension(fPanelWidth, fLineHeight));
 
-   // Map main frame
-   MapWindow();
+	// Map main frame
+	MapWindow();
 
-   // create second screen and its connections
-   BuildSecondInterface();
-   MakeSecondConnections();
+	// create second screen and its connections
+	BuildSecondInterface();
+	MakeSecondConnections();
 
-   // remove progress bar
-   DeleteElement(fProgressBar);
+	// remove progress bar
+	DeleteElement(fProgressBar);
 
-   // Map all subwindows of main frame
-   MapSubwindows();
+	// Map all subwindows of main frame
+	MapSubwindows();
 
-   // Initialize the layout algorithm
-   Resize(TGDimension(2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight));
+	// Initialize the layout algorithm
+	Resize(TGDimension(2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight));
 
-   // Map main frame
-   MapWindow();
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	// Map main frame
+	MapWindow();
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TSourceCalibration::BuildSecondInterface()
 {
-   SetLayoutManager(new TGVerticalLayout(this));
-   fTab = new TGTab(this, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight);
+	SetLayoutManager(new TGVerticalLayout(this));
+	fTab = new TGTab(this, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight);
 
-   fChannelTab.resize(fMatrices[0]->GetNbinsX());
-   for(auto& bin : fActiveBins) {
-      // create vector with projections of this channel for each source
-      std::vector<GH1D*> projections(fMatrices.size());
-      size_t             index = 0;
-      for(auto* matrix : fMatrices) {
-         projections[index] = new GH1D(matrix->ProjectionY(Form("%s_%s", fSource[index]->GetName(), matrix->GetXaxis()->GetBinLabel(bin)), bin, bin));
-         ++index;
-      }
-      auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-      // create a new tab in a new thread
-      if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
-      fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
-      //// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
-      //fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
-      //				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
-      //				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
-      //				std::cout << "created new tab " << newTab << std::endl;
-      //				return newTab;
-      //				})));
-      //// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
-      //if(fFutures.size() >= fNumberOfThreads) {
-      //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-      //	auto tmp = fFutures.front().second.get();
-      //	fChannelTab[fFutures.front().first] = tmp;
-      //	fFutures.pop();
-      //}
-   }
-   // wait for all remaining threads to finish
-   //while(!fFutures.empty()) {
-   //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-   //	auto tmp = fFutures.front().second.get();
-   //	fChannelTab[fFutures.front().first] = tmp;
-   //	fFutures.pop();
-   //}
+	fChannelTab.resize(fMatrices[0]->GetNbinsX());
+	for(auto& bin : fActiveBins) {
+		// create vector with projections of this channel for each source
+		std::vector<GH1D*> projections(fMatrices.size());
+		size_t             index = 0;
+		for(auto* matrix : fMatrices) {
+			projections[index] = new GH1D(matrix->ProjectionY(Form("%s_%s", fSource[index]->GetName(), matrix->GetXaxis()->GetBinLabel(bin)), bin, bin));
+			++index;
+		}
+		auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
+		// create a new tab in a new thread
+		if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
+		fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fSourceEnergy, fProgressBar);
+		//// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
+		//fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
+		//				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
+		//				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
+		//				std::cout << "created new tab " << newTab << std::endl;
+		//				return newTab;
+		//				})));
+		//// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
+		//if(fFutures.size() >= fNumberOfThreads) {
+		//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+		//	auto tmp = fFutures.front().second.get();
+		//	fChannelTab[fFutures.front().first] = tmp;
+		//	fFutures.pop();
+		//}
+	}
+	// wait for all remaining threads to finish
+	//while(!fFutures.empty()) {
+	//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+	//	auto tmp = fFutures.front().second.get();
+	//	fChannelTab[fFutures.front().first] = tmp;
+	//	fFutures.pop();
+	//}
 
-   //if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
+	//if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
 
-   //for(int i = 0; i < fChannelTab[0]->SourceTab()->GetNumberOfTabs(); ++i) {
-   //if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
-   //}
+	//for(int i = 0; i < fChannelTab[0]->SourceTab()->GetNumberOfTabs(); ++i) {
+	//if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
+	//}
 
-   AddFrame(fTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+	AddFrame(fTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
-   // bottom frame with navigation button group, text entries, etc.
-   fBottomFrame = new TGHorizontalFrame(this, 2 * fPanelWidth, TSourceCalibration::StatusbarHeight());
+	// bottom frame with navigation button group, text entries, etc.
+	fBottomFrame = new TGHorizontalFrame(this, 2 * fPanelWidth, TSourceCalibration::StatusbarHeight());
 
-   fLeftFrame       = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
-   fNavigationGroup = new TGHButtonGroup(fLeftFrame, "");
-   fPreviousButton  = new TGTextButton(fNavigationGroup, "&Previous");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
-   fPreviousButton->SetEnabled(false);
-   fDiscardButton = new TGTextButton(fNavigationGroup, "&Discard");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
-   fAcceptButton = new TGTextButton(fNavigationGroup, "&Accept");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept button " << fAcceptButton << std::endl; }
-   fAcceptAllButton = new TGTextButton(fNavigationGroup, "Accept All && Finish");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
-   fWriteButton = new TGTextButton(fNavigationGroup, "&Write");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "write button " << fWriteButton << std::endl; }
-   fNextButton = new TGTextButton(fNavigationGroup, "&Next");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
+	fLeftFrame       = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
+	fNavigationGroup = new TGHButtonGroup(fLeftFrame, "Navigation");
+	fPreviousButton  = new TGTextButton(fNavigationGroup, "&Previous");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
+	fPreviousButton->SetEnabled(false);
+	fDiscardButton = new TGTextButton(fNavigationGroup, "&Discard");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
+	fAcceptButton = new TGTextButton(fNavigationGroup, "&Accept");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept button " << fAcceptButton << std::endl; }
+	fAcceptAllButton = new TGTextButton(fNavigationGroup, "Accept All && Finish");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
+	fWriteButton = new TGTextButton(fNavigationGroup, "&Write");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "write button " << fWriteButton << std::endl; }
+	fNextButton = new TGTextButton(fNavigationGroup, "&Next");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
 
-   fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+	fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
 
-   fFittingGroup        = new TGHButtonGroup(fLeftFrame, "");
-   fFindPeaksButton     = new TGTextButton(fFittingGroup, "Find Peaks");
-   fFindPeaksFastButton = new TGTextButton(fFittingGroup, "&Find Peaks Fast");
-   fFindPeaksCalButton  = new TGTextButton(fFittingGroup, "&Use Calibration");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
-   fFindPeaksCalAllButton = new TGTextButton(fFittingGroup, "Use Calibration (All)");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find all peaks button " << fFindPeaksCalAllButton << std::endl; }
-   fCalibrateButton = new TGTextButton(fFittingGroup, "&Calibrate");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
-   fRemoveButton = new TGTextButton(fFittingGroup, "&Remove");
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "remove button " << fRemoveButton << std::endl; }
+	fFittingGroup        = new TGHButtonGroup(fLeftFrame, "Fitting/Calibrating");
+	fFindPeaksButton     = new TGTextButton(fFittingGroup, "Find Peaks");
+	fFindPeaksFastButton = new TGTextButton(fFittingGroup, "&Find Peaks Fast");
+	fFindPeaksCalButton  = new TGTextButton(fFittingGroup, "&Use Calibration");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find peaks button " << fFindPeaksButton << std::endl; }
+	fFindPeaksCalAllButton = new TGTextButton(fFittingGroup, "Use Calibration (All)");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "find all peaks button " << fFindPeaksCalAllButton << std::endl; }
+	fCalibrateButton = new TGTextButton(fFittingGroup, "&Calibrate");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
+	fRemoveButton = new TGTextButton(fFittingGroup, "&Remove");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "remove button " << fRemoveButton << std::endl; }
+	fRecursiveRemoveButton = new TGTextButton(fFittingGroup, "Recursive Remove");
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "remove button " << fRecursiveRemoveButton << std::endl; }
 
-   fLeftFrame->AddFrame(fFittingGroup, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+	fLeftFrame->AddFrame(fFittingGroup, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
-   fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
+	fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
 
-   fRightFrame     = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
-   fParameterFrame = new TGGroupFrame(fRightFrame, "Parameters", kHorizontalFrame);
-   fParameterFrame->SetLayoutManager(new TGMatrixLayout(fParameterFrame, 0, 4, 2));
-   fSigmaLabel          = new TGLabel(fParameterFrame, "Sigma");
-   fSigmaEntry          = new TGNumberEntry(fParameterFrame, fDefaultSigma, fDigitWidth, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
-   fThresholdLabel      = new TGLabel(fParameterFrame, "Threshold");
-   fThresholdEntry      = new TGNumberEntry(fParameterFrame, fDefaultThreshold, fDigitWidth, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
-   fDegreeLabel         = new TGLabel(fParameterFrame, "Degree of polynomial");
-   fDegreeEntry         = new TGNumberEntry(fParameterFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger, TGNumberFormat::EAttribute::kNEAPositive);
-   fMaxResidualLabel    = new TGLabel(fParameterFrame, "Max. residual (in sigma)");
-   fMaxResidualEntry    = new TGNumberEntry(fParameterFrame, fDefaultMaxResidual, fDigitWidth, kMaxResidualEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
-   fPeakRatioLabel      = new TGLabel(fParameterFrame, "Ratio found/source peaks");
-   fPeakRatioEntry      = new TGNumberEntry(fParameterFrame, fDefaultPeakRatio, fDigitWidth, kPeakRatioEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
-   fWriteNonlinearities = new TGCheckButton(fParameterFrame, "Write nonlinearities", kWriteNonlinearities);
-   fWriteNonlinearities->SetState(kButtonUp);
+	fRightFrame     = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
+	fParameterFrame = new TGGroupFrame(fRightFrame, "Parameters", kHorizontalFrame);
+	fParameterFrame->SetLayoutManager(new TGMatrixLayout(fParameterFrame, 0, 4, 2));
+	fSigmaLabel          = new TGLabel(fParameterFrame, "Sigma");
+	fSigmaEntry          = new TGNumberEntry(fParameterFrame, fDefaultSigma, fDigitWidth, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+	fThresholdLabel      = new TGLabel(fParameterFrame, "Threshold");
+	fThresholdEntry      = new TGNumberEntry(fParameterFrame, fDefaultThreshold, fDigitWidth, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
+	fDegreeLabel         = new TGLabel(fParameterFrame, "Degree of polynomial");
+	fDegreeEntry         = new TGNumberEntry(fParameterFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger, TGNumberFormat::EAttribute::kNEAPositive);
+	fMaxResidualLabel    = new TGLabel(fParameterFrame, "Max. residual (in sigma)");
+	fMaxResidualEntry    = new TGNumberEntry(fParameterFrame, fDefaultMaxResidual, fDigitWidth, kMaxResidualEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+	fPeakRatioLabel      = new TGLabel(fParameterFrame, "Ratio found/source peaks");
+	fPeakRatioEntry      = new TGNumberEntry(fParameterFrame, fDefaultPeakRatio, fDigitWidth, kPeakRatioEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+	fWriteNonlinearities = new TGCheckButton(fParameterFrame, "Write nonlinearities", kWriteNonlinearities);
+	fWriteNonlinearities->SetState(kButtonUp);
 
-   fParameterFrame->AddFrame(fSigmaLabel);
-   fParameterFrame->AddFrame(fSigmaEntry);
-   fParameterFrame->AddFrame(fThresholdLabel);
-   fParameterFrame->AddFrame(fThresholdEntry);
-   fParameterFrame->AddFrame(fDegreeLabel);
-   fParameterFrame->AddFrame(fDegreeEntry);
-   fParameterFrame->AddFrame(fMaxResidualLabel);
-   fParameterFrame->AddFrame(fMaxResidualEntry);
-   fParameterFrame->AddFrame(fPeakRatioLabel);
-   fParameterFrame->AddFrame(fPeakRatioEntry);
-   fParameterFrame->AddFrame(fWriteNonlinearities);
+	fParameterFrame->AddFrame(fSigmaLabel);
+	fParameterFrame->AddFrame(fSigmaEntry);
+	fParameterFrame->AddFrame(fThresholdLabel);
+	fParameterFrame->AddFrame(fThresholdEntry);
+	fParameterFrame->AddFrame(fDegreeLabel);
+	fParameterFrame->AddFrame(fDegreeEntry);
+	fParameterFrame->AddFrame(fMaxResidualLabel);
+	fParameterFrame->AddFrame(fMaxResidualEntry);
+	fParameterFrame->AddFrame(fPeakRatioLabel);
+	fParameterFrame->AddFrame(fPeakRatioEntry);
+	fParameterFrame->AddFrame(fWriteNonlinearities);
 
-   fRightFrame->AddFrame(fParameterFrame, new TGLayoutHints(kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
+	fRightFrame->AddFrame(fParameterFrame, new TGLayoutHints(kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
 
-   fBottomFrame->AddFrame(fRightFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight, 2, 2, 2, 2));
+	fBottomFrame->AddFrame(fRightFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight, 2, 2, 2, 2));
 
-   AddFrame(fBottomFrame, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+	AddFrame(fBottomFrame, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
-   SelectedTab(0);
+	SelectedTab(0);
 
-   fProgressBar->Reset();
-   fProgressBar->ShowPosition(true, true, "Peaks: %.0f");
-   for(auto* channelTab : fChannelTab) {
-      if(channelTab != nullptr) {
-         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-            for(int i = 0; i < 5; ++i) {
-               std::cout << "================================================================================" << std::endl;
-            }
-            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-         }
-         channelTab->Initialize(Sigma(), Threshold(), PeakRatio(), true, fFast);
-         channelTab->FindAllCalibratedPeaks();
-         channelTab->Calibrate();
-         channelTab->Draw();
-         channelTab->PrintCanvases();
-      }
-   }
+	fProgressBar->Reset();
+	fProgressBar->ShowPosition(true, true, "Peaks: %.0f");
+	for(auto* channelTab : fChannelTab) {
+		if(channelTab != nullptr) {
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+				for(int i = 0; i < 5; ++i) {
+					std::cout << "================================================================================" << std::endl;
+				}
+				for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+			}
+			channelTab->Initialize(true);
+			channelTab->FindAllCalibratedPeaks();
+			channelTab->Calibrate();
+			channelTab->Draw();
+			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+				channelTab->PrintCanvases();
+			}
+		}
+	}
 
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
 }
 
 void TSourceCalibration::MakeSecondConnections()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
-   fFittingGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Fitting(Int_t)");
-   fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
-   // we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
-   for(auto* channelTab : fChannelTab) {
-      if(channelTab != nullptr) {
-         channelTab->MakeConnections();
-      }
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
+	fFittingGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Fitting(Int_t)");
+	fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
+	// we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
+	for(auto* channelTab : fChannelTab) {
+		if(channelTab != nullptr) {
+			channelTab->MakeConnections();
+		}
+	}
 }
 
 void TSourceCalibration::DisconnectSecond()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
-   fFittingGroup->Disconnect("Clicked(Int_t)", this, "Fitting(Int_t)");
-   fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
-   for(auto* channelTab : fChannelTab) {
-      if(channelTab != nullptr) {
-         channelTab->Disconnect();
-      }
-   }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
+	fFittingGroup->Disconnect("Clicked(Int_t)", this, "Fitting(Int_t)");
+	fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
+	for(auto* channelTab : fChannelTab) {
+		if(channelTab != nullptr) {
+			channelTab->Disconnect();
+		}
+	}
 }
 
 void TSourceCalibration::Navigate(Int_t id)
 {
-   // we get the current source tab id and use it to get the channel tab from the right source tab
-   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
-   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
-   int currentChannelId = fTab->GetCurrent();
-   int actualChannelId  = fActualChannelId[currentChannelId];
-   int nofTabs          = fTab->GetNumberOfTabs();
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
-   switch(id) {
-   case ENavigate::kPrevious:   // previous
-      fTab->SetTab(currentChannelId - 1);
-      SelectedTab(currentChannelId - 1);
-      break;
-   case ENavigate::kDiscard:   // discard
-      // select the next (or if we are on the last tab, the previous) tab
-      if(currentChannelId < nofTabs - 1) {
-         fTab->SetTab(currentChannelId + 1);
-      } else {
-         fTab->SetTab(currentChannelId - 1);
-      }
-      // remove the original active tab
-      fTab->RemoveTab(currentChannelId);
-      break;
-   case ENavigate::kAccept:   // accept
-      AcceptChannel(currentChannelId);
-      break;
-   case ENavigate::kAcceptAll:   // accept all (no argument = -1 = all)
-      AcceptChannel();
-      return;
-   case ENavigate::kWrite:   // write
-      WriteCalibration();
-      break;
-   case ENavigate::kNext:   // next
-      fTab->SetTab(currentChannelId + 1);
-      SelectedTab(currentChannelId + 1);
-      break;
-   default:
-      break;
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+	// we get the current source tab id and use it to get the channel tab from the right source tab
+	// since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+	// for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+	int currentChannelId = fTab->GetCurrent();
+	int actualChannelId  = fActualChannelId[currentChannelId];
+	int nofTabs          = fTab->GetNumberOfTabs();
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+	switch(id) {
+		case ENavigate::kPrevious:   // previous
+			fTab->SetTab(currentChannelId - 1);
+			SelectedTab(currentChannelId - 1);
+			break;
+		case ENavigate::kDiscard:   // discard
+											 // select the next (or if we are on the last tab, the previous) tab
+			if(currentChannelId < nofTabs - 1) {
+				fTab->SetTab(currentChannelId + 1);
+			} else {
+				fTab->SetTab(currentChannelId - 1);
+			}
+			// remove the original active tab
+			fTab->RemoveTab(currentChannelId);
+			break;
+		case ENavigate::kAccept:   // accept
+			AcceptChannel(currentChannelId);
+			break;
+		case ENavigate::kAcceptAll:   // accept all (no argument = -1 = all)
+			AcceptChannel();
+			return;
+		case ENavigate::kWrite:   // write
+			WriteCalibration();
+			break;
+		case ENavigate::kNext:   // next
+			fTab->SetTab(currentChannelId + 1);
+			SelectedTab(currentChannelId + 1);
+			break;
+		default:
+			break;
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
 }
 
 void TSourceCalibration::Fitting(Int_t id)
 {
-   // we get the current source tab id and use it to get the channel tab from the right source tab
-   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
-   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
-   int currentChannelId = fTab->GetCurrent();
-   int actualChannelId  = fActualChannelId[currentChannelId];
-   int nofTabs          = fTab->GetNumberOfTabs();
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
-   switch(id) {
-   case EFitting::kFindPeaks:   // find peaks
-      FindPeaks();
-      break;
-   case EFitting::kFindPeaksFast:   // find peaks fast
-      FindPeaksFast();
-      break;
-   case EFitting::kFindPeaksCal:   // find calibrated peaks
-      FindCalibratedPeaks();
-      break;
-   case EFitting::kFindPeaksCalAll:   // find all calibrated peaks
-      FindAllCalibratedPeaks();
-      break;
-   case EFitting::kCalibrate:   // calibrate
-      Calibrate();
-      break;
-   case EFitting::kRemove:   // remove outliers
-      Remove();
-      break;
-   default:
-      break;
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+	// we get the current source tab id and use it to get the channel tab from the right source tab
+	// since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+	// for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+	int currentChannelId = fTab->GetCurrent();
+	int actualChannelId  = fActualChannelId[currentChannelId];
+	int nofTabs          = fTab->GetNumberOfTabs();
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+	switch(id) {
+		case EFitting::kFindPeaks:   // find peaks
+			FindPeaks();
+			break;
+		case EFitting::kFindPeaksFast:   // find peaks fast
+			FindPeaksFast();
+			break;
+		case EFitting::kFindPeaksCal:   // find calibrated peaks
+			FindCalibratedPeaks();
+			break;
+		case EFitting::kFindPeaksCalAll:   // find all calibrated peaks
+			FindAllCalibratedPeaks();
+			break;
+		case EFitting::kCalibrate:   // calibrate
+			Calibrate();
+			break;
+		case EFitting::kRemove:   // remove outliers
+			Remove();
+			break;
+		case EFitting::kRecursiveRemove:   // recursively remove outliers
+			RecursiveRemove();
+			break;
+		default:
+			break;
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
 }
 
 void TSourceCalibration::SelectedTab(Int_t id)
 {
-   /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
-   /// Also sets gPad to the projection of the source selected in this tab.
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", nofTabs " << fTab->GetNumberOfTabs() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(id < 0) { return; }
-   if(id == 0) {
-      fPreviousButton->SetEnabled(false);
-   } else {
-      fPreviousButton->SetEnabled(true);
-   }
+	/// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
+	/// Also sets gPad to the projection of the source selected in this tab.
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", nofTabs " << fTab->GetNumberOfTabs() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(id < 0) { return; }
+	if(id == 0) {
+		fPreviousButton->SetEnabled(false);
+	} else {
+		fPreviousButton->SetEnabled(true);
+	}
 
-   if(id >= fTab->GetNumberOfTabs() - 1) {
-      fNextButton->SetEnabled(false);
-   } else {
-      fNextButton->SetEnabled(true);
-   }
+	if(id >= fTab->GetNumberOfTabs() - 1) {
+		fNextButton->SetEnabled(false);
+	} else {
+		fNextButton->SetEnabled(true);
+	}
 
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
 
-   if(fChannelTab[fActiveBins[id] - 1] == nullptr) {
-      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab() == nullptr) {
-      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas() == nullptr) {
-      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas() == nullptr) {
-      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
-      return;
-   }
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
-   gPad = fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas();
-   fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()->cd();
-   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+	if(fChannelTab[fActiveBins[id] - 1] == nullptr) {
+		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab() == nullptr) {
+		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas() == nullptr) {
+		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas() == nullptr) {
+		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
+		return;
+	}
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+	gPad = fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas();
+	fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()->cd();
+	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TSourceCalibration::AcceptChannel(const int& channelId)
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   // select the next (or if we are on the last tab, the previous) tab
-   int nofTabs    = fTab->GetNumberOfTabs();
-   int minChannel = 0;
-   int maxChannel = nofTabs - 1;
-   if(channelId >= 0) {
-      minChannel = channelId;
-      maxChannel = channelId;
-   }
+	// select the next (or if we are on the last tab, the previous) tab
+	int nofTabs    = fTab->GetNumberOfTabs();
+	int minChannel = 0;
+	int maxChannel = nofTabs - 1;
+	if(channelId >= 0) {
+		minChannel = channelId;
+		maxChannel = channelId;
+	}
 
-   // we need to loop backward, because removing the first channel would make the second one the new first and so on
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   for(int currentChannelId = maxChannel; currentChannelId >= minChannel; --currentChannelId) {
-      int actualChannelId = fActualChannelId[currentChannelId];
-      if(fVerboseLevel > EVerbosity::kLoops) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << ", nofTabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	// we need to loop backward, because removing the first channel would make the second one the new first and so on
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	for(int currentChannelId = maxChannel; currentChannelId >= minChannel; --currentChannelId) {
+		int actualChannelId = fActualChannelId[currentChannelId];
+		if(fVerboseLevel > EVerbosity::kLoops) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << ", nofTabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-      if(minChannel == maxChannel) {   // we don't need to select the tab if we close all
-         if(currentChannelId < nofTabs) {
-            fTab->SetTab(currentChannelId + 1);
-            if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId + 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-         } else {
-            fTab->SetTab(currentChannelId - 1);
-            if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId - 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-         }
-      }
+		if(minChannel == maxChannel) {   // we don't need to select the tab if we close all
+			if(currentChannelId < nofTabs) {
+				fTab->SetTab(currentChannelId + 1);
+				if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId + 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			} else {
+				fTab->SetTab(currentChannelId - 1);
+				if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId - 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+			}
+		}
 
-      // remove the original active tab
-      fTab->RemoveTab(currentChannelId);   // this sets the selected tab to zero if the deleted tab is the currently selected one, which is why we do it now (after we've selected a new tab)
-      fActualChannelId.erase(fActualChannelId.begin() + currentChannelId);
-      fActiveBins.erase(fActiveBins.begin() + currentChannelId);
-   }
-   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   // check if this changes which buttons are enabled or not (not using the variables from the beginning of this block because they might have changed by now!)
-   SelectedTab(fTab->GetCurrent());
-   // if this was also the last source vector we initiate the last screen
-   if(fActualChannelId.empty() || fActiveBins.empty()) {
-      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "last channel tab done - writing files now" << std::endl; }
-      fEmitter = fAcceptAllButton;
-      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+		// remove the original active tab
+		fTab->RemoveTab(currentChannelId);   // this sets the selected tab to zero if the deleted tab is the currently selected one, which is why we do it now (after we've selected a new tab)
+		fActualChannelId.erase(fActualChannelId.begin() + currentChannelId);
+		fActiveBins.erase(fActiveBins.begin() + currentChannelId);
+	}
+	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+																																																						  // check if this changes which buttons are enabled or not (not using the variables from the beginning of this block because they might have changed by now!)
+	SelectedTab(fTab->GetCurrent());
+	// if this was also the last source vector we initiate the last screen
+	if(fActualChannelId.empty() || fActiveBins.empty()) {
+		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "last channel tab done - writing files now" << std::endl; }
+		fEmitter = fAcceptAllButton;
+		TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindPeaks()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(Sigma(), Threshold(), PeakRatio(), true, false);   // force = true, fast = false
-      Calibrate();
-   } else {
-      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(true, false);   // force = true, fast = false
+		Calibrate();
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindPeaksFast()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(Sigma(), Threshold(), PeakRatio(), true, true);   // force = true, fast = true
-      Calibrate();
-   } else {
-      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindPeaks(true, true);   // force = true, fast = true
+		Calibrate();
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindCalibratedPeaks()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindCalibratedPeaks();
-      Calibrate();
-   } else {
-      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindCalibratedPeaks();
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindAllCalibratedPeaks()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   for(auto& bin : fActiveBins) {
-      if(fChannelTab[bin] != nullptr) {
-         fChannelTab[bin]->FindCalibratedPeaks();
-         fChannelTab[bin]->Calibrate(Degree(), true);
-      } else {
-         std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << bin << "] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-      }
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	for(auto& bin : fActiveBins) {
+		if(fChannelTab[bin] != nullptr) {
+			fChannelTab[bin]->FindAllCalibratedPeaks();
+			fChannelTab[bin]->Calibrate();
+		} else {
+			std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << bin << "] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+		}
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::Calibrate()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate(Degree(), true);
-   } else {
-      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::Remove()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Remove(MaxResidual());
-   } else {
-      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   }
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Remove(MaxResidual());
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+}
+
+void TSourceCalibration::RecursiveRemove()
+{
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->RecursiveRemove(MaxResidual());
+	} else {
+		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	}
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::WriteCalibration()
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   std::ostringstream fileName;
-   for(auto* source : fSource) {
-      fileName << source->GetName();
-   }
-   fileName << ".cal";
-   TChannel::WriteCalFile(fileName.str());
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   if(fVerboseLevel > EVerbosity::kSubroutines) { TChannel::WriteCalFile(); }
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	std::ostringstream fileName;
+	for(auto* source : fSource) {
+		fileName << source->GetName();
+	}
+	fileName << ".cal";
+	TChannel::WriteCalFile(fileName.str());
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fVerboseLevel > EVerbosity::kSubroutines) { TChannel::WriteCalFile(); }
 }
 
 void TSourceCalibration::PrintLayout() const
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   Print();
-   if(fBottomFrame != nullptr) { fBottomFrame->Print(); }
-   if(fLeftFrame != nullptr) { fLeftFrame->Print(); }
-   if(fRightFrame != nullptr) { fRightFrame->Print(); }
-   if(fTab != nullptr) { fTab->Print(); }
-   std::cout << "TSourceCalibration all channel tabs:" << std::endl;
-   for(auto* channelTab : fChannelTab) {
-      if(channelTab != nullptr) { channelTab->PrintLayout(); }
-   }
+	Print();
+	if(fBottomFrame != nullptr) { fBottomFrame->Print(); }
+	if(fLeftFrame != nullptr) { fLeftFrame->Print(); }
+	if(fRightFrame != nullptr) { fRightFrame->Print(); }
+	if(fTab != nullptr) { fTab->Print(); }
+	std::cout << "TSourceCalibration all " << fChannelTab.size() << " channel tabs:" << std::endl;
+	for(auto* channelTab : fChannelTab) {
+		if(channelTab != nullptr) { channelTab->PrintLayout(); }
+	}
 }
 
 void TSourceCalibration::PrintCanvases() const
 {
-   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-   for(auto* channelTab : fChannelTab) {
-      if(channelTab != nullptr) { channelTab->PrintCanvases(); }
-   }
+	for(auto* channelTab : fChannelTab) {
+		if(channelTab != nullptr) { channelTab->PrintCanvases(); }
+	}
 }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -766,7 +766,7 @@ void TSourceTab::UpdateFits()
          std::cout << std::endl;
       }
    }
-   if(fFits.size() > 0 && fFits.front()->NumberOfPeaks() > 0 && fFits.back()->NumberOfPeaks() > 0) {
+   if(!fFits.empty() && fFits.front()->NumberOfPeaks() > 0 && fFits.back()->NumberOfPeaks() > 0) {
       fProjection->SetTitle(Form("%lu of %lu source peaks used, channel %.0f - %.0f", fFits.size(), fSourceEnergy.size(), fFits.front()->Peak(0)->Centroid(), fFits.back()->Peak(0)->Centroid()));
    } else {
       fProjection->SetTitle(Form("%lu of %lu source peaks used, channel ???? - ????", fFits.size(), fSourceEnergy.size()));
@@ -1796,7 +1796,7 @@ void TChannelTab::RecursiveRemove(const double& maxResidual)
    }
 
    // get the maximum residual
-   auto maxElement = std::max_element(fData->TotalResidualGraph()->GetX(), fData->TotalResidualGraph()->GetX() + fData->TotalResidualGraph()->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+   auto* maxElement = std::max_element(fData->TotalResidualGraph()->GetX(), fData->TotalResidualGraph()->GetX() + fData->TotalResidualGraph()->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
    auto index      = std::distance(fData->TotalResidualGraph()->GetX(), maxElement);
 
    if(std::abs(*maxElement) < maxResidual) {

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -467,8 +467,8 @@ TSourceTab::TSourceTab(TSourceCalibration* sourceCal, TChannelTab* channel, TGCo
    : fSourceCalibration(sourceCal), fChannelTab(channel), fSourceFrame(frame), fProjection(projection), fSourceName(sourceName), fSourceEnergy(std::move(sourceEnergy))
 {
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << __PRETTY_FUNCTION__ << RESET_COLOR << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	// default sorting of tuples is by the first entry, which is the source energy here, so no need for a custom sort condition
-	std::sort(fSourceEnergy.begin(), fSourceEnergy.end());
+   // default sorting of tuples is by the first entry, which is the source energy here, so no need for a custom sort condition
+   std::sort(fSourceEnergy.begin(), fSourceEnergy.end());
    BuildInterface();
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DCYAN << "interface built, finding peaks ... " << RESET_COLOR << std::endl; }
 }
@@ -671,20 +671,20 @@ void TSourceTab::ProjectionStatus(Int_t event, Int_t px, Int_t py, TObject* sele
    case kButton1Up:
       break;
    case kMouseMotion:
-		//{
-		//	auto* canvas = fProjectionCanvas->GetCanvas();
-		//	if(canvas == nullptr) {
-		//		Status("canvas nullptr", 0);
-		//		break;
-		//	}
-		//	auto* pad = canvas->GetSelectedPad();
-		//	if(pad == nullptr) {
-		//		Status("pad nullptr", 0);
-		//		break;
-		//	}
+      //{
+      //	auto* canvas = fProjectionCanvas->GetCanvas();
+      //	if(canvas == nullptr) {
+      //		Status("canvas nullptr", 0);
+      //		break;
+      //	}
+      //	auto* pad = canvas->GetSelectedPad();
+      //	if(pad == nullptr) {
+      //		Status("pad nullptr", 0);
+      //		break;
+      //	}
 
-		//	Status(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 0);
-		//}
+      //	Status(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 0);
+      //}
       break;
    case kMouseEnter:
       break;
@@ -732,12 +732,12 @@ void TSourceTab::UpdateFits()
       std::cout << "Updating functions for histogram " << fProjection->GetName() << " by deleting " << functions->GetEntries() << " functions:" << std::endl;
       for(auto* obj : *functions) {
          std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName();
-			if(obj->IsA() == TF1::Class()) {
-				std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
-			} else {
-				std::cout << " not a TF1";
-			}
-			std::cout << std::endl;
+         if(obj->IsA() == TF1::Class()) {
+            std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
+         } else {
+            std::cout << " not a TF1";
+         }
+         std::cout << std::endl;
       }
    }
    // remove all old fits (all have the same name/title of "gauss_total")
@@ -749,7 +749,7 @@ void TSourceTab::UpdateFits()
    // add all the fit functions of the good and the bad peaks
    for(auto* obj : fFits) {
       functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Added clone of " << obj->GetFitFunction() << " = " << functions->Last() << std::endl; }
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Added clone of " << obj->GetFitFunction() << " = " << functions->Last() << std::endl; }
    }
    for(auto* obj : fBadFits) {
       functions->Add(obj->GetFitFunction()->Clone("gauss_total"));
@@ -758,20 +758,20 @@ void TSourceTab::UpdateFits()
       std::cout << "And adding " << functions->GetEntries() << " functions instead:" << std::endl;
       for(auto* obj : *functions) {
          std::cout << obj << ": " << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName();
-			if(obj->IsA() == TF1::Class()) {
-				std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
-			} else {
-				std::cout << " not a TF1";
-			}
-			std::cout << std::endl;
+         if(obj->IsA() == TF1::Class()) {
+            std::cout << " line color " << static_cast<TF1*>(obj)->GetLineColor();
+         } else {
+            std::cout << " not a TF1";
+         }
+         std::cout << std::endl;
       }
    }
-	if(fFits.size() > 0 && fFits.front()->NumberOfPeaks() > 0 && fFits.back()->NumberOfPeaks() > 0) {
-		fProjection->SetTitle(Form("%lu of %lu source peaks used, channel %.0f - %.0f", fFits.size(), fSourceEnergy.size(), fFits.front()->Peak(0)->Centroid(), fFits.back()->Peak(0)->Centroid()));
-	} else {
-		fProjection->SetTitle(Form("%lu of %lu source peaks used, channel ???? - ????", fFits.size(), fSourceEnergy.size()));
-	}
-	fProjectionCanvas->GetCanvas()->Modified();
+   if(fFits.size() > 0 && fFits.front()->NumberOfPeaks() > 0 && fFits.back()->NumberOfPeaks() > 0) {
+      fProjection->SetTitle(Form("%lu of %lu source peaks used, channel %.0f - %.0f", fFits.size(), fSourceEnergy.size(), fFits.front()->Peak(0)->Centroid(), fFits.back()->Peak(0)->Centroid()));
+   } else {
+      fProjection->SetTitle(Form("%lu of %lu source peaks used, channel ???? - ????", fFits.size(), fSourceEnergy.size()));
+   }
+   fProjectionCanvas->GetCanvas()->Modified();
 }
 
 void TSourceTab::Draw()
@@ -846,8 +846,8 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
       return;
    }
 
-	// try and make sure the right canvas is selected as all fits are drawn in the currently selected canvas
-	gPad = fProjectionCanvas->GetCanvas();
+   // try and make sure the right canvas is selected as all fits are drawn in the currently selected canvas
+   gPad = fProjectionCanvas->GetCanvas();
 
    fPeaks.clear();
    fFits.clear();
@@ -855,14 +855,14 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    // Remove all associated functions from projection.
    // These are the poly markers, fits, and the pave stat
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-		std::cout << "calibration has " << calibration->GetNpar() << " parameters (";
-		for(int i = 0; i < calibration->GetNpar(); ++i) {
-			if(i != 0) {
-				std::cout << ", ";
-			}
-			std::cout << i << ": " << calibration->GetParameter(i);
-		}
-		std::cout << "), if linear offset is " << calibration->Eval(0) << " and gain is " << calibration->Eval(1) - calibration->Eval(0) << std::endl;
+      std::cout << "calibration has " << calibration->GetNpar() << " parameters (";
+      for(int i = 0; i < calibration->GetNpar(); ++i) {
+         if(i != 0) {
+            std::cout << ", ";
+         }
+         std::cout << i << ": " << calibration->GetParameter(i);
+      }
+      std::cout << "), if linear offset is " << calibration->Eval(0) << " and gain is " << calibration->Eval(1) - calibration->Eval(0) << std::endl;
       TList* functions = fProjection->GetListOfFunctions();
       std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << " before clearing" << std::endl;
       for(auto* obj : *functions) {
@@ -871,44 +871,44 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    }
    fProjection->GetListOfFunctions()->Clear();
 
-	std::map<TGauss*, std::tuple<double, double, double, double>> map;
+   std::map<TGauss*, std::tuple<double, double, double, double>> map;
 
    // loop over all source energies and check if we want to use the peak or if it's too weak
-	// for each source energy we calculate the channel it would be at
-	std::vector<std::pair<std::tuple<double, double, double, double>, double>> channelPos;
-	for(auto& tuple : fSourceEnergy) {
+   // for each source energy we calculate the channel it would be at
+   std::vector<std::pair<std::tuple<double, double, double, double>, double>> channelPos;
+   for(auto& tuple : fSourceEnergy) {
       if(std::get<2>(tuple) < TSourceCalibration::MinIntensity()) {
          if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
             std::cout << "Skipping peak at " << std::get<0>(tuple) << " keV with intensity " << std::get<2>(tuple) << " below required minimum intensity " << TSourceCalibration::MinIntensity() << std::endl;
          }
          continue;
       }
-		channelPos.emplace_back(tuple, calibration->GetX(std::get<0>(tuple)));
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      channelPos.emplace_back(tuple, calibration->GetX(std::get<0>(tuple)));
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << "Set channel position for " << channelPos.size() - 1 << ". peak to " << channelPos.back().second << " channels = " << std::get<0>(channelPos.back().first) << " keV" << std::endl;
       }
-	}
-	// loop over channel positions and fit the peaks
+   }
+   // loop over channel positions and fit the peaks
    for(size_t i = 0; i < channelPos.size(); ++i) {
       double lowRange  = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
       double highRange = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
-		// if the range for this peaks overlaps with the previous/next one, reduce the range but not more than half
-		// also check if the previous/next one is above the minimum intensity, because otherwise we would have skipped that one anyway
-		if(i > 0) {
+      // if the range for this peaks overlaps with the previous/next one, reduce the range but not more than half
+      // also check if the previous/next one is above the minimum intensity, because otherwise we would have skipped that one anyway
+      if(i > 0) {
          if(channelPos[i].second - lowRange < channelPos[i - 1].second + highRange) {
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-					std::cout << channelPos[i].second - lowRange << " < " << channelPos[i - 1].second + highRange << ": changing low range from " << lowRange << " to " << std::max(lowRange/2., (channelPos[i].second - channelPos[i - 1].second)/2.) << " = std::max(" << lowRange/2. << ", " << (channelPos[i].second - channelPos[i - 1].second)/2. << " = (" << channelPos[i].second << " - " << channelPos[i - 1].second << "/2.)" << std::endl;
-				}
-				lowRange = std::max(lowRange/2., (channelPos[i].second - channelPos[i - 1].second)/2.);
+               std::cout << channelPos[i].second - lowRange << " < " << channelPos[i - 1].second + highRange << ": changing low range from " << lowRange << " to " << std::max(lowRange / 2., (channelPos[i].second - channelPos[i - 1].second) / 2.) << " = std::max(" << lowRange / 2. << ", " << (channelPos[i].second - channelPos[i - 1].second) / 2. << " = (" << channelPos[i].second << " - " << channelPos[i - 1].second << "/2.)" << std::endl;
+            }
+            lowRange = std::max(lowRange / 2., (channelPos[i].second - channelPos[i - 1].second) / 2.);
          }
-		}
-		if(i + 1 < channelPos.size()) {
+      }
+      if(i + 1 < channelPos.size()) {
          if(channelPos[i].second + highRange > channelPos[i + 1].second - lowRange) {
-				if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-					std::cout << channelPos[i].second + highRange << " > " << channelPos[i + 1].second - lowRange << ": changing high range from " << highRange << " to " << std::max(highRange / 2., (channelPos[i + 1].second - channelPos[i].second) / 2.) << " = std::max(" << highRange / 2. << ", " << (channelPos[i + 1].second - channelPos[i].second) / 2. << " = (" << channelPos[i + 1].second << " - " << channelPos[i].second << "/2.)" << std::endl;
-				}
-            highRange = std::min(highRange/2., (channelPos[i + 1].second - channelPos[i].second)/2.);
-			}
+            if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+               std::cout << channelPos[i].second + highRange << " > " << channelPos[i + 1].second - lowRange << ": changing high range from " << highRange << " to " << std::max(highRange / 2., (channelPos[i + 1].second - channelPos[i].second) / 2.) << " = std::max(" << highRange / 2. << ", " << (channelPos[i + 1].second - channelPos[i].second) / 2. << " = (" << channelPos[i + 1].second << " - " << channelPos[i].second << "/2.)" << std::endl;
+            }
+            highRange = std::min(highRange / 2., (channelPos[i + 1].second - channelPos[i].second) / 2.);
+         }
       }
       if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
          std::cout << "Trying to fit peak " << channelPos[i].second << " in range " << channelPos[i].second - lowRange << " - " << channelPos[i].second + highRange << std::endl;
@@ -928,7 +928,7 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
          if(Good(peak, channelPos[i].second - lowRange, channelPos[i].second + highRange)) {
             fPeaks.push_back(peak);
             fFits.push_back(pf);
-				map[peak] = channelPos[i].first;
+            map[peak] = channelPos[i].first;
             if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
                std::cout << "Fitted peak " << channelPos[i].second - lowRange << " - " << channelPos[i].second + highRange << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
             }
@@ -944,624 +944,624 @@ void TSourceTab::FindCalibratedPeaks(const TF1* calibration)
    }
 
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": added " << fPeaks.size() << " peaks (" << fSourceEnergy.size() << " source energies, " << channelPos.size() << " channel positions)" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   fProjection->Sumw2(false);                                                                                                                                                                                         // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
+   fProjection->Sumw2(false);                                                                                                                                                                                                                                        // turn errors off, makes the histogram look like a histogram when using normal plotting (hist and samefunc doesn't work for some reason)
 
    std::sort(fFits.begin(), fFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
    std::sort(fBadFits.begin(), fBadFits.end(), [](const TPeakFitter* a, const TPeakFitter* b) { return a->GetFitFunction()->GetParameter("centroid_0") < b->GetFitFunction()->GetParameter("centroid_0"); });
    std::sort(fPeaks.begin(), fPeaks.end(), [](const TGauss* a, const TGauss* b) { return a->Centroid() < b->Centroid(); });
 
-	SetLineColors();
+   SetLineColors();
 
    UpdateFits();
 
-	Add(map);
+   Add(map);
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-		Double_t* x = fData->GetX();
-		Double_t* y = fData->GetY();
-		for(int i = 0; i < fData->GetN(); ++i) {
-			std::cout << "; " << x[i] << " - " << y[i];
-		}
-		std::cout << std::endl;
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << __PRETTY_FUNCTION__ << ": found " << fData->GetN() << " peaks";   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      Double_t* x = fData->GetX();
+      Double_t* y = fData->GetY();
+      for(int i = 0; i < fData->GetN(); ++i) {
+         std::cout << "; " << x[i] << " - " << y[i];
+      }
+      std::cout << std::endl;
+   }
 }
 
 void TSourceTab::Add(std::map<double, std::tuple<double, double, double, double>> map)
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
-	}
-	if(fData == nullptr) {
-		fData = new TGraphErrors(map.size());
-	} else {
-		fData->Set(map.size());
-	}
-	fData->SetLineColor(2);
-	fData->SetMarkerColor(2);
-	int i = 0;
-	for(auto iter = map.begin(); iter != map.end();) {
-		// more readable variable names
-		auto peakPos = iter->first;
-		auto energy  = std::get<0>(iter->second);
-		fData->SetPoint(i, peakPos, energy);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
-		}
-		++iter;
-		++i;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << "Accepted " << map.size() << " peaks" << std::endl;
-	}
-	fData->Sort();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
+   }
+   if(fData == nullptr) {
+      fData = new TGraphErrors(map.size());
+   } else {
+      fData->Set(map.size());
+   }
+   fData->SetLineColor(2);
+   fData->SetMarkerColor(2);
+   int i = 0;
+   for(auto iter = map.begin(); iter != map.end();) {
+      // more readable variable names
+      auto peakPos = iter->first;
+      auto energy  = std::get<0>(iter->second);
+      fData->SetPoint(i, peakPos, energy);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "Using peak with position " << peakPos << ", energy " << energy << std::endl;
+      }
+      ++iter;
+      ++i;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << "Accepted " << map.size() << " peaks" << std::endl;
+   }
+   fData->Sort();
 }
 
 void TSourceTab::Add(std::map<TGauss*, std::tuple<double, double, double, double>> map)
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
-	}
-	if(fData == nullptr) {
-		fData = new TGraphErrors(map.size());
-	} else {
-		fData->Set(map.size());
-	}
-	fData->SetLineColor(2);
-	fData->SetMarkerColor(2);
-	if(fFwhm == nullptr) {
-		fFwhm = new TGraphErrors(map.size());
-	} else {
-		fFwhm->Set(map.size());
-	}
-	fFwhm->SetLineColor(4);
-	fFwhm->SetMarkerColor(4);
-	int i = 0;
-	for(auto iter = map.begin(); iter != map.end();) {
-		// more readable variable names
-		auto peakPos     = iter->first->Centroid();
-		auto peakPosErr  = iter->first->CentroidErr();
-		auto peakArea    = iter->first->Area();
-		auto peakAreaErr = iter->first->AreaErr();
-		auto fwhm        = iter->first->FWHM();
-		auto fwhmErr     = iter->first->FWHMErr();
-		auto energy      = std::get<0>(iter->second);
-		auto energyErr   = std::get<1>(iter->second);
-		// drop this peak if the uncertainties in area or position are too large
-		if(!Good(iter->first)) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-				std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
-			}
-			iter = map.erase(iter);
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << "Erasing peak returned iterator " << std::distance(map.begin(), iter) << std::endl;
-			}
-		} else {
-			fData->SetPoint(i, peakPos, energy);
-			fData->SetPointError(i, peakPosErr, energyErr);
-			fFwhm->SetPoint(i, peakPos, fwhm);
-			fFwhm->SetPointError(i, peakPosErr, fwhmErr);
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << "Using peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
-			}
-			++iter;
-			++i;
-		}
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << "Accepted " << map.size() << " peaks" << std::endl;
-	}
-	// if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
-	fData->Set(map.size());
-	fFwhm->Set(map.size());
-	fData->Sort();
-	fFwhm->Sort();
-	// split poly marker into those peaks that were used, and those that weren't
-	TList* functions = fProjection->GetListOfFunctions();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-		std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << std::endl;
-		for(auto* obj : *functions) {
-			std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
-		}
-	}
-	auto* polym = static_cast<TPolyMarker*>(functions->FindObject("TPolyMarker"));
-	if(polym != nullptr) {
-		double*             oldX = polym->GetX();
-		double*             oldY = polym->GetY();
-		int                 size = polym->GetN();
-		std::vector<double> newX;
-		std::vector<double> newY;
-		std::vector<double> unusedX;
-		std::vector<double> unusedY;
-		for(i = 0; i < size; ++i) {
-			bool used = false;
-			for(auto point : map) {
-				if(TMath::Abs(oldX[i] - point.first->Centroid()) < fSourceCalibration->Sigma()) {
-					newX.push_back(oldX[i]);
-					newY.push_back(oldY[i]);
-					used = true;
-					break;
-				}
-			}
-			if(!used) {
-				unusedX.push_back(oldX[i]);
-				unusedY.push_back(oldY[i]);
-			}
-		}
-		polym->SetPolyMarker(newX.size(), newX.data(), newY.data());
-		auto* unusedMarkers = new TPolyMarker(unusedX.size(), unusedX.data(), unusedY.data());
-		unusedMarkers->SetMarkerStyle(23);   // triangle down
-		unusedMarkers->SetMarkerColor(16);   // light grey
-		functions->Add(unusedMarkers);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << fProjection->GetTitle() << ": " << size << " peaks founds total, " << polym->GetN() << " used, and " << unusedMarkers->GetN() << " unused" << std::endl;
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-				std::cout << "Used: ";
-				for(size_t m = 0; m < newX.size(); ++m) { std::cout << newX[m] << " - " << newY[m] << ";"; }
-				std::cout << std::endl;
-				std::cout << "Unused: ";
-				for(size_t m = 0; m < unusedX.size(); ++m) { std::cout << unusedX[m] << " - " << unusedY[m] << ";"; }
-				std::cout << std::endl;
-			}
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-				std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
-				for(auto* obj : *functions) {
-					std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
-				}
-			}
-		}
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DCYAN << "Adding map with " << map.size() << " data points, fData = " << fData << std::endl;
+   }
+   if(fData == nullptr) {
+      fData = new TGraphErrors(map.size());
+   } else {
+      fData->Set(map.size());
+   }
+   fData->SetLineColor(2);
+   fData->SetMarkerColor(2);
+   if(fFwhm == nullptr) {
+      fFwhm = new TGraphErrors(map.size());
+   } else {
+      fFwhm->Set(map.size());
+   }
+   fFwhm->SetLineColor(4);
+   fFwhm->SetMarkerColor(4);
+   int i = 0;
+   for(auto iter = map.begin(); iter != map.end();) {
+      // more readable variable names
+      auto peakPos     = iter->first->Centroid();
+      auto peakPosErr  = iter->first->CentroidErr();
+      auto peakArea    = iter->first->Area();
+      auto peakAreaErr = iter->first->AreaErr();
+      auto fwhm        = iter->first->FWHM();
+      auto fwhmErr     = iter->first->FWHMErr();
+      auto energy      = std::get<0>(iter->second);
+      auto energyErr   = std::get<1>(iter->second);
+      // drop this peak if the uncertainties in area or position are too large
+      if(!Good(iter->first)) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+            std::cout << "Dropping peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
+         }
+         iter = map.erase(iter);
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << "Erasing peak returned iterator " << std::distance(map.begin(), iter) << std::endl;
+         }
+      } else {
+         fData->SetPoint(i, peakPos, energy);
+         fData->SetPointError(i, peakPosErr, energyErr);
+         fFwhm->SetPoint(i, peakPos, fwhm);
+         fFwhm->SetPointError(i, peakPosErr, fwhmErr);
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << "Using peak with position " << peakPos << " +- " << peakPosErr << ", area " << peakArea << " +- " << peakAreaErr << ", energy " << energy << std::endl;
+         }
+         ++iter;
+         ++i;
+      }
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << "Accepted " << map.size() << " peaks" << std::endl;
+   }
+   // if we dropped a peak, we need to resize the graph, if we haven't dropped any this doesn't do anything
+   fData->Set(map.size());
+   fFwhm->Set(map.size());
+   fData->Sort();
+   fFwhm->Sort();
+   // split poly marker into those peaks that were used, and those that weren't
+   TList* functions = fProjection->GetListOfFunctions();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+      std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetName() << std::endl;
+      for(auto* obj : *functions) {
+         std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+      }
+   }
+   auto* polym = static_cast<TPolyMarker*>(functions->FindObject("TPolyMarker"));
+   if(polym != nullptr) {
+      double*             oldX = polym->GetX();
+      double*             oldY = polym->GetY();
+      int                 size = polym->GetN();
+      std::vector<double> newX;
+      std::vector<double> newY;
+      std::vector<double> unusedX;
+      std::vector<double> unusedY;
+      for(i = 0; i < size; ++i) {
+         bool used = false;
+         for(auto point : map) {
+            if(TMath::Abs(oldX[i] - point.first->Centroid()) < fSourceCalibration->Sigma()) {
+               newX.push_back(oldX[i]);
+               newY.push_back(oldY[i]);
+               used = true;
+               break;
+            }
+         }
+         if(!used) {
+            unusedX.push_back(oldX[i]);
+            unusedY.push_back(oldY[i]);
+         }
+      }
+      polym->SetPolyMarker(newX.size(), newX.data(), newY.data());
+      auto* unusedMarkers = new TPolyMarker(unusedX.size(), unusedX.data(), unusedY.data());
+      unusedMarkers->SetMarkerStyle(23);   // triangle down
+      unusedMarkers->SetMarkerColor(16);   // light grey
+      functions->Add(unusedMarkers);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << fProjection->GetTitle() << ": " << size << " peaks founds total, " << polym->GetN() << " used, and " << unusedMarkers->GetN() << " unused" << std::endl;
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+            std::cout << "Used: ";
+            for(size_t m = 0; m < newX.size(); ++m) { std::cout << newX[m] << " - " << newY[m] << ";"; }
+            std::cout << std::endl;
+            std::cout << "Unused: ";
+            for(size_t m = 0; m < unusedX.size(); ++m) { std::cout << unusedX[m] << " - " << unusedY[m] << ";"; }
+            std::cout << std::endl;
+         }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+            std::cout << functions->GetEntries() << " functions in projection " << fProjection->GetTitle() << std::endl;
+            for(auto* obj : *functions) {
+               std::cout << obj->GetName() << "/" << obj->GetTitle() << " - " << obj->ClassName() << std::endl;
+            }
+         }
+      }
+   }
 
-	// change color of fit functions for unused peaks
-	TIter    iter(functions);
-	TObject* item = nullptr;
-	while((item = iter.Next()) != nullptr) {
-		if(item->IsA() == TF1::Class() || item->IsA() == TGauss::Class()) {   // if the item is a TF1 or TGauss we see if we can find the centroid in the map of used peaks
-			double centroid = 0.;
-			if(item->IsA() == TF1::Class()) {
-				centroid = static_cast<TF1*>(item)->GetParameter(1);
-			} else {
-				centroid = static_cast<TGauss*>(item)->Centroid();
-			}
-			bool found = false;
-			for(auto point : map) {
-				if(TMath::Abs(centroid - point.first->Centroid()) < fSourceCalibration->Sigma()) {
-					found = true;
-					break;
-				}
-			}
-			// remove the TF1 if it wasn't found in the map
-			if(!found) {
-				//functions->Remove(item);
-				if(item->IsA() == TF1::Class()) {
-					static_cast<TF1*>(item)->SetLineColor(kGray);
-				} else {
-					static_cast<TGauss*>(item)->GetFitFunction()->SetLineColor(kGray);
-				}
-			}
-		}
-	}
+   // change color of fit functions for unused peaks
+   TIter    iter(functions);
+   TObject* item = nullptr;
+   while((item = iter.Next()) != nullptr) {
+      if(item->IsA() == TF1::Class() || item->IsA() == TGauss::Class()) {   // if the item is a TF1 or TGauss we see if we can find the centroid in the map of used peaks
+         double centroid = 0.;
+         if(item->IsA() == TF1::Class()) {
+            centroid = static_cast<TF1*>(item)->GetParameter(1);
+         } else {
+            centroid = static_cast<TGauss*>(item)->Centroid();
+         }
+         bool found = false;
+         for(auto point : map) {
+            if(TMath::Abs(centroid - point.first->Centroid()) < fSourceCalibration->Sigma()) {
+               found = true;
+               break;
+            }
+         }
+         // remove the TF1 if it wasn't found in the map
+         if(!found) {
+            //functions->Remove(item);
+            if(item->IsA() == TF1::Class()) {
+               static_cast<TF1*>(item)->SetLineColor(kGray);
+            } else {
+               static_cast<TGauss*>(item)->GetFitFunction()->SetLineColor(kGray);
+            }
+         }
+      }
+   }
 }
 
 void TSourceTab::ReplacePeak(const size_t& index, const double& channel)
 {
-	/// Replace the peak at the index with one centered at channel (calculated from an initial calibration and the source energy of this peak).
-	/// This replaces the TGauss* in fPeaks, and updates the values of this index in fData and fFwhm.
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DCYAN << __PRETTY_FUNCTION__ << ": index " << index << ", channel " << channel << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-		for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
-			std::cout << i << ": " << fPeaks[i]->Centroid() << " +- " << fPeaks[i]->CentroidErr() << " - " << fFits[i]->GetFitFunction()->GetParameter("centroid_0") << std::endl;
-		}
-	}
+   /// Replace the peak at the index with one centered at channel (calculated from an initial calibration and the source energy of this peak).
+   /// This replaces the TGauss* in fPeaks, and updates the values of this index in fData and fFwhm.
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": index " << index << ", channel " << channel << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
+         std::cout << i << ": " << fPeaks[i]->Centroid() << " +- " << fPeaks[i]->CentroidErr() << " - " << fFits[i]->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+      }
+   }
 
-	if(index >= fPeaks.size()) {
-		std::cerr << "Trying to replace peak at index " << index << " but there are only " << fPeaks.size() << " peaks!" << std::endl;
-		return;
-	}
+   if(index >= fPeaks.size()) {
+      std::cerr << "Trying to replace peak at index " << index << " but there are only " << fPeaks.size() << " peaks!" << std::endl;
+      return;
+   }
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << fPeaks.at(index)->Centroid() << " with new peak at channel " << channel << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Replacing old peak at index " << index << ", centroid " << fPeaks.at(index)->Centroid() << " with new peak at channel " << channel << std::endl; }
 
-	// calculate the fitting range (low to high) and adjust it so we ignore the old peak
-	double range = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
-	double low   = channel - range;
-	double high  = channel + range;
-	if(fPeaks.at(index)->Centroid() < channel) {
-		low = (fPeaks.at(index)->Centroid() + channel) / 2.;
-	} else {
-		high = (fPeaks.at(index)->Centroid() + channel) / 2.;
-	}
-	// if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
-	auto* pf   = new TPeakFitter(low, high);
-	auto* peak = new TGauss(channel);
-	pf->AddPeak(peak);
-	if(TSourceCalibration::LogFile().empty()) {
-		TRedirect redirect("/dev/null");
-		pf->Fit(fProjection, "retryfit");
-	} else {
-		pf->Fit(fProjection, "retryfit");
-	}
-	if(peak->Area() > 0) {
-		if(Good(peak, low, high)) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << index << ". peak/fit out of " << fPeaks.size() << "/" << fFits.size() << " peaks/fits: " << std::flush << fPeaks.at(index)->Centroid() << "/" << fFits.at(index)->GetFitFunction()->GetParameter("centroid_0") << std::endl;
-				std::cout << "Deleting " << index << ". peak " << fPeaks.at(index) << std::flush;
-			}
-			peak->SetLineColor(fPeaks.at(index)->GetLineColor());
-			delete fPeaks.at(index);
-			fPeaks[index] = peak;
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << " and setting it to " << fPeaks.at(index) << std::endl;
-			}
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << "Deleting " << index << ". fit " << fFits.at(index) << std::flush;
-			}
-			pf->GetFitFunction()->SetLineColor(fFits.at(index)->GetFitFunction()->GetLineColor());
-			delete fFits.at(index);
-			fFits[index] = pf;
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << " and setting it to " << fFits.at(index) << std::endl;
-			}
-			UpdateFits();
-			fData->SetPoint(index, peak->Centroid(), fData->GetPointY(index));
-			fData->SetPointError(index, peak->CentroidErr(), fData->GetErrorY(index));
-			fFwhm->SetPoint(index, peak->Centroid(), peak->FWHM());
-			fFwhm->SetPointError(index, peak->CentroidErr(), peak->FWHMErr());
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
-			}
-		} else {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
-			}
-		}
-	} else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
-	}
+   // calculate the fitting range (low to high) and adjust it so we ignore the old peak
+   double range = TSourceCalibration::FitRange() * fSourceCalibration->Sigma();
+   double low   = channel - range;
+   double high  = channel + range;
+   if(fPeaks.at(index)->Centroid() < channel) {
+      low = (fPeaks.at(index)->Centroid() + channel) / 2.;
+   } else {
+      high = (fPeaks.at(index)->Centroid() + channel) / 2.;
+   }
+   // if we aren't already redirecting the output, we redirect it to /dev/null and do a quiet fit, otherwise we do a normal fit since the output will be redirected to a file
+   auto* pf   = new TPeakFitter(low, high);
+   auto* peak = new TGauss(channel);
+   pf->AddPeak(peak);
+   if(TSourceCalibration::LogFile().empty()) {
+      TRedirect redirect("/dev/null");
+      pf->Fit(fProjection, "retryfit");
+   } else {
+      pf->Fit(fProjection, "retryfit");
+   }
+   if(peak->Area() > 0) {
+      if(Good(peak, low, high)) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << index << ". peak/fit out of " << fPeaks.size() << "/" << fFits.size() << " peaks/fits: " << std::flush << fPeaks.at(index)->Centroid() << "/" << fFits.at(index)->GetFitFunction()->GetParameter("centroid_0") << std::endl;
+            std::cout << "Deleting " << index << ". peak " << fPeaks.at(index) << std::flush;
+         }
+         peak->SetLineColor(fPeaks.at(index)->GetLineColor());
+         delete fPeaks.at(index);
+         fPeaks[index] = peak;
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << " and setting it to " << fPeaks.at(index) << std::endl;
+         }
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << "Deleting " << index << ". fit " << fFits.at(index) << std::flush;
+         }
+         pf->GetFitFunction()->SetLineColor(fFits.at(index)->GetFitFunction()->GetLineColor());
+         delete fFits.at(index);
+         fFits[index] = pf;
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << " and setting it to " << fFits.at(index) << std::endl;
+         }
+         UpdateFits();
+         fData->SetPoint(index, peak->Centroid(), fData->GetPointY(index));
+         fData->SetPointError(index, peak->CentroidErr(), fData->GetErrorY(index));
+         fFwhm->SetPoint(index, peak->Centroid(), peak->FWHM());
+         fFwhm->SetPointError(index, peak->CentroidErr(), peak->FWHMErr());
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << "Fitted peak " << low << " - " << high << " -> centroid " << peak->Centroid() << ", area " << peak->Area() << std::endl;
+         }
+      } else {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            std::cout << "We're ignoring bad fits, and this one has position " << peak->Centroid() << " +- " << peak->CentroidErr() << ", area " << peak->Area() << " +- " << peak->AreaErr() << std::endl;
+         }
+      }
+   } else if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "Ignoring peak at " << peak->Centroid() << " with negative area " << peak->Area() << std::endl;
+   }
 }
 
 void TSourceTab::RemovePoint(Int_t oldPoint)
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	// first thing to do is check if the graph the point was removed from matches the id of this tab
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
-	//auto erasedPeak = fPeaks.at(oldPoint);
-	fPeaks.erase(fPeaks.begin() + oldPoint);
-	auto* erasedFit = fFits.at(oldPoint);
-	fFits.erase(fFits.begin() + oldPoint);
-	fBadFits.push_back(erasedFit);
-	fData->RemovePoint(oldPoint);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DCYAN << __PRETTY_FUNCTION__ << ": oldPoint " << oldPoint << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   // first thing to do is check if the graph the point was removed from matches the id of this tab
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+   //auto erasedPeak = fPeaks.at(oldPoint);
+   fPeaks.erase(fPeaks.begin() + oldPoint);
+   auto* erasedFit = fFits.at(oldPoint);
+   fFits.erase(fFits.begin() + oldPoint);
+   fBadFits.push_back(erasedFit);
+   fData->RemovePoint(oldPoint);
 
-	SetLineColors();
+   SetLineColors();
 
-	UpdateFits();
-	
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
+   UpdateFits();
+
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { Print(); }
 }
 
 void TSourceTab::SetLineColors()
 {
-	/// This function sets the line colors of good and bad fits to alternating colors.
-	/// Red and blue for the good fits, and grey and dark grey for the bad fits.
-	
-	// set colors of good fits alternating to red or blue (peaks themselves are set to darker versions of those colors)
-	for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
-		if(i%2 == 0) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) red for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
-			fPeaks[i]->SetLineColor(kRed + 2); 
-			fFits[i]->GetFitFunction()->SetLineColor(kRed);
-		} else {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) blue for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
-			fPeaks[i]->SetLineColor(kBlue + 2); 
-			fFits[i]->GetFitFunction()->SetLineColor(kBlue);
-		}
-	}
+   /// This function sets the line colors of good and bad fits to alternating colors.
+   /// Red and blue for the good fits, and grey and dark grey for the bad fits.
 
-	// set colors of bad fits alterating to grey and dark grey
-	for(size_t i = 0; i < fBadFits.size(); ++i) {
-		if(i%2 == 0) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
-			fBadFits[i]->GetFitFunction()->SetLineColor(kGray);
-		} else {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to dark grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
-			fBadFits[i]->GetFitFunction()->SetLineColor(kGray + 2);
-		}
-	}
+   // set colors of good fits alternating to red or blue (peaks themselves are set to darker versions of those colors)
+   for(size_t i = 0; i < fPeaks.size() && i < fFits.size(); ++i) {
+      if(i % 2 == 0) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) red for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
+         fPeaks[i]->SetLineColor(kRed + 2);
+         fFits[i]->GetFitFunction()->SetLineColor(kRed);
+      } else {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to (dark) blue for peak " << fPeaks[i] << ", fit function " << fFits[i]->GetFitFunction() << std::endl; }
+         fPeaks[i]->SetLineColor(kBlue + 2);
+         fFits[i]->GetFitFunction()->SetLineColor(kBlue);
+      }
+   }
+
+   // set colors of bad fits alterating to grey and dark grey
+   for(size_t i = 0; i < fBadFits.size(); ++i) {
+      if(i % 2 == 0) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
+         fBadFits[i]->GetFitFunction()->SetLineColor(kGray);
+      } else {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << i << ": setting line colors to dark grey for fit function " << fBadFits[i]->GetFitFunction() << std::endl; }
+         fBadFits[i]->GetFitFunction()->SetLineColor(kGray + 2);
+      }
+   }
 }
 
 void TSourceTab::Status(const char* status, int position)
 {
-	fSourceStatusBar->SetText(status, position);
-	fSourceStatusBar->MapWindow();
-	fSourceFrame->MapSubwindows();
-	gVirtualX->Update();
+   fSourceStatusBar->SetText(status, position);
+   fSourceStatusBar->MapWindow();
+   fSourceFrame->MapSubwindows();
+   gVirtualX->Update();
 }
 
 void TSourceTab::Print() const
 {
-	std::cout << "Projection " << fProjection;
-	if(fProjection != nullptr) {
-		std::cout << " = " << fProjection->GetName() << "/" << fProjection->GetTitle();
-	} else {
-		std::cout << " is null";
-	}
-	std::cout << std::endl;
+   std::cout << "Projection " << fProjection;
+   if(fProjection != nullptr) {
+      std::cout << " = " << fProjection->GetName() << "/" << fProjection->GetTitle();
+   } else {
+      std::cout << " is null";
+   }
+   std::cout << std::endl;
 
-	std::cout << "Data " << fData;
-	if(fData != nullptr) {
-		std::cout << " = " << fData->GetName() << "/" << fData->GetTitle();
-	} else {
-		std::cout << " is null";
-	}
-	std::cout << std::endl;
+   std::cout << "Data " << fData;
+   if(fData != nullptr) {
+      std::cout << " = " << fData->GetName() << "/" << fData->GetTitle();
+   } else {
+      std::cout << " is null";
+   }
+   std::cout << std::endl;
 
-	std::cout << "Fwhm " << fFwhm;
-	if(fFwhm != nullptr) {
-		std::cout << " = " << fFwhm->GetName() << "/" << fFwhm->GetTitle();
-	} else {
-		std::cout << " is null";
-	}
-	std::cout << std::endl;
+   std::cout << "Fwhm " << fFwhm;
+   if(fFwhm != nullptr) {
+      std::cout << " = " << fFwhm->GetName() << "/" << fFwhm->GetTitle();
+   } else {
+      std::cout << " is null";
+   }
+   std::cout << std::endl;
 
-	std::cout << fFits.size() << " good fits:";
-	for(size_t i = 0; i < fFits.size(); ++i) {
-		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
-	}
-	std::cout << std::endl;
+   std::cout << fFits.size() << " good fits:";
+   for(size_t i = 0; i < fFits.size(); ++i) {
+      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+   }
+   std::cout << std::endl;
 
-	std::cout << fBadFits.size() << " bad fits:";
-	for(size_t i = 0; i < fBadFits.size(); ++i) {
-		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fBadFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
-	}
-	std::cout << std::endl;
+   std::cout << fBadFits.size() << " bad fits:";
+   for(size_t i = 0; i < fBadFits.size(); ++i) {
+      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fBadFits.at(i)->GetFitFunction()->GetParameter("centroid_0");
+   }
+   std::cout << std::endl;
 
-	std::cout << fPeaks.size() << " peaks:";
-	for(size_t i = 0; i < fPeaks.size(); ++i) {
-		std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fPeaks.at(i)->Centroid();
-	}
-	std::cout << std::endl;
+   std::cout << fPeaks.size() << " peaks:";
+   for(size_t i = 0; i < fPeaks.size(); ++i) {
+      std::cout << " " << std::setw(2) << i << " - " << std::setw(8) << fPeaks.at(i)->Centroid();
+   }
+   std::cout << std::endl;
 }
 
 void TSourceTab::PrintCanvases() const
 {
-	std::cout << "TSourceTab " << fSourceName << " projection canvas:" << std::endl;
-	fProjectionCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
+   std::cout << "TSourceTab " << fSourceName << " projection canvas:" << std::endl;
+   fProjectionCanvas->GetCanvas()->Print();
+   for(auto* obj : *(fProjectionCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
 }
 
 void TSourceTab::PrintLayout() const
 {
-	std::cout << "TSourceTab frame:" << std::endl;
-	fSourceFrame->Print();
-	std::cout << "TSourceTab canvas:" << std::endl;
-	fProjectionCanvas->Print();
-	std::cout << "TSourceTab status bar:" << std::endl;
-	fSourceStatusBar->Print();
+   std::cout << "TSourceTab frame:" << std::endl;
+   fSourceFrame->Print();
+   std::cout << "TSourceTab canvas:" << std::endl;
+   fProjectionCanvas->Print();
+   std::cout << "TSourceTab status bar:" << std::endl;
+   fSourceStatusBar->Print();
 }
 
 //////////////////////////////////////// TChannelTab ////////////////////////////////////////
 TChannelTab::TChannelTab(TSourceCalibration* sourceCal, std::vector<TNucleus*> nuclei, std::vector<GH1D*> projections, std::string name, TGCompositeFrame* frame, std::vector<std::vector<std::tuple<double, double, double, double>>> sourceEnergies, TGHProgressBar* progressBar)
-	: fChannelFrame(frame), fSourceTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fCanvasTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fProgressBar(progressBar), fSourceCalibration(sourceCal), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSourceEnergies(std::move(sourceEnergies))
+   : fChannelFrame(frame), fSourceTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fCanvasTab(new TGTab(frame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight() + 2 * TSourceCalibration::StatusbarHeight())), fProgressBar(progressBar), fSourceCalibration(sourceCal), fNuclei(std::move(nuclei)), fProjections(std::move(projections)), fName(std::move(name)), fSourceEnergies(std::move(sourceEnergies))
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DYELLOW << "========================================" << std::endl;
-		std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			<< " name = " << fName << ", fData = " << fData << std::endl;
-		std::cout << "========================================" << std::endl;
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DYELLOW << "========================================" << std::endl;
+      std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                << " name = " << fName << ", fData = " << fData << std::endl;
+      std::cout << "========================================" << std::endl;
+   }
 
-	BuildInterface();
+   BuildInterface();
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DYELLOW << "----------------------------------------" << std::endl;
-		std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			<< " channel " << fName << " done" << std::endl;
-		std::cout << "----------------------------------------" << std::endl;
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DYELLOW << "----------------------------------------" << std::endl;
+      std::cout << __PRETTY_FUNCTION__ << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                << " channel " << fName << " done" << std::endl;
+      std::cout << "----------------------------------------" << std::endl;
+   }
 }
 
 TChannelTab::~TChannelTab()
 {
-	delete fChannelFrame;
-	delete fSourceTab;
-	for(auto* channel : fSources) {
-		delete channel;
-	}
-	delete fCanvasTab;
-	delete fCalibrationFrame;
-	delete fCalibrationCanvas;
-	delete fResidualPad;
-	delete fCalibrationPad;
-	delete fChannelStatusBar;
-	delete fLegend;
-	delete fChi2Label;
-	delete fFwhmFrame;
-	delete fFwhmCanvas;
-	// delete all fProjections and all fNuclei?
-	delete fData;
-	delete fFwhm;
+   delete fChannelFrame;
+   delete fSourceTab;
+   for(auto* channel : fSources) {
+      delete channel;
+   }
+   delete fCanvasTab;
+   delete fCalibrationFrame;
+   delete fCalibrationCanvas;
+   delete fResidualPad;
+   delete fCalibrationPad;
+   delete fChannelStatusBar;
+   delete fLegend;
+   delete fChi2Label;
+   delete fFwhmFrame;
+   delete fFwhmCanvas;
+   // delete all fProjections and all fNuclei?
+   delete fData;
+   delete fFwhm;
 }
 
 void TChannelTab::BuildInterface()
 {
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-		fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
-	}
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+      fChannelFrame->SetLayoutManager(new TGHorizontalLayout(fChannelFrame));
+   }
 
-	fSources.resize(fNuclei.size(), nullptr);
-	//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	for(size_t source = 0; source < fNuclei.size(); ++source) {
-		CreateSourceTab(source);
-	}
+   fSources.resize(fNuclei.size(), nullptr);
+   //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": creating channels for bin 1 to " << fMatrix->GetNbinsX() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   for(size_t source = 0; source < fNuclei.size(); ++source) {
+      CreateSourceTab(source);
+   }
 
-	for(auto iter = fSources.begin(); iter != fSources.end(); ++iter) {
-		if(*iter == nullptr) {
-			fSources.erase(iter--);   // erase iterator and then go to the element before this one (and then the loop goes to the next one)
-		}
-	}
+   for(auto iter = fSources.begin(); iter != fSources.end(); ++iter) {
+      if(*iter == nullptr) {
+         fSources.erase(iter--);   // erase iterator and then go to the element before this one (and then the loop goes to the next one)
+      }
+   }
 
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-		fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+      fChannelFrame->AddFrame(fSourceTab, new TGLayoutHints(kLHintsLeft | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fCalibrationFrame = fCanvasTab->AddTab("Calibration");
-		fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
-		fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-		fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
-		std::array<int, 3> parts = {25, 35, 40};
-		fChannelStatusBar->SetParts(parts.data(), parts.size());
-		fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
-		fFwhmFrame = fCanvasTab->AddTab("FWHM");
-		fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
-		fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-		//fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fCalibrationFrame = fCanvasTab->AddTab("Calibration");
+      fCalibrationFrame->SetLayoutManager(new TGVerticalLayout(fCalibrationFrame));
+      fCalibrationCanvas = new TRootEmbeddedCanvas(Form("CalibrationCanvas%s", fName.c_str()), fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fCalibrationFrame->AddFrame(fCalibrationCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fChannelStatusBar        = new TGStatusBar(fCalibrationFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::StatusbarHeight());
+      std::array<int, 3> parts = {25, 35, 40};
+      fChannelStatusBar->SetParts(parts.data(), parts.size());
+      fCalibrationFrame->AddFrame(fChannelStatusBar, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+      fFwhmFrame = fCanvasTab->AddTab("FWHM");
+      fFwhmFrame->SetLayoutManager(new TGVerticalLayout(fFwhmFrame));
+      fFwhmCanvas = new TRootEmbeddedCanvas(Form("FwhmCanvas%s", fName.c_str()), fFwhmFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fFwhmFrame->AddFrame(fFwhmCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      //fChannelFrame->AddFrame(fCalibrationFrame, new TGLayoutHints(kLHintsRight | kLHintsBottom | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fInitFrame = fCanvasTab->AddTab("Initial");
-		fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
-		fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
-		fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+      fInitFrame = fCanvasTab->AddTab("Initial");
+      fInitFrame->SetLayoutManager(new TGVerticalLayout(fInitFrame));
+      fInitCanvas = new TRootEmbeddedCanvas(Form("InitCanvas%s", fName.c_str()), fInitFrame, TSourceCalibration::PanelWidth(), TSourceCalibration::PanelHeight());
+      fInitFrame->AddFrame(fInitCanvas, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
 
-		fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-	}
+      fChannelFrame->AddFrame(fCanvasTab, new TGLayoutHints(kLHintsRight | kLHintsTop | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+   }
 
-	UpdateData();
+   UpdateData();
 
-	{
-		//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-		fCalibrationCanvas->GetCanvas()->cd();
-		fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
-		fCalibrationPad->SetNumber(1);
-		fCalibrationPad->Draw();
-		fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
+   {
+      //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+      fCalibrationCanvas->GetCanvas()->cd();
+      fCalibrationPad = new TPad(Form("cal_%s", fName.c_str()), Form("calibration for %s", fName.c_str()), 0.2, 0., 1., 1.);
+      fCalibrationPad->SetNumber(1);
+      fCalibrationPad->Draw();
+      fCalibrationPad->AddExec("zoom", "TChannelTab::ZoomY()");
 
-		fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
+      fLegend = new TLegend(0.8, 0.3, 0.95, 0.3 + static_cast<double>(fNuclei.size()) * 0.05);   // x1, y1, x2, y2
 
-		fCalibrationCanvas->GetCanvas()->cd();
-		fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
-		fResidualPad->SetNumber(2);
-		fResidualPad->Draw();
-		fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
-	}
-	//Calibrate();   // also creates the residual and chi^2 label
+      fCalibrationCanvas->GetCanvas()->cd();
+      fResidualPad = new TPad(Form("res_%s", fName.c_str()), Form("residual for %s", fName.c_str()), 0.0, 0., 0.2, 1.);
+      fResidualPad->SetNumber(2);
+      fResidualPad->Draw();
+      fResidualPad->AddExec("zoom", "TChannelTab::ZoomY()");
+   }
+   //Calibrate();   // also creates the residual and chi^2 label
 
-	// check whether we want to use this initial calibration to find more peaks
-	//if(TSourceCalibration::UseCalibratedPeaks()) {
-	//	FindCalibratedPeaks();
-	//}
+   // check whether we want to use this initial calibration to find more peaks
+   //if(TSourceCalibration::UseCalibratedPeaks()) {
+   //	FindCalibratedPeaks();
+   //}
 
-	// get the fwhm graphs and plot them
-	UpdateFwhm();
-	//{
-	//	std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-	//	fFwhmCanvas->GetCanvas()->cd();
-	//	fFwhm->DrawCalibration("*");
-	//	fLegend->Draw();
-	//}
+   // get the fwhm graphs and plot them
+   UpdateFwhm();
+   //{
+   //	std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+   //	fFwhmCanvas->GetCanvas()->cd();
+   //	fFwhm->DrawCalibration("*");
+   //	fLegend->Draw();
+   //}
 }
 
 void TChannelTab::CreateSourceTab(size_t source)
 {
-	if(fProjections[source]->GetEntries() > 1000) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << DYELLOW << "Creating source tab " << source << ", using fSourceCalibration " << fSourceCalibration << std::endl;
-		}
-		TGCompositeFrame* tmpTab = nullptr;
-		{
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
-			//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-			tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
-		}
-		fSources[source] = new TSourceTab(fSourceCalibration, this, tmpTab, fProjections[source], fNuclei[source]->GetName(), fSourceEnergies[source]);
-		{
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
-			//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-			fProgressBar->Increment(1);
-			//if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
-		}
-	} else {
-		fSources[source] = nullptr;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << DYELLOW << "Skipping projection of source " << source << " = " << fProjections[source]->GetName() << ", only " << fProjections[source]->GetEntries() << " entries" << std::endl;
-		}
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << __PRETTY_FUNCTION__ << " source " << source << " done" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
+   if(fProjections[source]->GetEntries() > 1000) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << DYELLOW << "Creating source tab " << source << ", using fSourceCalibration " << fSourceCalibration << std::endl;
+      }
+      TGCompositeFrame* tmpTab = nullptr;
+      {
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to add tab" << std::endl; }
+         //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+         tmpTab = fSourceTab->AddTab(Form("%s_%s", fNuclei[source]->GetName(), fName.c_str()));
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after adding tab" << std::endl; }
+      }
+      fSources[source] = new TSourceTab(fSourceCalibration, this, tmpTab, fProjections[source], fNuclei[source]->GetName(), fSourceEnergies[source]);
+      {
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Creating unique lock on graphics mutex to increment status bar" << std::endl; }
+         //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+         fProgressBar->Increment(1);
+         //if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Releasing unique lock on graphics mutex after incrementing status bar" << std::endl; }
+      }
+   } else {
+      fSources[source] = nullptr;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << DYELLOW << "Skipping projection of source " << source << " = " << fProjections[source]->GetName() << ", only " << fProjections[source]->GetEntries() << " entries" << std::endl;
+      }
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << __PRETTY_FUNCTION__ << " source " << source << " done" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
 }
 
 void TChannelTab::MakeConnections()
 {
-	//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-	fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
-	for(auto* source : fSources) {
-		source->MakeConnections();
-	}
-	fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
-	fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
-	if(fData != nullptr) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			fData->Print();
-		}
-		fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
-	} else {
-		std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
-	}
+   //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+   fSourceTab->Connect("Selected(Int_t)", "TChannelTab", this, "SelectedTab(Int_t)");
+   for(auto* source : fSources) {
+      source->MakeConnections();
+   }
+   fCalibrationCanvas->GetCanvas()->Connect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", "TChannelTab", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
+   fCalibrationCanvas->Connect("ProcessedEvent(Event_t*)", "TChannelTab", this, "SelectCanvas(Event_t*)");
+   if(fData != nullptr) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": connecting fData " << fData << ":" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         fData->Print();
+      }
+      fData->Connect("RemovePoint(Int_t, Int_t)", "TChannelTab", this, "RemovePoint(Int_t, Int_t)");
+   } else {
+      std::cerr << DRED << "Failed to create connections for the data graph fData since it hasn't been created yet!" << std::endl;
+   }
 }
 
 void TChannelTab::Disconnect()
 {
-	//std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
-	fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
-	for(auto* source : fSources) {
-		source->Disconnect();
-	}
-	fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
-	fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
+   //std::unique_lock<std::mutex> graphicsLock(fSourceCalibration->GraphicsMutex());
+   fSourceTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
+   for(auto* source : fSources) {
+      source->Disconnect();
+   }
+   fCalibrationCanvas->GetCanvas()->Disconnect("ProcessedEvent(Int_t,Int_t,Int_t,TObject*)", this, "CalibrationStatus(Int_t,Int_t,Int_t,TObject*)");
+   fData->Disconnect("RemovePoint(Int_t, Int_t)", this, "RemovePoint(Int_t, Int_t)");
 }
 
 void TChannelTab::SelectedTab(Int_t id)
 {
-	/// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	fActiveSourceTab = id;
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
-	if(fSources[fActiveSourceTab] == nullptr) {
-		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(fSources[fActiveSourceTab]->ProjectionCanvas() == nullptr) {
-		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas() == nullptr) {
-		std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
-	gPad = fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas();
-	fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas()->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+   /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ": id " << id << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   fActiveSourceTab = id;
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "active source tab " << fActiveSourceTab << RESET_COLOR << std::endl; }
+   if(fSources[fActiveSourceTab] == nullptr) {
+      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(fSources[fActiveSourceTab]->ProjectionCanvas() == nullptr) {
+      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas() == nullptr) {
+      std::cout << "Failed to get fSources[" << fActiveSourceTab << "]->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+   gPad = fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas();
+   fSources[fActiveSourceTab]->ProjectionCanvas()->GetCanvas()->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TChannelTab::SelectCanvas(Event_t* event)
 {
-	if(event->fType == kEnterNotify) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << "Entered channel tab => changing gPad from " << gPad->GetName();
-		}
-		gPad = fCalibrationCanvas->GetCanvas();
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-			std::cout << " to " << gPad->GetName() << std::endl;
-		}
-	}
+   if(event->fType == kEnterNotify) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << "Entered channel tab => changing gPad from " << gPad->GetName();
+      }
+      gPad = fCalibrationCanvas->GetCanvas();
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+         std::cout << " to " << gPad->GetName() << std::endl;
+      }
+   }
 }
 
 void TChannelTab::RemovePoint(Int_t oldGraph, Int_t oldPoint)
@@ -1580,564 +1580,564 @@ void TChannelTab::RemovePoint(Int_t oldGraph, Int_t oldPoint)
 
 void TChannelTab::CalibrationStatus(Int_t event, Int_t px, Int_t py, TObject* selected)
 {
-	// looks like 51 is hovering over the object, 52 is moving the cursor over the object, and 53 is moving the cursort away from the object
-	// kButton1 = left mouse button, kButton2 = right mouse button
-	// enum EEventType {
-	//   kNoEvent       =  0,
-	//   kButton1Down   =  1, kButton2Down   =  2, kButton3Down   =  3, kKeyDown  =  4,
-	//   kWheelUp       =  5, kWheelDown     =  6, kButton1Shift  =  7, kButton1ShiftMotion  =  8,
-	//   kButton1Up     = 11, kButton2Up     = 12, kButton3Up     = 13, kKeyUp    = 14,
-	//   kButton1Motion = 21, kButton2Motion = 22, kButton3Motion = 23, kKeyPress = 24,
-	//   kArrowKeyPress = 25, kArrowKeyRelease = 26,
-	//   kButton1Locate = 41, kButton2Locate = 42, kButton3Locate = 43, kESC      = 27,
-	//   kMouseMotion   = 51, kMouseEnter    = 52, kMouseLeave    = 53,
-	//   kButton1Double = 61, kButton2Double = 62, kButton3Double = 63
-	//};
-	fChannelStatusBar->SetText(selected->GetName(), 0);
-	if(event == kKeyPress) {
-		fChannelStatusBar->SetText(Form("%c", static_cast<char>(px)), 1);
-	} else {
-		auto* canvas = fCalibrationCanvas->GetCanvas();
-		if(canvas == nullptr) {
-			fChannelStatusBar->SetText("canvas nullptr");
-			return;
-		}
-		auto* pad = canvas->GetSelectedPad();
-		if(pad == nullptr) {
-			fChannelStatusBar->SetText("pad nullptr");
-			return;
-		}
-		//if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
-		//	std::cout << "px " << px << ", py " << py << ";    gPad: px " << gPad->AbsPixeltoX(px) << ", py " << gPad->AbsPixeltoY(py) << ";    fCalibrationCanvas: px " << fCalibrationCanvas->GetCanvas()->AbsPixeltoX(px) << ", py " << fCalibrationCanvas->GetCanvas()->AbsPixeltoY(py) << ";    fResidualPad: px " << fResidualPad->AbsPixeltoX(px) << ", py " << fResidualPad->AbsPixeltoY(py) << ";    fCalibrationPad: px " << fCalibrationPad->AbsPixeltoX(px) << ", py " << fCalibrationPad->AbsPixeltoY(py) << ";    pad: px " << pad->AbsPixeltoX(px) << ", py " << pad->AbsPixeltoY(py) << std::endl;
-		//}
+   // looks like 51 is hovering over the object, 52 is moving the cursor over the object, and 53 is moving the cursort away from the object
+   // kButton1 = left mouse button, kButton2 = right mouse button
+   // enum EEventType {
+   //   kNoEvent       =  0,
+   //   kButton1Down   =  1, kButton2Down   =  2, kButton3Down   =  3, kKeyDown  =  4,
+   //   kWheelUp       =  5, kWheelDown     =  6, kButton1Shift  =  7, kButton1ShiftMotion  =  8,
+   //   kButton1Up     = 11, kButton2Up     = 12, kButton3Up     = 13, kKeyUp    = 14,
+   //   kButton1Motion = 21, kButton2Motion = 22, kButton3Motion = 23, kKeyPress = 24,
+   //   kArrowKeyPress = 25, kArrowKeyRelease = 26,
+   //   kButton1Locate = 41, kButton2Locate = 42, kButton3Locate = 43, kESC      = 27,
+   //   kMouseMotion   = 51, kMouseEnter    = 52, kMouseLeave    = 53,
+   //   kButton1Double = 61, kButton2Double = 62, kButton3Double = 63
+   //};
+   fChannelStatusBar->SetText(selected->GetName(), 0);
+   if(event == kKeyPress) {
+      fChannelStatusBar->SetText(Form("%c", static_cast<char>(px)), 1);
+   } else {
+      auto* canvas = fCalibrationCanvas->GetCanvas();
+      if(canvas == nullptr) {
+         fChannelStatusBar->SetText("canvas nullptr");
+         return;
+      }
+      auto* pad = canvas->GetSelectedPad();
+      if(pad == nullptr) {
+         fChannelStatusBar->SetText("pad nullptr");
+         return;
+      }
+      //if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) {
+      //	std::cout << "px " << px << ", py " << py << ";    gPad: px " << gPad->AbsPixeltoX(px) << ", py " << gPad->AbsPixeltoY(py) << ";    fCalibrationCanvas: px " << fCalibrationCanvas->GetCanvas()->AbsPixeltoX(px) << ", py " << fCalibrationCanvas->GetCanvas()->AbsPixeltoY(py) << ";    fResidualPad: px " << fResidualPad->AbsPixeltoX(px) << ", py " << fResidualPad->AbsPixeltoY(py) << ";    fCalibrationPad: px " << fCalibrationPad->AbsPixeltoX(px) << ", py " << fCalibrationPad->AbsPixeltoY(py) << ";    pad: px " << pad->AbsPixeltoX(px) << ", py " << pad->AbsPixeltoY(py) << std::endl;
+      //}
 
-		fChannelStatusBar->SetText(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 1);
-	}
+      fChannelStatusBar->SetText(Form("x = %f, y = %f", pad->AbsPixeltoX(px), pad->AbsPixeltoY(py)), 1);
+   }
 }
 
 void TChannelTab::UpdateData()
 {
-	/// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fData == nullptr) {
-		fData = new TCalibrationGraphSet("ADC channel", "Energy [keV]");
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	fData->Clear();
+   /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fData == nullptr) {
+      fData = new TCalibrationGraphSet("ADC channel", "Energy [keV]");
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fData = " << fData << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   fData->Clear();
 
-	fData->SetName(Form("data%s", fName.c_str()));
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "set name of fData using " << fName.c_str() << ": " << fData->GetName() << std::endl;
-		std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -2) << " data points after creation" << std::endl;
-		std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
-	}
-	for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
-		if(fSources[source]->Data() != nullptr && fSources[source]->Data()->GetN() > 0) {
-			int index = fData->Add(fSources[source]->Data(), fNuclei[source]->GetName());
-			if(index >= 0) {
-				fData->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
-				fData->SetMarkerColor(index, static_cast<Color_t>(source + 1));
-			}
-		}
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
-		fData->Print();
-	}
+   fData->SetName(Form("data%s", fName.c_str()));
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "set name of fData using " << fName.c_str() << ": " << fData->GetName() << std::endl;
+      std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -2) << " data points after creation" << std::endl;
+      std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
+   }
+   for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
+      if(fSources[source]->Data() != nullptr && fSources[source]->Data()->GetN() > 0) {
+         int index = fData->Add(fSources[source]->Data(), fNuclei[source]->GetName());
+         if(index >= 0) {
+            fData->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
+            fData->SetMarkerColor(index, static_cast<Color_t>(source + 1));
+         }
+      }
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "fData " << fData << ": " << (fData != nullptr ? fData->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
+      fData->Print();
+   }
 }
 
 void TChannelTab::UpdateFwhm()
 {
-	/// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fFwhm == nullptr) {
-		fFwhm = new TCalibrationGraphSet("ADC channel", "FWHM [ADC channel]");
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	fFwhm->Clear();
+   /// Copy data from all sources into one graph (which we use for the calib && source < fSources.size()ration).
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << " fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fFwhm == nullptr) {
+      fFwhm = new TCalibrationGraphSet("ADC channel", "FWHM [ADC channel]");
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " created fFwhm = " << fFwhm << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   fFwhm->Clear();
 
-	fFwhm->SetName(Form("fwhm%s", fName.c_str()));
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "set name of fFwhm using " << fName.c_str() << ": " << fFwhm->GetName() << std::endl;
-		std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -2) << " data points after creation" << std::endl;
-		std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
-	}
-	for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
-		if(fSources[source]->Fwhm() != nullptr && fSources[source]->Fwhm()->GetN() > 0) {
-			int index = fFwhm->Add(fSources[source]->Fwhm(), fNuclei[source]->GetName());
-			if(index >= 0) {
-				fFwhm->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
-				fFwhm->SetMarkerColor(index, static_cast<Color_t>(source + 1));
-			}
-		}
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
-		fFwhm->Print();
-	}
+   fFwhm->SetName(Form("fwhm%s", fName.c_str()));
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "set name of fFwhm using " << fName.c_str() << ": " << fFwhm->GetName() << std::endl;
+      std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -2) << " data points after creation" << std::endl;
+      std::cout << "Looping over " << fNuclei.size() << " sources, fSources.size() = " << fSources.size() << std::endl;
+   }
+   for(size_t source = 0; source < fNuclei.size() && source < fSources.size(); ++source) {
+      if(fSources[source]->Fwhm() != nullptr && fSources[source]->Fwhm()->GetN() > 0) {
+         int index = fFwhm->Add(fSources[source]->Fwhm(), fNuclei[source]->GetName());
+         if(index >= 0) {
+            fFwhm->SetLineColor(index, static_cast<Color_t>(source + 1));   //+1 for the color so that we start with 1 = black instead of 0 = white
+            fFwhm->SetMarkerColor(index, static_cast<Color_t>(source + 1));
+         }
+      }
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "fFwhm " << fFwhm << ": " << (fFwhm != nullptr ? fFwhm->GetN() : -1) << " data points after adding " << fNuclei.size() << " graphs" << std::endl;
+      fFwhm->Print();
+   }
 }
 
 void TChannelTab::Calibrate()
 {
-	/// This function fit's the final data of the given channel. It requires all other elements to have been created already.
-	if(TSourceCalibration::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fSourceCalibration->Degree() + 2);
-	calibration->FixParameter(0, fSourceCalibration->Degree());
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
-		std::cout << DYELLOW << "fData " << fData << ": ";
-		if(fData != nullptr) {
-			std::cout << fData->GetN() << " data points being fit, ";
-		}
-		double min = 0.;
-		double max = 0.;
-		calibration->GetRange(min, max);
-		std::cout << "range " << min << " - " << max << std::endl;
-	}
-	fData->Fit(calibration, "Q");
-	TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
-	for(int i = 2; i <= fSourceCalibration->Degree(); ++i) {
-		text.Append(Form(" + %.6f*x^%d", calibration->GetParameter(i + 1), i));
-	}
-	fChannelStatusBar->SetText(text.Data(), 2);
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
-	// re-calculate the residuals
-	fData->SetResidual(true);
+   /// This function fit's the final data of the given channel. It requires all other elements to have been created already.
+   if(TSourceCalibration::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   TF1* calibration = new TF1("fitfunction", ::Polynomial, 0., 10000., fSourceCalibration->Degree() + 2);
+   calibration->FixParameter(0, fSourceCalibration->Degree());
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) {
+      std::cout << DYELLOW << "fData " << fData << ": ";
+      if(fData != nullptr) {
+         std::cout << fData->GetN() << " data points being fit, ";
+      }
+      double min = 0.;
+      double max = 0.;
+      calibration->GetRange(min, max);
+      std::cout << "range " << min << " - " << max << std::endl;
+   }
+   fData->Fit(calibration, "Q");
+   TString text = Form("%.6f + %.6f*x", calibration->GetParameter(1), calibration->GetParameter(2));
+   for(int i = 2; i <= fSourceCalibration->Degree(); ++i) {
+      text.Append(Form(" + %.6f*x^%d", calibration->GetParameter(i + 1), i));
+   }
+   fChannelStatusBar->SetText(text.Data(), 2);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "re-calculating residuals and clearing fields" << std::endl; }
+   // re-calculate the residuals
+   fData->SetResidual(true);
 
-	fLegend->Clear();
-	fCalibrationPad->cd();
-	fData->DrawCalibration("*", fLegend);
-	fLegend->Draw();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "set chi2 label" << std::endl; }
-	// calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
-	// we position it in the top left corner about 50% of the width and 10% of the height of the graph
-	if(fChi2Label == nullptr) {
-		double left   = fData->GetMinimumX();
-		double right  = left + (fData->GetMaximumX() - left) * 0.5;
-		double top    = fData->GetMaximumY();
-		double bottom = top - (top - fData->GetMinimumY()) * 0.1;
+   fLegend->Clear();
+   fCalibrationPad->cd();
+   fData->DrawCalibration("*", fLegend);
+   fLegend->Draw();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "set chi2 label" << std::endl; }
+   // calculate the corners of the chi^2 label from the minimum and maximum x/y-values of the graph
+   // we position it in the top left corner about 50% of the width and 10% of the height of the graph
+   if(fChi2Label == nullptr) {
+      double left   = fData->GetMinimumX();
+      double right  = left + (fData->GetMaximumX() - left) * 0.5;
+      double top    = fData->GetMaximumY();
+      double bottom = top - (top - fData->GetMinimumY()) * 0.1;
 
-		fChi2Label = new TPaveText(left, bottom, right, top);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			fChi2Label->ConvertNDCtoPad();
-			std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << " coordinates: " << fChi2Label->GetX1() << "/" << fChi2Label->GetX1NDC() << " - " << fChi2Label->GetX2() << "/" << fChi2Label->GetX2NDC() << ", " << fChi2Label->GetY1() << "/" << fChi2Label->GetY1NDC() << " - " << fChi2Label->GetY2() << "/" << fChi2Label->GetY2NDC() << std::endl;
-			fData->Print("e");
-		}
-	} else {
-		fChi2Label->Clear();
-	}
-	fChi2Label->AddText(Form("#chi^{2}/NDF = %f", calibration->GetChisquare() / calibration->GetNDF()));
-	fChi2Label->SetFillColor(kWhite);
-	fChi2Label->Draw();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "fChi2Label set to:" << std::endl;
-		fChi2Label->GetListOfLines()->Print();
-		std::cout << "Text size " << fChi2Label->GetTextSize() << std::endl;
-	}
-	if(fInfoLabel == nullptr) {
-		fInfoLabel = new TPaveText(0, 0.95, 1., 1., "NDCNB");
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			fInfoLabel->ConvertNDCtoPad();
-			std::cout << "fInfoLabel created " << fInfoLabel << " (" << fInfoLabel->GetX1() << "/" << fInfoLabel->GetX1NDC() << " - " << fInfoLabel->GetX2() << "/" << fInfoLabel->GetX2NDC() << ", " << fInfoLabel->GetY1() << "/" << fInfoLabel->GetY1NDC() << " - " << fInfoLabel->GetY2() << "/" << fInfoLabel->GetY2NDC() << ", from 0, 0.95, 1., 1.) on gPad " << gPad->GetName() << std::endl;
-		}
-	} else {
-		fInfoLabel->Clear();
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			fInfoLabel->ConvertNDCtoPad();
-			std::cout << "fInfoLabel using existing " << fInfoLabel << " (" << fInfoLabel->GetX1() << "/" << fInfoLabel->GetX1NDC() << " - " << fInfoLabel->GetX2() << "/" << fInfoLabel->GetX2NDC() << ", " << fInfoLabel->GetY1() << "/" << fInfoLabel->GetY1NDC() << " - " << fInfoLabel->GetY2() << "/" << fInfoLabel->GetY2NDC() << ") on gPad " << gPad->GetName() << std::endl;
-		}
-	}
-	fInfoLabel->AddText(Form("Using %d peaks from %.0f to %.0f keV", fData->TotalGraph()->GetN(), fData->GetMinimumY(), fData->GetMaximumY()));
-	fInfoLabel->SetFillColor(kWhite);
-	fInfoLabel->Draw();
+      fChi2Label = new TPaveText(left, bottom, right, top);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         fChi2Label->ConvertNDCtoPad();
+         std::cout << "fChi2Label created " << fChi2Label << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fData->GetMinimumX() << "-" << fData->GetMaximumX() << ", " << fData->GetMinimumY() << "-" << fData->GetMaximumY() << ") on gPad " << gPad->GetName() << " coordinates: " << fChi2Label->GetX1() << "/" << fChi2Label->GetX1NDC() << " - " << fChi2Label->GetX2() << "/" << fChi2Label->GetX2NDC() << ", " << fChi2Label->GetY1() << "/" << fChi2Label->GetY1NDC() << " - " << fChi2Label->GetY2() << "/" << fChi2Label->GetY2NDC() << std::endl;
+         fData->Print("e");
+      }
+   } else {
+      fChi2Label->Clear();
+   }
+   fChi2Label->AddText(Form("#chi^{2}/NDF = %f", calibration->GetChisquare() / calibration->GetNDF()));
+   fChi2Label->SetFillColor(kWhite);
+   fChi2Label->Draw();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "fChi2Label set to:" << std::endl;
+      fChi2Label->GetListOfLines()->Print();
+      std::cout << "Text size " << fChi2Label->GetTextSize() << std::endl;
+   }
+   if(fInfoLabel == nullptr) {
+      fInfoLabel = new TPaveText(0, 0.95, 1., 1., "NDCNB");
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         fInfoLabel->ConvertNDCtoPad();
+         std::cout << "fInfoLabel created " << fInfoLabel << " (" << fInfoLabel->GetX1() << "/" << fInfoLabel->GetX1NDC() << " - " << fInfoLabel->GetX2() << "/" << fInfoLabel->GetX2NDC() << ", " << fInfoLabel->GetY1() << "/" << fInfoLabel->GetY1NDC() << " - " << fInfoLabel->GetY2() << "/" << fInfoLabel->GetY2NDC() << ", from 0, 0.95, 1., 1.) on gPad " << gPad->GetName() << std::endl;
+      }
+   } else {
+      fInfoLabel->Clear();
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         fInfoLabel->ConvertNDCtoPad();
+         std::cout << "fInfoLabel using existing " << fInfoLabel << " (" << fInfoLabel->GetX1() << "/" << fInfoLabel->GetX1NDC() << " - " << fInfoLabel->GetX2() << "/" << fInfoLabel->GetX2NDC() << ", " << fInfoLabel->GetY1() << "/" << fInfoLabel->GetY1NDC() << " - " << fInfoLabel->GetY2() << "/" << fInfoLabel->GetY2NDC() << ") on gPad " << gPad->GetName() << std::endl;
+      }
+   }
+   fInfoLabel->AddText(Form("Using %d peaks from %.0f to %.0f keV", fData->TotalGraph()->GetN(), fData->GetMinimumY(), fData->GetMaximumY()));
+   fInfoLabel->SetFillColor(kWhite);
+   fInfoLabel->Draw();
 
    fResidualPad->cd();
-	fData->DrawResidual("*");
+   fData->DrawResidual("*");
 
-	fCalibrationCanvas->GetCanvas()->Modified();
+   fCalibrationCanvas->GetCanvas()->Modified();
 
-	fData->FitFunction()->SetRange(0., 10000.);
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		double min = 0.;
-		double max = 0.;
-		calibration->GetRange(min, max);
-		std::cout << DYELLOW << "calibration has range " << min << " - " << max;
-		if(fData->FitFunction() != nullptr) {
-			fData->FitFunction()->GetRange(min, max);
-			std::cout << ",  fit function has range " << min << " - " << max;
-		}
-		std::cout << std::endl;
-	}
-	delete calibration;
+   fData->FitFunction()->SetRange(0., 10000.);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      double min = 0.;
+      double max = 0.;
+      calibration->GetRange(min, max);
+      std::cout << DYELLOW << "calibration has range " << min << " - " << max;
+      if(fData->FitFunction() != nullptr) {
+         fData->FitFunction()->GetRange(min, max);
+         std::cout << ",  fit function has range " << min << " - " << max;
+      }
+      std::cout << std::endl;
+   }
+   delete calibration;
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TChannelTab::RecursiveRemove(const double& maxResidual)
 {
-	/// This function goes through the residuals of the calibration and recursively removes each point that is above the maxResidual parameter.
-	/// The function requires an initial calibration to have residuals available.
-	/// After each point that is removed, it re-calibrates the data, producing new residuals.
+   /// This function goes through the residuals of the calibration and recursively removes each point that is above the maxResidual parameter.
+   /// The function requires an initial calibration to have residuals available.
+   /// After each point that is removed, it re-calibrates the data, producing new residuals.
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << ", max. residual " << maxResidual << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-	if(fData == nullptr) {
-		std::cout << "No longer have a data for channel " << Name() << "?" << std::endl;
-		return;
-	}
+   if(fData == nullptr) {
+      std::cout << "No longer have a data for channel " << Name() << "?" << std::endl;
+      return;
+   }
 
-	if(fData->TotalResidualGraph() == nullptr) {
-		std::cout << "No longer have a total residual graph for channel " << Name() << ". Maybe removed all points? Total graph has " << fData->TotalGraph()->GetN() << " points." << std::endl;
-		return;
-	}
+   if(fData->TotalResidualGraph() == nullptr) {
+      std::cout << "No longer have a total residual graph for channel " << Name() << ". Maybe removed all points? Total graph has " << fData->TotalGraph()->GetN() << " points." << std::endl;
+      return;
+   }
 
-	if(fData->TotalResidualGraph()->GetN() == 0) {
-		std::cout << "Recursively removed all data points for channel " << Name() << std::endl;
-		return;
-	}
+   if(fData->TotalResidualGraph()->GetN() == 0) {
+      std::cout << "Recursively removed all data points for channel " << Name() << std::endl;
+      return;
+   }
 
-	// get the maximum residual
-	auto maxElement = std::max_element(fData->TotalResidualGraph()->GetX(), fData->TotalResidualGraph()->GetX() + fData->TotalResidualGraph()->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
-	auto index = std::distance(fData->TotalResidualGraph()->GetX(), maxElement);
+   // get the maximum residual
+   auto maxElement = std::max_element(fData->TotalResidualGraph()->GetX(), fData->TotalResidualGraph()->GetX() + fData->TotalResidualGraph()->GetN(), [](double a, double b) { return std::abs(a) < std::abs(b); });
+   auto index      = std::distance(fData->TotalResidualGraph()->GetX(), maxElement);
 
-	if(std::abs(*maxElement) < maxResidual) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "largest residual is " << *maxElement << " at position " << index << " and is smaller than max. residual " << maxResidual << ": stopping recursive remove" << std::endl; }
-		return;
-	}
+   if(std::abs(*maxElement) < maxResidual) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "largest residual is " << *maxElement << " at position " << index << " and is smaller than max. residual " << maxResidual << ": stopping recursive remove" << std::endl; }
+      return;
+   }
 
-	// remove the index with the maximum residual
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << *maxElement << ") > " << maxResidual << ": removing index " << index << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
-	fData->RemovePoint(index);
+   // remove the index with the maximum residual
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "std::abs(" << *maxElement << ") > " << maxResidual << ": removing index " << index << "/" << fData->TotalResidualGraph()->GetN() << std::endl; }
+   fData->RemovePoint(index);
 
-	// update the data, and re-calibrate
-	UpdateData();
-	UpdateFwhm();
-	Calibrate();
+   // update the data, and re-calibrate
+   UpdateData();
+   UpdateFwhm();
+   Calibrate();
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "RecursiveRemove(" << maxResidual << ") being called again" << RESET_COLOR << std::endl; }
-	RecursiveRemove(maxResidual);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "RecursiveRemove(" << maxResidual << ") being called again" << RESET_COLOR << std::endl; }
+   RecursiveRemove(maxResidual);
 }
 
 void TChannelTab::UpdateChannel()
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-																																											  // write the actual parameters of the fit
-	std::stringstream str;
-	str << std::hex << fName;
-	int address = 0;
-	str >> address;
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
-	TF1* calibration = fData->FitFunction();
-	if(calibration == nullptr) {
-		std::cout << "Failed to find calibration in fData" << std::endl;
-		fData->TotalGraph()->GetListOfFunctions()->Print();
-		return;
-	}
-	std::vector<Float_t> parameters;
-	for(int i = 0; i <= calibration->GetParameter(0); ++i) {
-		parameters.push_back(static_cast<Float_t>(calibration->GetParameter(i + 1)));
-	}
-	TChannel* channel = TChannel::GetChannel(address, false);
-	if(channel == nullptr) {
-		std::cerr << "Failed to get channel for address " << hex(address, 4) << std::endl;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-		return;
-	}
-	channel->SetENGCoefficients(parameters);
-	channel->DestroyEnergyNonlinearity();
-	if(fSourceCalibration->WriteNonlinearities()) {
-		double* x = fData->GetX();
-		double* y = fData->GetY();
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
-		for(int i = 0; i < fData->GetN(); ++i) {
-			// nonlinearity expects y to be the true source energy minus the calibrated energy of the peak
-			// the source energy is y, the peak is x
-			channel->AddEnergyNonlinearityPoint(y[i], y[i] - calibration->Eval(x[i]));
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
-		}
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DYELLOW << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                                                                                                                                   // write the actual parameters of the fit
+   std::stringstream str;
+   str << std::hex << fName;
+   int address = 0;
+   str >> address;
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Got address " << hex(address, 4) << " from name " << fName << std::endl; }
+   TF1* calibration = fData->FitFunction();
+   if(calibration == nullptr) {
+      std::cout << "Failed to find calibration in fData" << std::endl;
+      fData->TotalGraph()->GetListOfFunctions()->Print();
+      return;
+   }
+   std::vector<Float_t> parameters;
+   for(int i = 0; i <= calibration->GetParameter(0); ++i) {
+      parameters.push_back(static_cast<Float_t>(calibration->GetParameter(i + 1)));
+   }
+   TChannel* channel = TChannel::GetChannel(address, false);
+   if(channel == nullptr) {
+      std::cerr << "Failed to get channel for address " << hex(address, 4) << std::endl;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      return;
+   }
+   channel->SetENGCoefficients(parameters);
+   channel->DestroyEnergyNonlinearity();
+   if(fSourceCalibration->WriteNonlinearities()) {
+      double* x = fData->GetX();
+      double* y = fData->GetY();
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Going to add " << fData->GetN() << " points to nonlinearity graph" << std::endl; }
+      for(int i = 0; i < fData->GetN(); ++i) {
+         // nonlinearity expects y to be the true source energy minus the calibrated energy of the peak
+         // the source energy is y, the peak is x
+         channel->AddEnergyNonlinearityPoint(y[i], y[i] - calibration->Eval(x[i]));
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { std::cout << "Added " << channel->GetEnergyNonlinearity().GetN() << ". point " << y[i] << ", " << y[i] - calibration->Eval(x[i]) << " = " << y[i] << " - " << calibration->Eval(x[i]) << std::endl; }
+      }
+   }
 }
 
 void TChannelTab::Initialize(const bool& force)
 {
-	// loop through sources and get rough calibration for each
-	for(auto* source : fSources) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
-			source->Print();
-		}
-		source->InitialCalibration(force);
-		fProgressBar->Increment(1);
-	}
-	// get this rough calibration data and calibrate
-	UpdateData();
-	Calibrate();
-	// copy the data to the initial data and draw it
-	fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
-		fInit->Print();
-	}
-	auto* oldPad = gPad;
-	fInitCanvas->GetCanvas()->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
-	fInit->DrawCalibration("*", fLegend);
-	// calculate the corners of the label from the minimum and maximum x/y-values of the graph
-	// we position it in the top left corner about 50% of the width and 10% of the height of the graph
-	if(fCalLabel == nullptr) {
-		double left   = fInit->GetMinimumX();
-		double right  = left + (fInit->GetMaximumX() - left) * 0.5;
-		double top    = fInit->GetMaximumY();
-		double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
+   // loop through sources and get rough calibration for each
+   for(auto* source : fSources) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << DYELLOW << "Rough calibration in source tab:" << std::endl;
+         source->Print();
+      }
+      source->InitialCalibration(force);
+      fProgressBar->Increment(1);
+   }
+   // get this rough calibration data and calibrate
+   UpdateData();
+   Calibrate();
+   // copy the data to the initial data and draw it
+   fInit = static_cast<TCalibrationGraphSet*>(fData->Clone(Form("init%s", fName.c_str())));
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "Cloned data " << fData->GetName() << " to " << fInit->GetName() << ":" << std::endl;
+      fInit->Print();
+   }
+   auto* oldPad = gPad;
+   fInitCanvas->GetCanvas()->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched from " << oldPad->GetName() << " to " << gPad->GetName() << std::endl; }
+   fInit->DrawCalibration("*", fLegend);
+   // calculate the corners of the label from the minimum and maximum x/y-values of the graph
+   // we position it in the top left corner about 50% of the width and 10% of the height of the graph
+   if(fCalLabel == nullptr) {
+      double left   = fInit->GetMinimumX();
+      double right  = left + (fInit->GetMaximumX() - left) * 0.5;
+      double top    = fInit->GetMaximumY();
+      double bottom = top - (top - fInit->GetMinimumY()) * 0.1;
 
-		fCalLabel = new TPaveText(left, bottom, right, top);
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
-		}
-	} else {
-		fCalLabel->Clear();
-	}
-	std::stringstream str;
-	if(fInit->FitFunction()->GetNpar() == 3) {
-		str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
-	} else {
-		str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
-	}
+      fCalLabel = new TPaveText(left, bottom, right, top);
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << "fCalLabel created " << fCalLabel << " (" << left << " - " << right << ", " << bottom << " - " << top << ", from " << fInit->GetMinimumX() << "-" << fInit->GetMaximumX() << ", " << fInit->GetMinimumY() << "-" << fInit->GetMaximumY() << ") on gPad " << gPad->GetName() << std::endl;
+      }
+   } else {
+      fCalLabel->Clear();
+   }
+   std::stringstream str;
+   if(fInit->FitFunction()->GetNpar() == 3) {
+      str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
+   } else {
+      str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
+   }
 
-	fCalLabel->AddText(str.str().c_str());
-	fCalLabel->SetFillColor(kWhite);
-	fCalLabel->Draw();
-	oldPad->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
+   fCalLabel->AddText(str.str().c_str());
+   fCalLabel->SetFillColor(kWhite);
+   fCalLabel->Draw();
+   oldPad->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << "Switched back to " << gPad->GetName() << std::endl; }
 }
 
 void TChannelTab::FindCalibratedPeaks()
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << DYELLOW << "Finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-		fSourceTab->Print();
-		for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
-			std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
-		}
-	}
-	fSources[fActiveSourceTab]->FindCalibratedPeaks(fData->FitFunction());
-	UpdateData();
-	UpdateFwhm();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << DYELLOW << "Done finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << DYELLOW << "Finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+      fSourceTab->Print();
+      for(int tab = 0; tab < fSourceTab->GetNumberOfTabs(); ++tab) {
+         std::cout << "Tab " << tab << " = " << fSourceTab->GetTabTab(tab) << " = " << fSourceTab->GetTabTab(tab)->GetText()->GetString() << (fSourceTab->GetTabTab(tab)->IsActive() ? " is active" : " is inactive") << (fSourceTab->GetTabTab(tab)->IsEnabled() ? " is enabled" : " is not enabled") << std::endl;
+      }
+   }
+   fSources[fActiveSourceTab]->FindCalibratedPeaks(fData->FitFunction());
+   UpdateData();
+   UpdateFwhm();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << DYELLOW << "Done finding calibrated peaks in source tab " << fActiveSourceTab << ". Old: " << fSourceTab->GetCurrent() << " = " << fSources[fSourceTab->GetCurrent()] << ", current tab element " << fSourceTab->GetCurrentTab() << " is enabled = " << fSourceTab->GetCurrentTab()->IsEnabled() << std::endl;
+   }
 }
 
 void TChannelTab::FindAllCalibratedPeaks()
 {
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << DYELLOW << "Finding calibrated peaks in all source tabs" << std::endl;
-	}
-	for(auto* source : fSources) {
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-			std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
-		}
-		source->FindCalibratedPeaks(fData->FitFunction());
-	}
-	UpdateData();
-	UpdateFwhm();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-		std::cout << DYELLOW << "Done finding calibrated peaks in all source tabs" << std::endl;
-	}
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << DYELLOW << "Finding calibrated peaks in all source tabs" << std::endl;
+   }
+   for(auto* source : fSources) {
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+         std::cout << DYELLOW << "Finding calibrated peaks in source tab " << source->SourceName() << std::endl;
+      }
+      source->FindCalibratedPeaks(fData->FitFunction());
+   }
+   UpdateData();
+   UpdateFwhm();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+      std::cout << DYELLOW << "Done finding calibrated peaks in all source tabs" << std::endl;
+   }
 }
 
 void TChannelTab::Draw()
 {
-	fFwhmCanvas->GetCanvas()->cd();
-	fFwhm->DrawCalibration("*");
-	fLegend->Draw();
-	for(auto* source : fSources) {
-		source->Draw();
-	}
+   fFwhmCanvas->GetCanvas()->cd();
+   fFwhm->DrawCalibration("*");
+   fLegend->Draw();
+   for(auto* source : fSources) {
+      source->Draw();
+   }
 }
 
 void TChannelTab::Write(TFile* output)
 {
-	/// Write graphs to output.
-	output->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "writing " << fName << std::endl; }
-	fData->Write(Form("calGraph_%s", fName.c_str()), TObject::kOverwrite);
-	fFwhm->Write(Form("fwhm_%s", fName.c_str()), TObject::kOverwrite);
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
+   /// Write graphs to output.
+   output->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "writing " << fName << std::endl; }
+   fData->Write(Form("calGraph_%s", fName.c_str()), TObject::kOverwrite);
+   fFwhm->Write(Form("fwhm_%s", fName.c_str()), TObject::kOverwrite);
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) { std::cout << DYELLOW << "wrote data " << fName << std::endl; }
 }
 
 void TChannelTab::ZoomX()
 {
-	/// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's x-axis range to be the same as the selected graphs
-	// find the histogram in the current pad
-	TH1* hist1 = nullptr;
-	for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
-		if(obj->InheritsFrom(TGraph::Class())) {
-			hist1 = static_cast<TGraph*>(obj)->GetHistogram();
-			break;
-		}
-	}
-	if(hist1 == nullptr) {
-		std::cout << "ZoomX - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
-		return;
-	}
+   /// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's x-axis range to be the same as the selected graphs
+   // find the histogram in the current pad
+   TH1* hist1 = nullptr;
+   for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
+      if(obj->InheritsFrom(TGraph::Class())) {
+         hist1 = static_cast<TGraph*>(obj)->GetHistogram();
+         break;
+      }
+   }
+   if(hist1 == nullptr) {
+      std::cout << "ZoomX - Failed to find histogram for pad " << gPad->GetName() << std::endl;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
+      return;
+   }
 
-	// extract base name and channel from pad name
-	std::string padName     = gPad->GetName();
-	std::string baseName    = padName.substr(0, 3);
-	std::string channelName = padName.substr(4);
+   // extract base name and channel from pad name
+   std::string padName     = gPad->GetName();
+   std::string baseName    = padName.substr(0, 3);
+   std::string channelName = padName.substr(4);
 
-	// find the corresponding partner pad to the selected one
-	std::string newName;
-	if(baseName == "cal") {
-		newName = "res_" + channelName;
-	} else if(baseName == "res") {
-		newName = "cal_" + channelName;
-	} else {
-		std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
-		return;
-	}
-	auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
-	if(newObj == nullptr) {
-		std::cout << "Failed to find " << newName << std::endl;
-		return;
-	}
+   // find the corresponding partner pad to the selected one
+   std::string newName;
+   if(baseName == "cal") {
+      newName = "res_" + channelName;
+   } else if(baseName == "res") {
+      newName = "cal_" + channelName;
+   } else {
+      std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
+      return;
+   }
+   auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
+   if(newObj == nullptr) {
+      std::cout << "Failed to find " << newName << std::endl;
+      return;
+   }
 
-	if(newObj->IsA() != TPad::Class()) {
-		std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
-		return;
-	}
-	auto* pad2 = static_cast<TPad*>(newObj);
-	if(pad2 == nullptr) {
-		std::cout << "Failed to find partner pad " << newName << std::endl;
-		return;
-	}
-	// find the histogram in the partner pad
-	TH1* hist2 = nullptr;
-	for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
-		if(obj->InheritsFrom(TGraph::Class())) {
-			hist2 = static_cast<TGraph*>(obj)->GetHistogram();
-			break;
-		}
-	}
-	if(hist2 == nullptr) {
-		std::cout << "ZoomX - Failed to find histogram for partner pad " << newName << std::endl;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
-		return;
-	}
+   if(newObj->IsA() != TPad::Class()) {
+      std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
+      return;
+   }
+   auto* pad2 = static_cast<TPad*>(newObj);
+   if(pad2 == nullptr) {
+      std::cout << "Failed to find partner pad " << newName << std::endl;
+      return;
+   }
+   // find the histogram in the partner pad
+   TH1* hist2 = nullptr;
+   for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
+      if(obj->InheritsFrom(TGraph::Class())) {
+         hist2 = static_cast<TGraph*>(obj)->GetHistogram();
+         break;
+      }
+   }
+   if(hist2 == nullptr) {
+      std::cout << "ZoomX - Failed to find histogram for partner pad " << newName << std::endl;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
+      return;
+   }
 
-	TAxis*   axis1  = hist1->GetXaxis();
-	Int_t    binmin = axis1->GetFirst();
-	Int_t    binmax = axis1->GetLast();
-	Double_t xmin   = axis1->GetBinLowEdge(binmin);
-	Double_t xmax   = axis1->GetBinLowEdge(binmax);
-	TAxis*   axis2  = hist2->GetXaxis();
-	Int_t    newmin = axis2->FindBin(xmin);
-	Int_t    newmax = axis2->FindBin(xmax);
-	axis2->SetRange(newmin, newmax);
-	pad2->Modified();
-	pad2->Update();
+   TAxis*   axis1  = hist1->GetXaxis();
+   Int_t    binmin = axis1->GetFirst();
+   Int_t    binmax = axis1->GetLast();
+   Double_t xmin   = axis1->GetBinLowEdge(binmin);
+   Double_t xmax   = axis1->GetBinLowEdge(binmax);
+   TAxis*   axis2  = hist2->GetXaxis();
+   Int_t    newmin = axis2->FindBin(xmin);
+   Int_t    newmax = axis2->FindBin(xmax);
+   axis2->SetRange(newmin, newmax);
+   pad2->Modified();
+   pad2->Update();
 }
 
 void TChannelTab::ZoomY()
 {
-	/// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's y-axis range to be the same as the selected graphs
-	// find the histogram in the current pad
-	TH1* hist1 = nullptr;
-	for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
-		if(obj->InheritsFrom(TGraph::Class())) {
-			hist1 = static_cast<TGraph*>(obj)->GetHistogram();
-			break;
-		}
-	}
-	if(hist1 == nullptr) {
-		std::cout << "ZoomY - Failed to find histogram for pad " << gPad->GetName() << std::endl;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
-		return;
-	}
+   /// finds corresponding graph (res_xxx for cal_xxx and vice versa) and sets it's y-axis range to be the same as the selected graphs
+   // find the histogram in the current pad
+   TH1* hist1 = nullptr;
+   for(const auto&& obj : *(gPad->GetListOfPrimitives())) {
+      if(obj->InheritsFrom(TGraph::Class())) {
+         hist1 = static_cast<TGraph*>(obj)->GetHistogram();
+         break;
+      }
+   }
+   if(hist1 == nullptr) {
+      std::cout << "ZoomY - Failed to find histogram for pad " << gPad->GetName() << std::endl;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { gPad->GetListOfPrimitives()->Print(); }
+      return;
+   }
 
-	// extract base name and channel from pad name
-	std::string padName     = gPad->GetName();
-	std::string baseName    = padName.substr(0, 3);
-	std::string channelName = padName.substr(4);
+   // extract base name and channel from pad name
+   std::string padName     = gPad->GetName();
+   std::string baseName    = padName.substr(0, 3);
+   std::string channelName = padName.substr(4);
 
-	// find the corresponding partner pad to the selected one
-	std::string newName;
-	if(baseName == "cal") {
-		newName = "res_" + channelName;
-	} else if(baseName == "res") {
-		newName = "cal_" + channelName;
-	} else {
-		std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
-		return;
-	}
-	auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
-	if(newObj == nullptr) {
-		std::cout << "Failed to find " << newName << std::endl;
-		return;
-	}
+   // find the corresponding partner pad to the selected one
+   std::string newName;
+   if(baseName == "cal") {
+      newName = "res_" + channelName;
+   } else if(baseName == "res") {
+      newName = "cal_" + channelName;
+   } else {
+      std::cout << "Unknown combination of pad " << gPad->GetName() << " and histogram " << hist1->GetName() << std::endl;
+      return;
+   }
+   auto* newObj = gPad->GetCanvas()->FindObject(newName.c_str());
+   if(newObj == nullptr) {
+      std::cout << "Failed to find " << newName << std::endl;
+      return;
+   }
 
-	if(newObj->IsA() != TPad::Class()) {
-		std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
-		return;
-	}
-	auto* pad2 = static_cast<TPad*>(newObj);
-	if(pad2 == nullptr) {
-		std::cout << "Failed to find partner pad " << newName << std::endl;
-		return;
-	}
-	// find the histogram in the partner pad
-	TH1* hist2 = nullptr;
-	for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
-		if(obj->InheritsFrom(TGraph::Class())) {
-			hist2 = static_cast<TGraph*>(obj)->GetHistogram();
-			break;
-		}
-	}
-	if(hist2 == nullptr) {
-		std::cout << "ZoomY - Failed to find histogram for partner pad " << newName << std::endl;
-		if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
-		return;
-	}
+   if(newObj->IsA() != TPad::Class()) {
+      std::cout << newObj << " = " << newObj->GetName() << ", " << newObj->GetTitle() << " is a " << newObj->ClassName() << " not a TPad" << std::endl;
+      return;
+   }
+   auto* pad2 = static_cast<TPad*>(newObj);
+   if(pad2 == nullptr) {
+      std::cout << "Failed to find partner pad " << newName << std::endl;
+      return;
+   }
+   // find the histogram in the partner pad
+   TH1* hist2 = nullptr;
+   for(const auto&& obj : *(pad2->GetListOfPrimitives())) {
+      if(obj->InheritsFrom(TGraph::Class())) {
+         hist2 = static_cast<TGraph*>(obj)->GetHistogram();
+         break;
+      }
+   }
+   if(hist2 == nullptr) {
+      std::cout << "ZoomY - Failed to find histogram for partner pad " << newName << std::endl;
+      if(TSourceCalibration::VerboseLevel() > EVerbosity::kLoops) { pad2->GetListOfPrimitives()->Print(); }
+      return;
+   }
 
-	hist2->SetMinimum(hist1->GetMinimum());
-	hist2->SetMaximum(hist1->GetMaximum());
+   hist2->SetMinimum(hist1->GetMinimum());
+   hist2->SetMaximum(hist1->GetMaximum());
 
-	pad2->Modified();
-	pad2->Update();
+   pad2->Modified();
+   pad2->Update();
 }
 
 void TChannelTab::PrintCanvases() const
 {
-	std::cout << "TChannelTab " << Name() << " calibration canvas:" << std::endl;
-	fCalibrationCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
-	std::cout << "TChannelTab fwhm canvas:" << std::endl;
-	fFwhmCanvas->GetCanvas()->Print();
-	for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
-		obj->Print();
-	}
-	for(auto* sourceTab : fSources) {
-		sourceTab->PrintCanvases();
-	}
+   std::cout << "TChannelTab " << Name() << " calibration canvas:" << std::endl;
+   fCalibrationCanvas->GetCanvas()->Print();
+   for(auto* obj : *(fCalibrationCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
+   std::cout << "TChannelTab fwhm canvas:" << std::endl;
+   fFwhmCanvas->GetCanvas()->Print();
+   for(auto* obj : *(fFwhmCanvas->GetCanvas()->GetListOfPrimitives())) {
+      obj->Print();
+   }
+   for(auto* sourceTab : fSources) {
+      sourceTab->PrintCanvases();
+   }
 }
 
 void TChannelTab::PrintLayout() const
 {
-	std::cout << "TChannelTab frame:" << std::endl;
-	fChannelFrame->Print();
-	std::cout << "TChannelTab canvas:" << std::endl;
-	fCalibrationCanvas->Print();
-	std::cout << "TChannelTab status bar:" << std::endl;
-	//fChannelStatusBar->Print();
-	for(auto* sourceTab : fSources) {
-		sourceTab->PrintLayout();
-	}
+   std::cout << "TChannelTab frame:" << std::endl;
+   fChannelFrame->Print();
+   std::cout << "TChannelTab canvas:" << std::endl;
+   fCalibrationCanvas->Print();
+   std::cout << "TChannelTab status bar:" << std::endl;
+   //fChannelStatusBar->Print();
+   for(auto* sourceTab : fSources) {
+      sourceTab->PrintLayout();
+   }
 }
 
 //////////////////////////////////////// TSourceCalibration ////////////////////////////////////////
@@ -2159,846 +2159,846 @@ size_t           TSourceCalibration::fNumberOfThreads    = 4;
 std::vector<int> TSourceCalibration::fBadBins;
 
 TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degree, int count...)
-	: TGMainFrame(nullptr, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree)
+   : TGMainFrame(nullptr, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight), fDefaultSigma(sigma), fDefaultThreshold(threshold), fDefaultDegree(degree)
 {
-	TH1::AddDirectory(false);   // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
+   TH1::AddDirectory(false);   // turns off warnings about multiple histograms with the same name because ROOT doesn't manage them anymore
 
-	va_list args;
-	va_start(args, count);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	for(int i = 0; i < count; ++i) {
-		fMatrices.push_back(va_arg(args, TH2*));   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-		if(fMatrices.back() == nullptr) {
-			std::cout << "Error, got nullptr as matrix input?" << std::endl;
-			fMatrices.pop_back();
-		}
-	}
-	va_end(args);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fVerboseLevel > EVerbosity::kQuiet) {
-		std::cout << DGREEN << __PRETTY_FUNCTION__ << ": verbose level " << fVerboseLevel << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			<< "using " << count << "/" << fMatrices.size() << " matrices:" << std::endl;
-		for(auto* mat : fMatrices) {
-			std::cout << mat << std::flush << " = " << mat->GetName() << std::endl;
-		}
-	}
+   va_list args;
+   va_start(args, count);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   for(int i = 0; i < count; ++i) {
+      fMatrices.push_back(va_arg(args, TH2*));   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      if(fMatrices.back() == nullptr) {
+         std::cout << "Error, got nullptr as matrix input?" << std::endl;
+         fMatrices.pop_back();
+      }
+   }
+   va_end(args);   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kQuiet) {
+      std::cout << DGREEN << __PRETTY_FUNCTION__ << ": verbose level " << fVerboseLevel << std::endl   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                << "using " << count << "/" << fMatrices.size() << " matrices:" << std::endl;
+      for(auto* mat : fMatrices) {
+         std::cout << mat << std::flush << " = " << mat->GetName() << std::endl;
+      }
+   }
 
-	fOldErrorLevel        = gErrorIgnoreLevel;
-	gErrorIgnoreLevel     = kError;
-	gPrintViaErrorHandler = true;   // redirects all printf's to root's normal message system
+   fOldErrorLevel        = gErrorIgnoreLevel;
+   gErrorIgnoreLevel     = kError;
+   gPrintViaErrorHandler = true;   // redirects all printf's to root's normal message system
 
-	if(!fLogFile.empty()) {
-		fRedirect = new TRedirect(fLogFile.c_str());
-		std::cout << "Starting redirect to " << fLogFile << std::endl;
-	}
+   if(!fLogFile.empty()) {
+      fRedirect = new TRedirect(fLogFile.c_str());
+      std::cout << "Starting redirect to " << fLogFile << std::endl;
+   }
 
-	// check matrices (# of filled bins and bin labels) and resize some vectors for later use
-	// use the first matrix to get a reference for everything
-	fNofBins = 0;
-	std::map<int, int> channelToIndex;   // used to be a member, but only used here
-	for(int bin = 1; bin <= fMatrices[0]->GetNbinsX(); ++bin) {
-		if(FilledBin(fMatrices[0], bin) && std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {
-			fActualChannelId.push_back(fNofBins);   // at this point fNofBins is the index at which this projection will end up
-			fActiveBins.push_back(bin);
-			channelToIndex[bin] = fNofBins;   // this map simply stores which bin ends up at which index
-			fChannelLabel.push_back(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-			if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
-			++fNofBins;
-		} else {
-			if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "skipping bin " << bin << std::endl; }
-		}
-	}
-	// now loop over all other matrices and check vs. the first one
-	for(size_t i = 1; i < fMatrices.size(); ++i) {
-		int tmpBins = 0;
-		for(int bin = 1; bin <= fMatrices[i]->GetNbinsX(); ++bin) {
-			if(FilledBin(fMatrices[i], bin), std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {   // good bin in the current matrix
-																																						// current index is tmpBins, so we check if the bin agrees with what we have
-				if(channelToIndex.find(bin) == channelToIndex.end() || tmpBins != channelToIndex[bin]) {   // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
-					std::ostringstream error;
-					error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (channelToIndex.find(bin) == channelToIndex.end() ? "not filled" : Form("%d", channelToIndex[bin])) << std::endl;
-					throw std::invalid_argument(error.str());
-				}
-				if(strcmp(fMatrices[0]->GetXaxis()->GetBinLabel(bin), fMatrices[i]->GetXaxis()->GetBinLabel(bin)) != 0) {   // bin is full and matches the bin in the first matrix so we check the labels
-					std::ostringstream error;
-					error << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
-					throw std::invalid_argument(error.str());
-				}
-				++tmpBins;
-			} else {
-				if(channelToIndex.find(bin) != channelToIndex.end()) {   //found an empty bin that was full in the first matrix
-					std::ostringstream error;
-					error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << channelToIndex[bin] << ". filled bin" << std::endl;
-					throw std::invalid_argument(error.str());
-				}
-			}
-		}
-	}
+   // check matrices (# of filled bins and bin labels) and resize some vectors for later use
+   // use the first matrix to get a reference for everything
+   fNofBins = 0;
+   std::map<int, int> channelToIndex;   // used to be a member, but only used here
+   for(int bin = 1; bin <= fMatrices[0]->GetNbinsX(); ++bin) {
+      if(FilledBin(fMatrices[0], bin) && std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {
+         fActualChannelId.push_back(fNofBins);   // at this point fNofBins is the index at which this projection will end up
+         fActiveBins.push_back(bin);
+         channelToIndex[bin] = fNofBins;   // this map simply stores which bin ends up at which index
+         fChannelLabel.push_back(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
+         if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << bin << ". bin: fNofBins " << fNofBins << ", channelToIndex[" << bin << "] " << channelToIndex[bin] << ", fActualChannelId.back() " << fActualChannelId.back() << std::endl; }
+         ++fNofBins;
+      } else {
+         if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "skipping bin " << bin << std::endl; }
+      }
+   }
+   // now loop over all other matrices and check vs. the first one
+   for(size_t i = 1; i < fMatrices.size(); ++i) {
+      int tmpBins = 0;
+      for(int bin = 1; bin <= fMatrices[i]->GetNbinsX(); ++bin) {
+         if(FilledBin(fMatrices[i], bin), std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {   // good bin in the current matrix
+                                                                                                                  // current index is tmpBins, so we check if the bin agrees with what we have
+            if(channelToIndex.find(bin) == channelToIndex.end() || tmpBins != channelToIndex[bin]) {              // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
+               std::ostringstream error;
+               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (channelToIndex.find(bin) == channelToIndex.end() ? "not filled" : Form("%d", channelToIndex[bin])) << std::endl;
+               throw std::invalid_argument(error.str());
+            }
+            if(strcmp(fMatrices[0]->GetXaxis()->GetBinLabel(bin), fMatrices[i]->GetXaxis()->GetBinLabel(bin)) != 0) {   // bin is full and matches the bin in the first matrix so we check the labels
+               std::ostringstream error;
+               error << i << ". matrix, " << bin << ". bin: label (" << fMatrices[i]->GetXaxis()->GetBinLabel(bin) << ") doesn't match bin label of the first matrix (" << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ")" << std::endl;
+               throw std::invalid_argument(error.str());
+            }
+            ++tmpBins;
+         } else {
+            if(channelToIndex.find(bin) != channelToIndex.end()) {   //found an empty bin that was full in the first matrix
+               std::ostringstream error;
+               error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is empty, but should be " << channelToIndex[bin] << ". filled bin" << std::endl;
+               throw std::invalid_argument(error.str());
+            }
+         }
+      }
+   }
 
-	if(fVerboseLevel > EVerbosity::kQuiet) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
+   if(fVerboseLevel > EVerbosity::kQuiet) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << std::endl; }
 
-	fOutput = new TFile("TSourceCalibration.root", "recreate");
-	if(!fOutput->IsOpen()) {
-		throw std::runtime_error("Unable to open output file \"TSourceCalibration.root\"!");
-	}
+   fOutput = new TFile("TSourceCalibration.root", "recreate");
+   if(!fOutput->IsOpen()) {
+      throw std::runtime_error("Unable to open output file \"TSourceCalibration.root\"!");
+   }
 
-	// build the first screen
-	BuildFirstInterface();
-	MakeFirstConnections();
+   // build the first screen
+   BuildFirstInterface();
+   MakeFirstConnections();
 
-	// Set a name to the main frame
-	SetWindowName("SourceCalibration");
+   // Set a name to the main frame
+   SetWindowName("SourceCalibration");
 
-	// Map all subwindows of main frame
-	MapSubwindows();
+   // Map all subwindows of main frame
+   MapSubwindows();
 
-	// Initialize the layout algorithm
-	Resize(GetDefaultSize());
+   // Initialize the layout algorithm
+   Resize(GetDefaultSize());
 
-	// Map main frame
-	MapWindow();
+   // Map main frame
+   MapWindow();
 }
 
 TSourceCalibration::~TSourceCalibration()
 {
-	fOutput->Close();
-	delete fOutput;
+   fOutput->Close();
+   delete fOutput;
 
-	gErrorIgnoreLevel = fOldErrorLevel;
+   gErrorIgnoreLevel = fOldErrorLevel;
 
-	delete fRedirect;
+   delete fRedirect;
 }
 
 void TSourceCalibration::BuildFirstInterface()
 {
-	/// Build initial interface with histogram <-> source assignment
+   /// Build initial interface with histogram <-> source assignment
 
-	auto* layoutManager = new TGTableLayout(this, fMatrices.size() + 1, 2, true, 5);
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
-	SetLayoutManager(layoutManager);
+   auto* layoutManager = new TGTableLayout(this, fMatrices.size() + 1, 2, true, 5);
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "created table layout manager with 2 columns, " << fMatrices.size() + 1 << " rows" << std::endl; }
+   SetLayoutManager(layoutManager);
 
-	// The matrices and source selection boxes
-	size_t i = 0;
-	for(i = 0; i < fMatrices.size(); ++i) {
-		fMatrixNames.push_back(new TGLabel(this, fMatrices[i]->GetName()));
-		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
-		fSource.push_back(nullptr);
-		fSourceEnergy.emplace_back();
-		fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
+   // The matrices and source selection boxes
+   size_t i = 0;
+   for(i = 0; i < fMatrices.size(); ++i) {
+      fMatrixNames.push_back(new TGLabel(this, fMatrices[i]->GetName()));
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Text height " << fMatrixNames.back()->GetFont()->TextHeight() << std::endl; }
+      fSource.push_back(nullptr);
+      fSourceEnergy.emplace_back();
+      fSourceBox.push_back(new TGComboBox(this, "Select source", kSourceBox + fSourceBox.size()));
 
-		int index = 0;
+      int index = 0;
 #if __cplusplus >= 201703L
-		// For some reasons getenv("GRSISYS") with strcat does not work (adds the "sub"-path twice).
-		// Have to do this by copying the getenv result into a c++-string.
-		if(std::getenv("GRSISYS") == nullptr) {
-			throw std::runtime_error("Failed to get environment variable $GRSISYS");
-		}
-		std::string path(std::getenv("GRSISYS"));
-		path += "/libraries/TAnalysis/SourceData/";
-		for(const auto& file : std::filesystem::directory_iterator(path)) {
-			if(file.is_regular_file() && file.path().extension().compare(".sou") == 0) {
-				fSourceBox.back()->AddEntry(file.path().stem().c_str(), index);
-				if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
-				if(std::strstr(fMatrices[i]->GetName(), file.path().stem().c_str()) != nullptr) {
-					fSourceBox.back()->Select(index);
-					SetSource(kSourceBox + fSourceBox.size() - 1, index);
-					if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": selected source " << index << std::endl; }
-				} else if(fVerboseLevel > EVerbosity::kSubroutines) {
-					std::cout << "matrix name " << fMatrices[i]->GetName() << " not matching " << file.path().stem().c_str() << std::endl;
-				}
-				++index;
-			}
-		}
-		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
+      // For some reasons getenv("GRSISYS") with strcat does not work (adds the "sub"-path twice).
+      // Have to do this by copying the getenv result into a c++-string.
+      if(std::getenv("GRSISYS") == nullptr) {
+         throw std::runtime_error("Failed to get environment variable $GRSISYS");
+      }
+      std::string path(std::getenv("GRSISYS"));
+      path += "/libraries/TAnalysis/SourceData/";
+      for(const auto& file : std::filesystem::directory_iterator(path)) {
+         if(file.is_regular_file() && file.path().extension().compare(".sou") == 0) {
+            fSourceBox.back()->AddEntry(file.path().stem().c_str(), index);
+            if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << "/" << index << ": Comparing matrix name " << fMatrices[i]->GetName() << " to file name " << file.path().stem().c_str() << std::endl; }
+            if(std::strstr(fMatrices[i]->GetName(), file.path().stem().c_str()) != nullptr) {
+               fSourceBox.back()->Select(index);
+               SetSource(kSourceBox + fSourceBox.size() - 1, index);
+               if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": selected source " << index << std::endl; }
+            } else if(fVerboseLevel > EVerbosity::kSubroutines) {
+               std::cout << "matrix name " << fMatrices[i]->GetName() << " not matching " << file.path().stem().c_str() << std::endl;
+            }
+            ++index;
+         }
+      }
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": created list with " << index << " sources" << std::endl; }
 #else
-		fSourceBox.back()->AddEntry("22Na", index);
-		if(std::strstr(fMatrices[i]->GetName(), "22Na") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
-		++index;
-		fSourceBox.back()->AddEntry("56Co", index);
-		if(std::strstr(fMatrices[i]->GetName(), "56Co") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
-		++index;
-		fSourceBox.back()->AddEntry("60Co", index);
-		if(std::strstr(fMatrices[i]->GetName(), "60Co") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
-		++index;
-		fSourceBox.back()->AddEntry("133Ba", index);
-		if(std::strstr(fMatrices[i]->GetName(), "133Ba") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
-		++index;
-		fSourceBox.back()->AddEntry("152Eu", index);
-		if(std::strstr(fMatrices[i]->GetName(), "152Eu") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
-		++index;
-		fSourceBox.back()->AddEntry("241Am", index);
-		if(std::strstr(fMatrices[i]->GetName(), "241Am") != nullptr) {
-			fSourceBox.back()->Select(index);
-			SetSource(kSourceBox + fSourceBox.size() - 1, index);
-		}
+      fSourceBox.back()->AddEntry("22Na", index);
+      if(std::strstr(fMatrices[i]->GetName(), "22Na") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
+      ++index;
+      fSourceBox.back()->AddEntry("56Co", index);
+      if(std::strstr(fMatrices[i]->GetName(), "56Co") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
+      ++index;
+      fSourceBox.back()->AddEntry("60Co", index);
+      if(std::strstr(fMatrices[i]->GetName(), "60Co") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
+      ++index;
+      fSourceBox.back()->AddEntry("133Ba", index);
+      if(std::strstr(fMatrices[i]->GetName(), "133Ba") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
+      ++index;
+      fSourceBox.back()->AddEntry("152Eu", index);
+      if(std::strstr(fMatrices[i]->GetName(), "152Eu") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
+      ++index;
+      fSourceBox.back()->AddEntry("241Am", index);
+      if(std::strstr(fMatrices[i]->GetName(), "241Am") != nullptr) {
+         fSourceBox.back()->Select(index);
+         SetSource(kSourceBox + fSourceBox.size() - 1, index);
+      }
 #endif
 
-		fSourceBox.back()->SetMinHeight(fPanelHeight / 2);
+      fSourceBox.back()->SetMinHeight(fPanelHeight / 2);
 
-		fSourceBox.back()->Resize(fSourceboxWidth, fLineHeight);
-		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
-		AddFrame(fMatrixNames.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
-		AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
-	}
+      fSourceBox.back()->Resize(fSourceboxWidth, fLineHeight);
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Attaching " << i << ". label to 0, 1, " << i << ", " << i + 1 << ", and box to 1, 2, " << i << ", " << i + 1 << std::endl; }
+      AddFrame(fMatrixNames.back(), new TGTableLayoutHints(0, 1, i, i + 1, kLHintsRight | kLHintsCenterY));
+      AddFrame(fSourceBox.back(), new TGTableLayoutHints(1, 2, i, i + 1, kLHintsLeft | kLHintsCenterY));
+   }
 
-	// The buttons
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
-	fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "start button " << fStartButton << std::endl; }
-	AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
-	Layout();
+   // The buttons
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Attaching start button to 0, 2, " << i << ", " << i + 1 << std::endl; }
+   fStartButton = new TGTextButton(this, "Accept && Continue", kStartButton);
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "start button " << fStartButton << std::endl; }
+   AddFrame(fStartButton, new TGTableLayoutHints(0, 2, i, i + 1, kLHintsCenterX | kLHintsCenterY));
+   Layout();
 }
 
 void TSourceCalibration::MakeFirstConnections()
 {
-	/// Create connections for the histogram <-> source assignment interface
+   /// Create connections for the histogram <-> source assignment interface
 
-	// Connect the selection of the source
-	for(auto* box : fSourceBox) {
-		box->Connect("Selected(Int_t, Int_t)", "TSourceCalibration", this, "SetSource(Int_t, Int_t)");
-	}
+   // Connect the selection of the source
+   for(auto* box : fSourceBox) {
+      box->Connect("Selected(Int_t, Int_t)", "TSourceCalibration", this, "SetSource(Int_t, Int_t)");
+   }
 
-	//Connect the clicking of buttons
-	fStartButton->Connect("Clicked()", "TSourceCalibration", this, "Start()");
+   //Connect the clicking of buttons
+   fStartButton->Connect("Clicked()", "TSourceCalibration", this, "Start()");
 }
 
 void TSourceCalibration::DisconnectFirst()
 {
-	/// Disconnect all signals from histogram <-> source assignment interface
-	for(auto* box : fSourceBox) {
-		box->Disconnect("Selected(Int_t, Int_t)", this, "SetSource(Int_t, Int_t)");
-	}
+   /// Disconnect all signals from histogram <-> source assignment interface
+   for(auto* box : fSourceBox) {
+      box->Disconnect("Selected(Int_t, Int_t)", this, "SetSource(Int_t, Int_t)");
+   }
 
-	fStartButton->Disconnect("Clicked()", this, "Start()");
+   fStartButton->Disconnect("Clicked()", this, "Start()");
 }
 
 void TSourceCalibration::DeleteElement(TGFrame* element)
 {
-	HideFrame(element);
-	RemoveFrame(element);
-	delete element;
-	element = nullptr;
+   HideFrame(element);
+   RemoveFrame(element);
+   delete element;
+   element = nullptr;
 }
 
 void TSourceCalibration::DeleteFirst()
 {
-	for(auto* name : fMatrixNames) {
-		DeleteElement(name);
-	}
-	fMatrixNames.clear();
-	for(auto* box : fSourceBox) {
-		DeleteElement(box);
-	}
-	fSourceBox.clear();
-	DeleteElement(fStartButton);
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
+   for(auto* name : fMatrixNames) {
+      DeleteElement(name);
+   }
+   fMatrixNames.clear();
+   for(auto* box : fSourceBox) {
+      DeleteElement(box);
+   }
+   fSourceBox.clear();
+   DeleteElement(fStartButton);
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Deleted start button " << fStartButton << std::endl; }
 }
 
 void TSourceCalibration::SetSource(Int_t windowId, Int_t entryId)
 {
-	int index = windowId - kSourceBox;
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	delete fSource[index];
-	auto* nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
-	TIter iter(nucleus->GetTransitionList());
-	fSourceEnergy[index].clear();
-	while(auto* transition = static_cast<TTransition*>(iter.Next())) {
-		fSourceEnergy[index].push_back(std::make_tuple(transition->GetEnergy(), transition->GetEnergyUncertainty(), transition->GetIntensity(), transition->GetIntensityUncertainty()));
-	}
-	fSource[index] = nucleus;
+   int index = windowId - kSourceBox;
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": windowId " << windowId << ", entryId " << entryId << " => " << index << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   delete fSource[index];
+   auto* nucleus = new TNucleus(fSourceBox[index]->GetListBox()->GetEntry(entryId)->GetTitle());
+   TIter iter(nucleus->GetTransitionList());
+   fSourceEnergy[index].clear();
+   while(auto* transition = static_cast<TTransition*>(iter.Next())) {
+      fSourceEnergy[index].push_back(std::make_tuple(transition->GetEnergy(), transition->GetEnergyUncertainty(), transition->GetIntensity(), transition->GetIntensityUncertainty()));
+   }
+   fSource[index] = nucleus;
 }
 
 void TSourceCalibration::HandleTimer()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fEmitter == fStartButton) {
-		SecondWindow();
-	} else if(fEmitter == fAcceptAllButton) {
-		for(auto& channelTab : fChannelTab) {
-			if(channelTab == nullptr) { continue; }
-			channelTab->UpdateChannel();
-			channelTab->Write(fOutput);
-		}
-		WriteCalibration();
-		std::cout << "Closing window" << std::endl;
-		CloseWindow();
-		std::cout << "all done" << std::endl;
-		exit(0);
-	}
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << ", fAcceptAllButton " << fAcceptAllButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fEmitter == fStartButton) {
+      SecondWindow();
+   } else if(fEmitter == fAcceptAllButton) {
+      for(auto& channelTab : fChannelTab) {
+         if(channelTab == nullptr) { continue; }
+         channelTab->UpdateChannel();
+         channelTab->Write(fOutput);
+      }
+      WriteCalibration();
+      std::cout << "Closing window" << std::endl;
+      CloseWindow();
+      std::cout << "all done" << std::endl;
+      exit(0);
+   }
 }
 
 void TSourceCalibration::Start()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fEmitter == nullptr) {                                                                                                                                         // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
-		fEmitter = fStartButton;
-		TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
-	}
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << ": fEmitter " << fEmitter << ", fStartButton " << fStartButton << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fEmitter == nullptr) {                                                                                                                                         // we only want to do this once at the beginning (after fEmitter was initialized to nullptr)
+      fEmitter = fStartButton;
+      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
+   }
 }
 
 void TSourceCalibration::SecondWindow()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-																																	// check that all sources have been set
-	for(size_t i = 0; i < fSource.size(); ++i) {
-		if(fSource[i] == nullptr) {
-			std::cerr << "Source " << i << " not set!" << std::endl;
-			return;
-		}
-	}
-	// now check that we don't have the same source twice (which wouldn't make sense)
-	for(size_t i = 0; i < fSource.size(); ++i) {
-		for(size_t j = i + 1; j < fSource.size(); ++j) {
-			if(*(fSource[i]) == *(fSource[j])) {
-				std::cerr << "Duplicate sources: " << i << " - " << fSource[i]->GetName() << " and " << j << " - " << fSource[j]->GetName() << std::endl;
-				return;
-			}
-		}
-	}
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                                                                                                   // check that all sources have been set
+   for(size_t i = 0; i < fSource.size(); ++i) {
+      if(fSource[i] == nullptr) {
+         std::cerr << "Source " << i << " not set!" << std::endl;
+         return;
+      }
+   }
+   // now check that we don't have the same source twice (which wouldn't make sense)
+   for(size_t i = 0; i < fSource.size(); ++i) {
+      for(size_t j = i + 1; j < fSource.size(); ++j) {
+         if(*(fSource[i]) == *(fSource[j])) {
+            std::cerr << "Duplicate sources: " << i << " - " << fSource[i]->GetName() << " and " << j << " - " << fSource[j]->GetName() << std::endl;
+            return;
+         }
+      }
+   }
 
-	// disconnect signals of first screen and remove all elements
-	DisconnectFirst();
-	RemoveAll();
-	DeleteFirst();
+   // disconnect signals of first screen and remove all elements
+   DisconnectFirst();
+   RemoveAll();
+   DeleteFirst();
 
-	SetLayoutManager(new TGVerticalLayout(this));
+   SetLayoutManager(new TGVerticalLayout(this));
 
-	// create intermediate progress bar
-	fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
-	fProgressBar->SetBarColor("lightblue");
-	fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
-	fProgressBar->ShowPosition(true, false, "Creating source tabs: %.0f");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
-	AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+   // create intermediate progress bar
+   fProgressBar = new TGHProgressBar(this, TGProgressBar::kFancy, fPanelWidth);
+   fProgressBar->SetBarColor("lightblue");
+   fProgressBar->SetRange(0., static_cast<Float_t>(fMatrices.size() * fActiveBins.size()));
+   fProgressBar->ShowPosition(true, false, "Creating source tabs: %.0f");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "Set range of progress bar to 0. - " << fProgressBar->GetMax() << " = " << fMatrices.size() * fActiveBins.size() << " = " << fMatrices.size() << "*" << fActiveBins.size() << std::endl; }
+   AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
-	// Map all subwindows of main frame
-	MapSubwindows();
+   // Map all subwindows of main frame
+   MapSubwindows();
 
-	// Initialize the layout algorithm
-	Resize(TGDimension(fPanelWidth, fLineHeight));
+   // Initialize the layout algorithm
+   Resize(TGDimension(fPanelWidth, fLineHeight));
 
-	// Map main frame
-	MapWindow();
+   // Map main frame
+   MapWindow();
 
-	// create second screen and its connections
-	BuildSecondInterface();
-	MakeSecondConnections();
+   // create second screen and its connections
+   BuildSecondInterface();
+   MakeSecondConnections();
 
-	// remove progress bar
-	DeleteElement(fProgressBar);
+   // remove progress bar
+   DeleteElement(fProgressBar);
 
-	// Map all subwindows of main frame
-	MapSubwindows();
+   // Map all subwindows of main frame
+   MapSubwindows();
 
-	// Initialize the layout algorithm
-	Resize(TGDimension(2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight));
+   // Initialize the layout algorithm
+   Resize(TGDimension(2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight));
 
-	// Map main frame
-	MapWindow();
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   // Map main frame
+   MapWindow();
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << " done" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 }
 
 void TSourceCalibration::BuildSecondInterface()
 {
-	SetLayoutManager(new TGVerticalLayout(this));
-	fTab = new TGTab(this, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight);
+   SetLayoutManager(new TGVerticalLayout(this));
+   fTab = new TGTab(this, 2 * fPanelWidth, fPanelHeight + 2 * fStatusbarHeight);
 
-	fChannelTab.resize(fMatrices[0]->GetNbinsX());
-	for(auto& bin : fActiveBins) {
-		// create vector with projections of this channel for each source
-		std::vector<GH1D*> projections(fMatrices.size());
-		size_t             index = 0;
-		for(auto* matrix : fMatrices) {
-			projections[index] = new GH1D(matrix->ProjectionY(Form("%s_%s", fSource[index]->GetName(), matrix->GetXaxis()->GetBinLabel(bin)), bin, bin));
-			++index;
-		}
-		auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
-		// create a new tab in a new thread
-		if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
-		fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fSourceEnergy, fProgressBar);
-		//// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
-		//fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
-		//				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
-		//				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
-		//				std::cout << "created new tab " << newTab << std::endl;
-		//				return newTab;
-		//				})));
-		//// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
-		//if(fFutures.size() >= fNumberOfThreads) {
-		//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-		//	auto tmp = fFutures.front().second.get();
-		//	fChannelTab[fFutures.front().first] = tmp;
-		//	fFutures.pop();
-		//}
-	}
-	// wait for all remaining threads to finish
-	//while(!fFutures.empty()) {
-	//	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
-	//	auto tmp = fFutures.front().second.get();
-	//	fChannelTab[fFutures.front().first] = tmp;
-	//	fFutures.pop();
-	//}
+   fChannelTab.resize(fMatrices[0]->GetNbinsX());
+   for(auto& bin : fActiveBins) {
+      // create vector with projections of this channel for each source
+      std::vector<GH1D*> projections(fMatrices.size());
+      size_t             index = 0;
+      for(auto* matrix : fMatrices) {
+         projections[index] = new GH1D(matrix->ProjectionY(Form("%s_%s", fSource[index]->GetName(), matrix->GetXaxis()->GetBinLabel(bin)), bin, bin));
+         ++index;
+      }
+      auto* frame = fTab->AddTab(fMatrices[0]->GetXaxis()->GetBinLabel(bin));
+      // create a new tab in a new thread
+      if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Creating channel for bin " << bin << std::endl; }
+      fChannelTab[bin - 1] = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fSourceEnergy, fProgressBar);
+      //// right now the lambda uses copies of all variables, not sure if that is neccesary, or if we only need that for projections?
+      //fFutures.emplace(std::make_pair(bin - 1, std::async(std::launch::async, [=] {
+      //				std::cout << "creating channel tab with these arguments: " << this << ", fSource vector of size " << fSource.size() << ", projection vector of size " << projections.size() << ", " << fMatrices[0]->GetXaxis()->GetBinLabel(bin) << ", " << frame << ", " << fDefaultSigma << ", " << fDefaultThreshold << ", " << fDefaultDegree << ", " << fSourceEnergy.size() << " source energy vectors, " << fProgressBar << "."<< std::endl;
+      //				auto* newTab = new TChannelTab(this, fSource, projections, fMatrices[0]->GetXaxis()->GetBinLabel(bin), frame, fDefaultSigma, fDefaultThreshold, fDefaultDegree, fSourceEnergy, fProgressBar);
+      //				std::cout << "created new tab " << newTab << std::endl;
+      //				return newTab;
+      //				})));
+      //// if we have too many threads running, get the result of the first one (this means waiting on that thread to finish) and assign the results
+      //if(fFutures.size() >= fNumberOfThreads) {
+      //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads running, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+      //	auto tmp = fFutures.front().second.get();
+      //	fChannelTab[fFutures.front().first] = tmp;
+      //	fFutures.pop();
+      //}
+   }
+   // wait for all remaining threads to finish
+   //while(!fFutures.empty()) {
+   //	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fFutures.size() << " threads left, waiting for thread #" << fFutures.front().first << " to finish before starting next, max. # threads " << fNumberOfThreads << std::endl; }
+   //	auto tmp = fFutures.front().second.get();
+   //	fChannelTab[fFutures.front().first] = tmp;
+   //	fFutures.pop();
+   //}
 
-	//if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
+   //if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << fMatrices.size() << " matrices with " << fMatrices[0]->GetNbinsX() << " x-bins, fNofBins " << fNofBins << ", fActualChannelId.size() " << fActualChannelId.size() << ", fChannelTab[0]->SourceTab()->GetNumberOfTabs() " << fChannelTab[0]->SourceTab()->GetNumberOfTabs() << std::endl; }
 
-	//for(int i = 0; i < fChannelTab[0]->SourceTab()->GetNumberOfTabs(); ++i) {
-	//if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
-	//}
+   //for(int i = 0; i < fChannelTab[0]->SourceTab()->GetNumberOfTabs(); ++i) {
+   //if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << i << ": " << fChannelTab[0]->SourceTab()->GetTabTab(i)->GetText()->GetString() << std::endl; }
+   //}
 
-	AddFrame(fTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+   AddFrame(fTab, new TGLayoutHints(kLHintsTop | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
 
-	// bottom frame with navigation button group, text entries, etc.
-	fBottomFrame = new TGHorizontalFrame(this, 2 * fPanelWidth, TSourceCalibration::StatusbarHeight());
+   // bottom frame with navigation button group, text entries, etc.
+   fBottomFrame = new TGHorizontalFrame(this, 2 * fPanelWidth, TSourceCalibration::StatusbarHeight());
 
-	fLeftFrame       = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
-	fNavigationGroup = new TGHButtonGroup(fLeftFrame, "Navigation");
-	fPreviousButton  = new TGTextButton(fNavigationGroup, "&Previous");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
-	fPreviousButton->SetEnabled(false);
-	fDiscardButton = new TGTextButton(fNavigationGroup, "&Discard");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
-	fAcceptButton = new TGTextButton(fNavigationGroup, "&Accept");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept button " << fAcceptButton << std::endl; }
-	fAcceptAllButton = new TGTextButton(fNavigationGroup, "Accept All && Finish");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
-	fWriteButton = new TGTextButton(fNavigationGroup, "&Write");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "write button " << fWriteButton << std::endl; }
-	fNextButton = new TGTextButton(fNavigationGroup, "&Next");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
+   fLeftFrame       = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
+   fNavigationGroup = new TGHButtonGroup(fLeftFrame, "Navigation");
+   fPreviousButton  = new TGTextButton(fNavigationGroup, "&Previous");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "prev button " << fPreviousButton << std::endl; }
+   fPreviousButton->SetEnabled(false);
+   fDiscardButton = new TGTextButton(fNavigationGroup, "&Discard");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "discard button " << fDiscardButton << std::endl; }
+   fAcceptButton = new TGTextButton(fNavigationGroup, "&Accept");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept button " << fAcceptButton << std::endl; }
+   fAcceptAllButton = new TGTextButton(fNavigationGroup, "Accept All && Finish");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "accept all button " << fAcceptAllButton << std::endl; }
+   fWriteButton = new TGTextButton(fNavigationGroup, "&Write");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "write button " << fWriteButton << std::endl; }
+   fNextButton = new TGTextButton(fNavigationGroup, "&Next");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "next button " << fNextButton << std::endl; }
 
-	fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+   fLeftFrame->AddFrame(fNavigationGroup, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
 
-	fFittingGroup        = new TGHButtonGroup(fLeftFrame, "Fitting/Calibrating");
+   fFittingGroup           = new TGHButtonGroup(fLeftFrame, "Fitting/Calibrating");
    fFindSourcePeaksButton  = new TGTextButton(fFittingGroup, "&Find Source Peaks");
    fFindChannelPeaksButton = new TGTextButton(fFittingGroup, "Find Channel Peaks");
    fFindAllPeaksButton     = new TGTextButton(fFittingGroup, "Find All Peaks");
-	fCalibrateButton = new TGTextButton(fFittingGroup, "&Calibrate");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
-	fRecursiveRemoveButton = new TGTextButton(fFittingGroup, "Recursive Remove");
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "remove button " << fRecursiveRemoveButton << std::endl; }
+   fCalibrateButton        = new TGTextButton(fFittingGroup, "&Calibrate");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "cal button " << fCalibrateButton << std::endl; }
+   fRecursiveRemoveButton = new TGTextButton(fFittingGroup, "Recursive Remove");
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "remove button " << fRecursiveRemoveButton << std::endl; }
 
-	fLeftFrame->AddFrame(fFittingGroup, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+   fLeftFrame->AddFrame(fFittingGroup, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
-	fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
+   fBottomFrame->AddFrame(fLeftFrame, new TGLayoutHints(kLHintsLeft, 2, 2, 2, 2));
 
-	fRightFrame     = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
-	fParameterFrame = new TGGroupFrame(fRightFrame, "Parameters", kHorizontalFrame);
-	fParameterFrame->SetLayoutManager(new TGMatrixLayout(fParameterFrame, 0, 4, 2));
-	fSigmaLabel          = new TGLabel(fParameterFrame, "Sigma");
-	fSigmaEntry          = new TGNumberEntry(fParameterFrame, fDefaultSigma, fDigitWidth, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
-	fThresholdLabel      = new TGLabel(fParameterFrame, "Threshold");
-	fThresholdEntry      = new TGNumberEntry(fParameterFrame, fDefaultThreshold, fDigitWidth, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
-	fDegreeLabel         = new TGLabel(fParameterFrame, "Degree of polynomial");
-	fDegreeEntry         = new TGNumberEntry(fParameterFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger, TGNumberFormat::EAttribute::kNEAPositive);
-	fMaxResidualLabel    = new TGLabel(fParameterFrame, "Max. residual (in keV)");
-	fMaxResidualEntry    = new TGNumberEntry(fParameterFrame, fDefaultMaxResidual, fDigitWidth, kMaxResidualEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+   fRightFrame     = new TGVerticalFrame(fBottomFrame, fPanelWidth, fParameterHeight);
+   fParameterFrame = new TGGroupFrame(fRightFrame, "Parameters", kHorizontalFrame);
+   fParameterFrame->SetLayoutManager(new TGMatrixLayout(fParameterFrame, 0, 4, 2));
+   fSigmaLabel       = new TGLabel(fParameterFrame, "Sigma");
+   fSigmaEntry       = new TGNumberEntry(fParameterFrame, fDefaultSigma, fDigitWidth, kSigmaEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
+   fThresholdLabel   = new TGLabel(fParameterFrame, "Threshold");
+   fThresholdEntry   = new TGNumberEntry(fParameterFrame, fDefaultThreshold, fDigitWidth, kThresholdEntry, TGNumberFormat::EStyle::kNESRealThree, TGNumberFormat::EAttribute::kNEAPositive, TGNumberFormat::ELimit::kNELLimitMinMax, 0., 1.);
+   fDegreeLabel      = new TGLabel(fParameterFrame, "Degree of polynomial");
+   fDegreeEntry      = new TGNumberEntry(fParameterFrame, fDefaultDegree, 2, kDegreeEntry, TGNumberFormat::EStyle::kNESInteger, TGNumberFormat::EAttribute::kNEAPositive);
+   fMaxResidualLabel = new TGLabel(fParameterFrame, "Max. residual (in keV)");
+   fMaxResidualEntry = new TGNumberEntry(fParameterFrame, fDefaultMaxResidual, fDigitWidth, kMaxResidualEntry, TGNumberFormat::EStyle::kNESRealTwo, TGNumberFormat::EAttribute::kNEAPositive);
 
-	fParameterFrame->AddFrame(fSigmaLabel);
-	fParameterFrame->AddFrame(fSigmaEntry);
-	fParameterFrame->AddFrame(fThresholdLabel);
-	fParameterFrame->AddFrame(fThresholdEntry);
-	fParameterFrame->AddFrame(fDegreeLabel);
-	fParameterFrame->AddFrame(fDegreeEntry);
-	fParameterFrame->AddFrame(fMaxResidualLabel);
-	fParameterFrame->AddFrame(fMaxResidualEntry);
+   fParameterFrame->AddFrame(fSigmaLabel);
+   fParameterFrame->AddFrame(fSigmaEntry);
+   fParameterFrame->AddFrame(fThresholdLabel);
+   fParameterFrame->AddFrame(fThresholdEntry);
+   fParameterFrame->AddFrame(fDegreeLabel);
+   fParameterFrame->AddFrame(fDegreeEntry);
+   fParameterFrame->AddFrame(fMaxResidualLabel);
+   fParameterFrame->AddFrame(fMaxResidualEntry);
 
-	fRightFrame->AddFrame(fParameterFrame, new TGLayoutHints(kLHintsTop | kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
+   fRightFrame->AddFrame(fParameterFrame, new TGLayoutHints(kLHintsTop | kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
 
-	fSettingsFrame = new TGGroupFrame(fRightFrame, "Settings", kHorizontalFrame);
-	fSettingsFrame->SetLayoutManager(new TGMatrixLayout(fSettingsFrame, 0, 2, 2));
-	fApplyToAll = new TGCheckButton(fSettingsFrame, "Apply to all channels", kApplyToAll);
-	fApplyToAll->SetState(kButtonUp);
-	fSettingsFrame->AddFrame(fApplyToAll);
-	fWriteNonlinearities = new TGCheckButton(fSettingsFrame, "Write nonlinearities", kWriteNonlinearities);
-	fWriteNonlinearities->SetState(kButtonUp);
-	fSettingsFrame->AddFrame(fWriteNonlinearities);
+   fSettingsFrame = new TGGroupFrame(fRightFrame, "Settings", kHorizontalFrame);
+   fSettingsFrame->SetLayoutManager(new TGMatrixLayout(fSettingsFrame, 0, 2, 2));
+   fApplyToAll = new TGCheckButton(fSettingsFrame, "Apply to all channels", kApplyToAll);
+   fApplyToAll->SetState(kButtonUp);
+   fSettingsFrame->AddFrame(fApplyToAll);
+   fWriteNonlinearities = new TGCheckButton(fSettingsFrame, "Write nonlinearities", kWriteNonlinearities);
+   fWriteNonlinearities->SetState(kButtonUp);
+   fSettingsFrame->AddFrame(fWriteNonlinearities);
 
-	fRightFrame->AddFrame(fSettingsFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
+   fRightFrame->AddFrame(fSettingsFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight | kLHintsExpandX, 2, 2, 2, 2));
 
-	fBottomFrame->AddFrame(fRightFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight, 2, 2, 2, 2));
+   fBottomFrame->AddFrame(fRightFrame, new TGLayoutHints(kLHintsBottom | kLHintsRight, 2, 2, 2, 2));
 
-	AddFrame(fBottomFrame, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
+   AddFrame(fBottomFrame, new TGLayoutHints(kLHintsBottom | kLHintsExpandX, 2, 2, 2, 2));
 
-	SelectedTab(0);
+   SelectedTab(0);
 
-	fProgressBar->Reset();
-	fProgressBar->ShowPosition(true, false, "Finding peaks for tab #%.0f");
-	for(auto* channelTab : fChannelTab) {
-		if(channelTab != nullptr) {
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-				for(int i = 0; i < 5; ++i) {
-					std::cout << "================================================================================" << std::endl;
-				}
-				for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
-			}
-			channelTab->Initialize(true);
-			channelTab->FindAllCalibratedPeaks();
-			channelTab->Calibrate();
-			channelTab->Draw();
-			if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
-				channelTab->PrintCanvases();
-			}
-		}
-	}
+   fProgressBar->Reset();
+   fProgressBar->ShowPosition(true, false, "Finding peaks for tab #%.0f");
+   for(auto* channelTab : fChannelTab) {
+      if(channelTab != nullptr) {
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+            for(int i = 0; i < 5; ++i) {
+               std::cout << "================================================================================" << std::endl;
+            }
+            for(int i = 0; i < 20; ++i) { std::cout << std::endl; }
+         }
+         channelTab->Initialize(true);
+         channelTab->FindAllCalibratedPeaks();
+         channelTab->Calibrate();
+         channelTab->Draw();
+         if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
+            channelTab->PrintCanvases();
+         }
+      }
+   }
 
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << "Second interface done" << std::endl; }
 }
 
 void TSourceCalibration::MakeSecondConnections()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
-	fFittingGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Fitting(Int_t)");
-	fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
-	// we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
-	for(auto* channelTab : fChannelTab) {
-		if(channelTab != nullptr) {
-			channelTab->MakeConnections();
-		}
-	}
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   fNavigationGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Navigate(Int_t)");
+   fFittingGroup->Connect("Clicked(Int_t)", "TSourceCalibration", this, "Fitting(Int_t)");
+   fTab->Connect("Selected(Int_t)", "TSourceCalibration", this, "SelectedTab(Int_t)");
+   // we don't need to connect the sigma, threshold, and degree number entries, those are automatically read when we start the calibration
+   for(auto* channelTab : fChannelTab) {
+      if(channelTab != nullptr) {
+         channelTab->MakeConnections();
+      }
+   }
 }
 
 void TSourceCalibration::DisconnectSecond()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
-	fFittingGroup->Disconnect("Clicked(Int_t)", this, "Fitting(Int_t)");
-	fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
-	for(auto* channelTab : fChannelTab) {
-		if(channelTab != nullptr) {
-			channelTab->Disconnect();
-		}
-	}
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   fNavigationGroup->Disconnect("Clicked(Int_t)", this, "Navigate(Int_t)");
+   fFittingGroup->Disconnect("Clicked(Int_t)", this, "Fitting(Int_t)");
+   fTab->Disconnect("Selected(Int_t)", this, "SelectedTab(Int_t)");
+   for(auto* channelTab : fChannelTab) {
+      if(channelTab != nullptr) {
+         channelTab->Disconnect();
+      }
+   }
 }
 
 void TSourceCalibration::Navigate(Int_t id)
 {
-	// we get the current source tab id and use it to get the channel tab from the right source tab
-	// since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
-	// for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
-	int currentChannelId = fTab->GetCurrent();
-	int actualChannelId  = fActualChannelId[currentChannelId];
-	int nofTabs          = fTab->GetNumberOfTabs();
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
-	switch(id) {
-		case ENavigate::kPrevious:   // previous
-			fTab->SetTab(currentChannelId - 1);
-			SelectedTab(currentChannelId - 1);
-			break;
-		case ENavigate::kDiscard:   // discard
-											 // select the next (or if we are on the last tab, the previous) tab
-			if(currentChannelId < nofTabs - 1) {
-				fTab->SetTab(currentChannelId + 1);
-			} else {
-				fTab->SetTab(currentChannelId - 1);
-			}
-			// remove the original active tab
-			fTab->RemoveTab(currentChannelId);
-			break;
-		case ENavigate::kAccept:   // accept
-			AcceptChannel(currentChannelId);
-			break;
-		case ENavigate::kAcceptAll:   // accept all (no argument = -1 = all)
-			AcceptChannel();
-			return;
-		case ENavigate::kWrite:   // write
-			WriteCalibration();
-			break;
-		case ENavigate::kNext:   // next
-			fTab->SetTab(currentChannelId + 1);
-			SelectedTab(currentChannelId + 1);
-			break;
-		default:
-			break;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   // we get the current source tab id and use it to get the channel tab from the right source tab
+   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+   int currentChannelId = fTab->GetCurrent();
+   int actualChannelId  = fActualChannelId[currentChannelId];
+   int nofTabs          = fTab->GetNumberOfTabs();
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   switch(id) {
+   case ENavigate::kPrevious:   // previous
+      fTab->SetTab(currentChannelId - 1);
+      SelectedTab(currentChannelId - 1);
+      break;
+   case ENavigate::kDiscard:   // discard
+                               // select the next (or if we are on the last tab, the previous) tab
+      if(currentChannelId < nofTabs - 1) {
+         fTab->SetTab(currentChannelId + 1);
+      } else {
+         fTab->SetTab(currentChannelId - 1);
+      }
+      // remove the original active tab
+      fTab->RemoveTab(currentChannelId);
+      break;
+   case ENavigate::kAccept:   // accept
+      AcceptChannel(currentChannelId);
+      break;
+   case ENavigate::kAcceptAll:   // accept all (no argument = -1 = all)
+      AcceptChannel();
+      return;
+   case ENavigate::kWrite:   // write
+      WriteCalibration();
+      break;
+   case ENavigate::kNext:   // next
+      fTab->SetTab(currentChannelId + 1);
+      SelectedTab(currentChannelId + 1);
+      break;
+   default:
+      break;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
 }
 
 void TSourceCalibration::Fitting(Int_t id)
 {
-	// we get the current source tab id and use it to get the channel tab from the right source tab
-	// since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
-	// for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
-	int currentChannelId = fTab->GetCurrent();
-	int actualChannelId  = fActualChannelId[currentChannelId];
-	int nofTabs          = fTab->GetNumberOfTabs();
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
-	switch(id) {
-		case EFitting::kFindSourcePeaks:   // find peaks for selected source
-			FindSourcePeaks();
-			break;
-		case EFitting::kFindChannelPeaks:   // find peaks for selected channel
-			FindChannelPeaks();
-			break;
-		case EFitting::kFindAllPeaks:   // find all peaks
-			FindAllPeaks();
-			break;
-		case EFitting::kCalibrate:   // calibrate
-			Calibrate();
-			break;
-		case EFitting::kRecursiveRemove:   // recursively remove outliers
-			RecursiveRemove();
-			break;
-		default:
-			break;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   // we get the current source tab id and use it to get the channel tab from the right source tab
+   // since the current id only refers to the position within the open tabs we need to keep track of the actual id it relates to
+   // for this we created a vector with all ids at the beginning and now remove the position correspoding to the current id when we remove the tab
+   int currentChannelId = fTab->GetCurrent();
+   int actualChannelId  = fActualChannelId[currentChannelId];
+   int nofTabs          = fTab->GetNumberOfTabs();
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", channel tab id " << currentChannelId << ", actual channel tab id " << actualChannelId << ", # of tabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << "Before: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
+   switch(id) {
+   case EFitting::kFindSourcePeaks:   // find peaks for selected source
+      FindSourcePeaks();
+      break;
+   case EFitting::kFindChannelPeaks:   // find peaks for selected channel
+      FindChannelPeaks();
+      break;
+   case EFitting::kFindAllPeaks:   // find all peaks
+      FindAllPeaks();
+      break;
+   case EFitting::kCalibrate:   // calibrate
+      Calibrate();
+      break;
+   case EFitting::kRecursiveRemove:   // recursively remove outliers
+      RecursiveRemove();
+      break;
+   default:
+      break;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "After: active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << std::endl; }
 }
 
 void TSourceCalibration::SelectedTab(Int_t id)
 {
-	/// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
-	/// Also sets gPad to the projection of the source selected in this tab.
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", nofTabs " << fTab->GetNumberOfTabs() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(id < 0) { return; }
-	if(id == 0) {
-		fPreviousButton->SetEnabled(false);
-	} else {
-		fPreviousButton->SetEnabled(true);
-	}
+   /// Simple function that enables and disables the previous and next buttons depending on which tab was selected.
+   /// Also sets gPad to the projection of the source selected in this tab.
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": id " << id << ", nofTabs " << fTab->GetNumberOfTabs() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(id < 0) { return; }
+   if(id == 0) {
+      fPreviousButton->SetEnabled(false);
+   } else {
+      fPreviousButton->SetEnabled(true);
+   }
 
-	if(id >= fTab->GetNumberOfTabs() - 1) {
-		fNextButton->SetEnabled(false);
-	} else {
-		fNextButton->SetEnabled(true);
-	}
+   if(id >= fTab->GetNumberOfTabs() - 1) {
+      fNextButton->SetEnabled(false);
+   } else {
+      fNextButton->SetEnabled(true);
+   }
 
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "active source tab of tab " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Name() << ", #" << fTab->GetCurrent() << " = bin " << fActiveBins[fTab->GetCurrent()] << ": " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->ActiveSourceTab() << RESET_COLOR << std::endl; }
 
-	if(fChannelTab[fActiveBins[id] - 1] == nullptr) {
-		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab() == nullptr) {
-		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas() == nullptr) {
-		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas() == nullptr) {
-		std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
-		return;
-	}
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
-	gPad = fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas();
-	fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()->cd();
-	if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
+   if(fChannelTab[fActiveBins[id] - 1] == nullptr) {
+      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab() == nullptr) {
+      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas() == nullptr) {
+      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas() == nullptr) {
+      std::cout << "Failed to get fChannelTab[" << fActiveBins[id] - 1 << " = fActiveBins[" << id << "]-1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()" << RESET_COLOR << std::endl;
+      return;
+   }
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << DGREEN << "Changing gpad from  \"" << gPad->GetName() << "\" to \""; }
+   gPad = fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas();
+   fChannelTab[fActiveBins[id] - 1]->SelectedSourceTab()->ProjectionCanvas()->GetCanvas()->cd();
+   if(TSourceCalibration::VerboseLevel() > EVerbosity::kBasicFlow) { std::cout << gPad->GetName() << "\"" << RESET_COLOR << std::endl; }
 }
 
 void TSourceCalibration::AcceptChannel(const int& channelId)
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": channelId " << channelId << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-	// select the next (or if we are on the last tab, the previous) tab
-	int nofTabs    = fTab->GetNumberOfTabs();
-	int minChannel = 0;
-	int maxChannel = nofTabs - 1;
-	if(channelId >= 0) {
-		minChannel = channelId;
-		maxChannel = channelId;
-	}
+   // select the next (or if we are on the last tab, the previous) tab
+   int nofTabs    = fTab->GetNumberOfTabs();
+   int minChannel = 0;
+   int maxChannel = nofTabs - 1;
+   if(channelId >= 0) {
+      minChannel = channelId;
+      maxChannel = channelId;
+   }
 
-	// we need to loop backward, because removing the first channel would make the second one the new first and so on
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	for(int currentChannelId = maxChannel; currentChannelId >= minChannel; --currentChannelId) {
-		int actualChannelId = fActualChannelId[currentChannelId];
-		if(fVerboseLevel > EVerbosity::kLoops) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << ", nofTabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   // we need to loop backward, because removing the first channel would make the second one the new first and so on
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": accepting channels " << maxChannel << " to " << minChannel << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   for(int currentChannelId = maxChannel; currentChannelId >= minChannel; --currentChannelId) {
+      int actualChannelId = fActualChannelId[currentChannelId];
+      if(fVerboseLevel > EVerbosity::kLoops) { std::cout << __PRETTY_FUNCTION__ << ": currentChannelId " << currentChannelId << ", actualChannelId " << actualChannelId << ", fChannelTab.size() " << fChannelTab.size() << ", fActualChannelId.size() " << fActualChannelId.size() << ", nofTabs " << nofTabs << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-		if(minChannel == maxChannel) {   // we don't need to select the tab if we close all
-			if(currentChannelId < nofTabs) {
-				fTab->SetTab(currentChannelId + 1);
-				if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId + 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			} else {
-				fTab->SetTab(currentChannelId - 1);
-				if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId - 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-			}
-		}
+      if(minChannel == maxChannel) {   // we don't need to select the tab if we close all
+         if(currentChannelId < nofTabs) {
+            fTab->SetTab(currentChannelId + 1);
+            if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId + 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         } else {
+            fTab->SetTab(currentChannelId - 1);
+            if(fVerboseLevel > EVerbosity::kLoops) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": set tab to " << currentChannelId - 1 << " = " << fTab->GetCurrent() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+         }
+      }
 
-		// remove the original active tab
-		fTab->RemoveTab(currentChannelId);   // this sets the selected tab to zero if the deleted tab is the currently selected one, which is why we do it now (after we've selected a new tab)
-		fActualChannelId.erase(fActualChannelId.begin() + currentChannelId);
-		fActiveBins.erase(fActiveBins.begin() + currentChannelId);
-	}
-	if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-																																																						  // check if this changes which buttons are enabled or not (not using the variables from the beginning of this block because they might have changed by now!)
-	SelectedTab(fTab->GetCurrent());
-	// if this was also the last source vector we initiate the last screen
-	if(fActualChannelId.empty() || fActiveBins.empty()) {
-		if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "last channel tab done - writing files now" << std::endl; }
-		fEmitter = fAcceptAllButton;
-		TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
-	}
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+      // remove the original active tab
+      fTab->RemoveTab(currentChannelId);   // this sets the selected tab to zero if the deleted tab is the currently selected one, which is why we do it now (after we've selected a new tab)
+      fActualChannelId.erase(fActualChannelId.begin() + currentChannelId);
+      fActiveBins.erase(fActiveBins.begin() + currentChannelId);
+   }
+   if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": # of channel tabs " << fActualChannelId.size() << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                                                                                                                                                                    // check if this changes which buttons are enabled or not (not using the variables from the beginning of this block because they might have changed by now!)
+   SelectedTab(fTab->GetCurrent());
+   // if this was also the last source vector we initiate the last screen
+   if(fActualChannelId.empty() || fActiveBins.empty()) {
+      if(fVerboseLevel > EVerbosity::kSubroutines) { std::cout << "last channel tab done - writing files now" << std::endl; }
+      fEmitter = fAcceptAllButton;
+      TTimer::SingleShot(fWaitMs, "TSourceCalibration", this, "HandleTimer()");
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindSourcePeaks()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fApplyToAll->IsDown()) {
-		auto* window = CreateProgressbar("Finding current source peaks in channel #%.0f");
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fApplyToAll->IsDown()) {
+      auto* window = CreateProgressbar("Finding current source peaks in channel #%.0f");
 
-		for(auto& bin : fActiveBins) {
-			if(fChannelTab[bin - 1] != nullptr) {
-				fChannelTab[bin - 1]->FindCalibratedPeaks();
-				fChannelTab[bin - 1]->Calibrate();
-			}
-			fProgressBar->Increment(1);
-		}
-		window->CloseWindow();
-		delete fProgressBar;
-	} else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindCalibratedPeaks();
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
-	} else {
-		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+      for(auto& bin : fActiveBins) {
+         if(fChannelTab[bin - 1] != nullptr) {
+            fChannelTab[bin - 1]->FindCalibratedPeaks();
+            fChannelTab[bin - 1]->Calibrate();
+         }
+         fProgressBar->Increment(1);
+      }
+      window->CloseWindow();
+      delete fProgressBar;
+   } else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindCalibratedPeaks();
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
+   } else {
+      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindChannelPeaks()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindAllCalibratedPeaks();
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
-	} else {
-		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->FindAllCalibratedPeaks();
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
+   } else {
+      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::FindAllPeaks()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	auto* window = CreateProgressbar("Finding all source peaks for channel #%.0f");
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   auto* window = CreateProgressbar("Finding all source peaks for channel #%.0f");
 
-	for(auto& bin : fActiveBins) {
-		if(fChannelTab[bin - 1] != nullptr) {
-			fChannelTab[bin - 1]->FindAllCalibratedPeaks();
-			fChannelTab[bin - 1]->Calibrate();
-		} else {
-			std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << bin << "] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-		}
-		fProgressBar->Increment(1);
-	}
-	window->CloseWindow();
-	delete fProgressBar;
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+   for(auto& bin : fActiveBins) {
+      if(fChannelTab[bin - 1] != nullptr) {
+         fChannelTab[bin - 1]->FindAllCalibratedPeaks();
+         fChannelTab[bin - 1]->Calibrate();
+      } else {
+         std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << bin << "] is a nullptr!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+      }
+      fProgressBar->Increment(1);
+   }
+   window->CloseWindow();
+   delete fProgressBar;
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::Calibrate()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fApplyToAll->IsDown()) {
-		auto* window = CreateProgressbar("Calibrating channel #%.0f");
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fApplyToAll->IsDown()) {
+      auto* window = CreateProgressbar("Calibrating channel #%.0f");
 
-		for(auto& bin : fActiveBins) {
-			if(fChannelTab[bin - 1] != nullptr) {
-				fChannelTab[bin - 1]->Calibrate();
-			}
-			fProgressBar->Increment(1);
-		}
-		window->CloseWindow();
-		delete fProgressBar;
-	} else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
-	} else {
-		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+      for(auto& bin : fActiveBins) {
+         if(fChannelTab[bin - 1] != nullptr) {
+            fChannelTab[bin - 1]->Calibrate();
+         }
+         fProgressBar->Increment(1);
+      }
+      window->CloseWindow();
+      delete fProgressBar;
+   } else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->Calibrate();
+   } else {
+      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::RecursiveRemove()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fApplyToAll->IsDown()) {
-		auto* window = CreateProgressbar("Recursively removing peaks for channel #%.0f");
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fApplyToAll->IsDown()) {
+      auto* window = CreateProgressbar("Recursively removing peaks for channel #%.0f");
 
-		for(auto& bin : fActiveBins) {
-			if(fChannelTab[bin - 1] != nullptr) {
-				if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Starting recursive remove for bin " << bin << ", fChannelTab[bin - 1] " << fChannelTab[bin - 1] << std::endl; }
-				fChannelTab[bin - 1]->RecursiveRemove(MaxResidual());
-			}
-			fProgressBar->Increment(1);
-		}
-		window->CloseWindow();
-		delete fProgressBar;
-	} else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
-		if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Starting recursive remove for bin " << fActiveBins[fTab->GetCurrent() - 1] << ", fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] << std::endl; }
-		fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->RecursiveRemove(MaxResidual());
-	} else {
-		std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	}
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
+      for(auto& bin : fActiveBins) {
+         if(fChannelTab[bin - 1] != nullptr) {
+            if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Starting recursive remove for bin " << bin << ", fChannelTab[bin - 1] " << fChannelTab[bin - 1] << std::endl; }
+            fChannelTab[bin - 1]->RecursiveRemove(MaxResidual());
+         }
+         fProgressBar->Increment(1);
+      }
+      window->CloseWindow();
+      delete fProgressBar;
+   } else if(fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] != nullptr) {
+      if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << "Starting recursive remove for bin " << fActiveBins[fTab->GetCurrent() - 1] << ", fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] " << fChannelTab[fActiveBins[fTab->GetCurrent()] - 1] << std::endl; }
+      fChannelTab[fActiveBins[fTab->GetCurrent()] - 1]->RecursiveRemove(MaxResidual());
+   } else {
+      std::cout << __PRETTY_FUNCTION__ << ": fChannelTab[" << fActiveBins[fTab->GetCurrent()] << " = fActiveBins[" << fTab->GetCurrent() << "]] is a nullptr (fApplyToAll is " << (fApplyToAll->IsDown() ? "down" : "up") << ")!" << std::endl;   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << RESET_COLOR << std::flush; }
 }
 
 void TSourceCalibration::WriteCalibration()
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	std::ostringstream fileName;
-	for(auto* source : fSource) {
-		fileName << source->GetName();
-	}
-	fileName << ".cal";
-	TChannel::WriteCalFile(fileName.str());
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-	if(fVerboseLevel > EVerbosity::kSubroutines) { TChannel::WriteCalFile(); }
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   std::ostringstream fileName;
+   for(auto* source : fSource) {
+      fileName << source->GetName();
+   }
+   fileName << ".cal";
+   TChannel::WriteCalFile(fileName.str());
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << ": wrote " << fileName.str() << " with " << TChannel::GetNumberOfChannels() << " channels" << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kSubroutines) { TChannel::WriteCalFile(); }
 }
 
 TGTransientFrame* TSourceCalibration::CreateProgressbar(const char* format)
 {
-	auto* window = new TGTransientFrame(gClient->GetRoot(), this, fPanelWidth, fStatusbarHeight);
-	fProgressBar = new TGHProgressBar(window, TGProgressBar::kFancy, fPanelWidth);
-	fProgressBar->SetBarColor("lightblue");
-	fProgressBar->SetRange(0., static_cast<Float_t>(fActiveBins.size()));
-	fProgressBar->ShowPosition(true, false, format);
-	window->AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
-	window->CenterOnParent();
-	window->MapSubwindows();
-	window->MapWindow();
-	window->Resize(window->GetDefaultSize());
+   auto* window = new TGTransientFrame(gClient->GetRoot(), this, fPanelWidth, fStatusbarHeight);
+   fProgressBar = new TGHProgressBar(window, TGProgressBar::kFancy, fPanelWidth);
+   fProgressBar->SetBarColor("lightblue");
+   fProgressBar->SetRange(0., static_cast<Float_t>(fActiveBins.size()));
+   fProgressBar->ShowPosition(true, false, format);
+   window->AddFrame(fProgressBar, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY | kLHintsExpandX | kLHintsExpandY, 0, 0, 0, 0));
+   window->CenterOnParent();
+   window->MapSubwindows();
+   window->MapWindow();
+   window->Resize(window->GetDefaultSize());
 
-	return window;
+   return window;
 }
 
 void TSourceCalibration::PrintLayout() const
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-	Print();
-	if(fBottomFrame != nullptr) { fBottomFrame->Print(); }
-	if(fLeftFrame != nullptr) { fLeftFrame->Print(); }
-	if(fRightFrame != nullptr) { fRightFrame->Print(); }
-	if(fTab != nullptr) { fTab->Print(); }
-	std::cout << "TSourceCalibration all " << fChannelTab.size() << " channel tabs:" << std::endl;
-	for(auto* channelTab : fChannelTab) {
-		if(channelTab != nullptr) { channelTab->PrintLayout(); }
-	}
+   Print();
+   if(fBottomFrame != nullptr) { fBottomFrame->Print(); }
+   if(fLeftFrame != nullptr) { fLeftFrame->Print(); }
+   if(fRightFrame != nullptr) { fRightFrame->Print(); }
+   if(fTab != nullptr) { fTab->Print(); }
+   std::cout << "TSourceCalibration all " << fChannelTab.size() << " channel tabs:" << std::endl;
+   for(auto* channelTab : fChannelTab) {
+      if(channelTab != nullptr) { channelTab->PrintLayout(); }
+   }
 }
 
 void TSourceCalibration::PrintCanvases() const
 {
-	if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+   if(fVerboseLevel > EVerbosity::kBasicFlow) { std::cout << DGREEN << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 
-	for(auto* channelTab : fChannelTab) {
-		if(channelTab != nullptr) { channelTab->PrintCanvases(); }
-	}
+   for(auto* channelTab : fChannelTab) {
+      if(channelTab != nullptr) { channelTab->PrintCanvases(); }
+   }
 }

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -1916,11 +1916,11 @@ void TChannelTab::Initialize(const double& sigma, const double& threshold, const
       fCalLabel->Clear();
    }
    std::stringstream str;
-	if(fInit->FitFunction()->GetNpar() == 3) {
-		str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
-	} else {
-		str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
-	}
+   if(fInit->FitFunction()->GetNpar() == 3) {
+      str << "Fit function: " << fInit->FitFunction()->GetParameter(1) << " + " << fInit->FitFunction()->GetParameter(2) << " x";
+   } else {
+      str << "Unknown fit function with " << fInit->FitFunction()->GetNpar() << " parameters";
+   }
    if(TSourceCalibration::VerboseLevel() > EVerbosity::kSubroutines) {
       std::cout << "Created label text \"" << str.str() << "\"" << std::endl;
    }


### PR DESCRIPTION
- Fixed almost all bugs in `TSourceCalibration`, only ones left are some graphics bugs that can easily be fixed by the user.
- Fixed a bug in `TRedirect` where the redirect would not get closed at the end, increasing the number of open files with every call to it.
- `TPeakFitter`: fit functions name now includes the range of the fit, and added access functions for the individual peaks.
- Fixed bug in `TSinglePeak` where `SetLineStyle` would actually set the colour, not the style of the line and added getters for both the colour and the style of the fit function.
