### PR TITLE
Fixed issue with TDetectorHit assignment operator

### DIFF
--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -20,7 +20,7 @@
 /// The TChannel is designed to hold all non-essential
 /// information of a TFragment (now the same as a hit; name, energy coeff, etc..)
 /// that would otherwise clog up the FragmentTree.  The TChannel class
-/// contains a static map to every channel make retrieval fairly
+/// contains a static map to every channel to make retrieval fairly
 /// easy.  The TChannel class also contains the ability to
 /// read and write a custom calibration file to set or
 /// save the TChannel information. Most of the information is read out

--- a/include/TDetectorHit.h
+++ b/include/TDetectorHit.h
@@ -77,8 +77,8 @@ public:
    TDetectorHit(TDetectorHit&&) noexcept = default;
    ~TDetectorHit();
 
-   TDetectorHit& operator=(const TDetectorHit&)     = default;
-   TDetectorHit& operator=(TDetectorHit&&) noexcept = default;
+   TDetectorHit& operator=(const TDetectorHit& rhs)     { rhs.Copy(*this); return *this; }
+   TDetectorHit& operator=(TDetectorHit&& rhs) noexcept { rhs.Copy(*this); return *this; }
 
    // static void SetPPGPtr(TPPG* ptr) { fPPG = ptr; }
 


### PR DESCRIPTION
Using the default does not work, we need to use a custom one that employs the (overloaded) Copy function.