### PR TITLE
Undid specifying of ROOT version for macOS

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -94,7 +94,7 @@ jobs:
         cmake --build root_v${{matrix.config.root}}-build -- install -j4
         elif [ "$RUNNER_OS" == "macOS" ]; then
         brew install libxpm
-        brew install root@${{matrix.config.root}}
+        brew install root
         fi
       shell: bash
 


### PR DESCRIPTION
Turns out that homebrew only supports the latest version ... Might have to switch to different method of installing if we want to specify the version ourselves.