### PR TITLE
Add pre-calibration charge drift correction

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -1,0 +1,72 @@
+# Energy calibration
+
+Energy calibration parameters are stored per channel in a GRSISort calibration
+file. `TDetectorHit::GetEnergy()` passes the integrated charge to
+`TChannel::CalibrateENG()`, which applies any configured charge correction and
+then the energy calibration.
+
+## Pre-calibration charge correction
+
+The optional `ENGChargeCorr` field provides a charge correction containing an
+offset, square-root coefficient, and gain, in that order:
+
+```text
+ENGChargeCorr: c0 cSqrt c1
+```
+
+For an input charge `q`, the corrected charge is
+
+```text
+q_corrected = c0 + cSqrt * sqrt(q) + c1 * q
+```
+
+The correction is applied after integration normalization and before selecting
+an energy-calibration range. The existing `ENGCoeff` polynomial is then evaluated
+using `q_corrected`. For example, a fifth-order calibration contains six
+coefficients:
+
+```text
+ENGCoeff: a0 a1 a2 a3 a4 a5
+```
+
+```text
+energy = a0 + a1 * q_corrected + a2 * q_corrected^2
+       + a3 * q_corrected^3 + a4 * q_corrected^4 + a5 * q_corrected^5
+```
+
+`ENGChargeCorr` must contain exactly three coefficients. A malformed entry is
+reported and ignored. The square-root term requires a non-negative normalized
+charge; a negative charge produces a non-finite corrected energy.
+
+### Compatibility
+
+`ENGChargeCorr` is optional. When it is absent, energy calibration follows the
+existing code path. The meaning and calculation of the existing `ENGDrift` and
+`ENGCoeff` fields have not changed.
+
+If both `ENGChargeCorr` and `ENGDrift` are present for a channel,
+`ENGChargeCorr` takes precedence and `ENGDrift` is not applied. New calibration
+files should use only one of these fields per channel.
+
+Programs must be rebuilt against a version of GRSISort that recognizes
+`ENGChargeCorr`. Older binaries skip unknown calibration fields and therefore
+cannot apply this correction, although they continue to process older
+calibration files normally.
+
+## Run-specific calibrations
+
+For run-by-run gain-drift correction, write the appropriate `ENGChargeCorr`
+coefficients into each run's calibration file. The existing `WriteCalToRoot`
+utility can embed the calibration without source changes:
+
+```sh
+WriteCalToRoot update run12345.cal analysis12345.root
+```
+
+Use a separate invocation for each run because one `WriteCalToRoot` invocation
+applies the same calibration file to every ROOT file supplied to it. Use
+`update` for a correction file that augments an existing embedded calibration.
+Use `replace` only when the supplied file contains the complete calibration.
+
+`WriteCalToRoot` must be rebuilt with the updated GRSISort libraries so that the
+new field is parsed and retained in the embedded calibration.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Once complete type `make` in the GRSISort directory
 
 See also [Setup Guide](https://github.com/GRIFFINCollaboration/GRSISort/wiki/Setting-up-GRSISort).
 
+For the energy calibration file format, including pre-calibration charge
+corrections, see [Energy calibration](CALIBRATION.md).
+
 -----------------------------------------
 ## Running
 
@@ -32,4 +35,3 @@ For information on running GRSISort see [Running-GRSISort](https://github.com/GR
 Everybody is welcome to help and expand the [wiki](http://github.com/GRIFFINCollaboration/GRSISort/wiki).
 
 See [Commenting Code for HTML](https://github.com/GRIFFINCollaboration/GRSISort/wiki/Html-How-To) for information about in-code documentation for the doxygen generated [Reference Guide](https://rawgit.com/wiki/GriffinCollaboration/GRSISort/technical-docs/ROOT-Gen-Html/htmldoc/annotated.html).
-

--- a/include/TChannel.h
+++ b/include/TChannel.h
@@ -94,20 +94,21 @@ private:
    TPriorityValue<TMnemonic*> fMnemonic;
    static TClassRef           fMnemonicClass;
 
-   TPriorityValue<std::vector<std::vector<Float_t>>>      fENGCoefficients;       ///< Energy calibration coeffs (low to high order)
-   TPriorityValue<std::vector<std::pair<double, double>>> fENGRanges;             ///< Range of energy calibrations
-   TPriorityValue<std::vector<double>>                    fENGChi2;               ///< Chi2 of the energy calibration
-   TPriorityValue<std::vector<Float_t>>                   fENGDriftCoefficents;   ///< Energy drift coefficents (applied after energy calibration has been applied)
-   TPriorityValue<std::vector<double>>                    fCFDCoefficients;       ///< CFD calibration coeffs (low to high order)
-   TPriorityValue<double>                                 fCFDChi2;               ///< Chi2 of the CFD calibration
-   TPriorityValue<std::vector<double>>                    fLEDCoefficients;       ///< LED calibration coeffs (low to high order)
-   TPriorityValue<double>                                 fLEDChi2;               ///< Chi2 of LED calibration
-   TPriorityValue<std::vector<double>>                    fTIMECoefficients;      ///< Time calibration coeffs (low to high order)
-   TPriorityValue<double>                                 fTIMEChi2;              ///< Chi2 of the Time calibration
-   TPriorityValue<std::vector<double>>                    fEFFCoefficients;       ///< Efficiency calibration coeffs (low to high order)
-   TPriorityValue<double>                                 fEFFChi2;               ///< Chi2 of Efficiency calibration
-   TPriorityValue<std::vector<double>>                    fCTCoefficients;        ///< Cross talk coefficients
-   TPriorityValue<TGraph>                                 fEnergyNonlinearity;    ///< Energy nonlinearity as TGraph, is used as E=E+GetEnergyNonlinearity(E), so y should be E(source)-calibration(peak)
+   TPriorityValue<std::vector<std::vector<Float_t>>>      fENGCoefficients;        ///< Energy calibration coeffs (low to high order)
+   TPriorityValue<std::vector<std::pair<double, double>>> fENGRanges;              ///< Range of energy calibrations
+   TPriorityValue<std::vector<double>>                    fENGChi2;                ///< Chi2 of the energy calibration
+   TPriorityValue<std::vector<Float_t>>                   fENGDriftCoefficents;    ///< Energy drift coefficients applied before energy calibration
+   TPriorityValue<std::vector<Float_t>>                   fENGChargeCorrections;   ///< Three-term pre-calibration charge correction: offset, square root, and gain
+   TPriorityValue<std::vector<double>>                    fCFDCoefficients;        ///< CFD calibration coeffs (low to high order)
+   TPriorityValue<double>                                 fCFDChi2;                ///< Chi2 of the CFD calibration
+   TPriorityValue<std::vector<double>>                    fLEDCoefficients;        ///< LED calibration coeffs (low to high order)
+   TPriorityValue<double>                                 fLEDChi2;                ///< Chi2 of LED calibration
+   TPriorityValue<std::vector<double>>                    fTIMECoefficients;       ///< Time calibration coeffs (low to high order)
+   TPriorityValue<double>                                 fTIMEChi2;               ///< Chi2 of the Time calibration
+   TPriorityValue<std::vector<double>>                    fEFFCoefficients;        ///< Efficiency calibration coeffs (low to high order)
+   TPriorityValue<double>                                 fEFFChi2;                ///< Chi2 of Efficiency calibration
+   TPriorityValue<std::vector<double>>                    fCTCoefficients;         ///< Cross talk coefficients
+   TPriorityValue<TGraph>                                 fEnergyNonlinearity;     ///< Energy nonlinearity as TGraph, is used as E=E+GetEnergyNonlinearity(E), so y should be E(source)-calibration(peak)
    TPriorityValue<TGraph>                                 fTimeNonlinearity;
 
    struct WaveFormShapePar {
@@ -199,6 +200,7 @@ public:
    std::vector<std::pair<double, double>> GetENGRanges() const { return fENGRanges.Value(); }
    std::pair<double, double>              GetENGRange(size_t range) const { return fENGRanges.Value()[range]; }
    std::vector<Float_t>                   GetENGDriftCoefficents() const { return fENGDriftCoefficents.Value(); }
+   std::vector<Float_t>                   GetENGChargeCorrections() const { return fENGChargeCorrections.Value(); }
 
    void AddENGCoefficient(Float_t temp, size_t range = 0)
    {
@@ -234,6 +236,7 @@ public:
       fENGRanges.Address()->at(range) = tmp;
    }
    void SetENGDriftCoefficents(const TPriorityValue<std::vector<Float_t>>& tmp) { fENGDriftCoefficents = tmp; }
+   void SetENGChargeCorrections(const TPriorityValue<std::vector<Float_t>>& tmp) { fENGChargeCorrections = tmp; }
    void SetCFDCoefficients(const TPriorityValue<std::vector<double>>& tmp) { fCFDCoefficients = tmp; }
    void SetLEDCoefficients(const TPriorityValue<std::vector<double>>& tmp) { fLEDCoefficients = tmp; }
    void SetTIMECoefficients(const TPriorityValue<std::vector<double>>& tmp) { fTIMECoefficients = tmp; }
@@ -340,7 +343,7 @@ private:
    static Int_t ReadFile(TFile* tempf);
 
    /// \cond CLASSIMP
-   ClassDefOverride(TChannel, 6)   // NOLINT(readability-else-after-return)
+   ClassDefOverride(TChannel, 7)   // NOLINT(readability-else-after-return)
    /// \endcond
 };
 /*! @} */

--- a/libraries/TFormat/TChannel.cxx
+++ b/libraries/TFormat/TChannel.cxx
@@ -1,5 +1,6 @@
 #include "TChannel.h"
 
+#include <cmath>
 #include <stdexcept>
 #include <fstream>
 #include <iostream>
@@ -74,6 +75,7 @@ TChannel::TChannel(const TChannel& chan) : TNamed(chan)
    SetENGRanges(chan.fENGRanges);
    SetAllENGChi2(chan.fENGChi2);
    SetENGDriftCoefficents(chan.fENGDriftCoefficents);
+   SetENGChargeCorrections(chan.fENGChargeCorrections);
    SetCFDCoefficients(chan.fCFDCoefficients);
    SetLEDCoefficients(chan.fLEDCoefficients);
    SetTIMECoefficients(chan.fTIMECoefficients);
@@ -112,6 +114,7 @@ TChannel::TChannel(TChannel&& chan) noexcept : TNamed(chan)
    SetENGRanges(chan.fENGRanges);
    SetAllENGChi2(chan.fENGChi2);
    SetENGDriftCoefficents(chan.fENGDriftCoefficents);
+   SetENGChargeCorrections(chan.fENGChargeCorrections);
    SetCFDCoefficients(chan.fCFDCoefficients);
    SetLEDCoefficients(chan.fLEDCoefficients);
    SetTIMECoefficients(chan.fTIMECoefficients);
@@ -149,6 +152,7 @@ TChannel::TChannel(TChannel* chan)
    SetENGRanges(chan->fENGRanges);
    SetAllENGChi2(chan->fENGChi2);
    SetENGDriftCoefficents(chan->fENGDriftCoefficents);
+   SetENGChargeCorrections(chan->fENGChargeCorrections);
    SetCFDCoefficients(chan->fCFDCoefficients);
    SetLEDCoefficients(chan->fLEDCoefficients);
    SetTIMECoefficients(chan->fTIMECoefficients);
@@ -187,6 +191,7 @@ TChannel& TChannel::operator=(const TChannel& rhs)
    SetENGRanges(rhs.fENGRanges);
    SetAllENGChi2(rhs.fENGChi2);
    SetENGDriftCoefficents(rhs.fENGDriftCoefficents);
+   SetENGChargeCorrections(rhs.fENGChargeCorrections);
    SetCFDCoefficients(rhs.fCFDCoefficients);
    SetLEDCoefficients(rhs.fLEDCoefficients);
    SetTIMECoefficients(rhs.fTIMECoefficients);
@@ -228,6 +233,7 @@ TChannel& TChannel::operator=(TChannel&& rhs) noexcept
    SetENGRanges(rhs.fENGRanges);
    SetAllENGChi2(rhs.fENGChi2);
    SetENGDriftCoefficents(rhs.fENGDriftCoefficents);
+   SetENGChargeCorrections(rhs.fENGChargeCorrections);
    SetCFDCoefficients(rhs.fCFDCoefficients);
    SetLEDCoefficients(rhs.fLEDCoefficients);
    SetTIMECoefficients(rhs.fTIMECoefficients);
@@ -347,6 +353,7 @@ void TChannel::OverWriteChannel(TChannel* chan)
    SetENGRanges(TPriorityValue<std::vector<std::pair<double, double>>>(chan->GetENGRanges(), EPriority::kForce));
    SetAllENGChi2(TPriorityValue<std::vector<double>>(chan->GetAllENGChi2(), EPriority::kForce));
    SetENGDriftCoefficents(TPriorityValue<std::vector<Float_t>>(chan->GetENGDriftCoefficents(), EPriority::kForce));
+   SetENGChargeCorrections(TPriorityValue<std::vector<Float_t>>(chan->GetENGChargeCorrections(), EPriority::kForce));
    SetCFDCoefficients(TPriorityValue<std::vector<double>>(chan->GetCFDCoeff(), EPriority::kForce));
    SetLEDCoefficients(TPriorityValue<std::vector<double>>(chan->GetLEDCoeff(), EPriority::kForce));
    SetTIMECoefficients(TPriorityValue<std::vector<double>>(chan->GetTIMECoeff(), EPriority::kForce));
@@ -386,6 +393,7 @@ void TChannel::AppendChannel(TChannel* chan)
    SetENGRanges(chan->fENGRanges);
    SetAllENGChi2(chan->fENGChi2);
    SetENGDriftCoefficents(chan->fENGDriftCoefficents);
+   SetENGChargeCorrections(chan->fENGChargeCorrections);
    SetCFDCoefficients(chan->fCFDCoefficients);
    SetLEDCoefficients(chan->fLEDCoefficients);
    SetTIMECoefficients(chan->fTIMECoefficients);
@@ -460,6 +468,7 @@ void TChannel::Clear(Option_t*)
    fENGRanges.Reset(std::vector<std::pair<double, double>>());
    fENGChi2.Reset(std::vector<double>());
    fENGDriftCoefficents.Reset(std::vector<Float_t>());
+   fENGChargeCorrections.Reset(std::vector<Float_t>());
    fCFDCoefficients.Reset(std::vector<double>());
    fCFDChi2.Reset(0.0);
    fLEDCoefficients.Reset(std::vector<double>());
@@ -575,6 +584,7 @@ void TChannel::DestroyENGCal()
    fENGRanges.Address()->clear();
    fENGChi2.Address()->clear();
    fENGDriftCoefficents.Address()->clear();
+   fENGChargeCorrections.Address()->clear();
 }
 
 void TChannel::DestroyCFDCal()
@@ -674,6 +684,14 @@ double TChannel::CalibrateENG(double charge) const
    if(fENGCoefficients.empty()) {
       return charge;
    }
+
+   // Apply the optional charge correction before selecting the calibration range.
+   // ENGChargeCorr contains the offset, square-root, and gain coefficients, in that order.
+   const bool useENGChargeCorrection = fENGChargeCorrections.size() == 3;
+   if(useENGChargeCorrection) {
+      charge = fENGChargeCorrections[0] + fENGChargeCorrections[1] * std::sqrt(charge) + fENGChargeCorrections[2] * charge;
+   }
+
    // select range to use, they should be sorted
    size_t currentRange = 0;
    if(!fENGRanges.empty()) {
@@ -703,7 +721,7 @@ double TChannel::CalibrateENG(double charge) const
    }
 
    // apply the drift correction first
-   if(!fENGDriftCoefficents.empty()) {
+   if(!useENGChargeCorrection && !fENGDriftCoefficents.empty()) {
       double corrCharge = -fENGDriftCoefficents[0];   // ILL subtracts the offset instead of adding it
       for(size_t i = 1; i < fENGDriftCoefficents.size(); i++) {
          corrCharge += fENGDriftCoefficents[i] * pow(charge, static_cast<double>(i));
@@ -936,6 +954,16 @@ std::string TChannel::PrintToString(Option_t*) const
       auto oldPrecision = str.precision();
       str.precision(9);
       for(auto coeff : fENGDriftCoefficents) {
+         str << coeff << "\t";
+      }
+      str.precision(oldPrecision);
+      str << std::endl;
+   }
+   if(!fENGChargeCorrections.empty()) {
+      str << "ENGChargeCorr:   ";
+      auto oldPrecision = str.precision();
+      str.precision(9);
+      for(auto coeff : fENGChargeCorrections) {
          str << coeff << "\t";
       }
       str.precision(oldPrecision);
@@ -1341,7 +1369,11 @@ Int_t TChannel::ParseInputData(const char* inputdata, Option_t* opt, EPriority p
                   range = 0;
                }
                if(range == 0) {
+                  // ENGChargeCorr is independent of the polynomial calibration and may appear before ENGCoeff.
+                  // Preserve it while resetting the existing energy calibration.
+                  const auto chargeCorrections = channel->fENGChargeCorrections;
                   channel->DestroyENGCal();
+                  channel->fENGChargeCorrections = chargeCorrections;
                   channel->fENGCoefficients.SetPriority(prio);
                }
                float value = 0.;
@@ -1359,6 +1391,17 @@ Int_t TChannel::ParseInputData(const char* inputdata, Option_t* opt, EPriority p
                float value = 0.;
                while(!(str >> value).fail()) {
                   channel->AddENGDriftCoefficent(value);
+               }
+            } else if(type == "ENGCHARGECORR") {
+               std::vector<Float_t> corrections;
+               float                value = 0.;
+               while(!(str >> value).fail()) {
+                  corrections.push_back(value);
+               }
+               if(corrections.size() != 3) {
+                  std::cerr << "ENGChargeCorr requires exactly three coefficients (offset, square root, gain), got " << corrections.size() << " on line " << linenumber << std::endl;
+               } else {
+                  channel->SetENGChargeCorrections(TPriorityValue<std::vector<Float_t>>(corrections, prio));
                }
             } else if(type == "LEDCOEFF") {
                channel->DestroyLEDCal();


### PR DESCRIPTION
Added an optional offset, square-root, and gain correction to charge before applying polynomial energy calibration. This allows for the optional work flow of gain-matching the detectors before  calibration, which will improve the statistics for calibration by being able to sum over all/multiple runs. Adding this feature should not change the behaviour of existing calibrations that do not contain the additional line of `ENGChargeCorr` in the .cal. See more in the `CALIBRATION.md`.