### PR TITLE
Added option to delete all hits in TDetector, not just clearing the vector containing them

### DIFF
--- a/examples/AngularCorrelationHelper.cxx
+++ b/examples/AngularCorrelationHelper.cxx
@@ -53,19 +53,18 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
 {
    bool eventInCycleCut = false;
    for(auto g1 = 0; g1 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g1) {
+      if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g1) > 1) continue;
       auto grif1 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g1) : fGriffin.GetSuppressedHit(g1));
       if(ExcludeDetector(grif1->GetDetector()) || ExcludeCrystal(grif1->GetArrayNumber())) continue;
-      if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g1) > 1) continue;
       if(!GoodCycleTime(std::fmod(grif1->GetTime() / 1e3, fCycleLength))) continue;
 
       // we only get here if at least one hit of the event is within the cycle cut
       eventInCycleCut = true;
 
-      for(auto g2 = 0; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
-         if(g1 == g2) continue;
+      for(auto g2 = g1 + 1; g2 < (fAddback ? fGriffin.GetSuppressedAddbackMultiplicity(&fGriffinBgo) : fGriffin.GetSuppressedMultiplicity(&fGriffinBgo)); ++g2) {
+         if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g2) > 1) continue;
          auto grif2 = (fAddback ? fGriffin.GetSuppressedAddbackHit(g2) : fGriffin.GetSuppressedHit(g2));
          if(ExcludeDetector(grif2->GetDetector()) || ExcludeCrystal(grif2->GetArrayNumber())) continue;
-         if(fSingleCrystal && fGriffin.GetNSuppressedAddbackFrags(g2) > 1) continue;
          if(!GoodCycleTime(std::fmod(grif2->GetTime() / 1e3, fCycleLength))) continue;
 
          // skip hits in the same detector when using addback, or in the same crystal when not using addback
@@ -85,10 +84,14 @@ void AngularCorrelationHelper::Exec(unsigned int slot, TGriffin& fGriffin, TGrif
          double ggTime = TMath::Abs(grif2->GetTime() - grif1->GetTime());
          if(ggTime <= fPrompt) {
             fH2[slot].at("AngularCorrelation")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+            fH2[slot].at("AngularCorrelation")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
             fH2[slot].at(Form("AngularCorrelation%d", angleIndex))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+            fH2[slot].at(Form("AngularCorrelation%d", angleIndex))->Fill(grif2->GetEnergy(), grif1->GetEnergy());
          } else if(fTimeRandomLow <= ggTime && ggTime <= fTimeRandomHigh) {
             fH2[slot].at("AngularCorrelationBG")->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+            fH2[slot].at("AngularCorrelationBG")->Fill(grif2->GetEnergy(), grif1->GetEnergy());
             fH2[slot].at(Form("AngularCorrelationBG%d", angleIndex))->Fill(grif1->GetEnergy(), grif2->GetEnergy());
+            fH2[slot].at(Form("AngularCorrelationBG%d", angleIndex))->Fill(grif2->GetEnergy(), grif1->GetEnergy());
          }
       }
 

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -64,10 +64,10 @@ public:
    {
       fHits.push_back(hit);
    }
-   void         Copy(TObject&) const override;                      //!<!
-   void         Clear(Option_t* = "") override { fHits.clear(); }   //!<!
-   virtual void ClearTransients();                                  //!<!
-   void         Print(Option_t* opt = "") const override;           //!<!
+   void         Copy(TObject&) const override;              //!<!
+   void         Clear(Option_t* = "") override;             //!<!
+   virtual void ClearTransients();                          //!<!
+   void         Print(Option_t* opt = "") const override;   //!<!
    virtual void Print(std::ostream& out) const;
 
    virtual Short_t                           GetMultiplicity() const { return static_cast<Short_t>(fHits.size()); }

--- a/libraries/TFormat/TDetector.cxx
+++ b/libraries/TFormat/TDetector.cxx
@@ -51,6 +51,16 @@ void TDetector::Print(std::ostream& out) const
    out << str.str();
 }
 
+void TDetector::Clear(Option_t* opt)
+{
+	if(strcmp(opt, "a") == 0) {
+		for(auto* hit : fHits) {
+			delete hit;
+		}
+	}
+	fHits.clear();
+}
+
 void TDetector::ClearTransients()
 {
    for(auto* hit : fHits) {


### PR DESCRIPTION
This option is "a", which solves an issue with a memory leak in the SimulationAngularCorrelations program. Since the default option is empty, this won't affect any existing code, but I will check if we can change other codes in a similar way and maybe reduce memory usage of grsisort that way.

Also changed the way we loop over the second hit in the AngularCorrelationHelper, might make it a bit faster?