### PR TITLE
Changes to deal with turning off DAQ during cycle

### DIFF
--- a/include/TAnalysisWriteLoop.h
+++ b/include/TAnalysisWriteLoop.h
@@ -35,7 +35,7 @@ public:
    {
       return fInputQueue;
    }
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& OutOfOrderQueue() { return fOutOfOrderQueue; }
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& OutOfOrderQueue() { return fOutOfOrderQueue; }
 #endif
 
    void ClearQueue() override;
@@ -68,7 +68,7 @@ private:
    std::map<TClass*, TDetector**>                                     fDetMap;
    std::map<TClass*, TDetector*>                                      fDefaultDets;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>  fInputQueue;
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>> fOutOfOrderQueue;
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>       fOutOfOrderQueue;
 #endif
 
    /// \cond CLASSIMP

--- a/include/TBgo.h
+++ b/include/TBgo.h
@@ -24,7 +24,7 @@ public:
 
    static TVector3 GetPosition(int DetNbr, int CryNbr = 5, double distance = 110.0);   //!<!
 #ifndef __CINT__
-   void AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan) override;   //!<!
+   void AddFragment(const std::shared_ptr<TFragment>& frag, TChannel* chan) override;   //!<!
 #endif
    void BuildHits() override {}   // no need to build any hits, everything already done in AddFragment
 

--- a/include/TCompiledHistograms.h
+++ b/include/TCompiledHistograms.h
@@ -25,7 +25,7 @@ public:
 
    void Load(const std::string& libName, const std::string& funcName);
 #ifndef __CINT__
-   void Fill(std::shared_ptr<const TFragment> frag);
+   void Fill(std::shared_ptr<TFragment> frag);
    void Fill(std::shared_ptr<TUnpackedEvent> detectors);
 #endif
    void Reload();

--- a/include/TDataParser.h
+++ b/include/TDataParser.h
@@ -60,11 +60,11 @@ public:
                                      kFME3 };
 
 #ifndef __CINT__
-   virtual std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& AddGoodOutputQueue(size_t maxSize = 50000)
+   virtual std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& AddGoodOutputQueue(size_t maxSize = 50000)
    {
       std::ostringstream name;
       name << "good_frag_queue_" << fGoodOutputQueues.size();
-      fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>(name.str(), maxSize));
+      fGoodOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>(name.str(), maxSize));
       return fGoodOutputQueues.back();
    }
 
@@ -80,7 +80,7 @@ public:
 
    virtual int Process(std::shared_ptr<TRawEvent>) = 0;
    void        Push(ThreadsafeQueue<std::shared_ptr<const TBadFragment>>& queue, const std::shared_ptr<TBadFragment>& frag);
-   void        Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>& queues, const std::shared_ptr<TFragment>& frag);
+   void        Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>& queues, const std::shared_ptr<TFragment>& frag);
 #endif
    virtual void   ClearQueue();
    virtual size_t ItemsPushed()
@@ -96,7 +96,7 @@ public:
 protected:
    // getters
 #ifndef __CINT__
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>& GoodOutputQueues() { return fGoodOutputQueues; }
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>& GoodOutputQueues() { return fGoodOutputQueues; }
 #endif
    bool      NoWaveforms() const { return fNoWaveforms; }
    bool      RecordDiag() const { return fRecordDiag; }
@@ -159,7 +159,7 @@ protected:
 
 private:
 #ifndef __CINT__
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>> fGoodOutputQueues;
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>> fGoodOutputQueues;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>           fBadOutputQueue;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag>>>                   fScalerOutputQueue;
 #endif

--- a/include/TDetBuildingLoop.h
+++ b/include/TDetBuildingLoop.h
@@ -33,7 +33,7 @@ public:
    ~TDetBuildingLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>>& InputQueue()
+   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>>& InputQueue()
    {
       return fInputQueue;
    }
@@ -64,7 +64,7 @@ private:
    explicit TDetBuildingLoop(std::string name);
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>> fInputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>> fInputQueue;
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>>  fOutputQueues;
 #endif
 

--- a/include/TDetector.h
+++ b/include/TDetector.h
@@ -51,7 +51,7 @@ public:
 
    virtual void BuildHits() { AbstractMethod("BuildHits()"); }   //!<!
 #ifndef __CINT__
-   virtual void AddFragment(const std::shared_ptr<const TFragment>&, TChannel*)
+   virtual void AddFragment(const std::shared_ptr<TFragment>&, TChannel*)
    {
       AbstractMethod("AddFragment()");
    }   //!<!

--- a/include/TEventBuildingLoop.h
+++ b/include/TEventBuildingLoop.h
@@ -41,15 +41,15 @@ public:
    ~TEventBuildingLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& InputQueue()
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& InputQueue()
    {
       return fInputQueue;
    }
-   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>>& OutputQueue()
+   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>>& OutputQueue()
    {
       return fOutputQueue;
    }
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& OutOfOrderQueue() { return fOutOfOrderQueue; }
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& OutOfOrderQueue() { return fOutOfOrderQueue; }
 #endif
 
    bool Iteration() override;
@@ -73,14 +73,16 @@ private:
    TEventBuildingLoop(std::string name, EBuildMode mode, uint64_t buildWindow);
 
 #ifndef __CINT__
-   bool CheckBuildCondition(const std::shared_ptr<const TFragment>&);
-   bool CheckTimeCondition(const std::shared_ptr<const TFragment>&);
-   bool CheckTimestampCondition(const std::shared_ptr<const TFragment>&);
-   bool CheckTriggerIdCondition(const std::shared_ptr<const TFragment>&);
+   bool CheckBuildCondition(const std::shared_ptr<TFragment>&);
+   bool CheckTimeCondition(const std::shared_ptr<TFragment>&);
+   bool CheckTimestampCondition(const std::shared_ptr<TFragment>&);
+   bool CheckTriggerIdCondition(const std::shared_ptr<TFragment>&);
 
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>              fInputQueue;
-   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>> fOutputQueue;
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>              fOutOfOrderQueue;
+   void CheckWrapAround(const std::shared_ptr<TFragment>&);
+
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>                    fInputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>> fOutputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>              fOutOfOrderQueue;
 #endif
 
    EBuildMode   fBuildMode;
@@ -89,11 +91,20 @@ private:
    bool         fPreviousSortingDepthError;
    bool         fSkipInputSort;
 
-#ifndef __CINT__
-   std::vector<std::shared_ptr<const TFragment>> fNextEvent;
+	std::string  fOffsetFile; ///< name of file with the offset (see below)
+	Long64_t		 fDaqTimeStampOffset{0}; ///< offset between DAQ timestamp (time since 1970 in s) and the timestamp of the first fragment of the run. Read from a file created by sorting the first subrun
+	Long64_t     fCycleLength{0}; ///< total length of cycle in us as defined by ODB
+	Long64_t     fTapeMoveLength{0}; ///< length of the tape move in us (code 0xc008)
+	Long64_t     fBackgroundLength{0}; ///< length of the background in us (code 0xc002)
+	Long64_t     fImplantDaqOnLength{0}; ///< length of the implant(s) in us (DAQ is on ) (code 0xc001)
+	Long64_t     fImplantDaqOffLength{0}; ///< length of the implant(s) in us (DAQ is off) (code 0x8001)
+	Long64_t     fDecayDaqOffLength{0}; ///< length of the decay with DAQ off in us (code 0x8004)
 
-   std::multiset<std::shared_ptr<const TFragment>,
-                 std::function<bool(std::shared_ptr<const TFragment>, std::shared_ptr<const TFragment>)>>
+#ifndef __CINT__
+   std::vector<std::shared_ptr<TFragment>> fNextEvent;
+
+   std::multiset<std::pair<std::shared_ptr<TFragment>, Long64_t>,
+                 std::function<bool(std::pair<std::shared_ptr<TFragment>, Long64_t>, std::pair<std::shared_ptr<TFragment>, Long64_t>)>>
       fOrdered;
 #endif
 

--- a/include/TFragDiagnosticsLoop.h
+++ b/include/TFragDiagnosticsLoop.h
@@ -33,7 +33,7 @@ public:
    ~TFragDiagnosticsLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& InputQueue() { return fInputQueue; }
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& InputQueue() { return fInputQueue; }
 #endif
 
    void ClearQueue() override;
@@ -55,7 +55,7 @@ protected:
 private:
    TFragDiagnosticsLoop(std::string name, const std::string& fOutputFilename);
 #ifndef __CINT__
-   void Process(const std::shared_ptr<const TFragment>& event);
+   void Process(const std::shared_ptr<TFragment>& event);
 #endif
    bool CreateHistograms();
 
@@ -92,7 +92,7 @@ private:
    TH2D* fLostAcceptedIdsTime{nullptr};
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>> fInputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>> fInputQueue;
 #endif
 
    /// \cond CLASSIMP

--- a/include/TFragHistLoop.h
+++ b/include/TFragHistLoop.h
@@ -33,7 +33,7 @@ public:
    ~TFragHistLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& InputQueue()
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& InputQueue()
    {
       return fInputQueue;
    }
@@ -75,7 +75,7 @@ private:
    std::string fOutputFilename;
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>> fInputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>> fInputQueue;
 #endif
 
    /// \cond CLASSIMP

--- a/include/TFragWriteLoop.h
+++ b/include/TFragWriteLoop.h
@@ -32,7 +32,7 @@ public:
    ~TFragWriteLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>&    InputQueue() { return fInputQueue; }
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>&    InputQueue() { return fInputQueue; }
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>& BadInputQueue() { return fBadInputQueue; }
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag>>>&         ScalerInputQueue() { return fScalerInputQueue; }
 #endif
@@ -56,7 +56,7 @@ protected:
 private:
    TFragWriteLoop(std::string name, const std::string& fOutputFilename);
 #ifndef __CINT__
-   void WriteEvent(const std::shared_ptr<const TFragment>& event);
+   void WriteEvent(const std::shared_ptr<TFragment>& event);
    void WriteBadEvent(const std::shared_ptr<const TBadFragment>& event);
    void WriteScaler(const std::shared_ptr<TEpicsFrag>& scaler);
 #endif
@@ -72,7 +72,7 @@ private:
    TEpicsFrag*   fScalerAddress;
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>    fInputQueue;
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>    fInputQueue;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>> fBadInputQueue;
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag>>>         fScalerInputQueue;
 #endif

--- a/include/TFragmentChainLoop.h
+++ b/include/TFragmentChainLoop.h
@@ -29,16 +29,16 @@
 class TFragmentChainLoop : public StoppableThread {
 public:
    static TFragmentChainLoop* Get(std::string name = "", TChain* chain = nullptr);
-   TFragmentChainLoop(const TFragmentChainLoop&)                = delete;
+   TFragmentChainLoop(TFragmentChainLoop&)                = delete;
    TFragmentChainLoop(TFragmentChainLoop&&) noexcept            = delete;
-   TFragmentChainLoop& operator=(const TFragmentChainLoop&)     = delete;
+   TFragmentChainLoop& operator=(TFragmentChainLoop&)     = delete;
    TFragmentChainLoop& operator=(TFragmentChainLoop&&) noexcept = delete;
    ~TFragmentChainLoop();
 
 #ifndef __CINT__
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& AddOutputQueue()
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& AddOutputQueue()
    {
-      fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>());
+      fOutputQueues.push_back(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>());
       return fOutputQueues.back();
    }
 #endif
@@ -67,7 +67,7 @@ private:
    TChain* fInputChain;
 #ifndef __CINT__
    TFragment*                                                                      fFragment;
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>> fOutputQueues;
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>> fOutputQueues;
 #endif
 
    bool fSelfStopping;

--- a/include/TFragmentMap.h
+++ b/include/TFragmentMap.h
@@ -28,7 +28,7 @@
 class TFragmentMap {
 public:
 #ifndef __CINT__
-   TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>& goodOutputQueue,
+   TFragmentMap(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>& goodOutputQueue,
                 std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>&           badOutputQueue);
 #endif
 
@@ -45,7 +45,7 @@ private:
                       std::multimap<UInt_t, std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t>>>::iterator>& range);
 
    std::multimap<UInt_t, std::tuple<std::shared_ptr<TFragment>, std::vector<Int_t>, std::vector<Short_t>>> fMap;
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>&                        fGoodOutputQueue;   //NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>&                        fGoodOutputQueue;   //NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>&                                  fBadOutputQueue;    //NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 #endif
 };

--- a/include/TPPG.h
+++ b/include/TPPG.h
@@ -164,7 +164,7 @@ public:
    Bool_t      MapIsEmpty() const;
    std::size_t PPGSize() const { return fPPGStatusMap->size() - 1; }
    std::size_t OdbPPGSize() const { return fOdbPPGCodes.size(); }
-   int16_t     OdbPPGCode(size_t index) const { return fOdbPPGCodes.at(index); }
+   uint16_t    OdbPPGCode(size_t index) const { return fOdbPPGCodes.at(index); }
    int         OdbDuration(size_t index) const { return fOdbDurations.at(index); }
    Long64_t    OdbCycleLength() const
    {
@@ -192,7 +192,7 @@ public:
    const TPPGData* First();
    const TPPGData* Last();
 
-   void SetOdbCycle(std::vector<int16_t> ppgCodes, std::vector<int> durations)
+   void SetOdbCycle(std::vector<uint16_t> ppgCodes, std::vector<int> durations)
    {
       fOdbPPGCodes  = std::move(ppgCodes);
       fOdbDurations = std::move(durations);
@@ -212,11 +212,11 @@ private:
    ULong64_t                fCycleLength{0};
    std::map<ULong64_t, int> fNumberOfCycleLengths;
 
-   std::vector<int16_t> fOdbPPGCodes;    ///< ppg state codes read from odb
-   std::vector<int>     fOdbDurations;   ///< duration of ppg state as read from odb
+   std::vector<uint16_t> fOdbPPGCodes;    ///< ppg state codes read from odb
+   std::vector<int>      fOdbDurations;   ///< duration of ppg state as read from odb
 
    bool                   fCycleSet{false};                //!<! flag to indicate whether the codes and durations have been calculated from the data
-   std::vector<int16_t>   fPPGCodes{0x8, 0x2, 0x1, 0x4};   //!<! ppg state codes (these are always set)
+   std::vector<uint16_t>  fPPGCodes{0x8, 0x2, 0x1, 0x4};   //!<! ppg state codes (these are always set)
    std::vector<ULong64_t> fDurations{0, 0, 0, 0};          //!<! duration of ppg state calculated from data
 
    /// \cond CLASSIMP

--- a/include/TParsingDiagnostics.h
+++ b/include/TParsingDiagnostics.h
@@ -30,14 +30,14 @@
 class TParsingDiagnosticsData : public TObject {
 public:
    TParsingDiagnosticsData();
-   explicit TParsingDiagnosticsData(const std::shared_ptr<const TFragment>& frag);
+   explicit TParsingDiagnosticsData(const std::shared_ptr<TFragment>& frag);
    TParsingDiagnosticsData(const TParsingDiagnosticsData&)                = default;
    TParsingDiagnosticsData(TParsingDiagnosticsData&&) noexcept            = default;
    TParsingDiagnosticsData& operator=(const TParsingDiagnosticsData&)     = default;
    TParsingDiagnosticsData& operator=(TParsingDiagnosticsData&&) noexcept = default;
    ~TParsingDiagnosticsData()                                             = default;
 
-   void Update(const std::shared_ptr<const TFragment>& frag);
+   void Update(const std::shared_ptr<TFragment>& frag);
    using TObject::Print;
    void Print(UInt_t address) const;
 
@@ -102,7 +102,7 @@ private:
 public:
 //"setter" functions
 #ifndef __CINT__
-   void GoodFragment(const std::shared_ptr<const TFragment>&);
+   void GoodFragment(const std::shared_ptr<TFragment>&);
 #endif
    void GoodFragment(Short_t detType)
    {

--- a/include/TRuntimeObjects.h
+++ b/include/TRuntimeObjects.h
@@ -29,7 +29,7 @@ class TRuntimeObjects : public TNamed {
 public:
 /// Constructor
 #ifndef __CINT__
-   TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* objects, TList* gates, std::vector<TFile*>& cut_files,
+   TRuntimeObjects(std::shared_ptr<TFragment> frag, TList* objects, TList* gates, std::vector<TFile*>& cut_files,
                    TDirectory* directory = nullptr, const char* name = "default");
 #endif
    TRuntimeObjects(TList* objects, TList* gates, std::vector<TFile*>& cut_files, TDirectory* directory = nullptr,
@@ -43,7 +43,7 @@ public:
       return fDetectors->GetDetector<T>();
    }
 
-   std::shared_ptr<const TFragment> GetFragment() { return fFrag; }
+   std::shared_ptr<TFragment> GetFragment() { return fFrag; }
 #endif
 
    TCutG* GetCut(const std::string& name);
@@ -123,7 +123,7 @@ public:
    }
 
 #ifndef __CINT__
-   void SetFragment(std::shared_ptr<const TFragment> frag)
+   void SetFragment(std::shared_ptr<TFragment> frag)
    {
       fFrag = std::move(frag);
    }
@@ -141,7 +141,7 @@ private:
    TDirectory*                                    FindDirectory(const char*);
 #ifndef __CINT__
    std::shared_ptr<TUnpackedEvent>  fDetectors;
-   std::shared_ptr<const TFragment> fFrag;
+   std::shared_ptr<TFragment> fFrag;
 #endif
    TList*               fObjects{nullptr};
    TList*               fGates{nullptr};

--- a/include/TUnpackedEvent.h
+++ b/include/TUnpackedEvent.h
@@ -32,8 +32,8 @@ public:
 
    std::vector<std::shared_ptr<TDetector>>& GetDetectors() { return fDetectors; }
    void                                     AddDetector(const std::shared_ptr<TDetector>& det) { fDetectors.push_back(det); }
-   void                                     AddRawData(const std::shared_ptr<const TFragment>& frag);
-   void                                     SetRawData(const std::vector<std::shared_ptr<const TFragment>>& fragments) { fFragments = fragments; }
+   void                                     AddRawData(const std::shared_ptr<TFragment>& frag);
+   void                                     SetRawData(const std::vector<std::shared_ptr<TFragment>>& fragments) { fFragments = fragments; }
 #endif
    void ClearRawData();
 
@@ -49,7 +49,7 @@ private:
    void BuildHits();
 
 #ifndef __CINT__
-   std::vector<std::shared_ptr<const TFragment>> fFragments;
+   std::vector<std::shared_ptr<TFragment>> fFragments;
    std::vector<std::shared_ptr<TDetector>>       fDetectors;
 #endif
 };

--- a/include/TUnpackingLoop.h
+++ b/include/TUnpackingLoop.h
@@ -41,7 +41,7 @@ public:
    {
       return fInputQueue;
    }
-   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>& AddGoodOutputQueue(size_t maxSize = 50000)
+   std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>& AddGoodOutputQueue(size_t maxSize = 50000)
    {
       return fParser->AddGoodOutputQueue(maxSize);
    }

--- a/libraries/TAnalysis/TBgo/TBgo.cxx
+++ b/libraries/TAnalysis/TBgo/TBgo.cxx
@@ -150,7 +150,7 @@ void TBgo::Print(std::ostream& out) const
    out << str.str();
 }
 
-void TBgo::AddFragment(const std::shared_ptr<const TFragment>& frag, TChannel* chan)
+void TBgo::AddFragment(const std::shared_ptr<TFragment>& frag, TChannel* chan)
 {
    // Builds the BGO Hits directly from the TFragment. Basically, loops through the hits for an event and sets
    // observables.

--- a/libraries/TDataParser/TDataParser.cxx
+++ b/libraries/TDataParser/TDataParser.cxx
@@ -31,7 +31,7 @@ TDataParser::~TDataParser()
 
 void TDataParser::ClearQueue()
 {
-   std::shared_ptr<const TFragment> frag;
+   std::shared_ptr<TFragment> frag;
    for(const auto& outQueue : fGoodOutputQueues) {
       while(outQueue->Size() != 0u) {
          outQueue->Pop(frag);
@@ -56,7 +56,7 @@ void TDataParser::SetFinished()
    fScalerOutputQueue->SetFinished();
 }
 
-void TDataParser::Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>& queues,
+void TDataParser::Push(std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>& queues,
                        const std::shared_ptr<TFragment>&                                                frag)
 {
    frag->SetFragmentId(fFragmentIdMap[frag->GetTriggerId()]);

--- a/libraries/TDataParser/TFragmentMap.cxx
+++ b/libraries/TDataParser/TFragmentMap.cxx
@@ -5,7 +5,7 @@
 bool TFragmentMap::fDebug = false;
 
 TFragmentMap::TFragmentMap(
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>>& goodOutputQueue,
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>>& goodOutputQueue,
    std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>&           badOutputQueue)
    : fGoodOutputQueue(goodOutputQueue), fBadOutputQueue(badOutputQueue)
 {

--- a/libraries/TFormat/TDetectorHit.cxx
+++ b/libraries/TFormat/TDetectorHit.cxx
@@ -143,7 +143,7 @@ void TDetectorHit::Copy(TObject& rhs, bool copywave) const
    }
 }
 
-//void TDetectorHit::CopyFragment(const TFragment& frag)
+//void TDetectorHit::CopyFragment(TFragment& frag)
 //{
 //	frag.Copy(*this);
 //}

--- a/libraries/TFormat/TParsingDiagnostics.cxx
+++ b/libraries/TFormat/TParsingDiagnostics.cxx
@@ -8,13 +8,13 @@
 
 TParsingDiagnosticsData::TParsingDiagnosticsData() = default;
 
-TParsingDiagnosticsData::TParsingDiagnosticsData(const std::shared_ptr<const TFragment>& frag)
+TParsingDiagnosticsData::TParsingDiagnosticsData(const std::shared_ptr<TFragment>& frag)
    : fMinChannelId(frag->GetChannelId()), fMaxChannelId(frag->GetChannelId()), fNumberOfHits(1),
      fDeadTime(frag->GetDeadTime()), fMinTimeStamp(frag->GetTimeStampNs()), fMaxTimeStamp(frag->GetTimeStampNs())
 {
 }
 
-void TParsingDiagnosticsData::Update(const std::shared_ptr<const TFragment>& frag)
+void TParsingDiagnosticsData::Update(const std::shared_ptr<TFragment>& frag)
 {
    UInt_t channelId = frag->GetChannelId();
    auto   timeStamp = frag->GetTimeStampNs();
@@ -110,7 +110,7 @@ void TParsingDiagnostics::Print(Option_t*) const
    }
 }
 
-void TParsingDiagnostics::GoodFragment(const std::shared_ptr<const TFragment>& frag)
+void TParsingDiagnostics::GoodFragment(const std::shared_ptr<TFragment>& frag)
 {
    /// increment the counter of good fragments for this detector type and check if any trigger ids have been lost
    fNumberOfGoodFragments[frag->GetDetectorType()]++;

--- a/libraries/TGRSIint/TGRSIint.cxx
+++ b/libraries/TGRSIint/TGRSIint.cxx
@@ -548,7 +548,7 @@ void TGRSIint::SetupPipeline()
    StoppableThread::StatusWidth(TGRSIOptions::Get()->StatusWidth());
 
    // Different queues that can show up
-   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<const TFragment>>>> fragmentQueues;
+   std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TFragment>>>> fragmentQueues;
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TEpicsFrag>>>>      scalerQueues;
    std::vector<std::shared_ptr<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>>  analysisQueues;
 

--- a/libraries/TLoops/TAnalysisWriteLoop.cxx
+++ b/libraries/TLoops/TAnalysisWriteLoop.cxx
@@ -39,7 +39,7 @@ TAnalysisWriteLoop::TAnalysisWriteLoop(std::string name, const std::string& outp
    : StoppableThread(std::move(name)),
      fOutputFile(TFile::Open(outputFilename.c_str(), "recreate")),
      fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TUnpackedEvent>>>()),
-     fOutOfOrderQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>())
+     fOutOfOrderQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>())
 {
    if(fOutputFile == nullptr || !fOutputFile->IsOpen()) {
       std::cerr << "Failed to open '" << outputFilename << "'" << std::endl;
@@ -103,7 +103,7 @@ bool TAnalysisWriteLoop::Iteration()
    }
 
    if(fOutOfOrder) {
-      std::shared_ptr<const TFragment> frag;
+      std::shared_ptr<TFragment> frag;
       fOutOfOrderQueue->Pop(frag, 0);
       if(frag != nullptr) {
          *fOutOfOrderFrag = *frag;

--- a/libraries/TLoops/TCompiledHistograms.cxx
+++ b/libraries/TLoops/TCompiledHistograms.cxx
@@ -132,7 +132,7 @@ void TCompiledHistograms::swap_lib(TCompiledHistograms& other)
    std::swap(fCheckEvery, other.fCheckEvery);
 }
 
-void TCompiledHistograms::Fill(std::shared_ptr<const TFragment> frag)
+void TCompiledHistograms::Fill(std::shared_ptr<TFragment> frag)
 {
    std::lock_guard<std::mutex> lock(fMutex);
    if(time(nullptr) > fLastChecked + fCheckEvery) {

--- a/libraries/TLoops/TDetBuildingLoop.cxx
+++ b/libraries/TLoops/TDetBuildingLoop.cxx
@@ -19,7 +19,7 @@ TDetBuildingLoop* TDetBuildingLoop::Get(std::string name)
 
 TDetBuildingLoop::TDetBuildingLoop(std::string name)
    : StoppableThread(std::move(name)),
-     fInputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>>())
+     fInputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>>())
 {
 }
 
@@ -27,7 +27,7 @@ TDetBuildingLoop::~TDetBuildingLoop() = default;
 
 bool TDetBuildingLoop::Iteration()
 {
-   std::vector<std::shared_ptr<const TFragment>> frags;
+   std::vector<std::shared_ptr<TFragment>> frags;
 
    InputSize(fInputQueue->Pop(frags));
    if(InputSize() < 0) {
@@ -58,7 +58,7 @@ bool TDetBuildingLoop::Iteration()
 
 void TDetBuildingLoop::ClearQueue()
 {
-   std::vector<std::shared_ptr<const TFragment>> rawEvent;
+   std::vector<std::shared_ptr<TFragment>> rawEvent;
    while(fInputQueue->Size() != 0u) {
       fInputQueue->Pop(rawEvent);
    }

--- a/libraries/TLoops/TEventBuildingLoop.cxx
+++ b/libraries/TLoops/TEventBuildingLoop.cxx
@@ -2,9 +2,11 @@
 
 #include "TGRSIOptions.h"
 #include "TSortingDiagnostics.h"
+#include "TRunInfo.h"
 
 #include <chrono>
 #include <thread>
+#include <fstream>
 
 TEventBuildingLoop* TEventBuildingLoop::Get(std::string name, EBuildMode mode, uint64_t buildWindow)
 {
@@ -20,34 +22,34 @@ TEventBuildingLoop* TEventBuildingLoop::Get(std::string name, EBuildMode mode, u
 }
 
 TEventBuildingLoop::TEventBuildingLoop(std::string name, EBuildMode mode, uint64_t buildWindow)
-   : StoppableThread(std::move(name)), fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>()),
-     fOutputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<const TFragment>>>>()),
-     fOutOfOrderQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>()), fBuildMode(mode),
+   : StoppableThread(std::move(name)), fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>()),
+     fOutputQueue(std::make_shared<ThreadsafeQueue<std::vector<std::shared_ptr<TFragment>>>>()),
+     fOutOfOrderQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>()), fBuildMode(mode),
      fSortingDepth(10000), fBuildWindow(buildWindow), fPreviousSortingDepthError(false), fSkipInputSort(TGRSIOptions::Get()->SkipInputSort())
 {
    std::cout << DYELLOW << (fSkipInputSort ? "Not sorting " : "Sorting ") << "input by time: ";
    switch(fBuildMode) {
    case EBuildMode::kTime:
-      fOrdered = decltype(fOrdered)([](const std::shared_ptr<const TFragment>& a, const std::shared_ptr<const TFragment>& b) {
-         return a->GetTime() < b->GetTime();
+      fOrdered = decltype(fOrdered)([](const std::pair<std::shared_ptr<TFragment>, Long64_t>& a, const std::pair<std::shared_ptr<TFragment>, Long64_t>& b) {
+         return a.first->GetTime() < b.first->GetTime();
       });
       std::cout << DYELLOW << "sorting by time, using build window of " << fBuildWindow << "!" << RESET_COLOR << std::endl;
       break;
    case EBuildMode::kTimestamp:
-      fOrdered = decltype(fOrdered)([](const std::shared_ptr<const TFragment>& a, const std::shared_ptr<const TFragment>& b) {
-         return a->GetTimeStampNs() < b->GetTimeStampNs();
+      fOrdered = decltype(fOrdered)([](const std::pair<std::shared_ptr<TFragment>, Long64_t>& a, const std::pair<std::shared_ptr<TFragment>, Long64_t>& b) {
+         return a.first->GetTimeStampNs() < b.first->GetTimeStampNs();
       });
       std::cout << DYELLOW << "sorting by timestamp, using build window of " << fBuildWindow << "!" << RESET_COLOR << std::endl;
       break;
    case EBuildMode::kTriggerId:
-      fOrdered = decltype(fOrdered)([](const std::shared_ptr<const TFragment>& a, const std::shared_ptr<const TFragment>& b) {
-         return a->GetTriggerId() < b->GetTriggerId();
+      fOrdered = decltype(fOrdered)([](const std::pair<std::shared_ptr<TFragment>, Long64_t>& a, const std::pair<std::shared_ptr<TFragment>, Long64_t>& b) {
+         return a.first->GetTriggerId() < b.first->GetTriggerId();
       });
       std::cout << DYELLOW << "sorting by trigger ID!" << RESET_COLOR << std::endl;
       break;
    case EBuildMode::kSkip:
       // no need for ordering, always return true
-      fOrdered = decltype(fOrdered)([](const std::shared_ptr<const TFragment>&, const std::shared_ptr<const TFragment>&) {
+      fOrdered = decltype(fOrdered)([](const std::pair<std::shared_ptr<TFragment>, Long64_t>&, const std::pair<std::shared_ptr<TFragment>, Long64_t>&) {
          return true;
       });
       std::cout << DYELLOW << "not sorting!" << RESET_COLOR << std::endl;
@@ -57,18 +59,53 @@ TEventBuildingLoop::TEventBuildingLoop(std::string name, EBuildMode mode, uint64
       throw std::runtime_error("Error in event building loop, no build mode selected. Maybe because no custom run info was loaded?");
       break;
    }
+
+   fOffsetFile = Form("offset%05d.txt", TRunInfo::RunNumber());
+   // if this is not the first sub-run, try to read the offset file
+   if(TRunInfo::SubRunNumber() > 0) {
+      std::ifstream file(fOffsetFile);
+      file >> fDaqTimeStampOffset;
+      std::cout << "Using previously determined daq time offset " << fDaqTimeStampOffset << " (read from " << fOffsetFile << ")" << std::endl;
+      file.close();
+   }
+
+   auto* ppg = TPPG::Get();
+	fCycleLength = ppg->OdbCycleLength();
+	
+	// the beam off where we collect data is the last step, so we add up all duration until we get there
+	for(size_t i = 0; i < ppg->OdbPPGSize(); ++i) {
+		if(ppg->OdbPPGCode(i) == 0xc008) {
+			fTapeMoveLength = ppg->OdbDuration(i);
+		}
+		if(ppg->OdbPPGCode(i) == 0xc002) {
+			fBackgroundLength = ppg->OdbDuration(i);
+		}
+		if(ppg->OdbPPGCode(i) == 0xc001) {
+			fImplantDaqOnLength = ppg->OdbDuration(i);
+		}
+		if(ppg->OdbPPGCode(i) == 0x8001) {
+			fImplantDaqOffLength = ppg->OdbDuration(i);
+		}
+		if(ppg->OdbPPGCode(i) == 0x8004) {
+			fDecayDaqOffLength = ppg->OdbDuration(i);
+		}
+	}
+   std::cout << "Using cycle length " << static_cast<double>(fCycleLength) / 1e6 << ", tape move length " << static_cast<double>(fTapeMoveLength) / 1e6
+             << ", background length " << static_cast<double>(fBackgroundLength) / 1e6 << ", implant length (DAQ on) " << static_cast<double>(fImplantDaqOnLength) / 1e6
+             << ", implant length (DAQ off) " << static_cast<double>(fImplantDaqOffLength) / 1e6 << ", and decay (DAQ off) length "
+             << static_cast<double>(fDecayDaqOffLength) / 1e6 << " to build events!" << std::endl;
 }
 
 TEventBuildingLoop::~TEventBuildingLoop() = default;
 
 void TEventBuildingLoop::ClearQueue()
 {
-   std::shared_ptr<const TFragment> singleEvent;
+   std::shared_ptr<TFragment> singleEvent;
    while(fInputQueue->Size() != 0u) {
       fInputQueue->Pop(singleEvent);
    }
 
-   std::vector<std::shared_ptr<const TFragment>> event;
+   std::vector<std::shared_ptr<TFragment>> event;
    while(fOutputQueue->Size() != 0u) {
       fOutputQueue->Pop(event);
    }
@@ -77,16 +114,18 @@ void TEventBuildingLoop::ClearQueue()
 bool TEventBuildingLoop::Iteration()
 {
    // Pull something off of the input queue.
-   std::shared_ptr<const TFragment> inputFragment = nullptr;
+   std::shared_ptr<TFragment> inputFragment = nullptr;
    InputSize(fInputQueue->Pop(inputFragment, 0));
    if(InputSize() < 0) {
       InputSize(0);
    }
 
    if(inputFragment != nullptr) {
+		Long64_t originalTimeStamp = inputFragment->GetTimeStamp();
+		CheckWrapAround(inputFragment);
       IncrementItemsPopped();
       if(!fSkipInputSort) {
-         fOrdered.insert(inputFragment);
+         fOrdered.insert(std::make_pair(inputFragment, originalTimeStamp));
          if(fOrdered.size() < fSortingDepth) {
             // Got a new event, but we want to have more to sort
             return true;
@@ -113,9 +152,9 @@ bool TEventBuildingLoop::Iteration()
    }
 
    // We have data, and we want to add it to the next fragment;
-   std::shared_ptr<const TFragment> nextFragment;
+   std::shared_ptr<TFragment> nextFragment;
    if(!fSkipInputSort) {
-      nextFragment = *fOrdered.begin();
+      nextFragment = (*fOrdered.begin()).first;
       fOrdered.erase(fOrdered.begin());
    } else {
       nextFragment = inputFragment;
@@ -128,7 +167,7 @@ bool TEventBuildingLoop::Iteration()
    return true;
 }
 
-bool TEventBuildingLoop::CheckBuildCondition(const std::shared_ptr<const TFragment>& frag)
+bool TEventBuildingLoop::CheckBuildCondition(const std::shared_ptr<TFragment>& frag)
 {
    switch(fBuildMode) {
    case EBuildMode::kTime: return CheckTimeCondition(frag); break;
@@ -145,7 +184,7 @@ bool TEventBuildingLoop::CheckBuildCondition(const std::shared_ptr<const TFragme
    return false;   // we should never reach this statement!
 }
 
-bool TEventBuildingLoop::CheckTimeCondition(const std::shared_ptr<const TFragment>& frag)
+bool TEventBuildingLoop::CheckTimeCondition(const std::shared_ptr<TFragment>& frag)
 {
    double time       = frag->GetTime();
    double eventStart = (!fNextEvent.empty() ? (TGRSIOptions::AnalysisOptions()->StaticWindow() ? fNextEvent[0]->GetTime()
@@ -181,7 +220,7 @@ bool TEventBuildingLoop::CheckTimeCondition(const std::shared_ptr<const TFragmen
    return true;
 }
 
-bool TEventBuildingLoop::CheckTimestampCondition(const std::shared_ptr<const TFragment>& frag)
+bool TEventBuildingLoop::CheckTimestampCondition(const std::shared_ptr<TFragment>& frag)
 {
    uint64_t timestamp  = frag->GetTimeStampNs();
    uint64_t eventStart = (!fNextEvent.empty() ? (TGRSIOptions::AnalysisOptions()->StaticWindow() ? fNextEvent[0]->GetTimeStampNs()
@@ -216,7 +255,7 @@ bool TEventBuildingLoop::CheckTimestampCondition(const std::shared_ptr<const TFr
    return true;
 }
 
-bool TEventBuildingLoop::CheckTriggerIdCondition(const std::shared_ptr<const TFragment>& frag)
+bool TEventBuildingLoop::CheckTriggerIdCondition(const std::shared_ptr<TFragment>& frag)
 {
    int64_t triggerId        = frag->GetTriggerId();
    int64_t currentTriggerId = (!fNextEvent.empty() ? fNextEvent[0]->GetTriggerId() : triggerId);
@@ -258,4 +297,33 @@ std::string TEventBuildingLoop::EndStatus()
        << std::endl;
 
    return str.str();
+}
+
+void TEventBuildingLoop::CheckWrapAround(const std::shared_ptr<TFragment>& frag)
+{
+	/// We check the wrap around due to us turning the DAQ off during the implant
+	/// and back on during the decay.
+	/// For this we use the very first fragment to determine the offset of the DAQ timestamp
+	/// (which is time in s from 01.1.1970), and then compare the difference between the timestamp in seconds
+	/// and the offset corrected DAQ timestamp to calculate the wrap around. 
+	/// Comments below are outdated!
+	/// If we are past the background plus both implants (ignoring the decay w/ DAQ off) we correct the timestamp
+	/// by adding the background, both implants, and the decay w/ DAQ on plus (the difference between TS and corr. DAQ TS
+	/// divided by the cycle length) times the cycle length. The latter ensure we only add full cycles.
+	Long64_t timeStamp      = frag->GetTimeStampNs();
+	time_t daqTimeStamp = frag->GetDaqTimeStamp();
+
+	if(fDaqTimeStampOffset == 0 && TRunInfo::SubRunNumber() == 0) {
+		fDaqTimeStampOffset = daqTimeStamp - timeStamp/1000000000;
+		std::ofstream file(fOffsetFile);
+		file<<fDaqTimeStampOffset;
+		file.close();
+		std::cout<<"Wrote daq time offset "<<fDaqTimeStampOffset<<" to "<<fOffsetFile<<std::endl;
+	}
+
+	Long64_t offset = daqTimeStamp - fDaqTimeStampOffset - timeStamp/1000000000;
+	if(offset > (fImplantDaqOffLength + fDecayDaqOffLength)/1000000 - 1) { // -1 to account for uncertainty of offset between DAQ time (1 s precision) and timestamps
+		timeStamp += (fTapeMoveLength + fBackgroundLength + fImplantDaqOnLength + fImplantDaqOffLength + fDecayDaqOffLength)*1000 + (offset/(fCycleLength/1000000))*fCycleLength*1000;
+		frag->SetTimeStamp(timeStamp/frag->GetTimeStampUnit());
+	}
 }

--- a/libraries/TLoops/TFragDiagnosticsLoop.cxx
+++ b/libraries/TLoops/TFragDiagnosticsLoop.cxx
@@ -38,7 +38,7 @@ TFragDiagnosticsLoop* TFragDiagnosticsLoop::Get(std::string name, std::string fO
 
 TFragDiagnosticsLoop::TFragDiagnosticsLoop(std::string name, const std::string& fOutputFilename)
    : StoppableThread(std::move(name)),
-     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>())
+     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>())
 {
    if(fOutputFilename != "/dev/null") {
       TThread::Lock();
@@ -61,7 +61,7 @@ TFragDiagnosticsLoop::~TFragDiagnosticsLoop()
 void TFragDiagnosticsLoop::ClearQueue()
 {
    while(fInputQueue->Size() != 0u) {
-      std::shared_ptr<const TFragment> event;
+      std::shared_ptr<TFragment> event;
       fInputQueue->Pop(event);
    }
 }
@@ -76,7 +76,7 @@ std::string TFragDiagnosticsLoop::EndStatus()
 
 bool TFragDiagnosticsLoop::Iteration()
 {
-   std::shared_ptr<const TFragment> event;
+   std::shared_ptr<TFragment> event;
    InputSize(fInputQueue->Pop(event, 0));
    if(InputSize() < 0) {
       InputSize(0);
@@ -195,7 +195,7 @@ bool TFragDiagnosticsLoop::CreateHistograms()
    return true;
 }
 
-void TFragDiagnosticsLoop::Process(const std::shared_ptr<const TFragment>& event)
+void TFragDiagnosticsLoop::Process(const std::shared_ptr<TFragment>& event)
 {
    if(fAccepted == nullptr || fLostNetworkPackets == nullptr || fLostChannelIds == nullptr ||
       fLostAcceptedIds == nullptr || fLostChannelIdsTime == nullptr || fLostAcceptedIdsTime == nullptr) {

--- a/libraries/TLoops/TFragHistLoop.cxx
+++ b/libraries/TLoops/TFragHistLoop.cxx
@@ -24,7 +24,7 @@ TFragHistLoop* TFragHistLoop::Get(std::string name)
 
 TFragHistLoop::TFragHistLoop(std::string name)
    : StoppableThread(std::move(name)), fOutputFile(nullptr), fOutputFilename("last.root"),
-     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>())
+     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>())
 {
    LoadLibrary(TGRSIOptions::Get()->FragmentHistogramLib());
 }
@@ -37,14 +37,14 @@ TFragHistLoop::~TFragHistLoop()
 void TFragHistLoop::ClearQueue()
 {
    while(fInputQueue->Size() != 0u) {
-      std::shared_ptr<const TFragment> event;
+      std::shared_ptr<TFragment> event;
       fInputQueue->Pop(event);
    }
 }
 
 bool TFragHistLoop::Iteration()
 {
-   std::shared_ptr<const TFragment> event;
+   std::shared_ptr<TFragment> event;
    InputSize(fInputQueue->Pop(event));
 
    if(event) {

--- a/libraries/TLoops/TFragWriteLoop.cxx
+++ b/libraries/TLoops/TFragWriteLoop.cxx
@@ -37,7 +37,7 @@ TFragWriteLoop* TFragWriteLoop::Get(std::string name, std::string fOutputFilenam
 
 TFragWriteLoop::TFragWriteLoop(std::string name, const std::string& fOutputFilename)
    : StoppableThread(std::move(name)), fOutputFile(nullptr), fEventTree(nullptr), fBadEventTree(nullptr), fScalerTree(nullptr),
-     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TFragment>>>()),
+     fInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TFragment>>>()),
      fBadInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<const TBadFragment>>>()),
      fScalerInputQueue(std::make_shared<ThreadsafeQueue<std::shared_ptr<TEpicsFrag>>>())
 {
@@ -73,7 +73,7 @@ TFragWriteLoop::~TFragWriteLoop()
 void TFragWriteLoop::ClearQueue()
 {
    while(fInputQueue->Size() != 0u) {
-      std::shared_ptr<const TFragment> event;
+      std::shared_ptr<TFragment> event;
       fInputQueue->Pop(event);
    }
 }
@@ -90,7 +90,7 @@ std::string TFragWriteLoop::EndStatus()
 
 bool TFragWriteLoop::Iteration()
 {
-   std::shared_ptr<const TFragment> event;
+   std::shared_ptr<TFragment> event;
    InputSize(fInputQueue->Pop(event, 0));
    if(InputSize() < 0) {
       InputSize(0);
@@ -197,7 +197,7 @@ void TFragWriteLoop::Write()
    }
 }
 
-void TFragWriteLoop::WriteEvent(const std::shared_ptr<const TFragment>& event)
+void TFragWriteLoop::WriteEvent(const std::shared_ptr<TFragment>& event)
 {
    if(fEventTree != nullptr) {
       *fEventAddress = *event;

--- a/libraries/TLoops/TFragmentChainLoop.cxx
+++ b/libraries/TLoops/TFragmentChainLoop.cxx
@@ -38,7 +38,7 @@ void TFragmentChainLoop::ClearQueue()
 {
    for(const auto& outQueue : fOutputQueues) {
       while(outQueue->Size() != 0u) {
-         std::shared_ptr<const TFragment> event;
+         std::shared_ptr<TFragment> event;
          outQueue->Pop(event);
       }
    }

--- a/libraries/TLoops/TRuntimeObjects.cxx
+++ b/libraries/TLoops/TRuntimeObjects.cxx
@@ -13,7 +13,7 @@
 
 std::map<std::string, TRuntimeObjects*> TRuntimeObjects::fRuntimeMap;
 
-TRuntimeObjects::TRuntimeObjects(std::shared_ptr<const TFragment> frag, TList* objects, TList* gates,
+TRuntimeObjects::TRuntimeObjects(std::shared_ptr<TFragment> frag, TList* objects, TList* gates,
                                  std::vector<TFile*>& cut_files, TDirectory* directory, const char* name)
    : fFrag(std::move(frag)), fObjects(objects), fGates(gates), fCut_files(cut_files), fDirectory(directory)
 {

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -32,7 +32,7 @@ void TUnpackedEvent::Build()
    ClearRawData();
 }
 
-void TUnpackedEvent::AddRawData(const std::shared_ptr<const TFragment>& frag)
+void TUnpackedEvent::AddRawData(const std::shared_ptr<TFragment>& frag)
 {
    fFragments.push_back(frag);
 }


### PR DESCRIPTION
**This branch requires the use of the S2049 branch for GRSIData as well!**

These changes were made to deal with the issues that arise from turning off the acquisition of data during the cycle (when the data rate gets too high). The way we do it is by relating events to the DAQ timestamp (in s since LINUX epoch) and for that we need to determine the offset between the first event (timestamp 0) and the DAQ timestamp at the beginning of the run. This means users need to first sort the first sub-run (which determines the offset and writes it to a file), before sorting the other sub-runs (which read the offset from that file).

Might re-visit this at some point to see if it is possible to implement those changes in the data parser instead of the event building loop, so that we can use constant TFragments throughout the code (meaning less changes between this branch and the main branch).

There is still an issue with some runs (like 22116), where we have some hits at the very beginning that are leftovers from the previous run and have large timestamps.