### PR TITLE
Moved TimeDrift correction from GetTimeStampNs to GetTime

### DIFF
--- a/libraries/TFormat/TDetectorHit.cxx
+++ b/libraries/TFormat/TDetectorHit.cxx
@@ -52,7 +52,7 @@ Double_t TDetectorHit::GetTime(const ETimeFlag&, Option_t*) const
       return SetTime(static_cast<Double_t>(static_cast<double>(GetTimeStamp()) + gRandom->Uniform()));
    }
 
-   return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd(), GetEnergy()));
+   return SetTime(tmpChan->GetTime(GetTimeStamp(), GetCfd(), GetEnergy()) * (1. - tmpChan->GetTimeDrift()));
 }
 
 Float_t TDetectorHit::GetCharge() const
@@ -228,9 +228,9 @@ Long64_t TDetectorHit::GetTimeStampNs(Option_t*) const
 {
    TChannel* tmpChan = GetChannel();
    if(tmpChan == nullptr) {
-      return GetTimeStamp();   // GetTimeStampUnit returns 1 of there is no channel
+      return GetTimeStamp();   // GetTimeStampUnit returns 1 if there is no channel
    }
-   return GetTimeStamp() * GetTimeStampUnit() * static_cast<Long64_t>((1.0 - tmpChan->GetTimeDrift())) - tmpChan->GetTimeOffset();
+   return GetTimeStamp() * GetTimeStampUnit() - tmpChan->GetTimeOffset();
 }
 
 Int_t TDetectorHit::GetTimeStampUnit() const


### PR DESCRIPTION
This should fix the issue of `GetTimeStampNs` returning zero if a time drift factor is applied (see #1574).

This is what the three time functions are doing now:
- GetTimeStamp: returns the timestamp as is, i.e. the bit value provided in the midas file, in whatever unit the digitizer of that channel records the timestamps.
- GetTimeStampNs: returns the timestamp in ns units, and applies an offset (this offset is important for aligning data when grsisort is set to use timestamps instead of time to build events).
- GetTime: Returns the time in ns units with the time offset applied (same as GetTimeStampNs), but also applies CFD, time walk, and time drift corrections. 

The CFD and time walk corrections as well as the time offset are applied in `TGRSIMnemonic::GetTime`, whereas the time drift correction is applied in `TDetectorHit::GetTime`. We could change this to have everything that is not digitizer dependent (i.e. everything apart from the CFD corrections) be applied in `TDetectorHit::GetTime`. That would mean we have the same functionality of time corrections for all different parser libraries in one place, instead of having the same code in multiple places. But this will require people to be careful to use the right grsisort and parser library versions together, because otherwise corrections might get applied twice or never (without creating compiler issues as other grsisort/parser library version mismatches do).
