### PR TITLE
Fixing #1654 by adding check if opening parentheses is before last dot

### DIFF
--- a/libraries/TGRSIint/TGRSIOptions.cxx
+++ b/libraries/TGRSIint/TGRSIOptions.cxx
@@ -483,7 +483,21 @@ kFileType TGRSIOptions::DetermineFileType(const std::string& filename)
    if(dotPos == std::string::npos || (dotPos < slashPos && slashPos != std::string::npos)) {
       return kFileType::TDR_FILE;
    }
-   std::string ext = filename.substr(dotPos + 1);
+   size_t openingPos = filename.find_first_of('(');
+   // if we find an opening parenthese, we might have a case where arguments are supplied to a script
+   std::string ext;
+   if(openingPos != std::string::npos) {
+      if(openingPos < dotPos) { // . is after the opening parenthese it might be part of the arguments, so search before that point
+         size_t newDotPos = filename.substr(0, openingPos).find_last_of('.');
+         if(newDotPos != std::string::npos) {
+            ext = filename.substr(newDotPos + 1, openingPos - newDotPos - 1);
+            if((ext == "c") || (ext == "C") || (ext == "c+") || (ext == "C+") || (ext == "c++") || (ext == "C++")) {
+               return kFileType::ROOT_MACRO;
+            }
+         }
+      }
+   }
+   ext = filename.substr(dotPos + 1);
 
    // check if this is a zipped file and if so get the extension before the zip-extension
    bool isZipped = (ext == "gz") || (ext == "bz2") || (ext == "zip");
@@ -548,13 +562,14 @@ kFileType TGRSIOptions::DetermineFileType(const std::string& filename)
    }
 
    // strip possible parenthese with arguments for the script from the extension
-   size_t openingPos = ext.find_first_of('(');
+   openingPos = ext.find_first_of('(');
    if(openingPos != std::string::npos) {
       ext = ext.substr(0, openingPos);
       if((ext == "c") || (ext == "C") || (ext == "c+") || (ext == "C+") || (ext == "c++") || (ext == "C++")) {
          return kFileType::ROOT_MACRO;
       }
    }
+   std::cout << "Unknown file extension \"" << ext << "\"" << std::endl;
    return kFileType::UNKNOWN_FILETYPE;
 }
 


### PR DESCRIPTION
We already had a check at the very end of the function to see if we have opening parentheses, but that check failed if the arguments to the script contained a dot, e.g. if a file path was used as an argument. In that case the extensions string was set to the extension of the file path argument, not the name of the script. 
So I added a check at the beginning if we can find a parentheses before the last dot. In that case we find the last dot before that and then check if the string between that dot and the opening parentheses gives us the right extension.
This might cause issues if someone decides to use a weird filename with parentheses in it, but we can cross that bridge whenever we get to it.