### PR TITLE
Fixed bug in GetTimeStampNs with time offset

### DIFF
--- a/libraries/TFormat/TDetectorHit.cxx
+++ b/libraries/TFormat/TDetectorHit.cxx
@@ -230,7 +230,7 @@ Long64_t TDetectorHit::GetTimeStampNs(Option_t*) const
    if(tmpChan == nullptr) {
       return GetTimeStamp();   // GetTimeStampUnit returns 1 of there is no channel
    }
-   return GetTimeStamp() * GetTimeStampUnit() * static_cast<Long64_t>((1.0 - tmpChan->GetTimeDrift()) - static_cast<double>(tmpChan->GetTimeOffset()));
+   return GetTimeStamp() * GetTimeStampUnit() * static_cast<Long64_t>((1.0 - tmpChan->GetTimeDrift())) - static_cast<double>(tmpChan->GetTimeOffset());
 }
 
 Int_t TDetectorHit::GetTimeStampUnit() const


### PR DESCRIPTION
The parentheses were places wrong so that any time offset of a channel would be multiplied into the timestamp.