### PR TITLE
Improvement to GainDrift program and linter fixes

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -9,23 +9,23 @@ void AngularCorrelationHelper::CreateHistograms(unsigned int slot)
       fBgoDeque[slot].emplace_back(new TGriffinBgo);
    }
 
-	// try and get the cycle length if we have a PPG provided
-	// but only if either the upper or the lower limit of the cycle time is set
-	if(fCycleTimeLow >= 0. || fCycleTimeHigh >= 0.) {
-		if(fPpg != nullptr) {
-			// the ODB cycle length is in microseconds!
-			fCycleLength = fPpg->OdbCycleLength();
-			if(slot == 0) {
-				std::stringstream str;
-				str << "Got ODB cycle length " << fCycleLength << " us = " << fCycleLength / 1e6 << " s" << std::endl;
-				std::cout << str.str();
-			}
-		} else if(slot == 0) {
-			std::stringstream str;
-			str << DRED << "No ppg provided, won't be able to apply cycle cut!" << RESET_COLOR << std::endl;
-			std::cout << str.str();
-		}
-	}
+   // try and get the cycle length if we have a PPG provided
+   // but only if either the upper or the lower limit of the cycle time is set
+   if(fCycleTimeLow >= 0. || fCycleTimeHigh >= 0.) {
+      if(fPpg != nullptr) {
+         // the ODB cycle length is in microseconds!
+         fCycleLength = fPpg->OdbCycleLength();
+         if(slot == 0) {
+            std::stringstream str;
+            str << "Got ODB cycle length " << fCycleLength << " us = " << fCycleLength / 1e6 << " s" << std::endl;
+            std::cout << str.str();
+         }
+      } else if(slot == 0) {
+         std::stringstream str;
+         str << DRED << "No ppg provided, won't be able to apply cycle cut!" << RESET_COLOR << std::endl;
+         std::cout << str.str();
+      }
+   }
 
    std::string conditions = fAddback ? "using addback" : "without addback";
    conditions += fSingleCrystal ? " single crystal" : "";
@@ -51,22 +51,22 @@ void AngularCorrelationHelper::CreateHistograms(unsigned int slot)
 
 void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGriffinBgo& fGriffinBgo)
 {
-	bool eventInCycleCut = false;
+   bool eventInCycleCut = false;
    for(auto g1 = 0; g1 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g1) {
       auto grif1 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g1) : fGriffin.GetSuppressedHit(g1));
       if(ExcludeDetector(grif1->GetDetector()) || ExcludeCrystal(grif1->GetArrayNumber())) continue;
-		if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g1) > 1) continue;
-		if(!GoodCycleTime(std::fmod(grif1->GetTime()/1e3, fCycleLength))) continue;
+      if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g1) > 1) continue;
+      if(!GoodCycleTime(std::fmod(grif1->GetTime() / 1e3, fCycleLength))) continue;
 
-		// we only get here if at least one hit of the event is within the cycle cut
-		eventInCycleCut = true;
+      // we only get here if at least one hit of the event is within the cycle cut
+      eventInCycleCut = true;
 
       for(auto g2 = 0; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
          if(g1 == g2) continue;
          auto grif2 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g2) : fGriffin.GetSuppressedHit(g2));
          if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber())) continue;
-			if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g2) > 1) continue;
-			if(!GoodCycleTime(std::fmod(grif2->GetTime()/1e3, fCycleLength))) continue;
+         if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g2) > 1) continue;
+         if(!GoodCycleTime(std::fmod(grif2->GetTime() / 1e3, fCycleLength))) continue;
 
          // skip hits in the same detector when using addback, or in the same crystal when not using addback
          if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) {
@@ -99,8 +99,8 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
          for(auto g2 = 0; g2 < (fAddback ? fLastGriffin->GetSuppressedAddbackMultiplicity(fLastBgo) : fLastGriffin->GetSuppressedMultiplicity(fLastBgo)); ++g2) {
             auto grif2 = (fAddback ? fLastGriffin->GetSuppressedAddbackHit(g2) : fLastGriffin->GetSuppressedHit(g2));
             if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber())) continue;
-				if(fSingleCrystal && fLastGriffin->GetNSuppressedAddbackFrags(g2) > 1) continue;
-				if(!GoodCycleTime(std::fmod(grif2->GetTime()/1e3, fCycleLength))) continue;
+            if(fSingleCrystal && fLastGriffin->GetNSuppressedAddbackFrags(g2) > 1) continue;
+            if(!GoodCycleTime(std::fmod(grif2->GetTime() / 1e3, fCycleLength))) continue;
 
             // skip hits in the same detector when using addback, or in the same crystal when not using addback
             if(grif1->GetDetector() == grif2->GetDetector() && (fAddback || grif1->GetCrystal() == grif2->GetCrystal())) continue;
@@ -119,15 +119,15 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
       }
    }
 
-	if(eventInCycleCut) {
-		// Add the current event to the queue, delete the oldest event in the queue, and pop the pointer from the queue.
-		fGriffinDeque[slot].emplace_back(new TGriffin(fGriffin));
-		fBgoDeque[slot].emplace_back(new TGriffinBgo(fGriffinBgo));
+   if(eventInCycleCut) {
+      // Add the current event to the queue, delete the oldest event in the queue, and pop the pointer from the queue.
+      fGriffinDeque[slot].emplace_back(new TGriffin(fGriffin));
+      fBgoDeque[slot].emplace_back(new TGriffinBgo(fGriffinBgo));
 
-		delete fGriffinDeque[slot].front();
-		delete fBgoDeque[slot].front();
+      delete fGriffinDeque[slot].front();
+      delete fBgoDeque[slot].front();
 
-		fGriffinDeque[slot].pop_front();
-		fBgoDeque[slot].pop_front();
-	}
+      fGriffinDeque[slot].pop_front();
+      fBgoDeque[slot].pop_front();
+   }
 }

--- a/examples/AngularCorrelationHelper.hh
+++ b/examples/AngularCorrelationHelper.hh
@@ -13,7 +13,7 @@ private:
    bool             fFolding{false};
    bool             fGrouping{false};
    bool             fAddback{true};
-	bool			     fSingleCrystal{false};
+   bool             fSingleCrystal{false};
    std::vector<int> fExcludedDetectors;
    std::vector<int> fExcludedCrystals;
 
@@ -21,10 +21,10 @@ private:
    double fTimeRandomLow{400.};    // Minimum time difference for gamma-gamma time random background
    double fTimeRandomHigh{600.};   // Maximum time difference for gamma-gamma time random background
 
-	Long64_t fCycleLength{0};
-   double fCycleTimeLow{-1.};    // Minimum time in the cycle in s (if both are -1 we ignore it)
-   double fCycleTimeHigh{-1.};   // Maximum time in the cycle in s (if both are -1 we ignore it)
-											  
+   Long64_t fCycleLength{0};
+   double   fCycleTimeLow{-1.};    // Minimum time in the cycle in s (if both are -1 we ignore it)
+   double   fCycleTimeHigh{-1.};   // Maximum time in the cycle in s (if both are -1 we ignore it)
+
    int    fBins{3000};
    double fMinEnergy{0.};
    double fMaxEnergy{3000.};
@@ -43,24 +43,25 @@ private:
       return std::binary_search(fExcludedCrystals.begin(), fExcludedCrystals.end(), arraynumber);
    }
 
-	bool GoodCycleTime(double timeInCycle) {
-		// check if the timeInCycle (in microseconds!) falls within the limits
-		// this could be done much smarter, but this might be easier to read
-		// if no limits are set we always are within the limits
-		if(fCycleTimeLow == -1. && fCycleTimeHigh == -1.) {
-			return true;
-		}
-		if(fCycleTimeLow == -1. && timeInCycle/1e6 < fCycleTimeHigh) {
-			return true;
-		}
-		if(fCycleTimeLow < timeInCycle/1e6 && fCycleTimeHigh == -1.) {
-			return true;
-		}
-		if(fCycleTimeLow < timeInCycle/1e6 && timeInCycle/1e6 < fCycleTimeHigh) {
-			return true;
-		}
-		return false;
-	}
+   bool GoodCycleTime(double timeInCycle)
+   {
+      // check if the timeInCycle (in microseconds!) falls within the limits
+      // this could be done much smarter, but this might be easier to read
+      // if no limits are set we always are within the limits
+      if(fCycleTimeLow == -1. && fCycleTimeHigh == -1.) {
+         return true;
+      }
+      if(fCycleTimeLow == -1. && timeInCycle / 1e6 < fCycleTimeHigh) {
+         return true;
+      }
+      if(fCycleTimeLow < timeInCycle / 1e6 && fCycleTimeHigh == -1.) {
+         return true;
+      }
+      if(fCycleTimeLow < timeInCycle / 1e6 && timeInCycle / 1e6 < fCycleTimeHigh) {
+         return true;
+      }
+      return false;
+   }
 
 public:
    explicit AngularCorrelationHelper(TList* list)
@@ -100,10 +101,10 @@ public:
       } else {
          std::cout << "No user settings provided, using default settings: ";
       }
-		if(fSingleCrystal && !fAddback) {
-			std::cerr << "Error, can't use single crystal method if not using addback! Setting addback to true!" << std::endl;
-			fAddback = true;
-		}
+      if(fSingleCrystal && !fAddback) {
+         std::cerr << "Error, can't use single crystal method if not using addback! Setting addback to true!" << std::endl;
+         fAddback = true;
+      }
       std::cout << std::boolalpha << "# of mixed events " << fNofMixedEvents << ", distance " << fGriffinDistance << " mm, single crystal " << fSingleCrystal << ", addback " << fAddback << ", folding " << fFolding << ", and grouping " << fGrouping << std::endl;
 
       fAngles = new TGriffinAngles(fGriffinDistance, fFolding, fGrouping, fAddback);

--- a/examples/ExampleEventHelper.cxx
+++ b/examples/ExampleEventHelper.cxx
@@ -111,7 +111,7 @@ void ExampleEventHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& gr
       if(promptBeta) {
          fH1[slot].at("griffinESuppAddbackBeta")->Fill(grif1->GetEnergy());
          if(fCycleLength > 0.) {
-            fH2[slot].at("griffinCycle")->Fill(std::fmod(grif1->GetTime()/1e3, fCycleLength)/1e6, grif1->GetEnergy());
+            fH2[slot].at("griffinCycle")->Fill(std::fmod(grif1->GetTime() / 1e3, fCycleLength) / 1e6, grif1->GetEnergy());
          }
          for(int g2 = g + 1; g2 < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++g2) {
             auto grif2 = grif.GetSuppressedAddbackHit(g2);
@@ -132,7 +132,7 @@ void ExampleEventHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& gr
    if(fCycleLength > 0.) {
       for(int z = 0; z < zds.GetMultiplicity(); ++z) {
          auto zds1 = zds.GetZeroDegreeHit(z);
-         fH1[slot].at("zdsCycle")->Fill(std::fmod(zds1->GetTime()/1e3, fCycleLength)/1e6);
+         fH1[slot].at("zdsCycle")->Fill(std::fmod(zds1->GetTime() / 1e3, fCycleLength) / 1e6);
       }
    }
 }

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -124,13 +124,13 @@ protected:
    static void Options(TGRSIOptions* val) { fOptions = val; }
 
 	void ItemsPopped(size_t itemsPopped) { if(fItemsPopped != nullptr) { *fItemsPopped = itemsPopped; } }
-	void InputSize(long inputSize) { if(fInputSize != nullptr) { *fInputSize = inputSize; } }
+	void InputSize(long inputSize) { if(fInputSize != nullptr) { *fInputSize = inputSize; } }   // NOLINT(google-runtime-int)
 
    void IncrementItemsPopped() { if(fItemsPopped != nullptr) { ++fItemsPopped; } }
    void IncrementInputSize() { if(fInputSize != nullptr) { ++fInputSize; } }
 
    void IncrementItemsPopped(size_t val) { if(fItemsPopped != nullptr) { fItemsPopped += val; } }
-   void IncrementInputSize(long val) { if(fInputSize != nullptr) { fInputSize += val; } }
+   void IncrementInputSize(long val) { if(fInputSize != nullptr) { fInputSize += val; } }   // NOLINT(google-runtime-int)
 
    void DecrementItemsPopped() { if(fItemsPopped != nullptr) { --fItemsPopped; } }
    void DecrementInputSize() { if(fInputSize != nullptr) { --fInputSize; } }

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -123,20 +123,43 @@ protected:
 
    static void Options(TGRSIOptions* val) { fOptions = val; }
 
-	void ItemsPopped(size_t itemsPopped) { if(fItemsPopped != nullptr) { *fItemsPopped = itemsPopped; } }
-	void InputSize(long inputSize) { if(fInputSize != nullptr) { *fInputSize = inputSize; } }   // NOLINT(google-runtime-int)
+   void ItemsPopped(size_t itemsPopped)
+   {
+      if(fItemsPopped != nullptr) { *fItemsPopped = itemsPopped; }
+   }
+   void InputSize(long inputSize)   // NOLINT(google-runtime-int)
+   {
+      if(fInputSize != nullptr) { *fInputSize = inputSize; }
+   }
 
-   void IncrementItemsPopped() { if(fItemsPopped != nullptr) { ++fItemsPopped; } }
-   void IncrementInputSize() { if(fInputSize != nullptr) { ++fInputSize; } }
+   void IncrementItemsPopped()
+   {
+      if(fItemsPopped != nullptr) { ++fItemsPopped; }
+   }
+   void IncrementInputSize()
+   {
+      if(fInputSize != nullptr) { ++fInputSize; }
+   }
 
-   void IncrementItemsPopped(size_t val) { if(fItemsPopped != nullptr) { fItemsPopped += val; } }
-   void IncrementInputSize(long val) { if(fInputSize != nullptr) { fInputSize += val; } }   // NOLINT(google-runtime-int)
+   void IncrementItemsPopped(size_t val)
+   {
+      if(fItemsPopped != nullptr) { fItemsPopped += val; }
+   }
+   void IncrementInputSize(long val)   // NOLINT(google-runtime-int)
+   {
+      if(fInputSize != nullptr) { fInputSize += val; }
+   }
 
-   void DecrementItemsPopped() { if(fItemsPopped != nullptr) { --fItemsPopped; } }
-   void DecrementInputSize() { if(fInputSize != nullptr) { --fInputSize; } }
+   void DecrementItemsPopped()
+   {
+      if(fItemsPopped != nullptr) { --fItemsPopped; }
+   }
+   void DecrementInputSize()
+   {
+      if(fInputSize != nullptr) { --fInputSize; }
+   }
 
 private:
-   // TODO consider making all of these private with protected access functions
 #ifndef __CINT__
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>> fGoodOutputQueues;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>           fBadOutputQueue;

--- a/include/TRawFile.h
+++ b/include/TRawFile.h
@@ -67,11 +67,11 @@ public:
    virtual std::string Filename() const { return fFilename; }   ///< Get the name of this file
    virtual void        Filename(const char* val) { fFilename = val; }
 
-	std::vector<char>& ReadBuffer() { return fReadBuffer; }
-   size_t BufferSize() const { return fReadBuffer.size(); }
-   char*  BufferData() { return fReadBuffer.data(); }
-   void   ClearBuffer() { fReadBuffer.clear(); }
-   void   ResizeBuffer(size_t newSize) { fReadBuffer.resize(newSize); }
+   std::vector<char>& ReadBuffer() { return fReadBuffer; }
+   size_t             BufferSize() const { return fReadBuffer.size(); }
+   char*              BufferData() { return fReadBuffer.data(); }
+   void               ClearBuffer() { fReadBuffer.clear(); }
+   void               ResizeBuffer(size_t newSize) { fReadBuffer.resize(newSize); }
 
 #ifndef __CINT__
    virtual std::shared_ptr<TRawEvent> GetOdbEvent()

--- a/include/TUserSettings.h
+++ b/include/TUserSettings.h
@@ -121,6 +121,10 @@ public:
          return def;
       }
    }
+   std::string GetString(const std::string& parameter, const char* def) const
+	{
+		return GetString(parameter, std::string(def));
+	}
    std::string GetString(const std::string& parameter, std::string def) const
    {
       try {

--- a/include/TUserSettings.h
+++ b/include/TUserSettings.h
@@ -122,9 +122,9 @@ public:
       }
    }
    std::string GetString(const std::string& parameter, const char* def) const
-	{
-		return GetString(parameter, std::string(def));
-	}
+   {
+      return GetString(parameter, std::string(def));
+   }
    std::string GetString(const std::string& parameter, std::string def) const
    {
       try {

--- a/util/GainDrift.cxx
+++ b/util/GainDrift.cxx
@@ -226,7 +226,7 @@ bool GoodFit(TRWPeak& peak, const double& low, const double& high, double& minFW
    return true;
 }
 
-double Polynomial(double* x, double* par) {
+double Polynomial(double* x, double* par) {   // NOLINT(readability-non-const-parameter)
 	double result = par[1];
 	for(int i = 0; i < par[0]; ++i) {
 		result += par[i+2] * TMath::Power(x[0], i+1);

--- a/util/GainDrift.cxx
+++ b/util/GainDrift.cxx
@@ -21,8 +21,8 @@ int main(int argc, char** argv)
 {
    bool printUsage = (argc == 1);
 
-	int							 degree = 1;
-   double                   range = 10.;
+   int                      degree = 1;
+   double                   range  = 10.;
    std::vector<double>      energies;
    std::vector<double>      energyUncertainties;
    std::vector<std::string> fileNames;
@@ -43,10 +43,10 @@ int main(int argc, char** argv)
       } else if(strcmp(argv[i], "-sf") == 0) {
          if(i + 1 < argc) {
             TUserSettings settings(argv[++i]);
-            degree = settings.GetInt("Degree", 1);
-            range = settings.GetDouble("Range", 10.);
-            minFWHM = settings.GetDouble("MinimumFWHM", 2.);
-            prefix = settings.GetString("Prefix", "GainDrift");
+            degree        = settings.GetInt("Degree", 1);
+            range         = settings.GetDouble("Range", 10.);
+            minFWHM       = settings.GetDouble("MinimumFWHM", 2.);
+            prefix        = settings.GetString("Prefix", "GainDrift");
             histogramName = settings.GetString("HistogramName", "EnergyVsChannel");
             if(!energies.empty()) {
                std::cerr << "Warning, already got " << energies.size() << " energies:";
@@ -82,12 +82,12 @@ int main(int argc, char** argv)
             energies.push_back(std::atof(argv[++i]));
          }
       } else if(strcmp(argv[i], "-ul") == 0) {
-			if(!energyUncertainties.empty()) {
-				std::cerr << "Warning, already got " << energyUncertainties.size() << " energy uncertainties:";
-				for(auto energy : energyUncertainties) { std::cerr << "   " << energy; }
-				std::cerr << std::endl;
+         if(!energyUncertainties.empty()) {
+            std::cerr << "Warning, already got " << energyUncertainties.size() << " energy uncertainties:";
+            for(auto energy : energyUncertainties) { std::cerr << "   " << energy; }
+            std::cerr << std::endl;
             std::cerr << "What is read from command line will not overwrite these but be added to them!" << std::endl;
-			}
+         }
          // if we have a next argument, check if it starts with '-'
          while(i + 1 < argc) {
             if(argv[i + 1][0] == '-') {
@@ -134,7 +134,7 @@ int main(int argc, char** argv)
       } else {
          std::cerr << "Error, unknown flag \"" << argv[i] << "\"!" << std::endl;
          printUsage = true;
-      }  
+      }
    }
 
    // check that we got the necessary parameters set
@@ -142,14 +142,14 @@ int main(int argc, char** argv)
       printUsage = true;
    }
 
-	// if we do not have any uncertainties, set them all to zero
-	if(energyUncertainties.empty()) {
-		energyUncertainties.resize(energies.size(), 0.);
-	}
+   // if we do not have any uncertainties, set them all to zero
+   if(energyUncertainties.empty()) {
+      energyUncertainties.resize(energies.size(), 0.);
+   }
 
-	// check that the number of uncertainties matches the number of energies
-	if(energyUncertainties.size() != energies.size()) {
-		std::cerr << "Error, mismatch between number of energies (" << energies.size() << ") and number of energy uncertainties (" << energyUncertainties.size() << ")!" << std::endl;
+   // check that the number of uncertainties matches the number of energies
+   if(energyUncertainties.size() != energies.size()) {
+      std::cerr << "Error, mismatch between number of energies (" << energies.size() << ") and number of energy uncertainties (" << energyUncertainties.size() << ")!" << std::endl;
       printUsage = true;
    }
 
@@ -226,19 +226,20 @@ bool GoodFit(TRWPeak& peak, const double& low, const double& high, double& minFW
    return true;
 }
 
-double Polynomial(double* x, double* par) {   // NOLINT(readability-non-const-parameter)
-	double result = par[1];
-	for(int i = 0; i < par[0]; ++i) {
-		result += par[i+2] * TMath::Power(x[0], i+1);
-	}
-	return result;
+double Polynomial(double* x, double* par)   // NOLINT(readability-non-const-parameter)
+{
+   double result = par[1];
+   for(int i = 0; i < par[0]; ++i) {
+      result += par[i + 2] * TMath::Power(x[0], i + 1);
+   }
+   return result;
 }
 
 void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> energyUncertainties, double range, double minFWHM, int degree, const std::string& prefix, const std::string& label, TFile* output)
 {
-   auto* yAxis  = hist->GetYaxis();
-   TF1*  polynomial = new TF1("polynomial", Polynomial, yAxis->GetBinLowEdge(yAxis->GetFirst()), yAxis->GetBinLowEdge(yAxis->GetLast()), degree+2);
-	polynomial->FixParameter(0, degree);
+   auto* yAxis      = hist->GetYaxis();
+   TF1*  polynomial = new TF1("polynomial", Polynomial, yAxis->GetBinLowEdge(yAxis->GetFirst()), yAxis->GetBinLowEdge(yAxis->GetLast()), degree + 2);
+   polynomial->FixParameter(0, degree);
 
    // loop over all x-bins
    for(int bin = 1; bin <= hist->GetXaxis()->GetNbins(); ++bin) {
@@ -251,8 +252,8 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       auto* redirect = new TRedirect("/dev/null", true);
       auto* graph    = new TGraphErrors;
       graph->SetName(Form("graph%s_%d", label.c_str(), bin));
-		graph->SetTitle(Form("Channel %s, bin %d;uncorr. energy;nominal energy", label.c_str(), bin));
-		int graphIndex = 0;
+      graph->SetTitle(Form("Channel %s, bin %d;uncorr. energy;nominal energy", label.c_str(), bin));
+      int graphIndex = 0;
       for(size_t i = 0; i < energies.size(); ++i) {
          TPeakFitter pf(energies[i] - range, energies[i] + range);
          TRWPeak     peak(energies[i]);
@@ -264,7 +265,7 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
          if(GoodFit(peak, energies[i] - range, energies[i] + range, minFWHM)) {
             graph->SetPoint(graphIndex, peak.Centroid(), energies[i]);
             graph->SetPointError(graphIndex, peak.CentroidErr(), energyUncertainties[i]);
-				++graphIndex;
+            ++graphIndex;
          } else {
             static_cast<TF1*>(proj->GetListOfFunctions()->Last())->SetLineColor(kGray);
             std::cout << "Not using bad fit with centroid " << peak.Centroid() << " +- " << peak.CentroidErr() << ", area " << peak.Area() << " +- " << peak.AreaErr() << ", fwhm " << peak.FWHM() << " in range " << energies[i] - range << " - " << energies[i] + range << std::endl;
@@ -274,9 +275,9 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       // reset the parameters of the polynomial function and fit the graph
       polynomial->SetParameter(1, 0.);
       polynomial->SetParameter(2, 1.);
-		for(int i = 3; i < degree + 2; ++i) {
-			polynomial->SetParameter(i, 0.);
-		}
+      for(int i = 3; i < degree + 2; ++i) {
+         polynomial->SetParameter(i, 0.);
+      }
       graph->Fit(polynomial, "q");
       delete redirect;
 
@@ -285,10 +286,10 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       std::cout << "bin " << bin << ":" << std::endl;
       graph->Print();
       std::cout << "polynomial fit " << degree << ". degree: " << polynomial->GetParameter(1) << " + " << polynomial->GetParameter(2) << " * x";
-		for(int i = 3; i < degree + 2; ++i) {
-			std::cout << " + " << polynomial->GetParameter(i) << " * x^" << i-1;
-		}
-		std::cout << std::endl;
+      for(int i = 3; i < degree + 2; ++i) {
+         std::cout << " + " << polynomial->GetParameter(i) << " * x^" << i - 1;
+      }
+      std::cout << std::endl;
       std::cout << "========================================" << std::endl;
 
       // get the channel belonging to this bin
@@ -301,10 +302,10 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       }
 
       // update the energy drift coefficents
-      std::vector<Float_t> coeff(degree+1);
-		for(int i = 0; i < degree+1; ++i) {
-			coeff[i] = static_cast<Float_t>(polynomial->GetParameter(i+1));
-		}
+      std::vector<Float_t> coeff(degree + 1);
+      for(int i = 0; i < degree + 1; ++i) {
+         coeff[i] = static_cast<Float_t>(polynomial->GetParameter(i + 1));
+      }
       TChannel::GetChannel(address)->SetENGDriftCoefficents(TPriorityValue<std::vector<Float_t>>(coeff, EPriority::kForce));
 
       // write spectrum and graph to output file

--- a/util/GainDrift.cxx
+++ b/util/GainDrift.cxx
@@ -41,6 +41,7 @@ int main(int argc, char** argv)
       } else if(strcmp(argv[i], "-sf") == 0) {
          if(i + 1 < argc) {
             TUserSettings settings(argv[++i]);
+            range = settings.GetDouble("Range", 10.);
             prefix = settings.GetString("Prefix", "GainDrift");
             histogramName = settings.GetString("HistogramName", "EnergyVsChannel");
             if(!energies.empty()) {
@@ -56,7 +57,7 @@ int main(int argc, char** argv)
                std::cerr << std::endl;
                std::cerr << "These will now be overwritten by what is read from the settings file " << argv[i] << std::endl;
             }
-            energyUncertainties = settings.GetDoubleVector("EnergyUncertainty");
+            energyUncertainties = settings.GetDoubleVector("EnergyUncertainties");
          } else {
             std::cout << "Error, -sf flag needs an argument!" << std::endl;
             printUsage = true;

--- a/util/GainDrift.cxx
+++ b/util/GainDrift.cxx
@@ -15,18 +15,20 @@
 #include "TPeakFitter.h"
 #include "TRWPeak.h"
 
-void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> energyUncertainties, double range, const std::string& prefix, const std::string& label, TFile* output);
+void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> energyUncertainties, double range, double minFWHM, int degree, const std::string& prefix, const std::string& label, TFile* output);
 
 int main(int argc, char** argv)
 {
    bool printUsage = (argc == 1);
 
+	int							 degree = 1;
    double                   range = 10.;
    std::vector<double>      energies;
    std::vector<double>      energyUncertainties;
    std::vector<std::string> fileNames;
    std::string              prefix        = "GainDrift";
    std::string              histogramName = "EnergyVsChannel";
+   double                   minFWHM       = 2.;
 
    for(int i = 1; i < argc; ++i) {
       if(strcmp(argv[i], "-if") == 0) {
@@ -41,7 +43,9 @@ int main(int argc, char** argv)
       } else if(strcmp(argv[i], "-sf") == 0) {
          if(i + 1 < argc) {
             TUserSettings settings(argv[++i]);
+            degree = settings.GetInt("Degree", 1);
             range = settings.GetDouble("Range", 10.);
+            minFWHM = settings.GetDouble("MinimumFWHM", 2.);
             prefix = settings.GetString("Prefix", "GainDrift");
             histogramName = settings.GetString("HistogramName", "EnergyVsChannel");
             if(!energies.empty()) {
@@ -92,11 +96,25 @@ int main(int argc, char** argv)
             // if we get here we can add the next argument to the list of energies
             energyUncertainties.push_back(std::atof(argv[++i]));
          }
+      } else if(strcmp(argv[i], "-d") == 0) {
+         if(i + 1 < argc) {
+            degree = std::atoi(argv[++i]);
+         } else {
+            std::cout << "Error, -d flag needs an argument!" << std::endl;
+            printUsage = true;
+         }
       } else if(strcmp(argv[i], "-r") == 0) {
          if(i + 1 < argc) {
             range = std::atof(argv[++i]);
          } else {
             std::cout << "Error, -r flag needs an argument!" << std::endl;
+            printUsage = true;
+         }
+      } else if(strcmp(argv[i], "-mw") == 0) {
+         if(i + 1 < argc) {
+            minFWHM = std::atof(argv[++i]);
+         } else {
+            std::cout << "Error, -mw flag needs an argument!" << std::endl;
             printUsage = true;
          }
       } else if(strcmp(argv[i], "-hn") == 0) {
@@ -113,7 +131,10 @@ int main(int argc, char** argv)
             std::cout << "Error, -pre flag needs an argument!" << std::endl;
             printUsage = true;
          }
-      }
+      } else {
+         std::cerr << "Error, unknown flag \"" << argv[i] << "\"!" << std::endl;
+         printUsage = true;
+      }  
    }
 
    // check that we got the necessary parameters set
@@ -128,16 +149,19 @@ int main(int argc, char** argv)
 
 	// check that the number of uncertainties matches the number of energies
 	if(energyUncertainties.size() != energies.size()) {
+		std::cerr << "Error, mismatch between number of energies (" << energies.size() << ") and number of energy uncertainties (" << energyUncertainties.size() << ")!" << std::endl;
       printUsage = true;
    }
 
    if(printUsage) {
-      std::cout << "Arguments for " << argv[0] << ":" << std::endl
+      std::cerr << "Arguments for " << argv[0] << ":" << std::endl
                 << "-if  <input files>                                (required)" << std::endl
                 << "-sf  <settings file>                              (semi-optional, TUserSettings format identifying the peaks to be used)" << std::endl
                 << "-el  <list of energies to be used>                (semi-optional, either this or a settings file need to be used)" << std::endl
                 << "-ul  <list of energy uncertainties to be used>    (optional, default = empty)" << std::endl
+                << "-d   <degree of fit>                              (optional, default = 1, i.e. linear)" << std::endl
                 << "-r   <+-range of fit>                             (optional, default = 10.)" << std::endl
+                << "-mw  <minimum FWHM for good fit>                  (optional, default = 2.)" << std::endl
                 << "-hn  <histogram name>                             (optional, default = \"EnergyVsChannel\")" << std::endl
                 << "-pre <prefix>                                     (optional, default = \"GainDrift\")" << std::endl;
 
@@ -172,7 +196,7 @@ int main(int argc, char** argv)
       TRunInfo::ReadInfoFromFile(file);
       auto label = TRunInfo::CreateLabel(true);
       // find the gain drift for all channels
-      FindGainDrift(hist, energies, energyUncertainties, range, prefix, label, output);
+      FindGainDrift(hist, energies, energyUncertainties, range, minFWHM, degree, prefix, label, output);
 
       // write the gain drift to new cal-file
       TChannel::WriteCalFile(Form("%s%s.cal", prefix.c_str(), label.c_str()));
@@ -189,12 +213,12 @@ int main(int argc, char** argv)
    return 0;
 }
 
-bool GoodFit(TRWPeak& peak, const double& low, const double& high)
+bool GoodFit(TRWPeak& peak, const double& low, const double& high, double& minFWHM)
 {
    // for a good fit the centroid should be in the fitting range
    if(peak.Centroid() < low || high < peak.Centroid()) { return false; }
-   // for a good fit the FWHM should be less than half the fitting range (half is kind of arbitrary)
-   if(peak.FWHM() > (high - low) / 2.) { return false; }
+   // for a good fit the FWHM should be less than half the fitting range (half is kind of arbitrary), and larger than the minimum (2 is default value)
+   if(peak.FWHM() < minFWHM || peak.FWHM() > (high - low) / 2.) { return false; }
    // for a good fit the area should be positive (can't really put a non-arbitrary positive limit on this)
    if(peak.Area() < 0.) { return false; }
 
@@ -202,10 +226,19 @@ bool GoodFit(TRWPeak& peak, const double& low, const double& high)
    return true;
 }
 
-void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> energyUncertainties, double range, const std::string& prefix, const std::string& label, TFile* output)
+double Polynomial(double* x, double* par) {
+	double result = par[1];
+	for(int i = 0; i < par[0]; ++i) {
+		result += par[i+2] * TMath::Power(x[0], i+1);
+	}
+	return result;
+}
+
+void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> energyUncertainties, double range, double minFWHM, int degree, const std::string& prefix, const std::string& label, TFile* output)
 {
    auto* yAxis  = hist->GetYaxis();
-   TF1*  linear = new TF1("linear", "[0] + [1]*x", yAxis->GetBinLowEdge(yAxis->GetFirst()), yAxis->GetBinLowEdge(yAxis->GetLast()));
+   TF1*  polynomial = new TF1("polynomial", Polynomial, yAxis->GetBinLowEdge(yAxis->GetFirst()), yAxis->GetBinLowEdge(yAxis->GetLast()), degree+2);
+	polynomial->FixParameter(0, degree);
 
    // loop over all x-bins
    for(int bin = 1; bin <= hist->GetXaxis()->GetNbins(); ++bin) {
@@ -218,6 +251,7 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       auto* redirect = new TRedirect("/dev/null", true);
       auto* graph    = new TGraphErrors;
       graph->SetName(Form("graph%s_%d", label.c_str(), bin));
+		graph->SetTitle(Form("Channel %s, bin %d;uncorr. energy;nominal energy", label.c_str(), bin));
 		int graphIndex = 0;
       for(size_t i = 0; i < energies.size(); ++i) {
          TPeakFitter pf(energies[i] - range, energies[i] + range);
@@ -227,9 +261,9 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
 
          proj->GetListOfFunctions()->Add(pf.GetFitFunction()->Clone(Form("fit%.1f", energies[i])));
          // check if the fit was good
-         if(GoodFit(peak, energies[i] - range, energies[i] + range)) {
-            graph->SetPoint(graphIndex, energies[i], peak.Centroid());
-            graph->SetPointError(graphIndex, energyUncertainties[i], peak.CentroidErr());
+         if(GoodFit(peak, energies[i] - range, energies[i] + range, minFWHM)) {
+            graph->SetPoint(graphIndex, peak.Centroid(), energies[i]);
+            graph->SetPointError(graphIndex, peak.CentroidErr(), energyUncertainties[i]);
 				++graphIndex;
          } else {
             static_cast<TF1*>(proj->GetListOfFunctions()->Last())->SetLineColor(kGray);
@@ -237,16 +271,24 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
          }
       }
 
-      // reset the parameters of the linear function and fit the graph
-      linear->SetParameters(0., 1.);
-      graph->Fit(linear, "q");
+      // reset the parameters of the polynomial function and fit the graph
+      polynomial->SetParameter(1, 0.);
+      polynomial->SetParameter(2, 1.);
+		for(int i = 3; i < degree + 2; ++i) {
+			polynomial->SetParameter(i, 0.);
+		}
+      graph->Fit(polynomial, "q");
       delete redirect;
 
       redirect = new TRedirect(Form("%s.log", prefix.c_str()), true);
 
       std::cout << "bin " << bin << ":" << std::endl;
       graph->Print();
-      std::cout << "linear fit: " << linear->GetParameter(0) << " + " << linear->GetParameter(1) << " * x" << std::endl;
+      std::cout << "polynomial fit " << degree << ". degree: " << polynomial->GetParameter(1) << " + " << polynomial->GetParameter(2) << " * x";
+		for(int i = 3; i < degree + 2; ++i) {
+			std::cout << " + " << polynomial->GetParameter(i) << " * x^" << i-1;
+		}
+		std::cout << std::endl;
       std::cout << "========================================" << std::endl;
 
       // get the channel belonging to this bin
@@ -259,7 +301,10 @@ void FindGainDrift(TH2* hist, std::vector<double> energies, std::vector<double> 
       }
 
       // update the energy drift coefficents
-      std::vector<Float_t> coeff = {static_cast<Float_t>(linear->GetParameter(0)), static_cast<Float_t>(linear->GetParameter(1))};
+      std::vector<Float_t> coeff(degree+1);
+		for(int i = 0; i < degree+1; ++i) {
+			coeff[i] = static_cast<Float_t>(polynomial->GetParameter(i+1));
+		}
       TChannel::GetChannel(address)->SetENGDriftCoefficents(TPriorityValue<std::vector<Float_t>>(coeff, EPriority::kForce));
 
       // write spectrum and graph to output file


### PR DESCRIPTION
**GainDrift**

Introduced the option to add energy uncertainties and fixed a bug where any bad fit would cause the corresponding graph to have a data point at 0, 0.
Added a minimum FWHM for fits to be accepted as good, and the option to change the degree of the polynomial fitted.
Updated what is read from the user settings file to add (almost?) all command line parameters.

**Linter**

Added a function to `TUserSettings` to get a string with a provided default `const char*`, before these calls would see the pointer get converted to a boolean and then the function w/o the default value was called.

Added a few exceptions for the linter, for `long` arguments that are used to pass value to be assigned to the `std::atomic_long` member of `TDataParser`, and for the non-constant pointer for the parameters in the fit function used in `GainDrift` (ROOT requires this non-constant version).