### PR TITLE
Small changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(GRSISort)
 
 #----------------------------------------------------------------------------
+# Check that we are building out of source
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+	message(FATAL_ERROR "In-source builds are not recommended, please re-run from a separate build directory, or specify the build directory via the -B flag.")
+endif()
+
+#----------------------------------------------------------------------------
 # find git (to set version correctly)
 find_package(Git REQUIRED)
 

--- a/libraries/TGUI/TSourceCalibration.cxx
+++ b/libraries/TGUI/TSourceCalibration.cxx
@@ -2210,8 +2210,8 @@ TSourceCalibration::TSourceCalibration(double sigma, double threshold, int degre
    for(size_t i = 1; i < fMatrices.size(); ++i) {
       int tmpBins = 0;
       for(int bin = 1; bin <= fMatrices[i]->GetNbinsX(); ++bin) {
-         if(FilledBin(fMatrices[i], bin), std::find(fBadBins.begin(), fBadBins.end(), bin) == fBadBins.end()) {   // good bin in the current matrix
-                                                                                                                  // current index is tmpBins, so we check if the bin agrees with what we have
+         if(FilledBin(fMatrices[i], bin)) {   // good bin in the current matrix
+															 // current index is tmpBins, so we check if the bin agrees with what we have
             if(channelToIndex.find(bin) == channelToIndex.end() || tmpBins != channelToIndex[bin]) {              // found a full bin, but the corresponding bin in the first matrix isn't full or a different bin
                std::ostringstream error;
                error << "Mismatch in " << i << ". matrix (" << fMatrices[i]->GetName() << "), bin " << bin << " is " << tmpBins << ". filled bin, but should be " << (channelToIndex.find(bin) == channelToIndex.end() ? "not filled" : Form("%d", channelToIndex[bin])) << std::endl;

--- a/util/WriteCalToRoot.cxx
+++ b/util/WriteCalToRoot.cxx
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
 
    // See if we can open the cal file
    if(TChannel::ReadCalFile(argv[2]) < 1) {
-      std::cout << "Bad Cal File: " << argv[1] << std::endl;
+      std::cout << "Bad Cal File: " << argv[2] << std::endl;
       return 1;
    }
 

--- a/util/grsiframe.cxx
+++ b/util/grsiframe.cxx
@@ -79,11 +79,7 @@ int main(int argc, char** argv)
    // determine the name of the helper (from the provided helper library) to create a redirect of stdout
    std::string logFileName = opt->DataFrameLibrary();
    logFileName             = logFileName.substr(logFileName.find_last_of('/') + 1);   // strip everything before the last slash
-   if(logFileName.find("Helper") != std::string::npos) {
-      logFileName = logFileName.substr(0, logFileName.find("Helper"));   // strip "Helper" and anything after it (like the extension)
-   } else {
-      logFileName = logFileName.substr(0, logFileName.find_last_of('.'));   // strip extension since we didn't find "Helper" in the name
-   }
+	logFileName = logFileName.substr(0, logFileName.find_last_of('.'));   // strip extension
    logFileName.append(TRunInfo::CreateLabel(true));
    logFileName.append(".log");
 


### PR DESCRIPTION
- CMakeLists.txt: added check for in-source build.
- WriteCalToRoot: Fixed bug where the wrong command line argument was reported if the cal-file is bad.
- grsiframe: When determining the name of the log-file we only remove the extension of the helper file, not the "Helper" part of it.