### PR TITLE
Added CrossTalkFix program

### DIFF
--- a/examples/CrossTalkCheckHelper.cxx
+++ b/examples/CrossTalkCheckHelper.cxx
@@ -1,0 +1,32 @@
+#include "CrossTalkCheckHelper.hh"
+
+void CrossTalkCheckHelper::CreateHistograms(unsigned int slot)
+{
+   // total addback spectrum
+   fH1[slot]["griffinESuppAddback"]             = new TH1F("griffinESuppAddback", Form("Suppressed griffin addback energy;energy [keV];counts/%.1f keV", (fHighEnergy - fLowEnergy) / fEnergyBins), fEnergyBins, fLowEnergy, fHighEnergy);
+
+   // addback spectrum with 1-4 cyrstals/fragments involved
+   for(int nCry = 1; nCry <= 4; ++nCry) {
+      fH1[slot][Form("griffinESuppAddback%d", nCry)]             = new TH1F(Form("griffinESuppAddback%d", nCry), Form("Suppressed griffin addback energy with %d crystals/fragments;energy [keV];counts/%.1f keV", nCry, (fHighEnergy - fLowEnergy) / fEnergyBins), fEnergyBins, fLowEnergy, fHighEnergy);
+   }
+}
+
+// TODO: Change the function arguments to match the detectors you want to use and the declaration in the header file!
+void CrossTalkCheckHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo)   // NOLINT
+{
+   // we use .at() here instead of [] so that we get meaningful error message if a histogram we try to fill wasn't created
+   // e.g. because of a typo
+
+   // loop over suppressed griffin addback hits
+   for(int g = 0; g < grif.GetSuppressedAddbackMultiplicity(&grifBgo); ++g) {
+      auto* grif1 = grif.GetSuppressedAddbackHit(g);
+      fH1[slot].at("griffinESuppAddback")->Fill(grif1->GetEnergy());
+      if(1 <= grif.GetNSuppressedAddbackFrags(g) && grif.GetNSuppressedAddbackFrags(g) <= 4) {
+         fH1[slot].at(Form("griffinESuppAddback%d", grif.GetNSuppressedAddbackFrags(g)))->Fill(grif1->GetEnergy());
+      }
+   }
+}
+
+void CrossTalkCheckHelper::EndOfSort(std::shared_ptr<std::map<std::string, TList>>& list)
+{
+}

--- a/examples/CrossTalkCheckHelper.hh
+++ b/examples/CrossTalkCheckHelper.hh
@@ -1,0 +1,60 @@
+#ifndef CROSSTALKCHECKHELPER_HH
+#define CROSSTALKCHECKHELPER_HH
+
+#include "TGRSIHelper.h"
+#include "TGRSIOptions.h"
+
+#include "TGriffin.h"
+#include "TGriffinBgo.h"
+
+// This is a custom action which respects a well defined interface. It supports parallelism,
+// in the sense that it behaves correctly if implicit multi threading is enabled.
+// Note the plural: in presence of a MT execution, internally more than a single TList is created.
+// The detector types in the specifcation of Book must match those in the call to it as well as those in the Exec function (and be in the same order)!
+
+class CrossTalkCheckHelper : public TGRSIHelper, public ROOT::Detail::RDF::RActionImpl<CrossTalkCheckHelper> {
+public:
+   // constructor sets the prefix (which is used for the output file as well)
+   // and calls Setup which in turn also calls CreateHistograms
+   explicit CrossTalkCheckHelper(TList* list)
+      : TGRSIHelper(list)
+   {
+      if(fUserSettings != nullptr) {
+         fEnergyBins = fUserSettings->GetInt("Energy.Bins", fEnergyBins);
+         fLowEnergy  = fUserSettings->GetDouble("Energy.Low", fLowEnergy);
+         fHighEnergy = fUserSettings->GetDouble("Energy.High", fHighEnergy);
+      }
+      Prefix("CrossTalkCheck");
+      Setup();
+   }
+
+   ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override
+   {
+      std::cout << "Using options:" << std::endl;
+      TGRSIOptions::Get()->Print();
+      if(TGRSIOptions::Get()->NumberOfEvents() > 0) {
+         return d->Range(TGRSIOptions::Get()->NumberOfEvents()).Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
+      }
+      return d->Book<TGriffin, TGriffinBgo>(std::move(*this), {"TGriffin", "TGriffinBgo"});
+   }
+   // this function creates and books all histograms
+   void CreateHistograms(unsigned int slot) override;
+   // this function gets called for every single event and fills the histograms
+   void Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifBgo);
+   // this function is optional and is called after the output lists off all slots/workers have been merged
+   void EndOfSort(std::shared_ptr<std::map<std::string, TList>>& list) override;
+
+private:
+   // any constants that are set in the CreateHistograms function and used in the Exec function can be stored here
+   // or any other settings
+   int fEnergyBins{10000};
+   double fLowEnergy{0.};
+   double fHighEnergy{2000.};
+};
+
+// These are needed functions used by TDataFrameLibrary to create and destroy the instance of this helper
+extern "C" CrossTalkCheckHelper* CreateHelper(TList* list) { return new CrossTalkCheckHelper(list); }
+
+extern "C" void DestroyHelper(TGRSIHelper* helper) { delete helper; }
+
+#endif

--- a/examples/CrossTalkHelper.cxx
+++ b/examples/CrossTalkHelper.cxx
@@ -5,39 +5,23 @@ bool pileup_reject = false;
 const double gg_time_low  = -200.;
 const double gg_time_high = 300.;
 
-// Beta gamma histograms
-const double gb_time_low  = -250.;
-const double gb_time_high = 350.;
-
 // default k-value this might have to be adjusted for each experiment!!!
 const Short_t defaultKValue = 379;
 
-bool Addback(TGriffinHit* one, TGriffinHit* two)
-{
-   return ((one->GetDetector() == two->GetDetector()) && (std::fabs(one->GetTime() - two->GetTime()) < 300.));
-}
-
 bool PromptCoincidence(TGriffinHit* one, TGriffinHit* two)
 {
-
    return ((two->GetTime() - one->GetTime()) >= gg_time_low) && ((two->GetTime() - one->GetTime()) <= gg_time_high);
 }
 
 void CrossTalkHelper::CreateHistograms(unsigned int slot)
 {
    for(int det_num = 1; det_num <= 16; ++det_num) {
-      std::string aedet_str  = Form("aEdet%d", det_num);
-      std::string gedet_str  = Form("gEdet%d", det_num);
-      std::string ae2det_str = Form("aE2det%d", det_num);
-      fH1[slot][aedet_str]   = new TH1D(Form("aEdet%d", det_num), Form("Addback detector %d", det_num), 1500, 0, 1500);
-      fH1[slot][gedet_str]   = new TH1D(Form("geEdet%d", det_num), Form("Singles detector %d", det_num), 1500, 0, 1500);
-      fH1[slot][ae2det_str]  = new TH1D(Form("aE2det%d", det_num), Form("Addback with 2 hits, detector %d", det_num), 1500, 0, 1500);
-      for(int crys_1 = 0; crys_1 < 4; ++crys_1) {
-         for(int crys_2 = crys_1 + 1; crys_2 < 4; ++crys_2) {
-            std::string name_str  = Form("det_%d_%d_%d", det_num, crys_1, crys_2);
+      for(int crys1 = 0; crys1 < 4; ++crys1) {
+         for(int crys2 = crys1 + 1; crys2 < 4; ++crys2) {
+            std::string name_str  = Form("det_%d_%d_%d", det_num, crys1, crys2);
             const char* hist_name = name_str.c_str();
             std::cout << "Creating histogram: " << hist_name;
-            fH2[slot][name_str] = new TH2I(hist_name, hist_name, 1500, 0, 1500, 1500, 0, 1500);
+            fH2[slot][name_str] = new TH2I(hist_name, Form("Detector #%d, crystal %d vs. crystal %d", det_num, crys2, crys1), 1500, 0, 1500, 1500, 0, 1500);
             std::cout << " at address: " << fH2[slot][hist_name] << std::endl;
          }
       }
@@ -62,20 +46,16 @@ void CrossTalkHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifB
    for(auto gr1 = 0; gr1 < grif.GetSuppressedMultiplicity(&grifBgo); ++gr1) {
       auto* grif1 = grif.GetSuppressedHit(gr1);
       if(pileup_reject && (grif1->GetKValue() != defaultKValue)) { continue; }   // This pileup number might have to change for other expmnts
-      fH1[slot].at(Form("gEdet%d", grif1->GetDetector()))->Fill(grif1->GetEnergy());
       fH2[slot].at("gE_chan")->Fill(grif1->GetArrayNumber(), grif1->GetEnergy());
       fH1[slot].at("gE")->Fill(grif1->GetEnergy());
       fH1[slot].at("gEnoCT")->Fill(grif1->GetNoCTEnergy());
       for(auto gr2 = gr1 + 1; gr2 < grif.GetSuppressedMultiplicity(&grifBgo); ++gr2) {
          auto* grif2 = grif.GetSuppressedHit(gr2);
          if(pileup_reject && grif2->GetKValue() != defaultKValue) { continue; }   // This pileup number might have to change for other expmnts
-         if((detMultiplicity[grif1->GetDetector()] == 2) && Addback(grif1, grif2)) {
-            TGriffinHit* lowCrystalHit  = nullptr;
-            TGriffinHit* highCrystalHit = nullptr;
-            if(grif1->GetCrystal() < grif2->GetCrystal()) {
-               lowCrystalHit  = grif1;
-               highCrystalHit = grif2;
-            } else {
+         if((detMultiplicity[grif1->GetDetector()] == 2) && grif.AddbackCriterion(grif1, grif2)) {
+            TGriffinHit* lowCrystalHit  = grif1;
+            TGriffinHit* highCrystalHit = grif2;
+            if(grif1->GetCrystal() > grif2->GetCrystal()) {
                lowCrystalHit  = grif2;
                highCrystalHit = grif1;
             }
@@ -90,8 +70,6 @@ void CrossTalkHelper::Exec(unsigned int slot, TGriffin& grif, TGriffinBgo& grifB
       auto* grif1 = grif.GetSuppressedAddbackHit(gr1);
       if(pileup_reject && (grif1->GetKValue() != defaultKValue)) { continue; }   // This pileup number might have to change for other expmnts
       fH1[slot].at("aE")->Fill(grif1->GetEnergy());
-      fH1[slot].at(Form("aEdet%d", grif1->GetDetector()))->Fill(grif1->GetEnergy());
       fH1[slot].at("aMult")->Fill(grif.GetNSuppressedAddbackFrags(gr1));
-      if(grif.GetNSuppressedAddbackFrags(gr1) == 2) { fH1[slot].at(Form("aE2det%d", grif1->GetDetector()))->Fill(grif1->GetEnergy()); }
    }
 }

--- a/examples/CrossTalkHelper.hh
+++ b/examples/CrossTalkHelper.hh
@@ -11,7 +11,7 @@ public:
    explicit CrossTalkHelper(TList* list)
       : TGRSIHelper(list)
    {
-      Prefix("Crosstalk");
+      Prefix("CrossTalk");
       Setup();
    }
    ROOT::RDF::RResultPtr<std::map<std::string, TList>> Book(ROOT::RDataFrame* d) override

--- a/include/TDecay.h
+++ b/include/TDecay.h
@@ -49,9 +49,8 @@ public:
 #endif
 
    template <class PtrObj, typename MemFn>
-   TDecayFit(const char* name, const PtrObj& p, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar,
-             const char* className = nullptr, const char* methodName = nullptr)
-      : TF1(name, p, memFn, xmin, xmax, npar, className, methodName)
+   TDecayFit(const char* name, const PtrObj& p, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar)
+      : TF1(name, p, memFn, xmin, xmax, npar)
    {
       DefaultGraphs();
    }

--- a/include/TGRSIFit.h
+++ b/include/TGRSIFit.h
@@ -22,8 +22,8 @@ protected:
    TGRSIFit(const char* name, Double_t xmin, Double_t xmax, Int_t npar) : TF1(name, xmin, xmax, npar) { Clear(); }
    TGRSIFit(const char* name, const ROOT::Math::ParamFunctor& func, Double_t xmin = 0, Double_t xmax = 1, Int_t npar = 0) : TF1(name, func, xmin, xmax, npar) { Clear(); }
    template <class PtrObj, typename MemFn>
-   TGRSIFit(const char* name, const PtrObj& pointer, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar, const char* class_name, const char* fcn_name)
-      : TF1(name, pointer, memFn, xmin, xmax, npar, class_name, fcn_name)
+   TGRSIFit(const char* name, const PtrObj& pointer, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar)
+      : TF1(name, pointer, memFn, xmin, xmax, npar)
    {
       Clear();
    }

--- a/include/TGRSIUtilities.h
+++ b/include/TGRSIUtilities.h
@@ -23,4 +23,7 @@ inline size_t FindFileSize(const char* fname)
    return fsize;
 }
 
+const char* GetColorFromNumber(int number);
+const char* GetLongColorFromNumber(int number);
+
 #endif

--- a/include/TNucleus.h
+++ b/include/TNucleus.h
@@ -33,6 +33,18 @@ public:
 
    ~TNucleus();
 
+   enum class EFlag : uint8_t { kDefault, kUnobserved, kInferred, kTentative, kObserved};
+
+   void SetObserved() { fFlag = EFlag::kObserved; }
+   void SetUnobserved() { fFlag = EFlag::kUnobserved; }
+   void SetInferred() { fFlag = EFlag::kInferred; }
+   void SetTentative() { fFlag = EFlag::kTentative; }
+
+   bool Observed() { return fFlag == EFlag::kObserved; }
+   bool Unobserved() { return fFlag == EFlag::kUnobserved; }
+   bool Inferred() { return fFlag == EFlag::kInferred; }
+   bool Tentative() { return fFlag == EFlag::kTentative; }
+
    static void ParseName(const char* name, std::string& symbol, int& number, std::string& element)
    {
       ParseName(std::string(name), symbol, number, element);
@@ -93,12 +105,13 @@ private:
    static std::string fSourceDirectory;          //!<! path of directory with .sou files
    static bool        fSourceDirectoryChecked;   //!<! flag to indicate whetehr the source directory path has been checked
 
-   int         fA{0};             ///< Number of nucleons (Z + N)
-   int         fN{0};             ///< Number of neutrons (N)
-   int         fZ{0};             ///< Number of protons (Z)
-   double      fMass{0.};         ///< Mass (in MeV)
-   double      fMassExcess{0.};   ///< Mass excess (in MeV)
-   std::string fSymbol;           ///< Atomic symbol (ex. Ba, C, O, N)
+   int         fA{0};                    ///< Number of nucleons (Z + N)
+   int         fN{0};                    ///< Number of neutrons (N)
+   int         fZ{0};                    ///< Number of protons (Z)
+   double      fMass{0.};                ///< Mass (in MeV)
+   double      fMassExcess{0.};          ///< Mass excess (in MeV)
+   std::string fSymbol;                  ///< Atomic symbol (ex. Ba, C, O, N)
+   EFlag       fFlag{EFlag::kDefault};   ///< Flag indicating if nucleus is observed, unobserved, inferred, or tentative
 
    TSortedList fTransitionListByIntensity;
    TSortedList fTransitionListByEnergy;

--- a/libraries/GROOT/GCube.cxx
+++ b/libraries/GROOT/GCube.cxx
@@ -94,10 +94,13 @@ Int_t GCube::BufferEmpty(Int_t action)
       fBuffer = buffer;
    }
 
-   if(CanExtendAllAxes() || fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin() ||
-      fZaxis.GetXmax() <= fZaxis.GetXmin()) {
+   const bool xbinAuto = fXaxis.GetXmax() <= fXaxis.GetXmin();
+   const bool ybinAuto = fYaxis.GetXmax() <= fYaxis.GetXmin();
+   const bool zbinAuto = fZaxis.GetXmax() <= fZaxis.GetXmin();
+   const bool extend = CanExtendAllAxes();
+   if(extend || xbinAuto || ybinAuto || zbinAuto) {
       // find min, max of entries in buffer
-      // for the symmetric matrix x- and y-range are the same
+      // for the symmetric matrix x-, y- and z-range are the same
       Double_t min = fBuffer[2];
       Double_t max = min;
       if(fBuffer[3] < min) {
@@ -129,9 +132,12 @@ Int_t GCube::BufferEmpty(Int_t action)
             max = z;
          }
       }
-      if(fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin() ||
-         fZaxis.GetXmax() <= fZaxis.GetXmin()) {
+      if(xbinAuto || ybinAuto || zbinAuto) {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 40, 0)
          THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this, min, max, min, max, min, max);
+#else
+         THLimitsFinder::GetLimitsFinder()->FindGoodLimitsXYZ(this, min, max, min, max, min, max, xbinAuto ? 0 : fXaxis.GetNbins(), ybinAuto ? 0 : fYaxis.GetNbins(), zbinAuto ? 0 : fZaxis.GetNbins());
+#endif
       } else {
          fBuffer     = nullptr;
          Int_t keep  = fBufferSize;

--- a/libraries/GROOT/GHSym.cxx
+++ b/libraries/GROOT/GHSym.cxx
@@ -101,7 +101,10 @@ Int_t GHSym::BufferEmpty(Int_t action)
       fBuffer = buffer;
    }
 
-   if(CanExtendAllAxes() || fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin()) {
+   const bool xbinAuto = fXaxis.GetXmax() <= fXaxis.GetXmin();
+   const bool ybinAuto = fYaxis.GetXmax() <= fYaxis.GetXmin();
+   const bool extend = CanExtendAllAxes();
+   if(extend || xbinAuto || ybinAuto) {
       // find min, max of entries in buffer
       // for the symmetric matrix x- and y-range are the same
       Double_t min = fBuffer[2];
@@ -128,8 +131,12 @@ Int_t GHSym::BufferEmpty(Int_t action)
             max = y;
          }
       }
-      if(fXaxis.GetXmax() <= fXaxis.GetXmin() || fYaxis.GetXmax() <= fYaxis.GetXmin()) {
+      if(xbinAuto || ybinAuto) {
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 40, 0)
          THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this, min, max, min, max);
+#else
+         THLimitsFinder::GetLimitsFinder()->FindGoodLimitsXY(this, min, max, min, max, xbinAuto ? 0 : fXaxis.GetNbins(), ybinAuto ? 0 : fYaxis.GetNbins());
+#endif
       } else {
          fBuffer     = nullptr;
          Int_t keep  = fBufferSize;

--- a/libraries/GROOT/TLevelScheme.cxx
+++ b/libraries/GROOT/TLevelScheme.cxx
@@ -378,22 +378,22 @@ void TLevel::Draw(const double& left, const double& right)
       y.push_back(fEnergy + fOffset);
       x.push_back(left + tickLength);
       y.push_back(fEnergy + fOffset);
-      x.push_back(left + tickLength + std::fabs(fOffset) / 2.);
+      x.push_back(left + tickLength + std::abs(fOffset) / 2.);
       y.push_back(fEnergy);
-      if(fDebug) { std::cout << "Non-zero offset " << fOffset << " => left line " << left << ", " << fEnergy + fOffset << " via " << left + tickLength << ", " << fEnergy + fOffset << " to " << left + tickLength + std::fabs(fOffset) / 2. << ", " << fEnergy << std::endl; }
+      if(fDebug) { std::cout << "Non-zero offset " << fOffset << " => left line " << left << ", " << fEnergy + fOffset << " via " << left + tickLength << ", " << fEnergy + fOffset << " to " << left + tickLength + std::abs(fOffset) / 2. << ", " << fEnergy << std::endl; }
    }
-   x.push_back(left + tickLength + std::fabs(fOffset) / 2.);
+   x.push_back(left + tickLength + std::abs(fOffset) / 2.);
    y.push_back(fEnergy);
-   x.push_back(right - tickLength - std::fabs(fOffset) / 2.);
+   x.push_back(right - tickLength - std::abs(fOffset) / 2.);
    y.push_back(fEnergy);
    if(fOffset != 0.) {
-      x.push_back(right - tickLength - std::fabs(fOffset) / 2.);
+      x.push_back(right - tickLength - std::abs(fOffset) / 2.);
       y.push_back(fEnergy);
       x.push_back(right - tickLength);
       y.push_back(fEnergy + fOffset);
       x.push_back(right);
       y.push_back(fEnergy + fOffset);
-      if(fDebug) { std::cout << "Non-zero offset " << fOffset << " => right line " << right - tickLength - std::fabs(fOffset) / 2. << ", " << fEnergy << " via " << right - tickLength << ", " << fEnergy + fOffset << " to " << right << ", " << fEnergy + fOffset << std::endl; }
+      if(fDebug) { std::cout << "Non-zero offset " << fOffset << " => right line " << right - tickLength - std::abs(fOffset) / 2. << ", " << fEnergy << " via " << right - tickLength << ", " << fEnergy + fOffset << " to " << right << ", " << fEnergy + fOffset << std::endl; }
    }
    SetPolyLine(x.size(), x.data(), y.data());
    TPolyLine::Draw();
@@ -526,7 +526,7 @@ TLevel* TBand::FindLevel(double energy, double energyUncertainty)
    double  en    = low->first;
    TLevel* level = &(low->second);
    for(auto& it = ++low; it != high; ++it) {
-      if(std::fabs(energy - en) > std::fabs(energy - it->first)) {
+      if(std::abs(energy - en) > std::abs(energy - it->first)) {
          en    = it->first;
          level = &(it->second);
       }
@@ -786,7 +786,7 @@ TGamma* TLevelScheme::FindGamma(double energy, double energyUncertainty)
 
    auto* result = list[0];
    for(size_t i = 1; i < list.size(); ++i) {
-      if(std::fabs(list[i]->Energy() - energy) < std::fabs(result->Energy() - energy)) { result = list[i]; }
+      if(std::abs(list[i]->Energy() - energy) < std::abs(result->Energy() - energy)) { result = list[i]; }
    }
 
    return result;

--- a/libraries/TAnalysis/TCal/TEfficiencyCalibration.cxx
+++ b/libraries/TAnalysis/TCal/TEfficiencyCalibration.cxx
@@ -168,7 +168,7 @@ TFitResultPtr TEfficiencyCalibration::Fit(Option_t*)
    // This fits the relative efficiency curve
    UInt_t n_rel_graphs = fRelativeEffGraph->GetListOfGraphs()->GetSize();
    delete fRelativeFit;
-   fRelativeFit = new TF1("fRelativeFit", this, &TEfficiencyCalibration::PhotoPeakEfficiency, 0, 8000, 8 + n_rel_graphs, "TEfficiencyCalibration", "PhotoPeakEfficiency");
+   fRelativeFit = new TF1("fRelativeFit", this, &TEfficiencyCalibration::PhotoPeakEfficiency, 0, 8000, 8 + n_rel_graphs);
 
    // Start by naming the parameters of the fit
    for(int mapIdx = 0; mapIdx < static_cast<int>(fGraphMap.size()); ++mapIdx) {
@@ -301,16 +301,13 @@ bool TEfficiencyCalibration::ScaleToAbsolute()
 {
    if((fAbsEffGraph->GetListOfGraphs()->GetSize() != 0) && (fRelativeFit != nullptr)) {
       if(fAbsoluteFunc == nullptr) {
-         fAbsoluteFunc = new TF1("fAbsoluteFunc", this, &TEfficiencyCalibration::AbsoluteEfficiency, 0, 8000, 9,
-                                 "TEfficiencyCalibration", "AbsoluteEfficiency");
+         fAbsoluteFunc = new TF1("fAbsoluteFunc", this, &TEfficiencyCalibration::AbsoluteEfficiency, 0, 8000, 9);
       }
       fAbsoluteFunc->SetParName(0, "Scale");
       for(int i = 0; i < 8; ++i) {
          fAbsoluteFunc->SetParName(i + 1, Form("a%d", i));
-         fAbsoluteFunc->SetParameter(i + 1,
-                                     fRelativeFit->GetParameter(i + fRelativeEffGraph->GetListOfGraphs()->GetSize()));
-         fAbsoluteFunc->SetParError(i + 1,
-                                    fRelativeFit->GetParError(i + fRelativeEffGraph->GetListOfGraphs()->GetSize()));
+         fAbsoluteFunc->SetParameter(i + 1, fRelativeFit->GetParameter(i + fRelativeEffGraph->GetListOfGraphs()->GetSize()));
+         fAbsoluteFunc->SetParError(i + 1, fRelativeFit->GetParError(i + fRelativeEffGraph->GetListOfGraphs()->GetSize()));
       }
 
       // we need to find the average amount that we must scale the relative efficiency fit by in order to have it line

--- a/libraries/TAnalysis/TGRSIFit/TDecay.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TDecay.cxx
@@ -127,14 +127,12 @@ TSingleDecay::TSingleDecay(TSingleDecay* parent, Double_t tlow, Double_t thigh)
       fGeneration  = 1;
    }
    // This will potentially leak with ROOT IO, shouldnt be a big deal. Might come back to this later
-   fDecayFunc = new TDecayFit(Form("decayfunc_gen%d", fGeneration), this, &TSingleDecay::ActivityFunc, 0, 10, 2,
-                              "TSingleDecay", "ActivityFunc");
+   fDecayFunc = new TDecayFit(Form("decayfunc_gen%d", fGeneration), this, &TSingleDecay::ActivityFunc, 0, 10, 2);
    fDecayFunc->SetDecay(this);
    fDecayFunc->SetParameters(fFirstParent->GetIntensity(), 0.0);
    fDecayFunc->SetParNames("Intensity", "DecayRate");
 
-   fTotalDecayFunc = new TDecayFit(Form("totaldecayfunc_gen%d", fGeneration), this, &TSingleDecay::ActivityFunc, 0, 10,
-                                   fGeneration + 1, "TSingleDecay", "ActivityFunc");
+   fTotalDecayFunc = new TDecayFit(Form("totaldecayfunc_gen%d", fGeneration), this, &TSingleDecay::ActivityFunc, 0, 10, fGeneration + 1);
    fTotalDecayFunc->SetDecay(this);
    SetTotalDecayParameters();
    if(fFirstParent != this) {
@@ -175,13 +173,12 @@ TSingleDecay::TSingleDecay(UInt_t generation, TSingleDecay* parent, Double_t tlo
 
    fGeneration = generation;
 
-   fDecayFunc = new TDecayFit("tmpname", this, &TSingleDecay::ActivityFunc, 0, 10, 2, "TSingleDecay", "ActivityFunc");
+   fDecayFunc = new TDecayFit("tmpname", this, &TSingleDecay::ActivityFunc, 0, 10, 2);
    fDecayFunc->SetDecay(this);
    fDecayFunc->SetParameters(fFirstParent->GetIntensity(), 0.0);
    fDecayFunc->SetParNames("Intensity", "DecayRate");
 
-   fTotalDecayFunc = new TDecayFit("tmpname", this, &TSingleDecay::ActivityFunc, 0, 10, fGeneration + 1, "TSingleDecay",
-                                   "ActivityFunc");
+   fTotalDecayFunc = new TDecayFit("tmpname", this, &TSingleDecay::ActivityFunc, 0, 10, fGeneration + 1);
    fTotalDecayFunc->SetDecay(this);
    SetTotalDecayParameters();
    if(fFirstParent != this) {
@@ -477,8 +474,7 @@ TDecayChain::TDecayChain(UInt_t generations)
       parent = curDecay;
    }
 
-   fChainFunc = new TDecayFit("tmpname", this, &TDecayChain::ChainActivityFunc, 0, 10, fDecayChain.size() + 1,
-                              "TDecayChain", "ChainActivityFunc");
+   fChainFunc = new TDecayFit("tmpname", this, &TDecayChain::ChainActivityFunc, 0, 10, fDecayChain.size() + 1);
    fChainFunc->SetDecay(this);
    SetChainParameters();
    fChainId = fChainCounter;
@@ -624,7 +620,7 @@ void TDecayChain::SetRange(Double_t xlow, Double_t xhigh)
 TDecay::TDecay(std::vector<TDecayChain*> chainList)
    : fChainList(std::move(chainList))
 {
-   fFitFunc = new TDecayFit("tmpfit", this, &TDecay::DecayFit, 0, 10, 1, "TDecay", "DecayFit");
+   fFitFunc = new TDecayFit("tmpfit", this, &TDecay::DecayFit, 0, 10, 1);
    fFitFunc->SetDecay(this);
    RemakeMap();
    SetParameters();
@@ -731,7 +727,7 @@ void TDecay::SetParameters()
    fFitFunc->GetParLimits(0, tmpbglow, tmpbghigh);
    Double_t tmpbgerr = fFitFunc->GetParError(0);
    delete fFitFunc;
-   fFitFunc = new TDecayFit("tmpfit", this, &TDecay::DecayFit, xlow, xhigh, unq_chains + unq_decays + 1, "TDecay", "DecayFit");
+   fFitFunc = new TDecayFit("tmpfit", this, &TDecay::DecayFit, xlow, xhigh, unq_chains + unq_decays + 1);
    fFitFunc->SetDecay(this);
    fFitFunc->SetParName(0, "Background");
    fFitFunc->SetParameter(0, tmpbg);
@@ -777,7 +773,7 @@ void TDecay::DrawComponents(Option_t*, Bool_t)
    Double_t high = 0.;
    fFitFunc->GetRange(low, high);
 
-   TF1* tmp_comp = new TF1("tmpname", this, &TDecay::ComponentFunc, low, high, 1, "TDecay", "ComponentFunc");
+   TF1* tmp_comp = new TF1("tmpname", this, &TDecay::ComponentFunc, low, high, 1);
    for(auto& iter : fDecayMap) {
       tmp_comp->SetName(Form("Component_%d", iter.first));
       tmp_comp->SetParameter(0, iter.first);

--- a/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
+++ b/libraries/TAnalysis/TGRSIFit/TMultiPeak.cxx
@@ -11,12 +11,12 @@
 Bool_t TMultiPeak::fLogLikelihoodFlag = false;
 
 TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t>& centroids, Option_t*)
-   : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5, "TMultiPeak", "MultiPhotoPeakBG")
+   : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, xlow, xhigh, centroids.size() * 6 + 5)
 {
    std::cout << "Warning, the class TMultiPeak is deprecated (use TPeakFitter instead)!" << std::endl;
    Clear();
    // We make the background first so we can send it to the TPeaks.
-   fBackground = new TF1(Form("MPbackground_%d_to_%d", static_cast<Int_t>(xlow), static_cast<Int_t>(xhigh)), this, &TMultiPeak::MultiStepBG, xlow, xhigh, centroids.size() * 6 + 5, "TMuliPeak", "MultiStepBG");
+   fBackground = new TF1(Form("MPbackground_%d_to_%d", static_cast<Int_t>(xlow), static_cast<Int_t>(xhigh)), this, &TMultiPeak::MultiStepBG, xlow, xhigh, centroids.size() * 6 + 5);
    fBackground->SetNpx(1000);
    fBackground->SetLineStyle(2);
    fBackground->SetLineColor(kBlack);
@@ -47,12 +47,12 @@ TMultiPeak::TMultiPeak(Double_t xlow, Double_t xhigh, const std::vector<Double_t
    InitNames();
 }
 
-TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, 0, 1000, 10, "TMultiPeak", "MultiPhotoPeakBG")
+TMultiPeak::TMultiPeak() : TGRSIFit("multipeakbg", this, &TMultiPeak::MultiPhotoPeakBG, 0, 1000, 10)
 {
    std::cout << "Warning, the class TMultiPeak is deprecated (use TPeakFitter instead)!" << std::endl;
    // I don't think this constructor should be used, RD.
    InitNames();
-   fBackground = new TF1("background", this, &TMultiPeak::MultiStepBG, 1000, 10, 10, "TMultiPeak", "MultiStepBG");   // This is a weird nonsense line.
+   fBackground = new TF1("background", this, &TMultiPeak::MultiStepBG, 1000, 10, 10);   // This is a weird nonsense line.
    fBackground->SetNpx(1000);
    fBackground->SetLineStyle(2);
    fBackground->SetLineColor(kBlack);
@@ -451,8 +451,7 @@ void TMultiPeak::DrawPeaks()
       Double_t centroid = peak->GetCentroid();
       Double_t range    = 2. * peak->GetFWHM();
 
-      auto* sum = new TF1(Form("tmp%s", peak->GetName()), this, &TMultiPeak::SinglePeakBG, centroid - range, centroid + range,
-                          fPeakVec.size() * 6 + 11, "TMultiPeak", "SinglePeakBG");
+      auto* sum = new TF1(Form("tmp%s", peak->GetName()), this, &TMultiPeak::SinglePeakBG, centroid - range, centroid + range, fPeakVec.size() * 6 + 11);
 
       for(int j = 0; j < GetNpar(); ++j) {
          sum->SetParameter(j, GetParameter(j));

--- a/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TAB3Peak.cxx
@@ -3,8 +3,8 @@
 
 void TAB3Peak::Centroid(const Double_t& centroid)
 {
-   SetFitFunction(new TF1("ab_fit", this, &TAB3Peak::TotalFunction, 0, 1, 8, "TAB3Peak", "TotalFunction"));
-   SetPeakFunction(new TF1("ab_peak", this, &TAB3Peak::PeakFunction, 0, 1, 7, "TAB3Peak", "PeakFunction"));
+   SetFitFunction(new TF1("ab_fit", this, &TAB3Peak::TotalFunction, 0, 1, 8));
+   SetPeakFunction(new TF1("ab_peak", this, &TAB3Peak::PeakFunction, 0, 1, 7));
    InitParNames();
    GetFitFunction()->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool>{false, false, false, false, false, false, false, true});
@@ -165,9 +165,9 @@ void TAB3Peak::DrawComponents(Option_t* opt)
    if(fTwoHitOnGlobal != nullptr) { fTwoHitOnGlobal->Delete(); }
    if(fThreeHitOnGlobal != nullptr) { fThreeHitOnGlobal->Delete(); }
    // Make a copy of the total function, and then tack on the global background parameters.
-   fOneHitOnGlobal   = new TF1("draw_component1", this, &TAB3Peak::OneHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar(), "TAB3Peak", "OneHitPeakOnGlobalFunction");
-   fTwoHitOnGlobal   = new TF1("draw_component2", this, &TAB3Peak::TwoHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar(), "TAB3Peak", "TwoHitPeakOnGlobalFunction");
-   fThreeHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::ThreeHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar(), "TAB3Peak", "ThreeHitPeakOnGlobalFunction");
+   fOneHitOnGlobal   = new TF1("draw_component1", this, &TAB3Peak::OneHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar());
+   fTwoHitOnGlobal   = new TF1("draw_component2", this, &TAB3Peak::TwoHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar());
+   fThreeHitOnGlobal = new TF1("draw_component2", this, &TAB3Peak::ThreeHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar());
    for(int i = 0; i < GetFitFunction()->GetNpar(); ++i) {
       fOneHitOnGlobal->SetParameter(i, GetFitFunction()->GetParameter(i));
       fTwoHitOnGlobal->SetParameter(i, GetFitFunction()->GetParameter(i));

--- a/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TABPeak.cxx
@@ -3,8 +3,8 @@
 
 void TABPeak::Centroid(const Double_t& centroid)
 {
-   SetFitFunction(new TF1("ab_fit", this, &TABPeak::TotalFunction, 0, 1, 6, "TABPeak", "TotalFunction"));
-   SetPeakFunction(new TF1("ab_peak", this, &TABPeak::PeakFunction, 0, 1, 5, "TABPeak", "PeakFunction"));
+   SetFitFunction(new TF1("ab_fit", this, &TABPeak::TotalFunction, 0, 1, 6));
+   SetPeakFunction(new TF1("ab_peak", this, &TABPeak::PeakFunction, 0, 1, 5));
    InitParNames();
    GetFitFunction()->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool>{false, false, false, false, false, true});
@@ -137,8 +137,8 @@ void TABPeak::DrawComponents(Option_t* opt)
    if(fOneHitOnGlobal != nullptr) { fOneHitOnGlobal->Delete(); }
    if(fTwoHitOnGlobal != nullptr) { fTwoHitOnGlobal->Delete(); }
    // Make a copy of the total function, and then tack on the global background parameters.
-   fOneHitOnGlobal = new TF1("draw_component1", this, &TABPeak::OneHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar(), "TABPeak", "OneHitPeakOnGlobalFunction");
-   fTwoHitOnGlobal = new TF1("draw_component2", this, &TABPeak::TwoHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar(), "TABPeak", "TwoHitPeakOnGlobalFunction");
+   fOneHitOnGlobal = new TF1("draw_component1", this, &TABPeak::OneHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar());
+   fTwoHitOnGlobal = new TF1("draw_component2", this, &TABPeak::TwoHitPeakOnGlobalFunction, low, high, GetFitFunction()->GetNpar() + GetGlobalBackground()->GetNpar());
    for(int i = 0; i < GetFitFunction()->GetNpar(); ++i) {
       fOneHitOnGlobal->SetParameter(i, GetFitFunction()->GetParameter(i));
       fTwoHitOnGlobal->SetParameter(i, GetFitFunction()->GetParameter(i));

--- a/libraries/TAnalysis/TPeakFitting/TGauss.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TGauss.cxx
@@ -13,8 +13,8 @@ TGauss::TGauss(Double_t centroid, Double_t relativeLimit)
 void TGauss::Centroid(const Double_t& centroid)
 {
    if(TPeakFitter::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << std::endl; }   // NOLINT(cppcoreguidelines-pro-type-const-cast, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
-   SetFitFunction(new TF1("gauss_total", this, &TGauss::TotalFunction, 0, 1, 3, "TGauss", "TotalFunction"));
-   SetPeakFunction(new TF1("gauss_peak", this, &TGauss::PeakFunction, 0, 1, 3, "TGauss", "TotalFunction"));   // peak = total function
+   SetFitFunction(new TF1("gauss_total", this, &TGauss::TotalFunction, 0, 1, 3));
+   SetPeakFunction(new TF1("gauss_peak", this, &TGauss::PeakFunction, 0, 1, 3));   // peak = total function
    if(TPeakFitter::VerboseLevel() >= EVerbosity::kSubroutines) { std::cout << "Set the fit and peak functions" << std::endl; }
    InitParNames();
    GetFitFunction()->SetParameter(1, centroid);

--- a/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TPeakFitter.cxx
@@ -13,7 +13,7 @@ EVerbosity TPeakFitter::fVerboseLevel = EVerbosity::kQuiet;
 TPeakFitter::TPeakFitter(const Double_t& rangeLow, const Double_t& rangeHigh)
    : fRangeLow(rangeLow), fRangeHigh(rangeHigh)
 {
-   fBGToFit = new TF1("fbg", this, &TPeakFitter::DefaultBackgroundFunction, fRangeLow, fRangeHigh, 4, "TPeakFitter", "DefaultBackgroundFunction");
+   fBGToFit = new TF1("fbg", this, &TPeakFitter::DefaultBackgroundFunction, fRangeLow, fRangeHigh, 4);
    fBGToFit->FixParameter(3, 0);
    fBGToFit->SetLineColor(static_cast<Color_t>(kRed + fColorIndex));
    if(fVerboseLevel >= EVerbosity::kSubroutines) { std::cout << __PRETTY_FUNCTION__ << ": constructed peak fitter " << this << " using range " << fRangeLow << " - " << fRangeHigh << std::endl; }   // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
@@ -119,7 +119,7 @@ TFitResultPtr TPeakFitter::Fit(TH1* fit_hist, Option_t* opt)
    TVirtualFitter::SetMaxIterations(100000);
    TVirtualFitter::SetPrecision(1e-4);
    if(fTotalFitFunction == nullptr) {
-      fTotalFitFunction = new TF1(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh), this, &TPeakFitter::FitFunction, fRangeLow, fRangeHigh, GetNParameters(), "TPeakFitter", "FitFunction");
+      fTotalFitFunction = new TF1(Form("total_fit_%.0f_%.0f", fRangeLow, fRangeHigh), this, &TPeakFitter::FitFunction, fRangeLow, fRangeHigh, GetNParameters());
    }
    fTotalFitFunction->SetLineColor(static_cast<Color_t>(kMagenta + fColorIndex));
    fTotalFitFunction->SetRange(fRangeLow, fRangeHigh);
@@ -197,7 +197,7 @@ void TPeakFitter::UpdatePeakParameters(const TFitResultPtr& fit_res, TH1* fit_hi
    // what their new parameters should be.
    Int_t param_counter = 0;
 
-   TF1* global_bg = new TF1("global_bg", this, &TPeakFitter::BackgroundFunction, fRangeLow, fRangeHigh, fTotalFitFunction->GetNpar(), "TPeakFitter", "BackgroundFunction");
+   TF1* global_bg = new TF1("global_bg", this, &TPeakFitter::BackgroundFunction, fRangeLow, fRangeHigh, fTotalFitFunction->GetNpar());
    global_bg->SetParameters(fTotalFitFunction->GetParameters());
 
    // Start by looping through all of the peaks in the fitter.

--- a/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TRWPeak.cxx
@@ -4,8 +4,8 @@
 
 void TRWPeak::Centroid(const Double_t& centroid)
 {
-   SetFitFunction(new TF1("rw_total", this, &TRWPeak::TotalFunction, 0, 1, 6, "TRWPeak", "TotalFunction"));
-   SetPeakFunction(new TF1("rw_peak", this, &TRWPeak::PeakFunction, 0, 1, 5, "TRWPeak", "PeakFunction"));
+   SetFitFunction(new TF1("rw_total", this, &TRWPeak::TotalFunction, 0, 1, 6));
+   SetPeakFunction(new TF1("rw_peak", this, &TRWPeak::PeakFunction, 0, 1, 5));
    InitParNames();
    GetFitFunction()->SetParameter(1, centroid);
    SetListOfBGPar(std::vector<bool>{false, false, false, false, false, true});

--- a/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
+++ b/libraries/TAnalysis/TPeakFitting/TSinglePeak.cxx
@@ -28,7 +28,7 @@ Int_t TSinglePeak::GetNParameters() const
 TF1* TSinglePeak::GetBackgroundFunction()
 {
    if(fBackgroundFunction == nullptr) {
-      fBackgroundFunction = new TF1("peak_bg", this, &TSinglePeak::BackgroundFunction, 0, 1, fTotalFunction->GetNpar(), "TSinglePeak", "BackgroundFunction");
+      fBackgroundFunction = new TF1("peak_bg", this, &TSinglePeak::BackgroundFunction, 0, 1, fTotalFunction->GetNpar());
       fBackgroundFunction->SetLineStyle(9);
    }
    return fBackgroundFunction;
@@ -113,7 +113,7 @@ void TSinglePeak::Draw(Option_t* opt)
    fGlobalBackground->GetRange(low, high);
    if(fPeakOnGlobal != nullptr) { fPeakOnGlobal->Delete(); }
    // Make a copy of the total function, and then tack on the global background parameters.
-   fPeakOnGlobal = new TF1("draw_peak", this, &TSinglePeak::PeakOnGlobalFunction, low, high, fTotalFunction->GetNpar() + fGlobalBackground->GetNpar(), "TSinglePeak", "PeakOnGlobalFunction");
+   fPeakOnGlobal = new TF1("draw_peak", this, &TSinglePeak::PeakOnGlobalFunction, low, high, fTotalFunction->GetNpar() + fGlobalBackground->GetNpar());
    for(int i = 0; i < fTotalFunction->GetNpar(); ++i) {
       fPeakOnGlobal->SetParameter(i, fTotalFunction->GetParameter(i));
    }

--- a/libraries/TFormat/GValue.cxx
+++ b/libraries/TFormat/GValue.cxx
@@ -7,12 +7,13 @@
 #include <utility>
 #include <fstream>
 #include <sstream>
+#include <cmath>
 
 #include "TGRSIUtilities.h"
 
 // std::string GValue::fValueData
 // std::map<unsigned int, GValue*> GValue::fValueMap;
-GValue*                        GValue::fDefaultValue = new GValue("GValue", sqrt(-1));
+GValue*                        GValue::fDefaultValue = new GValue("GValue", std::sqrt(-1.));
 std::map<std::string, GValue*> GValue::fValueVector;
 
 GValue::GValue(const char* name, double value, EPriority priority)
@@ -38,7 +39,7 @@ void GValue::Copy(TObject& obj) const
 
 double GValue::Value(const std::string& name)
 {
-   return GValue::Value(name, sqrt(-1));
+   return GValue::Value(name, std::sqrt(-1.));
 }
 
 double GValue::Value(const std::string& name, const double& defaultValue)

--- a/libraries/TFormat/TGRSIUtilities.cxx
+++ b/libraries/TFormat/TGRSIUtilities.cxx
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <fstream>
+#include <algorithm>
 
 #include "TObjArray.h"
 #include "TObjString.h"

--- a/libraries/TFormat/TGRSIUtilities.cxx
+++ b/libraries/TFormat/TGRSIUtilities.cxx
@@ -105,3 +105,26 @@ int GetSubRunNumber(const std::string& fileName)
    }
    return -1;
 }
+
+const char* GetColorFromNumber(int number)
+{
+   switch(number) {
+      case(0): return "B";
+      case(1): return "G";
+      case(2): return "R";
+      case(3): return "W";
+   };
+   return "X";
+}
+
+const char* GetLongColorFromNumber(int number)
+{
+   switch(number) {
+      case(0): return "Blue";
+      case(1): return "Green";
+      case(2): return "Red";
+      case(3): return "White";
+   };
+   return "Unknown";
+}
+

--- a/util/CrossTalkFix.cxx
+++ b/util/CrossTalkFix.cxx
@@ -29,7 +29,7 @@ double CrossTalkFit(double* x, double* par)   // NOLINT(readability-non-const-pa
    return x[0] * slope + intercept;
 }
 
-double* CrossTalkFix(TFile* inputFile, int det, double energy, int minimumCounts, std::string channelPrefix, std::string channelPostfix)
+double* CrossTalkFix(TFile* inputFile, int det, double energy, int minimumCounts, const std::string& channelPrefix, const std::string& channelPostfix)
 {
    // The outfile is implicit since it was the last file that was open.
    static double largestCorrection = 0.0;

--- a/util/CrossTalkFix.cxx
+++ b/util/CrossTalkFix.cxx
@@ -1,0 +1,295 @@
+#include <iostream>
+
+#include "TFile.h"
+#include "TH2.h"
+#include "TF1.h"
+#include "TCutG.h"
+#include "TGraphErrors.h"
+#include "TString.h"
+#include "TObjString.h"
+#include "TObjArray.h"
+#include "TProfile.h"
+
+#include "Globals.h"
+#include "TGRSIUtilities.h"
+#include "TChannel.h"
+#include "TUserSettings.h"
+
+double CrossTalkFit(double* x, double* par)   // NOLINT(readability-non-const-parameter)
+{
+   // This function is the linear fit function, but uses the CT coefficients as parameters instead of slope and
+   // intercept
+   double k0     = par[0] / (1. - par[0]);
+   double k1     = par[1] / (1. - par[1]);
+   double energy = par[2];
+
+   double slope     = -(1. + k0) / (1. + k1);
+   double intercept = energy * (1. + k0 / (1. + k1));
+
+   return x[0] * slope + intercept;
+}
+
+double* CrossTalkFix(TFile* inputFile, int det, double energy, int minimumCounts, std::string channelPrefix, std::string channelPostfix)
+{
+   // The outfile is implicit since it was the last file that was open.
+   static double largestCorrection = 0.0;
+
+   // Clear all of the CT calibrations for this detector.
+   for(int i = 0; i < 4; ++i) {
+      auto* channelName = Form("%s%02d%s%s", channelPrefix.c_str(), det, GetColorFromNumber(i), channelPostfix.c_str());
+      TChannel* chan = TChannel::FindChannelByName(channelName);
+      if(chan == nullptr) {
+         std::cout << DRED << "Couldn't find a channel for " << channelName << RESET_COLOR << std::endl;
+         continue;
+      }
+      chan->DestroyCTCal();
+   }
+
+   static int largestDet      = -1;
+   static int largestCrystal1 = -1;
+   static int largestCrystal2 = -1;
+
+   std::string namebase = Form("det_%d", det);
+
+   // This range seems to be working fairly well since no shift should be larger than say 6 or 7 keV
+   double lowCut  = energy - 15;
+   double highCut = energy + 15;
+
+   // create diagonal cut
+   std::array<double, 5> xpts = {lowCut, 0, 0, highCut, lowCut};
+   std::array<double, 5> ypts = {0, lowCut, highCut, 0, 0};
+   TCutG                 cut("cut", 5, xpts.data(), ypts.data());
+
+   auto* d  = new double[16];   // matrix of coefficients
+   auto* eD = new double[16];   // matrix of errors
+
+   for(int crystal1 = 0; crystal1 < 4; crystal1++) {
+      for(int crystal2 = crystal1 + 1; crystal2 < 4; crystal2++) {
+         // Load all of the addback matrices in and put them into a vector of TH2*
+         std::string name = Form("%s_%d_%d", namebase.c_str(), crystal1, crystal2);
+         TH2*        mat  = dynamic_cast<TH2*>(inputFile->Get(name.c_str()));
+         if(mat == nullptr) {
+            std::cout << "can not find:  " << name << std::endl;
+            return nullptr;
+         }
+         std::cout << mat->GetName() << std::endl;
+         int xbins = mat->GetNbinsX();
+         int ybins = mat->GetNbinsY();
+
+         TH2* cmat = dynamic_cast<TH2*>(mat->Clone(Form("%s_clone", mat->GetName())));
+         cmat->Reset();
+
+         // I make a graph out of the "addback line" because I don't like the way TProfile handles the empty bins
+         auto* fitGraph = new TGraphErrors;
+         fitGraph->SetNameTitle(Form("%s_graph", mat->GetName()), "Graph");
+
+         // This loop turns the addback plot and TCut into the TGraphErrors
+         int rejectedBins = 0;
+         for(int i = 1; i <= xbins; i++) {
+            bool insideYet = false;
+            for(int j = 1; j <= ybins; j++) {
+               double xc = mat->GetXaxis()->GetBinCenter(i);
+               double yc = mat->GetYaxis()->GetBinCenter(j);
+               if(cut.IsInside(xc, yc) != 0) {
+                  if(!insideYet) {
+                     insideYet = true;
+                  }
+                  cmat->Fill(xc, yc, mat->GetBinContent(i, j));
+               }
+            }
+            cmat->GetXaxis()->SetRange(i, i);
+            // This makes sure that there are at least 4 counts in the "y bin". I'd prefer this to be higher,
+            // but that requires more 60Co statistics. The reason I do this is because RMS and SD of the mean really only
+            // works for us if we have enough counts that the mean is actually a good representation of the true value.
+            // This is something TProfile does not do for us, and seems to skew the result a bit.
+            if(cmat->Integral() > minimumCounts) {
+               fitGraph->SetPoint(fitGraph->GetN(), cmat->GetYaxis()->GetBinCenter(i), cmat->GetMean(2));
+               fitGraph->SetPointError(fitGraph->GetN() - 1, cmat->GetXaxis()->GetBinWidth(i), cmat->GetMeanError(2));
+            } else {
+               ++rejectedBins;
+            }
+         }
+         // unzoom the x-axis
+         cmat->GetXaxis()->SetRange(1, cmat->GetXaxis()->GetNbins());
+         cmat->Write();
+
+         if(rejectedBins > 0) {
+            std::cout << name << ": rejected " << rejectedBins << " bins out of " << xbins << " bins, because the number of counts in the projection of this bin is less than " << minimumCounts << std::endl;
+         }
+
+         if(fitGraph->GetN() <= 0) {
+            std::cout << name << ": graph doesn't have any data points (" << fitGraph->GetN() << "), going to skip fitting it" << std::endl;
+            continue;
+         }
+
+         // This fits the TGraph
+         auto* fpx = new TF1(Form("pxfit_%i_%i_%i", det, crystal1, crystal2), CrossTalkFit, 6, 1167, 3);
+         fpx->SetParameter(0, 0.0001);
+         fpx->SetParameter(1, 0.0001);
+         fpx->SetParameter(2, energy);
+         fpx->FixParameter(2, energy);
+         fitGraph->Fit(fpx);
+         fitGraph->Write();
+         delete fitGraph;
+
+         // create and write profile
+         TProfile* px = cmat->ProfileX();
+         px->Write();
+         // Make a residuals plot
+         TH1* residualPlot = new TH1D(Form("%s_resid", fpx->GetName()), "residuals", 2000, 0, 2000);
+         for(int i = 0; i < residualPlot->GetNbinsX(); ++i) {
+            if(px->GetBinContent(i) != 0) {
+               residualPlot->SetBinContent(i, px->GetBinContent(i) - fpx->Eval(residualPlot->GetBinCenter(i)));
+            }
+            residualPlot->SetBinError(i, px->GetBinError(i));
+         }
+         residualPlot->Write();
+         delete residualPlot;
+         delete cmat;
+
+         // for some reason from here on out crystal1 and crystal2 are used in reverse?
+         // was this maybe because before we used xind and yind instead which were from the tokenized name using entry N-1 (for xind) and N-2 (for yind)?
+         // temporary swapped the two - except for the largest stuff?
+         std::cout << "=====================" << std::endl;
+         std::cout << mat->GetName() << std::endl;
+         std::cout << "d" << crystal1 << crystal2 << " at zero   " << (fpx->Eval(energy)) / energy << std::endl;
+         std::cout << "=====================" << std::endl;
+
+         // Fill the parameter matrix with the parameters from the fit.
+         d[crystal2 * 4 + crystal1]  = fpx->GetParameter(0);
+         d[crystal1 * 4 + crystal2]  = fpx->GetParameter(1);
+         eD[crystal2 * 4 + crystal1] = fpx->GetParError(0);
+         eD[crystal1 * 4 + crystal2] = fpx->GetParError(1);
+
+         // Keep track of the largest correction and output that to screen,
+         // This helps identify problem channels, or mistakes
+         if(fpx->GetParameter(0) > largestCorrection) {
+            largestCorrection = fpx->GetParameter(0);
+            largestDet        = det;
+            largestCrystal2   = crystal2;
+            largestCrystal1   = crystal1;
+         }
+         if(fpx->GetParameter(1) > largestCorrection) {
+            largestCorrection = fpx->GetParameter(1);
+            largestDet        = det;
+            largestCrystal2   = crystal2;
+            largestCrystal1   = crystal1;
+         }
+      }   //for(int crystal2 = crystal1 + 1; crystal2 < 4; crystal2++)
+   }   // for(int crystal1 = 0; crystal1 < 4; crystal1++)
+
+   std::cout << " -------------------- " << std::endl;
+   std::cout << " -------------------- " << std::endl;
+   std::cout << std::endl;
+
+   // Set the diagonal elements to 0 since you can't cross-talk yourself
+   // store current precision and set to fixed 10 precision
+   std::streamsize prec = std::cout.precision();
+   std::cout.precision(10);
+   std::cout.setf(std::ios::fixed, std::ios::floatfield);
+   for(int i = 0; i < 4; i++) {
+      for(int j = 0; j < 4; j++) {
+         if(i == j) {
+            d[i * 4 + j]  = 0.0000;
+            eD[i * 4 + j] = 0.0000;
+         }
+         // output a matrix to screen
+         std::cout << d[j * 4 + i] << "\t";
+
+         // Time to find the proper channels and build the corrections xind/i is row number
+         auto* channelName = Form("%s%02d%s%s", channelPrefix.c_str(), det, GetColorFromNumber(j), channelPostfix.c_str());
+         TChannel* chan = TChannel::FindChannelByName(channelName);
+         if(chan == nullptr) {
+            std::cout << DRED << "Couldn't find a channel for " << channelName << RESET_COLOR << std::endl;
+            continue;
+         }
+         // Writes the coefficient to the found channel above
+         chan->AddCTCoefficient(d[i * 4 + j]);
+      }
+      std::cout << std::endl;
+   }
+   // set precision back to old value and remove fixed flag
+   std::cout.precision(prec);
+   std::cout.unsetf(std::ios::floatfield);
+
+   std::cout << std::endl;
+   std::cout << "Largest correction = " << largestCorrection << " Shift = " << largestCorrection * energy << std::endl;
+   std::cout << "Largest combo, det = " << largestDet << " Crystals = " << largestCrystal1 << ", " << largestCrystal2 << std::endl;
+   std::cout << " -------------------- " << std::endl;
+   std::cout << " -------------------- " << std::endl;
+   return d;
+}
+
+#ifndef __CINT__
+int main(int argc, char** argv)
+{
+   // Do basic file checks
+   if(argc != 3 && argc != 4) {
+      std::cout << "Usage: " << argv[0] << " <matrix file> <cal file> <user settings (optional)>" << std::endl;
+      std::cout << "User settings available (with default values where applicable), note whether integers, doubles, or strings are used:" << std::endl
+                << "CrossTalkEnergy: 1332." << std::endl
+                << "MinimumCounts: 10" << std::endl
+                << "FirstDetector: 1" << std::endl
+                << "LastDetector: 16" << std::endl
+                << "ExcludedDetectors: (int vector, i.e. comma separated list of integers between FirstDetector and LastDetector)" << std::endl
+                << "ChannelPrefix: GRG" << std::endl
+                << "ChannelPostfix: N00A" << std::endl;
+      return 1;
+   }
+
+   // We need a cal file to find the channels to write the corrections to
+   if(TChannel::ReadCalFile(argv[2]) < 0) {
+      std::cout << "Aborting" << std::endl;
+      exit(1);
+   }
+
+   auto* inputFile = new TFile(argv[1]);
+   if(inputFile == nullptr || !inputFile->IsOpen()) {
+      std::cout << "Failed to open file '" << argv[1] << "'!" << std::endl;
+      return 1;
+   }
+
+   // Create the output file
+   std::string outputFileName = argv[1];
+   auto        lastSlash      = outputFileName.find_last_of('/');
+   if(lastSlash != std::string::npos) {
+      outputFileName = std::string("ct_") + outputFileName.substr(lastSlash + 1);
+   } else {
+      outputFileName = std::string("ct_") + std::string(argv[1]);
+   }
+
+   auto* outputFile = new TFile(outputFileName.c_str(), "recreate");
+
+   // read user settings
+   auto* userSettings = new TUserSettings();
+   if(argc == 4) {
+      userSettings->ReadSettings(argv[3]);
+   }
+
+   std::vector<int> excludedDetectors;
+   try {
+      excludedDetectors = userSettings->GetIntVector("ExcludedDetectors", true);
+   } catch(std::out_of_range& e) {
+   }
+
+   double energy = userSettings->GetDouble("CrossTalkEnergy", 1332.);
+   int minimumCounts = userSettings->GetInt("MinimumCounts", 10);
+   std::string channelPrefix = userSettings->GetString("ChannelPrefix", "GRG");
+   std::string channelPostfix = userSettings->GetString("ChannelPostfix", "N00A");
+
+   for(int d = userSettings->GetInt("FirstDetector", 1); d <= userSettings->GetInt("LastDetector", 16); d++) {
+      if(!excludedDetectors.empty() && std::find(excludedDetectors.begin(), excludedDetectors.end(), d) != excludedDetectors.end()) {
+         std::cout << "Skipping excluded detector " << d << std::endl;
+         continue;
+      }
+      std::cout << "Starting CrossTalkFix for detector " << d << ", using energy " << userSettings->GetDouble("CrossTalkEnergy", 1332.) << ", and minimum counts " << userSettings->GetInt("MinimumCounts", 10) << std::endl;
+      CrossTalkFix(inputFile, d, energy, minimumCounts, channelPrefix, channelPostfix);
+   }
+
+   // This function writes a corrections cal_file which can be loaded in with your normal cal file.
+   TChannel::WriteCTCorrections("ct_correction.cal");
+
+   outputFile->Write();
+   outputFile->Close();
+}
+#endif

--- a/util/grsi-config
+++ b/util/grsi-config
@@ -44,8 +44,8 @@ if [ "$?" -ne "0" ]; then
 	fullpath1=$fullpath
 fi
 
-libdir=$GRSISYS/lib
-incdir=$GRSISYS/include
+libdir=${GRSISYS:?}/lib
+incdir=${GRSISYS:?}/include
 
 # lists of libraries, these are used to form the "-l<library name>" flags for the linker
 grsilibs="TGRSIint TFormat TLoops TKinematics TSRIM TBetaDecay TCal TReaction TPeakFitting"
@@ -162,12 +162,12 @@ while test $# -gt 0; do
 			lib=${1%-cflags}; # remove trailing -cflags
 			lib=${lib#--};  # remove leading  --
 			# check that the config script exists
-			if [ -e "$GRSISYS/$lib/util/config" ] ; then
-				out="$out $("$GRSISYS/$lib/util/config" --cflags)"
+			if [ -e "${GRSISYS:?}/$lib/util/config" ] ; then
+				out="$out $("${GRSISYS:?}/$lib/util/config" --cflags)"
 			else 
 				lib=$(echo "$lib" | tr '[:upper:]' '[:lower:]')
-				if [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
-					out="$out $("$GRSISYS/_deps/$lib-src/util/config" --cflags)"
+				if [ -e "${GRSISYS:?}/_deps/$lib-src/util/config" ] ; then
+					out="$out $("${GRSISYS:?}/_deps/$lib-src/util/config" --cflags)"
 				fi
 			fi
 			;;
@@ -175,12 +175,12 @@ while test $# -gt 0; do
 			lib=${1%-incdir}; # remove trailing -incdir
 			lib=${lib#--};  # remove leading  --
 			# check that the config script exists
-			if [ -e "$GRSISYS/$lib/util/config" ] ; then
-				out="$out $("$GRSISYS/$lib/util/config" --incdir)"
+			if [ -e "${GRSISYS:?}/$lib/util/config" ] ; then
+				out="$out $("${GRSISYS:?}/$lib/util/config" --incdir)"
 			else 
 				lib=$(echo "$lib" | tr '[:upper:]' '[:lower:]')
-				if [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
-					out="$out $("$GRSISYS/_deps/$lib-src/util/config" --incdir)"
+				if [ -e "${GRSISYS:?}/_deps/$lib-src/util/config" ] ; then
+					out="$out $("${GRSISYS:?}/_deps/$lib-src/util/config" --incdir)"
 				fi
 			fi
 			;;
@@ -188,12 +188,12 @@ while test $# -gt 0; do
 			lib=${1%-libs}; # remove trailing -libs
 			lib=${lib#--};  # remove leading  --
 			# check that the config script exists
-			if [ -e "$GRSISYS/$lib/util/config" ] ; then
-				out="$out $("$GRSISYS/$lib/util/config" --libs)"
+			if [ -e "${GRSISYS:?}/$lib/util/config" ] ; then
+				out="$out $("${GRSISYS:?}/$lib/util/config" --libs)"
 			else 
 				lib=$(echo "$lib" | tr '[:upper:]' '[:lower:]')
-				if [ -e "$GRSISYS/_deps/$lib-src/util/config" ] ; then
-					out="$out $("$GRSISYS/_deps/$lib-src/util/config" --libs)"
+				if [ -e "${GRSISYS:?}/_deps/$lib-src/util/config" ] ; then
+					out="$out $("${GRSISYS:?}/_deps/$lib-src/util/config" --libs)"
 				fi
 			fi
 			;;


### PR DESCRIPTION
This program is a more general version of GrifinCTFix (which relies on the `TGriffin` class and is part of the GRSIData repository). To support this the `GetColorFromNumber` function was added to `TGRSIUtilities.h` (as well as a `GetLongColorFromNumber` function).

Also used this opportunity to do a small cleanup and update of the cross talk helper.

In addition I updated the code to work with ROOT 6.40, which mainly involved changing instances where a deprecated TF1 constructor was used. I double checked and this changed code still compiles with ROOT 6.26.02 (on of the older versions installed on our servers).